### PR TITLE
[codex] Implement admin IAM user update and property assignment commands

### DIFF
--- a/internal/application/iam/assign_user_properties.go
+++ b/internal/application/iam/assign_user_properties.go
@@ -2,11 +2,10 @@ package iam
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 
-	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
-	"stds_backend/internal/platform/database/users"
 	"stds_backend/internal/shared/apperr"
 )
 
@@ -18,13 +17,13 @@ type AssignUserPropertiesInput struct {
 
 // AssignUserPropertiesService replaces a user's property assignment list.
 type AssignUserPropertiesService struct {
-	userRepo       users.Repository
-	propertyReader dbpropertyquery.Repository
+	userRepo       ManagedUserPropertyAssignmentRepository
+	propertyReader PropertyExistenceChecker
 	claimsSync     ManagedUserClaimsSyncer
 }
 
 // NewAssignUserPropertiesService returns an AssignUserPropertiesService.
-func NewAssignUserPropertiesService(userRepo users.Repository, propertyReader dbpropertyquery.Repository, claimsSync ManagedUserClaimsSyncer) *AssignUserPropertiesService {
+func NewAssignUserPropertiesService(userRepo ManagedUserPropertyAssignmentRepository, propertyReader PropertyExistenceChecker, claimsSync ManagedUserClaimsSyncer) *AssignUserPropertiesService {
 	return &AssignUserPropertiesService{
 		userRepo:       userRepo,
 		propertyReader: propertyReader,
@@ -33,7 +32,7 @@ func NewAssignUserPropertiesService(userRepo users.Repository, propertyReader db
 }
 
 // Execute validates assignment rules, replaces assignments, and refreshes Firebase claims.
-func (s *AssignUserPropertiesService) Execute(ctx context.Context, input AssignUserPropertiesInput) (*users.User, error) {
+func (s *AssignUserPropertiesService) Execute(ctx context.Context, input AssignUserPropertiesInput) (*ManagedUser, error) {
 	targetUserID := strings.TrimSpace(input.TargetUserID)
 	if targetUserID == "" {
 		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
@@ -44,7 +43,7 @@ func (s *AssignUserPropertiesService) Execute(ctx context.Context, input AssignU
 	target, err := s.userRepo.FindByID(ctx, targetUserID)
 	if err != nil {
 		switch err {
-		case users.ErrNotFound:
+		case ErrManagedUserNotFound:
 			return nil, apperr.ErrUserNotFound
 		default:
 			return nil, apperr.ErrInternalServerError.WithCause(err)
@@ -57,22 +56,26 @@ func (s *AssignUserPropertiesService) Execute(ctx context.Context, input AssignU
 
 	propertyIDs := normalizePropertyIDs(input.PropertyIDs)
 	for _, propertyID := range propertyIDs {
-		if _, err := s.propertyReader.FindByID(ctx, propertyID); err != nil {
-			switch err {
-			case dbpropertyquery.ErrNotFound:
+		exists, err := s.propertyReader.Exists(ctx, propertyID)
+		if err != nil {
+			if errors.Is(err, ErrManagedPropertyNotFound) {
 				return nil, apperr.ErrPropertyNotFound.WithDetails(map[string]interface{}{
 					"property_id": propertyID,
 				})
-			default:
-				return nil, apperr.ErrInternalServerError.WithCause(err)
 			}
+			return nil, apperr.ErrInternalServerError.WithCause(err)
+		}
+		if !exists {
+			return nil, apperr.ErrPropertyNotFound.WithDetails(map[string]interface{}{
+				"property_id": propertyID,
+			})
 		}
 	}
 
 	user, err := s.userRepo.ReplaceAssignedProperties(ctx, targetUserID, propertyIDs)
 	if err != nil {
 		switch err {
-		case users.ErrNotFound:
+		case ErrManagedUserNotFound:
 			return nil, apperr.ErrUserNotFound
 		default:
 			return nil, apperr.ErrInternalServerError.WithCause(err)

--- a/internal/application/iam/assign_user_properties.go
+++ b/internal/application/iam/assign_user_properties.go
@@ -42,12 +42,10 @@ func (s *AssignUserPropertiesService) Execute(ctx context.Context, input AssignU
 
 	target, err := s.userRepo.FindByID(ctx, targetUserID)
 	if err != nil {
-		switch err {
-		case ErrManagedUserNotFound:
+		if errors.Is(err, apperr.ErrUserNotFound) {
 			return nil, apperr.ErrUserNotFound
-		default:
-			return nil, apperr.ErrInternalServerError.WithCause(err)
 		}
+		return nil, apperr.ErrInternalServerError.WithCause(err)
 	}
 
 	if target.Role == "owner" {
@@ -58,11 +56,6 @@ func (s *AssignUserPropertiesService) Execute(ctx context.Context, input AssignU
 	for _, propertyID := range propertyIDs {
 		exists, err := s.propertyReader.Exists(ctx, propertyID)
 		if err != nil {
-			if errors.Is(err, ErrManagedPropertyNotFound) {
-				return nil, apperr.ErrPropertyNotFound.WithDetails(map[string]interface{}{
-					"property_id": propertyID,
-				})
-			}
 			return nil, apperr.ErrInternalServerError.WithCause(err)
 		}
 		if !exists {
@@ -74,12 +67,10 @@ func (s *AssignUserPropertiesService) Execute(ctx context.Context, input AssignU
 
 	user, err := s.userRepo.ReplaceAssignedProperties(ctx, targetUserID, propertyIDs)
 	if err != nil {
-		switch err {
-		case ErrManagedUserNotFound:
+		if errors.Is(err, apperr.ErrUserNotFound) {
 			return nil, apperr.ErrUserNotFound
-		default:
-			return nil, apperr.ErrInternalServerError.WithCause(err)
 		}
+		return nil, apperr.ErrInternalServerError.WithCause(err)
 	}
 
 	if s.claimsSync == nil {

--- a/internal/application/iam/assign_user_properties.go
+++ b/internal/application/iam/assign_user_properties.go
@@ -1,0 +1,103 @@
+package iam
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
+	"stds_backend/internal/platform/database/users"
+	"stds_backend/internal/shared/apperr"
+)
+
+// AssignUserPropertiesInput is the admin payload for POST /users/{id}/property-assignments.
+type AssignUserPropertiesInput struct {
+	TargetUserID string
+	PropertyIDs  []string
+}
+
+// AssignUserPropertiesService replaces a user's property assignment list.
+type AssignUserPropertiesService struct {
+	userRepo       users.Repository
+	propertyReader dbpropertyquery.Repository
+	claimsSync     ManagedUserClaimsSyncer
+}
+
+// NewAssignUserPropertiesService returns an AssignUserPropertiesService.
+func NewAssignUserPropertiesService(userRepo users.Repository, propertyReader dbpropertyquery.Repository, claimsSync ManagedUserClaimsSyncer) *AssignUserPropertiesService {
+	return &AssignUserPropertiesService{
+		userRepo:       userRepo,
+		propertyReader: propertyReader,
+		claimsSync:     claimsSync,
+	}
+}
+
+// Execute validates assignment rules, replaces assignments, and refreshes Firebase claims.
+func (s *AssignUserPropertiesService) Execute(ctx context.Context, input AssignUserPropertiesInput) (*users.User, error) {
+	targetUserID := strings.TrimSpace(input.TargetUserID)
+	if targetUserID == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field": "id",
+		})
+	}
+
+	target, err := s.userRepo.FindByID(ctx, targetUserID)
+	if err != nil {
+		switch err {
+		case users.ErrNotFound:
+			return nil, apperr.ErrUserNotFound
+		default:
+			return nil, apperr.ErrInternalServerError.WithCause(err)
+		}
+	}
+
+	if target.Role == "owner" {
+		return nil, apperr.ErrCannotAssignPropertyToOwner
+	}
+
+	propertyIDs := normalizePropertyIDs(input.PropertyIDs)
+	for _, propertyID := range propertyIDs {
+		if _, err := s.propertyReader.FindByID(ctx, propertyID); err != nil {
+			switch err {
+			case dbpropertyquery.ErrNotFound:
+				return nil, apperr.ErrPropertyNotFound.WithDetails(map[string]interface{}{
+					"property_id": propertyID,
+				})
+			default:
+				return nil, apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+	}
+
+	user, err := s.userRepo.ReplaceAssignedProperties(ctx, targetUserID, propertyIDs)
+	if err != nil {
+		switch err {
+		case users.ErrNotFound:
+			return nil, apperr.ErrUserNotFound
+		default:
+			return nil, apperr.ErrInternalServerError.WithCause(err)
+		}
+	}
+
+	if s.claimsSync == nil {
+		return nil, apperr.ErrInternalServerError
+	}
+	if err := s.claimsSync.Sync(ctx, user.FirebaseUID, user.Role, user.AssignedPropertyIDs); err != nil {
+		return nil, apperr.ErrInternalServerError.WithCause(err)
+	}
+
+	return user, nil
+}
+
+func normalizePropertyIDs(values []string) []string {
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+
+	slices.Sort(result)
+	return slices.Compact(result)
+}

--- a/internal/application/iam/assign_user_properties_test.go
+++ b/internal/application/iam/assign_user_properties_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
-	"stds_backend/internal/platform/database/users"
 	"stds_backend/internal/shared/apperr"
 )
 
@@ -38,7 +36,7 @@ func TestAssignUserPropertiesServiceExecute(t *testing.T) {
 
 	t.Run("rejects owner target", func(t *testing.T) {
 		repo := &assignUserPropertiesRepo{
-			findUser: &users.User{ID: "user-1", FirebaseUID: "uid-owner", Name: "Owner", Role: "owner"},
+			findUser: &ManagedUser{ID: "user-1", FirebaseUID: "uid-owner", Name: "Owner", Role: "owner"},
 		}
 		service := NewAssignUserPropertiesService(repo, &propertyReaderSpy{}, &claimsSyncSpy{})
 
@@ -88,18 +86,14 @@ func TestAssignUserPropertiesServiceExecute(t *testing.T) {
 }
 
 type assignUserPropertiesRepo struct {
-	findUser            *users.User
+	findUser            *ManagedUser
 	findErr             error
 	replaceErr          error
 	replaceCalls        int
 	replacedPropertyIDs []string
 }
 
-func (r *assignUserPropertiesRepo) FindByFirebaseUID(_ context.Context, _ string) (*users.User, error) {
-	return nil, errors.New("not used")
-}
-
-func (r *assignUserPropertiesRepo) FindByID(_ context.Context, id string) (*users.User, error) {
+func (r *assignUserPropertiesRepo) FindByID(_ context.Context, id string) (*ManagedUser, error) {
 	if r.findErr != nil {
 		return nil, r.findErr
 	}
@@ -107,7 +101,7 @@ func (r *assignUserPropertiesRepo) FindByID(_ context.Context, id string) (*user
 		return r.findUser, nil
 	}
 
-	return &users.User{
+	return &ManagedUser{
 		ID:                  id,
 		FirebaseUID:         "uid-1",
 		Email:               "organizer@studio.com",
@@ -121,23 +115,7 @@ func (r *assignUserPropertiesRepo) FindByID(_ context.Context, id string) (*user
 	}, nil
 }
 
-func (r *assignUserPropertiesRepo) List(_ context.Context, _ users.ListParams) ([]users.User, error) {
-	return nil, errors.New("not used")
-}
-
-func (r *assignUserPropertiesRepo) Create(_ context.Context, _ users.CreateUserParams) (*users.User, error) {
-	return nil, errors.New("not used")
-}
-
-func (r *assignUserPropertiesRepo) UpdateCurrentUser(_ context.Context, _ string, _ users.UpdateCurrentUserParams) (*users.User, error) {
-	return nil, errors.New("not used")
-}
-
-func (r *assignUserPropertiesRepo) UpdateManagedUser(_ context.Context, _ string, _ users.UpdateManagedUserParams) (*users.User, error) {
-	return nil, errors.New("not used")
-}
-
-func (r *assignUserPropertiesRepo) ReplaceAssignedProperties(_ context.Context, id string, propertyIDs []string) (*users.User, error) {
+func (r *assignUserPropertiesRepo) ReplaceAssignedProperties(_ context.Context, id string, propertyIDs []string) (*ManagedUser, error) {
 	if r.replaceErr != nil {
 		return nil, r.replaceErr
 	}
@@ -145,7 +123,7 @@ func (r *assignUserPropertiesRepo) ReplaceAssignedProperties(_ context.Context, 
 	r.replaceCalls++
 	r.replacedPropertyIDs = propertyIDs
 
-	return &users.User{
+	return &ManagedUser{
 		ID:                  id,
 		FirebaseUID:         "uid-1",
 		Email:               "organizer@studio.com",
@@ -159,22 +137,14 @@ func (r *assignUserPropertiesRepo) ReplaceAssignedProperties(_ context.Context, 
 	}, nil
 }
 
-func (r *assignUserPropertiesRepo) DeleteByID(_ context.Context, _ string) error {
-	return errors.New("not used")
-}
-
 type propertyReaderSpy struct {
 	missingIDs map[string]struct{}
 }
 
-func (s *propertyReaderSpy) FindByID(_ context.Context, propertyID string) (*dbpropertyquery.Property, error) {
+func (s *propertyReaderSpy) Exists(_ context.Context, propertyID string) (bool, error) {
 	if _, ok := s.missingIDs[propertyID]; ok {
-		return nil, dbpropertyquery.ErrNotFound
+		return false, ErrManagedPropertyNotFound
 	}
 
-	return &dbpropertyquery.Property{ID: propertyID}, nil
-}
-
-func (s *propertyReaderSpy) ListAccessible(_ context.Context, _ string, _ string, _ []string) ([]dbpropertyquery.Property, error) {
-	return nil, errors.New("not used")
+	return true, nil
 }

--- a/internal/application/iam/assign_user_properties_test.go
+++ b/internal/application/iam/assign_user_properties_test.go
@@ -143,7 +143,7 @@ type propertyReaderSpy struct {
 
 func (s *propertyReaderSpy) Exists(_ context.Context, propertyID string) (bool, error) {
 	if _, ok := s.missingIDs[propertyID]; ok {
-		return false, ErrManagedPropertyNotFound
+		return false, nil
 	}
 
 	return true, nil

--- a/internal/application/iam/assign_user_properties_test.go
+++ b/internal/application/iam/assign_user_properties_test.go
@@ -1,0 +1,180 @@
+package iam
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
+	"stds_backend/internal/platform/database/users"
+	"stds_backend/internal/shared/apperr"
+)
+
+func TestAssignUserPropertiesServiceExecute(t *testing.T) {
+	t.Run("replaces assignments and syncs claims", func(t *testing.T) {
+		repo := &assignUserPropertiesRepo{}
+		propertyRepo := &propertyReaderSpy{}
+		claims := &claimsSyncSpy{}
+		service := NewAssignUserPropertiesService(repo, propertyRepo, claims)
+
+		user, err := service.Execute(context.Background(), AssignUserPropertiesInput{
+			TargetUserID: "user-1",
+			PropertyIDs:  []string{"property-2", "property-1", "property-2"},
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(repo.replacedPropertyIDs) != 2 {
+			t.Fatalf("expected 2 unique property ids, got %d", len(repo.replacedPropertyIDs))
+		}
+		if user.AssignedPropertyIDs[0] != "property-1" {
+			t.Fatalf("expected sorted property ids, got %v", user.AssignedPropertyIDs)
+		}
+		if claims.role != "organizer" {
+			t.Fatalf("expected organizer role, got %q", claims.role)
+		}
+	})
+
+	t.Run("rejects owner target", func(t *testing.T) {
+		repo := &assignUserPropertiesRepo{
+			findUser: &users.User{ID: "user-1", FirebaseUID: "uid-owner", Name: "Owner", Role: "owner"},
+		}
+		service := NewAssignUserPropertiesService(repo, &propertyReaderSpy{}, &claimsSyncSpy{})
+
+		_, err := service.Execute(context.Background(), AssignUserPropertiesInput{
+			TargetUserID: "user-1",
+			PropertyIDs:  []string{"property-1"},
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		var appErr *apperr.Error
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected apperr.Error, got %T", err)
+		}
+		if appErr.Code != apperr.CodeCannotAssignPropertyToOwner {
+			t.Fatalf("expected %s, got %s", apperr.CodeCannotAssignPropertyToOwner, appErr.Code)
+		}
+	})
+
+	t.Run("maps missing property to property not found", func(t *testing.T) {
+		service := NewAssignUserPropertiesService(&assignUserPropertiesRepo{}, &propertyReaderSpy{missingIDs: map[string]struct{}{"property-2": {}}}, &claimsSyncSpy{})
+
+		_, err := service.Execute(context.Background(), AssignUserPropertiesInput{
+			TargetUserID: "user-1",
+			PropertyIDs:  []string{"property-2"},
+		})
+		if err == nil || err.Error() != "Property not found." {
+			t.Fatalf("expected property not found, got %v", err)
+		}
+	})
+
+	t.Run("maps claims sync failure to internal server error after persistence", func(t *testing.T) {
+		repo := &assignUserPropertiesRepo{}
+		service := NewAssignUserPropertiesService(repo, &propertyReaderSpy{}, &claimsSyncSpy{err: errors.New("firebase down")})
+
+		_, err := service.Execute(context.Background(), AssignUserPropertiesInput{
+			TargetUserID: "user-1",
+			PropertyIDs:  []string{"property-1"},
+		})
+		if err == nil || err.Error() != "Internal server error." {
+			t.Fatalf("expected internal server error, got %v", err)
+		}
+		if repo.replaceCalls != 1 {
+			t.Fatalf("expected persisted assignment before claims sync failure, got %d calls", repo.replaceCalls)
+		}
+	})
+}
+
+type assignUserPropertiesRepo struct {
+	findUser            *users.User
+	findErr             error
+	replaceErr          error
+	replaceCalls        int
+	replacedPropertyIDs []string
+}
+
+func (r *assignUserPropertiesRepo) FindByFirebaseUID(_ context.Context, _ string) (*users.User, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *assignUserPropertiesRepo) FindByID(_ context.Context, id string) (*users.User, error) {
+	if r.findErr != nil {
+		return nil, r.findErr
+	}
+	if r.findUser != nil {
+		return r.findUser, nil
+	}
+
+	return &users.User{
+		ID:                  id,
+		FirebaseUID:         "uid-1",
+		Email:               "organizer@studio.com",
+		Name:                "Organizer",
+		Role:                "organizer",
+		PermissionOverrides: []map[string]interface{}{},
+		AssignedPropertyIDs: []string{"property-1"},
+		CreatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		Version:             1,
+	}, nil
+}
+
+func (r *assignUserPropertiesRepo) List(_ context.Context, _ users.ListParams) ([]users.User, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *assignUserPropertiesRepo) Create(_ context.Context, _ users.CreateUserParams) (*users.User, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *assignUserPropertiesRepo) UpdateCurrentUser(_ context.Context, _ string, _ users.UpdateCurrentUserParams) (*users.User, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *assignUserPropertiesRepo) UpdateManagedUser(_ context.Context, _ string, _ users.UpdateManagedUserParams) (*users.User, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *assignUserPropertiesRepo) ReplaceAssignedProperties(_ context.Context, id string, propertyIDs []string) (*users.User, error) {
+	if r.replaceErr != nil {
+		return nil, r.replaceErr
+	}
+
+	r.replaceCalls++
+	r.replacedPropertyIDs = propertyIDs
+
+	return &users.User{
+		ID:                  id,
+		FirebaseUID:         "uid-1",
+		Email:               "organizer@studio.com",
+		Name:                "Organizer",
+		Role:                "organizer",
+		PermissionOverrides: []map[string]interface{}{},
+		AssignedPropertyIDs: propertyIDs,
+		CreatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:           time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
+		Version:             2,
+	}, nil
+}
+
+func (r *assignUserPropertiesRepo) DeleteByID(_ context.Context, _ string) error {
+	return errors.New("not used")
+}
+
+type propertyReaderSpy struct {
+	missingIDs map[string]struct{}
+}
+
+func (s *propertyReaderSpy) FindByID(_ context.Context, propertyID string) (*dbpropertyquery.Property, error) {
+	if _, ok := s.missingIDs[propertyID]; ok {
+		return nil, dbpropertyquery.ErrNotFound
+	}
+
+	return &dbpropertyquery.Property{ID: propertyID}, nil
+}
+
+func (s *propertyReaderSpy) ListAccessible(_ context.Context, _ string, _ string, _ []string) ([]dbpropertyquery.Property, error) {
+	return nil, errors.New("not used")
+}

--- a/internal/application/iam/create_user_test.go
+++ b/internal/application/iam/create_user_test.go
@@ -243,6 +243,14 @@ func (f fakeUserRepo) UpdateCurrentUser(_ context.Context, _ string, _ users.Upd
 	return nil, users.ErrNotFound
 }
 
+func (f fakeUserRepo) UpdateManagedUser(_ context.Context, _ string, _ users.UpdateManagedUserParams) (*users.User, error) {
+	return nil, users.ErrNotFound
+}
+
+func (f fakeUserRepo) ReplaceAssignedProperties(_ context.Context, _ string, _ []string) (*users.User, error) {
+	return nil, users.ErrNotFound
+}
+
 func (f *fakeUserRepo) DeleteByID(_ context.Context, id string) error {
 	f.deletedID = id
 	return nil

--- a/internal/application/iam/managed_user.go
+++ b/internal/application/iam/managed_user.go
@@ -2,15 +2,8 @@ package iam
 
 import (
 	"context"
-	"errors"
 	"time"
 )
-
-// ErrManagedUserNotFound indicates that no managed user matched the requested lookup.
-var ErrManagedUserNotFound = errors.New("managed user not found")
-
-// ErrManagedPropertyNotFound indicates that a requested property does not exist.
-var ErrManagedPropertyNotFound = errors.New("managed property not found")
 
 // ManagedUser is the application-facing user shape for admin IAM mutations.
 type ManagedUser struct {

--- a/internal/application/iam/managed_user.go
+++ b/internal/application/iam/managed_user.go
@@ -1,0 +1,38 @@
+package iam
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// ErrManagedUserNotFound indicates that no managed user matched the requested lookup.
+var ErrManagedUserNotFound = errors.New("managed user not found")
+
+// ErrManagedPropertyNotFound indicates that a requested property does not exist.
+var ErrManagedPropertyNotFound = errors.New("managed property not found")
+
+// ManagedUser is the application-facing user shape for admin IAM mutations.
+type ManagedUser struct {
+	ID                  string
+	FirebaseUID         string
+	Email               string
+	Name                string
+	Role                string
+	PermissionOverrides []map[string]interface{}
+	AssignedPropertyIDs []string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+	Version             int
+}
+
+// ManagedUserPropertyAssignmentRepository defines persistence needed for property assignment updates.
+type ManagedUserPropertyAssignmentRepository interface {
+	FindByID(ctx context.Context, id string) (*ManagedUser, error)
+	ReplaceAssignedProperties(ctx context.Context, id string, assignedPropertyIDs []string) (*ManagedUser, error)
+}
+
+// PropertyExistenceChecker validates whether a property exists.
+type PropertyExistenceChecker interface {
+	Exists(ctx context.Context, propertyID string) (bool, error)
+}

--- a/internal/application/iam/send_user_password_reset_test.go
+++ b/internal/application/iam/send_user_password_reset_test.go
@@ -88,6 +88,14 @@ func (r sendResetUserRepo) UpdateCurrentUser(_ context.Context, _ string, _ user
 	return nil, users.ErrNotFound
 }
 
+func (r sendResetUserRepo) UpdateManagedUser(_ context.Context, _ string, _ users.UpdateManagedUserParams) (*users.User, error) {
+	return nil, users.ErrNotFound
+}
+
+func (r sendResetUserRepo) ReplaceAssignedProperties(_ context.Context, _ string, _ []string) (*users.User, error) {
+	return nil, users.ErrNotFound
+}
+
 func (r sendResetUserRepo) DeleteByID(_ context.Context, _ string) error {
 	return users.ErrNotFound
 }

--- a/internal/application/iam/sync_auth_test.go
+++ b/internal/application/iam/sync_auth_test.go
@@ -85,6 +85,14 @@ func (syncAuthUserRepo) UpdateCurrentUser(_ context.Context, _ string, _ users.U
 	return nil, users.ErrNotFound
 }
 
+func (syncAuthUserRepo) UpdateManagedUser(_ context.Context, _ string, _ users.UpdateManagedUserParams) (*users.User, error) {
+	return nil, users.ErrNotFound
+}
+
+func (syncAuthUserRepo) ReplaceAssignedProperties(_ context.Context, _ string, _ []string) (*users.User, error) {
+	return nil, users.ErrNotFound
+}
+
 func (syncAuthUserRepo) DeleteByID(_ context.Context, _ string) error {
 	return users.ErrNotFound
 }

--- a/internal/application/iam/update_user.go
+++ b/internal/application/iam/update_user.go
@@ -74,7 +74,7 @@ func (s *UpdateUserService) Execute(ctx context.Context, input UpdateUserInput) 
 	}
 
 	role := current.Role
-	roleChanged := false
+	shouldSyncClaims := input.Role != nil
 	if input.Role != nil {
 		role = strings.TrimSpace(*input.Role)
 		switch {
@@ -85,11 +85,13 @@ func (s *UpdateUserService) Execute(ctx context.Context, input UpdateUserInput) 
 				"role": role,
 			})
 		}
-		roleChanged = role != current.Role
 	}
 
 	if actorUserID == current.ID && current.Role == "admin" && role != "admin" {
 		return nil, apperr.ErrAdminCannotDowngradeSelf
+	}
+	if shouldSyncClaims && s.claimsSync == nil {
+		return nil, apperr.ErrInternalServerError
 	}
 
 	user, err := s.userRepo.UpdateManagedUser(ctx, targetUserID, users.UpdateManagedUserParams{
@@ -105,10 +107,7 @@ func (s *UpdateUserService) Execute(ctx context.Context, input UpdateUserInput) 
 		}
 	}
 
-	if roleChanged {
-		if s.claimsSync == nil {
-			return nil, apperr.ErrInternalServerError
-		}
+	if shouldSyncClaims {
 		if err := s.claimsSync.Sync(ctx, user.FirebaseUID, user.Role, user.AssignedPropertyIDs); err != nil {
 			return nil, apperr.ErrInternalServerError.WithCause(err)
 		}

--- a/internal/application/iam/update_user.go
+++ b/internal/application/iam/update_user.go
@@ -1,0 +1,118 @@
+package iam
+
+import (
+	"context"
+	"strings"
+	"unicode/utf8"
+
+	"stds_backend/internal/platform/database/users"
+	"stds_backend/internal/shared/apperr"
+)
+
+// ManagedUserClaimsSyncer updates Firebase claims after managed user mutations.
+type ManagedUserClaimsSyncer interface {
+	Sync(ctx context.Context, firebaseUID string, role string, assignedPropertyIDs []string) error
+}
+
+// UpdateUserInput is the admin-managed payload for PATCH /users/{id}.
+type UpdateUserInput struct {
+	ActorUserID  string
+	TargetUserID string
+	Name         *string
+	Role         *string
+}
+
+// UpdateUserService updates admin-managed user fields.
+type UpdateUserService struct {
+	userRepo   users.Repository
+	claimsSync ManagedUserClaimsSyncer
+}
+
+// NewUpdateUserService returns an UpdateUserService.
+func NewUpdateUserService(userRepo users.Repository, claimsSync ManagedUserClaimsSyncer) *UpdateUserService {
+	return &UpdateUserService{
+		userRepo:   userRepo,
+		claimsSync: claimsSync,
+	}
+}
+
+// Execute validates the admin payload, persists the managed update, and refreshes claims when needed.
+func (s *UpdateUserService) Execute(ctx context.Context, input UpdateUserInput) (*users.User, error) {
+	targetUserID := strings.TrimSpace(input.TargetUserID)
+	actorUserID := strings.TrimSpace(input.ActorUserID)
+	if targetUserID == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field": "id",
+		})
+	}
+	if actorUserID == "" {
+		return nil, apperr.ErrUnauthorized
+	}
+	if input.Name == nil && input.Role == nil {
+		return nil, apperr.ErrBadRequest
+	}
+
+	current, err := s.userRepo.FindByID(ctx, targetUserID)
+	if err != nil {
+		switch err {
+		case users.ErrNotFound:
+			return nil, apperr.ErrUserNotFound
+		default:
+			return nil, apperr.ErrInternalServerError.WithCause(err)
+		}
+	}
+
+	name := current.Name
+	if input.Name != nil {
+		name = strings.TrimSpace(*input.Name)
+		switch {
+		case name == "":
+			return nil, apperr.ErrValidationNameRequired
+		case utf8.RuneCountInString(name) > maxCurrentUserNameLength:
+			return nil, apperr.ErrValidationNameTooLong
+		}
+	}
+
+	role := current.Role
+	roleChanged := false
+	if input.Role != nil {
+		role = strings.TrimSpace(*input.Role)
+		switch {
+		case role == "":
+			return nil, apperr.ErrValidationRoleRequired
+		case !isValidRole(role):
+			return nil, apperr.ErrValidationRoleInvalid.WithDetails(map[string]interface{}{
+				"role": role,
+			})
+		}
+		roleChanged = role != current.Role
+	}
+
+	if actorUserID == current.ID && current.Role == "admin" && role != "admin" {
+		return nil, apperr.ErrAdminCannotDowngradeSelf
+	}
+
+	user, err := s.userRepo.UpdateManagedUser(ctx, targetUserID, users.UpdateManagedUserParams{
+		Name: name,
+		Role: role,
+	})
+	if err != nil {
+		switch err {
+		case users.ErrNotFound:
+			return nil, apperr.ErrUserNotFound
+		default:
+			return nil, apperr.ErrInternalServerError.WithCause(err)
+		}
+	}
+
+	if roleChanged {
+		if s.claimsSync == nil {
+			return nil, apperr.ErrInternalServerError
+		}
+		if err := s.claimsSync.Sync(ctx, user.FirebaseUID, user.Role, user.AssignedPropertyIDs); err != nil {
+			return nil, apperr.ErrInternalServerError.WithCause(err)
+		}
+	}
+
+	return user, nil
+}

--- a/internal/application/iam/update_user_test.go
+++ b/internal/application/iam/update_user_test.go
@@ -1,0 +1,211 @@
+package iam
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"stds_backend/internal/platform/database/users"
+	"stds_backend/internal/shared/apperr"
+)
+
+func TestUpdateUserServiceExecute(t *testing.T) {
+	t.Run("updates managed fields and syncs claims when role changes", func(t *testing.T) {
+		repo := &managedUserRepo{}
+		claims := &claimsSyncSpy{}
+		service := NewUpdateUserService(repo, claims)
+
+		name := "  Updated Organizer  "
+		role := "staff"
+		user, err := service.Execute(context.Background(), UpdateUserInput{
+			ActorUserID:  "admin-1",
+			TargetUserID: "user-1",
+			Name:         &name,
+			Role:         &role,
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if user.Name != "Updated Organizer" {
+			t.Fatalf("expected trimmed name, got %q", user.Name)
+		}
+		if repo.updatedName != "Updated Organizer" {
+			t.Fatalf("expected repo name Updated Organizer, got %q", repo.updatedName)
+		}
+		if repo.updatedRole != "staff" {
+			t.Fatalf("expected repo role staff, got %q", repo.updatedRole)
+		}
+		if claims.firebaseUID != "uid-1" {
+			t.Fatalf("expected claims sync uid-1, got %q", claims.firebaseUID)
+		}
+		if claims.role != "staff" {
+			t.Fatalf("expected claims role staff, got %q", claims.role)
+		}
+	})
+
+	t.Run("rejects self downgrade", func(t *testing.T) {
+		repo := &managedUserRepo{
+			findUser: &users.User{ID: "admin-1", FirebaseUID: "uid-1", Name: "Admin", Role: "admin", AssignedPropertyIDs: []string{"property-1"}},
+		}
+		service := NewUpdateUserService(repo, &claimsSyncSpy{})
+		role := "organizer"
+
+		_, err := service.Execute(context.Background(), UpdateUserInput{
+			ActorUserID:  "admin-1",
+			TargetUserID: "admin-1",
+			Role:         &role,
+		})
+		if err == nil {
+			t.Fatal("expected error")
+		}
+
+		var appErr *apperr.Error
+		if !errors.As(err, &appErr) {
+			t.Fatalf("expected apperr.Error, got %T", err)
+		}
+		if appErr.Code != apperr.CodeAdminCannotDowngradeSelf {
+			t.Fatalf("expected %s, got %s", apperr.CodeAdminCannotDowngradeSelf, appErr.Code)
+		}
+	})
+
+	t.Run("rejects invalid role", func(t *testing.T) {
+		repo := &managedUserRepo{}
+		service := NewUpdateUserService(repo, &claimsSyncSpy{})
+		role := "invalid"
+
+		_, err := service.Execute(context.Background(), UpdateUserInput{
+			ActorUserID:  "admin-1",
+			TargetUserID: "user-1",
+			Role:         &role,
+		})
+		if err == nil || err.Error() != "Role is invalid." {
+			t.Fatalf("expected role invalid, got %v", err)
+		}
+	})
+
+	t.Run("maps missing target user to not found", func(t *testing.T) {
+		repo := &managedUserRepo{findErr: users.ErrNotFound}
+		service := NewUpdateUserService(repo, &claimsSyncSpy{})
+		role := "staff"
+
+		_, err := service.Execute(context.Background(), UpdateUserInput{
+			ActorUserID:  "admin-1",
+			TargetUserID: "user-1",
+			Role:         &role,
+		})
+		if err == nil || err.Error() != "User not found." {
+			t.Fatalf("expected user not found, got %v", err)
+		}
+	})
+
+	t.Run("maps claims sync failure to internal server error after persistence", func(t *testing.T) {
+		repo := &managedUserRepo{}
+		service := NewUpdateUserService(repo, &claimsSyncSpy{err: errors.New("firebase down")})
+		role := "staff"
+
+		_, err := service.Execute(context.Background(), UpdateUserInput{
+			ActorUserID:  "admin-1",
+			TargetUserID: "user-1",
+			Role:         &role,
+		})
+		if err == nil || err.Error() != "Internal server error." {
+			t.Fatalf("expected internal server error, got %v", err)
+		}
+		if repo.updateCalls != 1 {
+			t.Fatalf("expected persisted update before claims sync failure, got %d calls", repo.updateCalls)
+		}
+	})
+}
+
+type managedUserRepo struct {
+	findUser    *users.User
+	findErr     error
+	updateErr   error
+	updateCalls int
+	updatedName string
+	updatedRole string
+}
+
+func (r *managedUserRepo) FindByFirebaseUID(_ context.Context, _ string) (*users.User, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *managedUserRepo) FindByID(_ context.Context, id string) (*users.User, error) {
+	if r.findErr != nil {
+		return nil, r.findErr
+	}
+	if r.findUser != nil {
+		return r.findUser, nil
+	}
+
+	return &users.User{
+		ID:                  id,
+		FirebaseUID:         "uid-1",
+		Email:               "organizer@studio.com",
+		Name:                "Organizer",
+		Role:                "organizer",
+		PermissionOverrides: []map[string]interface{}{},
+		AssignedPropertyIDs: []string{"property-1"},
+		CreatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		Version:             1,
+	}, nil
+}
+
+func (r *managedUserRepo) List(_ context.Context, _ users.ListParams) ([]users.User, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *managedUserRepo) Create(_ context.Context, _ users.CreateUserParams) (*users.User, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *managedUserRepo) UpdateCurrentUser(_ context.Context, _ string, _ users.UpdateCurrentUserParams) (*users.User, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *managedUserRepo) UpdateManagedUser(_ context.Context, id string, params users.UpdateManagedUserParams) (*users.User, error) {
+	if r.updateErr != nil {
+		return nil, r.updateErr
+	}
+
+	r.updateCalls++
+	r.updatedName = params.Name
+	r.updatedRole = params.Role
+
+	return &users.User{
+		ID:                  id,
+		FirebaseUID:         "uid-1",
+		Email:               "organizer@studio.com",
+		Name:                params.Name,
+		Role:                params.Role,
+		PermissionOverrides: []map[string]interface{}{},
+		AssignedPropertyIDs: []string{"property-1"},
+		CreatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:           time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
+		Version:             2,
+	}, nil
+}
+
+func (r *managedUserRepo) ReplaceAssignedProperties(_ context.Context, _ string, _ []string) (*users.User, error) {
+	return nil, errors.New("not used")
+}
+
+func (r *managedUserRepo) DeleteByID(_ context.Context, _ string) error {
+	return errors.New("not used")
+}
+
+type claimsSyncSpy struct {
+	err         error
+	firebaseUID string
+	role        string
+	properties  []string
+}
+
+func (s *claimsSyncSpy) Sync(_ context.Context, firebaseUID string, role string, assignedPropertyIDs []string) error {
+	s.firebaseUID = firebaseUID
+	s.role = role
+	s.properties = assignedPropertyIDs
+	return s.err
+}

--- a/internal/application/iam/update_user_test.go
+++ b/internal/application/iam/update_user_test.go
@@ -116,6 +116,34 @@ func TestUpdateUserServiceExecute(t *testing.T) {
 			t.Fatalf("expected persisted update before claims sync failure, got %d calls", repo.updateCalls)
 		}
 	})
+
+	t.Run("retries claims sync when request repeats same role after prior partial failure", func(t *testing.T) {
+		repo := &managedUserRepo{
+			findUser: &users.User{
+				ID:                  "user-1",
+				FirebaseUID:         "uid-1",
+				Email:               "organizer@studio.com",
+				Name:                "Organizer",
+				Role:                "staff",
+				AssignedPropertyIDs: []string{"property-1"},
+			},
+		}
+		claims := &claimsSyncSpy{}
+		service := NewUpdateUserService(repo, claims)
+		role := "staff"
+
+		_, err := service.Execute(context.Background(), UpdateUserInput{
+			ActorUserID:  "admin-1",
+			TargetUserID: "user-1",
+			Role:         &role,
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if claims.role != "staff" {
+			t.Fatalf("expected claims role staff, got %q", claims.role)
+		}
+	})
 }
 
 type managedUserRepo struct {

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -628,7 +628,7 @@ func (s *APIServer) AssignUserProperties(c *gin.Context, id string) {
 		return
 	}
 
-	c.JSON(http.StatusOK, toUserResponse(user))
+	c.JSON(http.StatusOK, toManagedUserResponse(user))
 }
 
 func toUserResponse(user *users.User) api.UserResponse {
@@ -661,6 +661,35 @@ func toUserResponse(user *users.User) api.UserResponse {
 }
 
 func toCurrentUserResponse(user *domainusers.User) api.UserResponse {
+	id, ok := parseUUID(user.ID)
+	email := openapi_types.Email(user.Email)
+	role := api.UserResponseRole(user.Role)
+	createdAt := user.CreatedAt
+	updatedAt := user.UpdatedAt
+	version := user.Version
+	firebaseUID := user.FirebaseUID
+	name := user.Name
+
+	response := api.UserResponse{
+		AssignedPropertyIds: toUUIDList(user.AssignedPropertyIDs),
+		CreatedAt:           &createdAt,
+		Email:               &email,
+		FirebaseUid:         &firebaseUID,
+		Name:                &name,
+		PermissionOverrides: &user.PermissionOverrides,
+		Role:                &role,
+		UpdatedAt:           &updatedAt,
+		Version:             &version,
+	}
+
+	if ok {
+		response.Id = &id
+	}
+
+	return response
+}
+
+func toManagedUserResponse(user *appiam.ManagedUser) api.UserResponse {
 	id, ok := parseUUID(user.ID)
 	email := openapi_types.Email(user.Email)
 	role := api.UserResponseRole(user.Role)

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -30,6 +30,8 @@ type APIServer struct {
 	sendPasswordReset *appiam.SendUserPasswordResetService
 	syncAuthService   *appiam.SyncAuthService
 	updateCurrentUser *appiam.UpdateCurrentUserService
+	updateUser        *appiam.UpdateUserService
+	assignProperties  *appiam.AssignUserPropertiesService
 	jobTriggerService *appjobs.TriggerService
 	propertyQueryRepo dbpropertyquery.Repository
 	createPropertySvc *appproperty.CreatePropertyService
@@ -43,6 +45,8 @@ func NewAPIServer(
 	sendPasswordReset *appiam.SendUserPasswordResetService,
 	syncAuthService *appiam.SyncAuthService,
 	updateCurrentUser *appiam.UpdateCurrentUserService,
+	updateUser *appiam.UpdateUserService,
+	assignProperties *appiam.AssignUserPropertiesService,
 	jobTriggerService *appjobs.TriggerService,
 	propertyQueryRepo dbpropertyquery.Repository,
 	createPropertySvc *appproperty.CreatePropertyService,
@@ -53,6 +57,8 @@ func NewAPIServer(
 		sendPasswordReset: sendPasswordReset,
 		syncAuthService:   syncAuthService,
 		updateCurrentUser: updateCurrentUser,
+		updateUser:        updateUser,
+		assignProperties:  assignProperties,
 		jobTriggerService: jobTriggerService,
 		propertyQueryRepo: propertyQueryRepo,
 		createPropertySvc: createPropertySvc,
@@ -551,10 +557,79 @@ func (s *APIServer) GetUser(c *gin.Context, id string) {
 }
 
 // UpdateUser handles user updates.
-func (s *APIServer) UpdateUser(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) UpdateUser(c *gin.Context, id string) {
+	if _, err := uuid.Parse(id); err != nil {
+		c.Error(apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "id",
+			"reason": "must be a valid UUID",
+		}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	var request api.UpdateUserRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	var role *string
+	if request.Role != nil {
+		value := string(*request.Role)
+		role = &value
+	}
+
+	user, err := s.updateUser.Execute(c.Request.Context(), appiam.UpdateUserInput{
+		ActorUserID:  principal.UserID,
+		TargetUserID: id,
+		Name:         request.Name,
+		Role:         role,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toUserResponse(user))
+}
 
 // AssignUserProperties handles property assignment updates for a user.
-func (s *APIServer) AssignUserProperties(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) AssignUserProperties(c *gin.Context, id string) {
+	if _, err := uuid.Parse(id); err != nil {
+		c.Error(apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "id",
+			"reason": "must be a valid UUID",
+		}))
+		return
+	}
+
+	var request api.PropertyAssignmentRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	propertyIDs := make([]string, 0, len(request.PropertyIds))
+	for _, propertyID := range request.PropertyIds {
+		propertyIDs = append(propertyIDs, propertyID.String())
+	}
+
+	user, err := s.assignProperties.Execute(c.Request.Context(), appiam.AssignUserPropertiesInput{
+		TargetUserID: id,
+		PropertyIDs:  propertyIDs,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toUserResponse(user))
+}
 
 func toUserResponse(user *users.User) api.UserResponse {
 	id, ok := parseUUID(user.ID)

--- a/internal/http/middleware/middleware_test.go
+++ b/internal/http/middleware/middleware_test.go
@@ -413,6 +413,25 @@ func (fakeUserRepo) UpdateCurrentUser(_ context.Context, id string, params users
 	}, nil
 }
 
+func (fakeUserRepo) UpdateManagedUser(_ context.Context, id string, params users.UpdateManagedUserParams) (*users.User, error) {
+	return &users.User{
+		ID:                  id,
+		FirebaseUID:         "uid-1",
+		Name:                params.Name,
+		Role:                params.Role,
+		AssignedPropertyIDs: []string{"property-1"},
+	}, nil
+}
+
+func (fakeUserRepo) ReplaceAssignedProperties(_ context.Context, id string, assignedPropertyIDs []string) (*users.User, error) {
+	return &users.User{
+		ID:                  id,
+		FirebaseUID:         "uid-1",
+		Role:                "organizer",
+		AssignedPropertyIDs: assignedPropertyIDs,
+	}, nil
+}
+
 func (fakeUserRepo) DeleteByID(_ context.Context, _ string) error {
 	return nil
 }

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -49,6 +49,8 @@ func New(
 	sendPasswordResetService *appiam.SendUserPasswordResetService,
 	syncAuthService *appiam.SyncAuthService,
 	updateCurrentUserService *appiam.UpdateCurrentUserService,
+	updateUserService *appiam.UpdateUserService,
+	assignUserPropertiesService *appiam.AssignUserPropertiesService,
 	jobTriggerService *appjobs.TriggerService,
 	propertyQueryRepo dbpropertyquery.Repository,
 	createPropertyService *appproperty.CreatePropertyService,
@@ -68,7 +70,7 @@ func New(
 	engine.GET("/openapi.yaml", docsHandler.OpenAPI)
 	engine.GET("/scalar", docsHandler.Scalar)
 
-	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, jobTriggerService, propertyQueryRepo, createPropertyService), api.GinServerOptions{
+	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, createPropertyService), api.GinServerOptions{
 		BaseURL: "/api/v1",
 		Middlewares: []api.MiddlewareFunc{
 			protectedAPIMiddleware(appCfg, authenticator, userRepo, authzRepos),

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -417,6 +417,122 @@ func TestUpdateCurrentUserRejectsNameThatIsTooLong(t *testing.T) {
 	}
 }
 
+func TestUpdateUserReturnsUpdatedManagedUser(t *testing.T) {
+	repo := fakeUserRepo{role: "admin"}
+	claimsCall := &customClaimsCall{}
+	engine := newTestEngine(repo, fakeAuthenticator{role: "admin", setCustomClaimsSink: claimsCall}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{})
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/users/00000000-0000-0000-0000-000000000001", strings.NewReader(`{"name":"Updated User","role":"staff"}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if payload["role"] != "staff" {
+		t.Fatalf("expected updated role staff, got %v", payload["role"])
+	}
+	if claimsCall.role != "staff" {
+		t.Fatalf("expected claims role staff, got %q", claimsCall.role)
+	}
+}
+
+func TestUpdateUserRejectsAdminSelfDowngradeWithValidUUID(t *testing.T) {
+	repo := fakeUserRepo{userID: "00000000-0000-0000-0000-000000000001", role: "admin"}
+	engine := newTestEngine(repo, fakeAuthenticator{role: "admin"}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{})
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/users/00000000-0000-0000-0000-000000000001", strings.NewReader(`{"role":"organizer"}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if payload["error_code"] != "ADMIN_CANNOT_DOWNGRADE_SELF" {
+		t.Fatalf("expected ADMIN_CANNOT_DOWNGRADE_SELF, got %v", payload["error_code"])
+	}
+}
+
+func TestAssignUserPropertiesReturnsUpdatedUser(t *testing.T) {
+	repo := fakeUserRepo{role: "admin"}
+	claimsCall := &customClaimsCall{}
+	engine := newTestEngine(repo, fakeAuthenticator{role: "admin", setCustomClaimsSink: claimsCall}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/00000000-0000-0000-0000-000000000001/property-assignments", strings.NewReader(`{
+		"property_ids":[
+			"10000000-0000-0000-0000-000000000001",
+			"10000000-0000-0000-0000-000000000002"
+		]
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	assigned, ok := payload["assigned_property_ids"].([]any)
+	if !ok || len(assigned) != 2 {
+		t.Fatalf("expected 2 assigned property ids, got %v", payload["assigned_property_ids"])
+	}
+	if len(claimsCall.assignedPropertyIDs) != 2 {
+		t.Fatalf("expected claims sync assignments, got %v", claimsCall.assignedPropertyIDs)
+	}
+}
+
+func TestAssignUserPropertiesRejectsOwnerTarget(t *testing.T) {
+	repo := fakeUserRepo{role: "admin", findByIDRole: "owner"}
+	engine := newTestEngine(repo, fakeAuthenticator{role: "admin"}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/00000000-0000-0000-0000-000000000001/property-assignments", strings.NewReader(`{
+		"property_ids":["10000000-0000-0000-0000-000000000001"]
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if payload["error_code"] != "CANNOT_ASSIGN_PROPERTY_TO_OWNER" {
+		t.Fatalf("expected CANNOT_ASSIGN_PROPERTY_TO_OWNER, got %v", payload["error_code"])
+	}
+}
+
 func TestTriggerUserPasswordResetReturnsNoContent(t *testing.T) {
 	repo := fakeUserRepo{role: "admin"}
 	notificationSender := &testNotificationSender{}
@@ -901,6 +1017,7 @@ type fakeAuthenticator struct {
 	role                string
 	assignedPropertyIDs []string
 	setCustomClaimsErr  error
+	setCustomClaimsSink *customClaimsCall
 	createUserErr       error
 	resetLink           string
 	resetLinkErr        error
@@ -924,7 +1041,12 @@ func (f fakeAuthenticator) VerifyIDToken(_ context.Context, token string) (*plat
 	}, nil
 }
 
-func (f fakeAuthenticator) SetCustomClaims(_ context.Context, _ string, _ string, _ []string) error {
+func (f fakeAuthenticator) SetCustomClaims(_ context.Context, firebaseUID string, role string, assignedPropertyIDs []string) error {
+	if f.setCustomClaimsSink != nil {
+		f.setCustomClaimsSink.firebaseUID = firebaseUID
+		f.setCustomClaimsSink.role = role
+		f.setCustomClaimsSink.assignedPropertyIDs = assignedPropertyIDs
+	}
 	return f.setCustomClaimsErr
 }
 
@@ -956,7 +1078,9 @@ func (f fakeAuthenticator) DeleteUser(_ context.Context, _ string) error {
 }
 
 type fakeUserRepo struct {
+	userID               string
 	role                 string
+	findByIDRole         string
 	assignedPropertyIDs  []string
 	findByIDErr          error
 	listUsers            []users.User
@@ -964,6 +1088,11 @@ type fakeUserRepo struct {
 	listParamsSink       *users.ListParams
 	createErr            error
 	updateCurrentUserErr error
+	updateManagedUserErr error
+	replaceAssignedErr   error
+	updatedManagedName   string
+	updatedManagedRole   string
+	replacedPropertyIDs  []string
 }
 
 type fakePropertyRepo struct {
@@ -991,15 +1120,25 @@ type fakeJobRunsRepo struct {
 	status   dbjobruns.Status
 }
 
+type customClaimsCall struct {
+	firebaseUID         string
+	role                string
+	assignedPropertyIDs []string
+}
+
 func (f fakeUserRepo) FindByFirebaseUID(_ context.Context, firebaseUID string) (*users.User, error) {
 	if firebaseUID == "missing" {
 		return nil, users.ErrNotFound
 	}
 
 	assigned := firstAssignedPropertyIDs(f.assignedPropertyIDs)
+	userID := "user-1"
+	if f.userID != "" {
+		userID = f.userID
+	}
 
 	return &users.User{
-		ID:                  "user-1",
+		ID:                  userID,
 		FirebaseUID:         "uid-1",
 		Email:               "organizer@studio.com",
 		Name:                "Organizer",
@@ -1022,7 +1161,7 @@ func (f fakeUserRepo) FindByID(_ context.Context, id string) (*users.User, error
 		FirebaseUID:         "uid-1",
 		Email:               "organizer@studio.com",
 		Name:                "Organizer",
-		Role:                firstRole(f.role),
+		Role:                firstRoleValue(f.findByIDRole, f.role),
 		PermissionOverrides: []map[string]interface{}{},
 		AssignedPropertyIDs: firstAssignedPropertyIDs(f.assignedPropertyIDs),
 		CreatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
@@ -1090,6 +1229,49 @@ func (f fakeUserRepo) UpdateCurrentUser(_ context.Context, id string, params use
 		Role:                firstRole(f.role),
 		PermissionOverrides: []map[string]interface{}{},
 		AssignedPropertyIDs: firstAssignedPropertyIDs(f.assignedPropertyIDs),
+		CreatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:           time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC),
+		Version:             2,
+	}, nil
+}
+
+func (f fakeUserRepo) UpdateManagedUser(_ context.Context, id string, params users.UpdateManagedUserParams) (*users.User, error) {
+	if f.updateManagedUserErr != nil {
+		return nil, f.updateManagedUserErr
+	}
+
+	f.updatedManagedName = params.Name
+	f.updatedManagedRole = params.Role
+
+	return &users.User{
+		ID:                  id,
+		FirebaseUID:         "uid-1",
+		Email:               "organizer@studio.com",
+		Name:                params.Name,
+		Role:                params.Role,
+		PermissionOverrides: []map[string]interface{}{},
+		AssignedPropertyIDs: firstAssignedPropertyIDs(f.assignedPropertyIDs),
+		CreatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:           time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC),
+		Version:             2,
+	}, nil
+}
+
+func (f fakeUserRepo) ReplaceAssignedProperties(_ context.Context, id string, propertyIDs []string) (*users.User, error) {
+	if f.replaceAssignedErr != nil {
+		return nil, f.replaceAssignedErr
+	}
+
+	f.replacedPropertyIDs = propertyIDs
+
+	return &users.User{
+		ID:                  id,
+		FirebaseUID:         "uid-1",
+		Email:               "organizer@studio.com",
+		Name:                "Organizer",
+		Role:                firstRole(f.role),
+		PermissionOverrides: []map[string]interface{}{},
+		AssignedPropertyIDs: propertyIDs,
 		CreatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 		UpdatedAt:           time.Date(2026, 4, 19, 10, 0, 0, 0, time.UTC),
 		Version:             2,
@@ -1285,6 +1467,8 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 		appiam.NewSendUserPasswordResetService(repo, authenticator, appnotification.NewService(notificationSender)),
 		appiam.NewSyncAuthService(repo, appiam.NewCustomClaimsService(authenticator)),
 		appiam.NewUpdateCurrentUserService(repo),
+		appiam.NewUpdateUserService(repo, appiam.NewCustomClaimsService(authenticator)),
+		appiam.NewAssignUserPropertiesService(repo, fakePropertyQueryRepo{}, appiam.NewCustomClaimsService(authenticator)),
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		fakePropertyQueryRepo{},
 		createPropertyService,
@@ -1310,6 +1494,16 @@ func firstAssignedPropertyIDs(assigned []string) []string {
 func firstRole(role string) string {
 	if role != "" {
 		return role
+	}
+
+	return "organizer"
+}
+
+func firstRoleValue(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
 	}
 
 	return "organizer"

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -30,6 +30,7 @@ import (
 	"stds_backend/internal/platform/database/users"
 	platformfirebase "stds_backend/internal/platform/firebase"
 	platformnotification "stds_backend/internal/platform/notification"
+	"stds_backend/internal/shared/apperr"
 )
 
 func TestGetPropertyUsesFormalAPIWiring(t *testing.T) {
@@ -1134,7 +1135,7 @@ func (a testManagedUserRepositoryAdapter) FindByID(ctx context.Context, id strin
 	user, err := a.repo.FindByID(ctx, id)
 	if err != nil {
 		if err == users.ErrNotFound {
-			return nil, appiam.ErrManagedUserNotFound
+			return nil, apperr.ErrUserNotFound
 		}
 		return nil, err
 	}
@@ -1157,7 +1158,7 @@ func (a testManagedUserRepositoryAdapter) ReplaceAssignedProperties(ctx context.
 	user, err := a.repo.ReplaceAssignedProperties(ctx, id, assignedPropertyIDs)
 	if err != nil {
 		if err == users.ErrNotFound {
-			return nil, appiam.ErrManagedUserNotFound
+			return nil, apperr.ErrUserNotFound
 		}
 		return nil, err
 	}
@@ -1184,7 +1185,7 @@ func (a testPropertyExistenceChecker) Exists(ctx context.Context, propertyID str
 	_, err := a.repo.FindByID(ctx, propertyID)
 	if err != nil {
 		if err == dbpropertyquery.ErrNotFound {
-			return false, appiam.ErrManagedPropertyNotFound
+			return false, nil
 		}
 		return false, err
 	}

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -1126,6 +1126,72 @@ type customClaimsCall struct {
 	assignedPropertyIDs []string
 }
 
+type testManagedUserRepositoryAdapter struct {
+	repo *fakeUserRepo
+}
+
+func (a testManagedUserRepositoryAdapter) FindByID(ctx context.Context, id string) (*appiam.ManagedUser, error) {
+	user, err := a.repo.FindByID(ctx, id)
+	if err != nil {
+		if err == users.ErrNotFound {
+			return nil, appiam.ErrManagedUserNotFound
+		}
+		return nil, err
+	}
+
+	return &appiam.ManagedUser{
+		ID:                  user.ID,
+		FirebaseUID:         user.FirebaseUID,
+		Email:               user.Email,
+		Name:                user.Name,
+		Role:                user.Role,
+		PermissionOverrides: user.PermissionOverrides,
+		AssignedPropertyIDs: user.AssignedPropertyIDs,
+		CreatedAt:           user.CreatedAt,
+		UpdatedAt:           user.UpdatedAt,
+		Version:             user.Version,
+	}, nil
+}
+
+func (a testManagedUserRepositoryAdapter) ReplaceAssignedProperties(ctx context.Context, id string, assignedPropertyIDs []string) (*appiam.ManagedUser, error) {
+	user, err := a.repo.ReplaceAssignedProperties(ctx, id, assignedPropertyIDs)
+	if err != nil {
+		if err == users.ErrNotFound {
+			return nil, appiam.ErrManagedUserNotFound
+		}
+		return nil, err
+	}
+
+	return &appiam.ManagedUser{
+		ID:                  user.ID,
+		FirebaseUID:         user.FirebaseUID,
+		Email:               user.Email,
+		Name:                user.Name,
+		Role:                user.Role,
+		PermissionOverrides: user.PermissionOverrides,
+		AssignedPropertyIDs: user.AssignedPropertyIDs,
+		CreatedAt:           user.CreatedAt,
+		UpdatedAt:           user.UpdatedAt,
+		Version:             user.Version,
+	}, nil
+}
+
+type testPropertyExistenceChecker struct {
+	repo fakePropertyQueryRepo
+}
+
+func (a testPropertyExistenceChecker) Exists(ctx context.Context, propertyID string) (bool, error) {
+	_, err := a.repo.FindByID(ctx, propertyID)
+	if err != nil {
+		if err == dbpropertyquery.ErrNotFound {
+			return false, appiam.ErrManagedPropertyNotFound
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
 func (f fakeUserRepo) FindByFirebaseUID(_ context.Context, firebaseUID string) (*users.User, error) {
 	if firebaseUID == "missing" {
 		return nil, users.ErrNotFound
@@ -1468,7 +1534,11 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 		appiam.NewSyncAuthService(repo, appiam.NewCustomClaimsService(authenticator)),
 		appiam.NewUpdateCurrentUserService(repo),
 		appiam.NewUpdateUserService(repo, appiam.NewCustomClaimsService(authenticator)),
-		appiam.NewAssignUserPropertiesService(repo, fakePropertyQueryRepo{}, appiam.NewCustomClaimsService(authenticator)),
+		appiam.NewAssignUserPropertiesService(
+			testManagedUserRepositoryAdapter{repo: repo},
+			testPropertyExistenceChecker{repo: fakePropertyQueryRepo{}},
+			appiam.NewCustomClaimsService(authenticator),
+		),
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		fakePropertyQueryRepo{},
 		createPropertyService,

--- a/internal/platform/database/users/repository.go
+++ b/internal/platform/database/users/repository.go
@@ -50,6 +50,12 @@ type UpdateCurrentUserParams struct {
 	Name string
 }
 
+// UpdateManagedUserParams contains the admin-managed fields a caller may edit.
+type UpdateManagedUserParams struct {
+	Name string
+	Role string
+}
+
 // ListParams contains supported filters for listing active users.
 type ListParams struct {
 	Role   string
@@ -64,6 +70,8 @@ type Repository interface {
 	List(ctx context.Context, params ListParams) ([]User, error)
 	Create(ctx context.Context, params CreateUserParams) (*User, error)
 	UpdateCurrentUser(ctx context.Context, id string, params UpdateCurrentUserParams) (*User, error)
+	UpdateManagedUser(ctx context.Context, id string, params UpdateManagedUserParams) (*User, error)
+	ReplaceAssignedProperties(ctx context.Context, id string, assignedPropertyIDs []string) (*User, error)
 	DeleteByID(ctx context.Context, id string) error
 }
 
@@ -248,6 +256,78 @@ RETURNING
 			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("update current user: %w", err)
+	}
+
+	return user, nil
+}
+
+// UpdateManagedUser updates admin-managed fields for a single active user.
+func (r *SQLRepository) UpdateManagedUser(ctx context.Context, id string, params UpdateManagedUserParams) (*User, error) {
+	const query = `
+UPDATE users
+SET name = $2,
+	role = $3,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	firebase_uid,
+	email,
+	name,
+	role,
+	COALESCE(permission_overrides, '[]'::jsonb)::text AS permission_overrides,
+	COALESCE(assigned_property_ids, '[]'::jsonb)::text AS assigned_property_ids,
+	created_at,
+	updated_at,
+	version
+`
+
+	user, err := scanUser(r.db.QueryRowContext(ctx, query, id, params.Name, params.Role))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update managed user: %w", err)
+	}
+
+	return user, nil
+}
+
+// ReplaceAssignedProperties replaces the assigned property list for a single active user.
+func (r *SQLRepository) ReplaceAssignedProperties(ctx context.Context, id string, assignedPropertyIDs []string) (*User, error) {
+	payload, err := json.Marshal(assignedPropertyIDs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal assigned property ids: %w", err)
+	}
+
+	const query = `
+UPDATE users
+SET assigned_property_ids = $2::jsonb,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	firebase_uid,
+	email,
+	name,
+	role,
+	COALESCE(permission_overrides, '[]'::jsonb)::text AS permission_overrides,
+	COALESCE(assigned_property_ids, '[]'::jsonb)::text AS assigned_property_ids,
+	created_at,
+	updated_at,
+	version
+`
+
+	user, err := scanUser(r.db.QueryRowContext(ctx, query, id, string(payload)))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("replace assigned properties: %w", err)
 	}
 
 	return user, nil

--- a/internal/platform/database/users/repository_test.go
+++ b/internal/platform/database/users/repository_test.go
@@ -191,3 +191,126 @@ LIMIT $1 OFFSET $2`)).
 		t.Fatalf("ExpectationsWereMet: %v", err)
 	}
 }
+
+func TestUpdateManagedUserUpdatesNameAndRole(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+UPDATE users
+SET name = $2,
+	role = $3,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	firebase_uid,
+	email,
+	name,
+	role,
+	COALESCE(permission_overrides, '[]'::jsonb)::text AS permission_overrides,
+	COALESCE(assigned_property_ids, '[]'::jsonb)::text AS assigned_property_ids,
+	created_at,
+	updated_at,
+	version
+`)).
+		WithArgs("user-1", "Updated Name", "staff").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "firebase_uid", "email", "name", "role", "permission_overrides", "assigned_property_ids", "created_at", "updated_at", "version",
+		}).AddRow(
+			"user-1",
+			"uid-1",
+			"organizer@studio.com",
+			"Updated Name",
+			"staff",
+			"[]",
+			`["property-1"]`,
+			now,
+			now,
+			2,
+		))
+
+	user, err := repo.UpdateManagedUser(context.Background(), "user-1", UpdateManagedUserParams{
+		Name: "Updated Name",
+		Role: "staff",
+	})
+	if err != nil {
+		t.Fatalf("UpdateManagedUser: %v", err)
+	}
+	if user.Role != "staff" {
+		t.Fatalf("expected role staff, got %s", user.Role)
+	}
+	if user.Name != "Updated Name" {
+		t.Fatalf("expected Updated Name, got %s", user.Name)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestReplaceAssignedPropertiesPersistsJSONList(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+UPDATE users
+SET assigned_property_ids = $2::jsonb,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	firebase_uid,
+	email,
+	name,
+	role,
+	COALESCE(permission_overrides, '[]'::jsonb)::text AS permission_overrides,
+	COALESCE(assigned_property_ids, '[]'::jsonb)::text AS assigned_property_ids,
+	created_at,
+	updated_at,
+	version
+`)).
+		WithArgs("user-1", `["property-1","property-2"]`).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "firebase_uid", "email", "name", "role", "permission_overrides", "assigned_property_ids", "created_at", "updated_at", "version",
+		}).AddRow(
+			"user-1",
+			"uid-1",
+			"organizer@studio.com",
+			"Organizer",
+			"organizer",
+			"[]",
+			`["property-1","property-2"]`,
+			now,
+			now,
+			2,
+		))
+
+	user, err := repo.ReplaceAssignedProperties(context.Background(), "user-1", []string{"property-1", "property-2"})
+	if err != nil {
+		t.Fatalf("ReplaceAssignedProperties: %v", err)
+	}
+	if len(user.AssignedPropertyIDs) != 2 {
+		t.Fatalf("expected 2 property ids, got %d", len(user.AssignedPropertyIDs))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}

--- a/internal/server/iam_adapters.go
+++ b/internal/server/iam_adapters.go
@@ -6,6 +6,7 @@ import (
 	appiam "stds_backend/internal/application/iam"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
 	dbusers "stds_backend/internal/platform/database/users"
+	"stds_backend/internal/shared/apperr"
 )
 
 type managedUserRepositoryAdapter struct {
@@ -16,7 +17,7 @@ func (a managedUserRepositoryAdapter) FindByID(ctx context.Context, id string) (
 	user, err := a.repo.FindByID(ctx, id)
 	if err != nil {
 		if err == dbusers.ErrNotFound {
-			return nil, appiam.ErrManagedUserNotFound
+			return nil, apperr.ErrUserNotFound
 		}
 		return nil, err
 	}
@@ -28,7 +29,7 @@ func (a managedUserRepositoryAdapter) ReplaceAssignedProperties(ctx context.Cont
 	user, err := a.repo.ReplaceAssignedProperties(ctx, id, assignedPropertyIDs)
 	if err != nil {
 		if err == dbusers.ErrNotFound {
-			return nil, appiam.ErrManagedUserNotFound
+			return nil, apperr.ErrUserNotFound
 		}
 		return nil, err
 	}
@@ -44,7 +45,7 @@ func (a propertyExistenceCheckerAdapter) Exists(ctx context.Context, propertyID 
 	_, err := a.repo.FindByID(ctx, propertyID)
 	if err != nil {
 		if err == dbpropertyquery.ErrNotFound {
-			return false, appiam.ErrManagedPropertyNotFound
+			return false, nil
 		}
 		return false, err
 	}

--- a/internal/server/iam_adapters.go
+++ b/internal/server/iam_adapters.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+
+	appiam "stds_backend/internal/application/iam"
+	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
+	dbusers "stds_backend/internal/platform/database/users"
+)
+
+type managedUserRepositoryAdapter struct {
+	repo dbusers.Repository
+}
+
+func (a managedUserRepositoryAdapter) FindByID(ctx context.Context, id string) (*appiam.ManagedUser, error) {
+	user, err := a.repo.FindByID(ctx, id)
+	if err != nil {
+		if err == dbusers.ErrNotFound {
+			return nil, appiam.ErrManagedUserNotFound
+		}
+		return nil, err
+	}
+
+	return toManagedUser(user), nil
+}
+
+func (a managedUserRepositoryAdapter) ReplaceAssignedProperties(ctx context.Context, id string, assignedPropertyIDs []string) (*appiam.ManagedUser, error) {
+	user, err := a.repo.ReplaceAssignedProperties(ctx, id, assignedPropertyIDs)
+	if err != nil {
+		if err == dbusers.ErrNotFound {
+			return nil, appiam.ErrManagedUserNotFound
+		}
+		return nil, err
+	}
+
+	return toManagedUser(user), nil
+}
+
+type propertyExistenceCheckerAdapter struct {
+	repo dbpropertyquery.Repository
+}
+
+func (a propertyExistenceCheckerAdapter) Exists(ctx context.Context, propertyID string) (bool, error) {
+	_, err := a.repo.FindByID(ctx, propertyID)
+	if err != nil {
+		if err == dbpropertyquery.ErrNotFound {
+			return false, appiam.ErrManagedPropertyNotFound
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func toManagedUser(user *dbusers.User) *appiam.ManagedUser {
+	return &appiam.ManagedUser{
+		ID:                  user.ID,
+		FirebaseUID:         user.FirebaseUID,
+		Email:               user.Email,
+		Name:                user.Name,
+		Role:                user.Role,
+		PermissionOverrides: user.PermissionOverrides,
+		AssignedPropertyIDs: user.AssignedPropertyIDs,
+		CreatedAt:           user.CreatedAt,
+		UpdatedAt:           user.UpdatedAt,
+		Version:             user.Version,
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -71,7 +71,11 @@ func New(cfg *config.Config) (*Server, error) {
 	syncAuthService := appiam.NewSyncAuthService(userRepo, customClaimsService)
 	updateCurrentUserService := appiam.NewUpdateCurrentUserService(userRepo)
 	updateUserService := appiam.NewUpdateUserService(userRepo, customClaimsService)
-	assignUserPropertiesService := appiam.NewAssignUserPropertiesService(userRepo, propertyQueryRepo, customClaimsService)
+	assignUserPropertiesService := appiam.NewAssignUserPropertiesService(
+		managedUserRepositoryAdapter{repo: userRepo},
+		propertyExistenceCheckerAdapter{repo: propertyQueryRepo},
+		customClaimsService,
+	)
 	txRunner := dbtxrunner.New(db, bus)
 	createPropertyService := appproperty.NewCreatePropertyService(propertyRepo, txRunner)
 	jobTriggerService := appjobs.NewTriggerService(jobRunsRepo, nil, cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,6 +70,8 @@ func New(cfg *config.Config) (*Server, error) {
 	customClaimsService := appiam.NewCustomClaimsService(authenticator)
 	syncAuthService := appiam.NewSyncAuthService(userRepo, customClaimsService)
 	updateCurrentUserService := appiam.NewUpdateCurrentUserService(userRepo)
+	updateUserService := appiam.NewUpdateUserService(userRepo, customClaimsService)
+	assignUserPropertiesService := appiam.NewAssignUserPropertiesService(userRepo, propertyQueryRepo, customClaimsService)
 	txRunner := dbtxrunner.New(db, bus)
 	createPropertyService := appproperty.NewCreatePropertyService(propertyRepo, txRunner)
 	jobTriggerService := appjobs.NewTriggerService(jobRunsRepo, nil, cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)
@@ -77,7 +79,7 @@ func New(cfg *config.Config) (*Server, error) {
 	engine := router.New(cfg.App, logger, db, authenticator, userRepo, router.AuthorizationRepositories{
 		Properties:        propertyRepo,
 		ResourceOwnership: resourceOwnershipRepo,
-	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, jobTriggerService, propertyQueryRepo, createPropertyService)
+	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, createPropertyService)
 
 	return &Server{
 		httpServer: &http.Server{

--- a/internal/shared/apperr/common.go
+++ b/internal/shared/apperr/common.go
@@ -43,6 +43,10 @@ const (
 	CodeValidationElectricityPriceInvalid = "VALIDATION_ELECTRICITY_PRICE_INVALID"
 	// CodeValidationWindowKeyRequired identifies missing scheduler window keys.
 	CodeValidationWindowKeyRequired = "VALIDATION_WINDOW_KEY_REQUIRED"
+	// CodeAdminCannotDowngradeSelf identifies self-role downgrade attempts by admins.
+	CodeAdminCannotDowngradeSelf = "ADMIN_CANNOT_DOWNGRADE_SELF"
+	// CodeCannotAssignPropertyToOwner identifies property assignment attempts targeting owners.
+	CodeCannotAssignPropertyToOwner = "CANNOT_ASSIGN_PROPERTY_TO_OWNER"
 )
 
 var (
@@ -165,5 +169,17 @@ var (
 		CodeValidationWindowKeyRequired,
 		http.StatusBadRequest,
 		"window_key is required.",
+	)
+	// ErrAdminCannotDowngradeSelf is returned when an admin attempts to remove their own admin role.
+	ErrAdminCannotDowngradeSelf = New(
+		CodeAdminCannotDowngradeSelf,
+		http.StatusUnprocessableEntity,
+		"Admin cannot downgrade own role.",
+	)
+	// ErrCannotAssignPropertyToOwner is returned when property assignment targets an owner account.
+	ErrCannotAssignPropertyToOwner = New(
+		CodeCannotAssignPropertyToOwner,
+		http.StatusUnprocessableEntity,
+		"Property assignment target must be a studio member, not an owner.",
 	)
 )


### PR DESCRIPTION
## Summary
- implement `PATCH /users/{id}` for admin-managed user updates following the current schema
- implement `POST /users/{id}/property-assignments` with property validation and owner-target rejection
- persist DB updates first, then refresh Firebase custom claims using Strategy A
- add focused application, repository, router, and middleware-facing test coverage

## Why
Issue #8 requires the remaining IAM admin command endpoints for managed user updates and property assignments.

## Validation
- `go test ./internal/application/iam ./internal/platform/database/users ./internal/http/router ./internal/http/middleware`

## Issue
Closes #8
