### PR TITLE
[007][P2][Property][Read] Implement GET /properties/{id}/rooms and GET /rooms/{id}

### DIFF
--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -322,7 +322,49 @@ func (s *APIServer) ListPropertyPendingMeters(c *gin.Context, id string) { write
 
 // ListPropertyRooms handles room listing for a property.
 func (s *APIServer) ListPropertyRooms(c *gin.Context, id string, params api.ListPropertyRoomsParams) {
-	writeNotImplemented(c)
+	status := ""
+	if params.Status != nil {
+		status = string(*params.Status)
+		if !isSupportedRoomStatus(status) {
+			c.Error(apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+				"field":  "status",
+				"reason": "must be one of vacant, occupied, maintenance",
+			}))
+			return
+		}
+	}
+
+	pagination, err := queryparams.NormalizePagination(params.Page, params.Limit)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	rooms, err := s.propertyQueryRepo.ListRoomsByProperty(c.Request.Context(), id, status, pagination.Limit, pagination.Offset)
+	if err != nil {
+		c.Error(apperr.ErrInternalServerError.WithCause(err))
+		return
+	}
+
+	if len(rooms) == 0 {
+		_, err := s.propertyQueryRepo.FindByID(c.Request.Context(), id)
+		if err != nil {
+			switch err {
+			case dbpropertyquery.ErrNotFound:
+				c.Error(apperr.ErrPropertyNotFound)
+			default:
+				c.Error(apperr.ErrInternalServerError.WithCause(err))
+			}
+			return
+		}
+	}
+
+	items := make([]api.RoomResponse, 0, len(rooms))
+	for _, room := range rooms {
+		items = append(items, toRoomResponse(&room))
+	}
+
+	c.JSON(http.StatusOK, api.RoomListResponse{Data: &items})
 }
 
 // CreatePropertyRoom handles room creation within a property.
@@ -371,7 +413,20 @@ func (s *APIServer) ProgressRepairRequest(c *gin.Context, id string) { writeNotI
 func (s *APIServer) DeleteRoom(c *gin.Context, id string) { writeNotImplemented(c) }
 
 // GetRoom handles room detail retrieval.
-func (s *APIServer) GetRoom(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) GetRoom(c *gin.Context, id string) {
+	room, err := s.propertyQueryRepo.FindRoomByID(c.Request.Context(), id)
+	if err != nil {
+		switch err {
+		case dbpropertyquery.ErrRoomNotFound:
+			c.Error(apperr.ErrRoomNotFound)
+		default:
+			c.Error(apperr.ErrInternalServerError.WithCause(err))
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, toRoomResponse(room))
+}
 
 // ListRoomAttachments handles room attachment listing.
 func (s *APIServer) ListRoomAttachments(c *gin.Context, id openapi_types.UUID) {
@@ -843,6 +898,37 @@ func toPropertyResponse(property *dbpropertyquery.Property) api.PropertyResponse
 	return response
 }
 
+func toRoomResponse(room *dbpropertyquery.Room) api.RoomResponse {
+	id, ok := parseUUID(room.ID)
+	propertyID, propertyOK := parseUUID(room.PropertyID)
+	name := room.Name
+	status := api.RoomResponseStatus(room.Status)
+	createdAt := room.CreatedAt
+	updatedAt := room.UpdatedAt
+
+	response := api.RoomResponse{
+		DefaultRentAmount: room.DefaultRentAmount,
+		Facilities:        room.Facilities,
+		Floor:             room.Floor,
+		Name:              &name,
+		Notes:             room.Notes,
+		RoomType:          room.RoomType,
+		Size:              room.Size,
+		Status:            &status,
+		UpdatedAt:         &updatedAt,
+		Zone:              room.Zone,
+		CreatedAt:         &createdAt,
+	}
+	if ok {
+		response.Id = &id
+	}
+	if propertyOK {
+		response.PropertyId = &propertyID
+	}
+
+	return response
+}
+
 func toCreatedPropertyResponse(property *appproperty.Property) api.PropertyResponse {
 	queryShape := &dbpropertyquery.Property{
 		ID:                               property.ID,
@@ -857,4 +943,13 @@ func toCreatedPropertyResponse(property *appproperty.Property) api.PropertyRespo
 	}
 
 	return toPropertyResponse(queryShape)
+}
+
+func isSupportedRoomStatus(status string) bool {
+	switch status {
+	case "vacant", "occupied", "maintenance":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -360,8 +361,8 @@ func (s *APIServer) ListPropertyRooms(c *gin.Context, id string, params api.List
 	}
 
 	items := make([]api.RoomResponse, 0, len(rooms))
-	for _, room := range rooms {
-		items = append(items, toRoomResponse(&room))
+	for i := range rooms {
+		items = append(items, toRoomResponse(&rooms[i]))
 	}
 
 	c.JSON(http.StatusOK, api.RoomListResponse{Data: &items})
@@ -416,8 +417,8 @@ func (s *APIServer) DeleteRoom(c *gin.Context, id string) { writeNotImplemented(
 func (s *APIServer) GetRoom(c *gin.Context, id string) {
 	room, err := s.propertyQueryRepo.FindRoomByID(c.Request.Context(), id)
 	if err != nil {
-		switch err {
-		case dbpropertyquery.ErrRoomNotFound:
+		switch {
+		case errors.Is(err, apperr.ErrRoomNotFound):
 			c.Error(apperr.ErrRoomNotFound)
 		default:
 			c.Error(apperr.ErrInternalServerError.WithCause(err))

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -33,3 +33,30 @@ func TestToPropertyResponseAllowsNilElectricityUnitPrice(t *testing.T) {
 		t.Fatalf("expected electricity_unit_price null, got %v", payload["electricity_unit_price"])
 	}
 }
+
+func TestToRoomResponseAllowsNilOptionalFields(t *testing.T) {
+	response := toRoomResponse(&dbpropertyquery.Room{
+		ID:         "20000000-0000-0000-0000-000000000001",
+		PropertyID: "10000000-0000-0000-0000-000000000001",
+		Name:       "101 Room",
+		Status:     "vacant",
+		CreatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+	})
+
+	body, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	for _, field := range []string{"size", "floor", "room_type", "facilities", "default_rent_amount", "notes", "zone"} {
+		if value, ok := payload[field]; !ok || value != nil {
+			t.Fatalf("expected %s null, got %v", field, payload[field])
+		}
+	}
+}

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -673,7 +673,7 @@ func TestAssignUserPropertiesRejectsOwnerTarget(t *testing.T) {
 func TestTriggerUserPasswordResetReturnsNoContent(t *testing.T) {
 	repo := fakeUserRepo{role: "admin"}
 	notificationSender := &testNotificationSender{}
-	engine := newTestEngineWithNotificationSender(repo, fakeAuthenticator{role: "admin"}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{}, notificationSender, appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)))
+	engine := newTestEngineWithNotificationSender(repo, fakeAuthenticator{role: "admin"}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{}, notificationSender, fakePropertyQueryRepo{}, appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/user-1/password-reset", nil)
 	req.Header.Set("Authorization", "Bearer valid-token")
@@ -833,6 +833,7 @@ func TestCreateUserReturnsNotificationErrorCodeWhenDispatchFails(t *testing.T) {
 		"",
 		fakeJobRunsRepo{},
 		&testNotificationSender{sendErr: errors.New("resend down")},
+		fakePropertyQueryRepo{},
 		appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
 	)
 
@@ -932,7 +933,7 @@ func TestCreatePropertyAcceptsDecimalElectricityPrice(t *testing.T) {
 
 	repo := fakeUserRepo{}
 	createPropertyService := appproperty.NewCreatePropertyService(testSQLPropertyRepositoryAdapter{repo: dbproperties.NewRepository(db)}, dbtxrunner.New(db, nil))
-	engine := newTestEngineWithCreatePropertyService(repo, fakeAuthenticator{}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{}, createPropertyService)
+	engine := newTestEngineWithCreatePropertyService(repo, fakeAuthenticator{}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{}, createPropertyService)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/properties", strings.NewReader(`{
 		"name":"Property A",
@@ -984,6 +985,209 @@ func TestGetBillResolvesPropertyAccessThroughOwnershipQuery(t *testing.T) {
 
 	if resp.Code != http.StatusNotImplemented {
 		t.Fatalf("expected 501, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestListPropertyRoomsReturnsAccessibleRooms(t *testing.T) {
+	call := &listRoomsCall{}
+	propertyQueryRepo := fakePropertyQueryRepo{
+		listRoomsCall: call,
+		rooms: []dbpropertyquery.Room{
+			{
+				ID:         testRoomID1,
+				PropertyID: testPropertyID1,
+				Name:       "101 Room",
+				Status:     "vacant",
+				CreatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+				UpdatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+	engine := newTestEngineWithPropertyQueryRepo(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		propertyQueryRepo,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/properties/"+testPropertyID1+"/rooms?status=vacant&page=2&limit=1", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	if call.propertyID != testPropertyID1 || call.status != "vacant" || call.limit != 1 || call.offset != 1 {
+		t.Fatalf("unexpected list rooms call: %+v", *call)
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	data, ok := payload["data"].([]any)
+	if !ok || len(data) != 1 {
+		t.Fatalf("expected 1 room, got %v", payload["data"])
+	}
+
+	item, ok := data[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected room object, got %T", data[0])
+	}
+	if item["id"] != testRoomID1 {
+		t.Fatalf("expected room id %s, got %v", testRoomID1, item["id"])
+	}
+	if item["property_id"] != testPropertyID1 {
+		t.Fatalf("expected property id %s, got %v", testPropertyID1, item["property_id"])
+	}
+	if item["status"] != "vacant" {
+		t.Fatalf("expected status vacant, got %v", item["status"])
+	}
+}
+
+func TestListPropertyRoomsRejectsInvalidStatus(t *testing.T) {
+	engine := newTestEngineWithPropertyQueryRepo(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/properties/"+testPropertyID1+"/rooms?status=invalid", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["error_code"] != apperr.CodeBadRequest {
+		t.Fatalf("expected BAD_REQUEST, got %v", payload["error_code"])
+	}
+}
+
+func TestListPropertyRoomsReturnsPropertyNotFoundForAdminWhenPropertyMissing(t *testing.T) {
+	engine := newTestEngineWithPropertyQueryRepo(
+		fakeUserRepo{role: "admin"},
+		fakeAuthenticator{role: "admin"},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{
+			rooms:       []dbpropertyquery.Room{},
+			propertyErr: dbpropertyquery.ErrNotFound,
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/properties/"+testMissingPropertyID+"/rooms", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["error_code"] != apperr.CodePropertyNotFound {
+		t.Fatalf("expected PROPERTY_NOT_FOUND, got %v", payload["error_code"])
+	}
+}
+
+func TestGetRoomReturnsAccessibleRoom(t *testing.T) {
+	engine := newTestEngineWithPropertyQueryRepo(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{
+			propertyByRoomID: map[string]string{
+				testRoomID1: testPropertyID1,
+			},
+		},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{
+			room: &dbpropertyquery.Room{
+				ID:         testRoomID1,
+				PropertyID: testPropertyID1,
+				Name:       "101 Room",
+				Status:     "occupied",
+				CreatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+				UpdatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+			},
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rooms/"+testRoomID1, nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["id"] != testRoomID1 {
+		t.Fatalf("expected room id %s, got %v", testRoomID1, payload["id"])
+	}
+	if payload["status"] != "occupied" {
+		t.Fatalf("expected occupied status, got %v", payload["status"])
+	}
+}
+
+func TestGetRoomRejectsUnauthorizedPropertyAccess(t *testing.T) {
+	engine := newTestEngineWithPropertyQueryRepo(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID2}},
+		fakePropertyRepo{
+			ownerByPropertyID: map[string]string{
+				testPropertyID1: "owner-1",
+			},
+		},
+		fakeResourceOwnershipRepo{
+			propertyByRoomID: map[string]string{
+				testRoomID1: testPropertyID1,
+			},
+		},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rooms/"+testRoomID1, nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
 	}
 }
 
@@ -1410,8 +1614,21 @@ type fakePropertyRepo struct {
 }
 
 type fakePropertyQueryRepo struct {
-	property   *dbpropertyquery.Property
-	properties []dbpropertyquery.Property
+	property       *dbpropertyquery.Property
+	propertyErr    error
+	properties     []dbpropertyquery.Property
+	room           *dbpropertyquery.Room
+	roomErr        error
+	rooms          []dbpropertyquery.Room
+	listRoomsCall  *listRoomsCall
+	findRoomIDSink *string
+}
+
+type listRoomsCall struct {
+	propertyID string
+	status     string
+	limit      int
+	offset     int
 }
 
 type fakeResourceOwnershipRepo struct {
@@ -1813,6 +2030,10 @@ func (a testSQLPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx
 }
 
 func (f fakePropertyQueryRepo) FindByID(_ context.Context, propertyID string) (*dbpropertyquery.Property, error) {
+	if f.propertyErr != nil {
+		return nil, f.propertyErr
+	}
+
 	if f.property != nil {
 		return f.property, nil
 	}
@@ -1849,6 +2070,83 @@ func (f fakePropertyQueryRepo) ListAccessible(_ context.Context, _ string, _ str
 			UpdatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 			Version:                          1,
 		},
+	}, nil
+}
+
+func (f fakePropertyQueryRepo) ListRoomsByProperty(_ context.Context, propertyID string, status string, limit int, offset int) ([]dbpropertyquery.Room, error) {
+	if f.listRoomsCall != nil {
+		f.listRoomsCall.propertyID = propertyID
+		f.listRoomsCall.status = status
+		f.listRoomsCall.limit = limit
+		f.listRoomsCall.offset = offset
+	}
+	if f.roomErr != nil {
+		return nil, f.roomErr
+	}
+	if f.rooms != nil {
+		return f.rooms, nil
+	}
+
+	size := 10.5
+	defaultRentAmount := 12000
+	floor := "1F"
+	roomType := "suite"
+	notes := "Window room"
+	zone := "A"
+	facilities := map[string]interface{}{"ac": true}
+
+	return []dbpropertyquery.Room{
+		{
+			ID:                testRoomID1,
+			PropertyID:        propertyID,
+			Name:              "101 Room",
+			Status:            "vacant",
+			Size:              &size,
+			Floor:             &floor,
+			RoomType:          &roomType,
+			Facilities:        &facilities,
+			DefaultRentAmount: &defaultRentAmount,
+			Notes:             &notes,
+			Zone:              &zone,
+			CreatedAt:         time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+			UpdatedAt:         time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		},
+	}, nil
+}
+
+func (f fakePropertyQueryRepo) FindRoomByID(_ context.Context, roomID string) (*dbpropertyquery.Room, error) {
+	if f.findRoomIDSink != nil {
+		*f.findRoomIDSink = roomID
+	}
+	if f.roomErr != nil {
+		return nil, f.roomErr
+	}
+	if f.room != nil {
+		return f.room, nil
+	}
+
+	size := 10.5
+	defaultRentAmount := 12000
+	floor := "1F"
+	roomType := "suite"
+	notes := "Window room"
+	zone := "A"
+	facilities := map[string]interface{}{"ac": true}
+
+	return &dbpropertyquery.Room{
+		ID:                roomID,
+		PropertyID:        testPropertyID1,
+		Name:              "101 Room",
+		Status:            "vacant",
+		Size:              &size,
+		Floor:             &floor,
+		RoomType:          &roomType,
+		Facilities:        &facilities,
+		DefaultRentAmount: &defaultRentAmount,
+		Notes:             &notes,
+		Zone:              &zone,
+		CreatedAt:         time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:         time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 	}, nil
 }
 
@@ -1915,6 +2213,18 @@ func (fakeJobRunsRepo) Fail(_ context.Context, _ string, _ string) error     { r
 func (fakeJobRunsRepo) Skip(_ context.Context, _ string, _ string) error     { return nil }
 
 func newTestEngine(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo) *gin.Engine {
+	return newTestEngineWithPropertyQueryRepo(
+		userRepo,
+		authenticator,
+		propertyRepo,
+		ownershipRepo,
+		schedulerKey,
+		jobRunsRepo,
+		fakePropertyQueryRepo{},
+	)
+}
+
+func newTestEngineWithPropertyQueryRepo(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository) *gin.Engine {
 	return newTestEngineWithCreatePropertyService(
 		userRepo,
 		authenticator,
@@ -1922,11 +2232,12 @@ func newTestEngine(userRepo fakeUserRepo, authenticator fakeAuthenticator, prope
 		ownershipRepo,
 		schedulerKey,
 		jobRunsRepo,
+		propertyQueryRepo,
 		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
 	)
 }
 
-func newTestEngineWithCreatePropertyService(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, createPropertyService *appproperty.CreatePropertyService) *gin.Engine {
+func newTestEngineWithCreatePropertyService(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, createPropertyService *appproperty.CreatePropertyService) *gin.Engine {
 	return newTestEngineWithNotificationSender(
 		userRepo,
 		authenticator,
@@ -1935,11 +2246,12 @@ func newTestEngineWithCreatePropertyService(userRepo fakeUserRepo, authenticator
 		schedulerKey,
 		jobRunsRepo,
 		&testNotificationSender{},
+		propertyQueryRepo,
 		createPropertyService,
 	)
 }
 
-func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, notificationSender *testNotificationSender, createPropertyService *appproperty.CreatePropertyService) *gin.Engine {
+func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, notificationSender *testNotificationSender, propertyQueryRepo dbpropertyquery.Repository, createPropertyService *appproperty.CreatePropertyService) *gin.Engine {
 	repo := &userRepo
 	userAccountRepo := testUserAccountRepositoryAdapter{repo: repo}
 	return New(
@@ -1963,7 +2275,7 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 			appiam.NewCustomClaimsService(authenticator),
 		),
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
-		fakePropertyQueryRepo{},
+		propertyQueryRepo,
 		createPropertyService,
 	)
 }

--- a/internal/platform/database/propertyquery/repository.go
+++ b/internal/platform/database/propertyquery/repository.go
@@ -3,6 +3,7 @@ package propertyquery
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -11,6 +12,9 @@ import (
 
 // ErrNotFound indicates that no active property matched the requested lookup.
 var ErrNotFound = errors.New("property query not found")
+
+// ErrRoomNotFound indicates that no active room matched the requested lookup.
+var ErrRoomNotFound = errors.New("room query not found")
 
 // Property is the read model returned by property queries.
 type Property struct {
@@ -25,10 +29,29 @@ type Property struct {
 	Version                          int
 }
 
+// Room is the read model returned by room queries.
+type Room struct {
+	ID                string
+	PropertyID        string
+	Name              string
+	Status            string
+	Size              *float64
+	Floor             *string
+	RoomType          *string
+	Facilities        *map[string]interface{}
+	DefaultRentAmount *int
+	Notes             *string
+	Zone              *string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
 // Repository serves read-model queries for properties.
 type Repository interface {
 	FindByID(ctx context.Context, propertyID string) (*Property, error)
 	ListAccessible(ctx context.Context, role string, userID string, assignedPropertyIDs []string) ([]Property, error)
+	ListRoomsByProperty(ctx context.Context, propertyID string, status string, limit int, offset int) ([]Room, error)
+	FindRoomByID(ctx context.Context, roomID string) (*Room, error)
 }
 
 // SQLRepository reads properties from PostgreSQL.
@@ -110,6 +133,67 @@ WHERE deleted_at IS NULL
 	return properties, nil
 }
 
+// ListRoomsByProperty returns active rooms for a property with optional status filtering.
+func (r *SQLRepository) ListRoomsByProperty(ctx context.Context, propertyID string, status string, limit int, offset int) ([]Room, error) {
+	base := `
+SELECT id, property_id, name, status, size, floor, room_type, facilities::text, default_rent_amount, notes, zone, created_at, updated_at
+FROM rooms
+WHERE property_id = $1
+  AND deleted_at IS NULL
+`
+	args := []any{propertyID}
+
+	if status != "" {
+		args = append(args, status)
+		base += fmt.Sprintf(" AND status = $%d", len(args))
+	}
+
+	args = append(args, limit, offset)
+	base += fmt.Sprintf(" ORDER BY created_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
+
+	rows, err := r.db.QueryContext(ctx, base, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list rooms by property: %w", err)
+	}
+	defer rows.Close()
+
+	rooms := make([]Room, 0)
+	for rows.Next() {
+		room, err := scanRoom(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan room row: %w", err)
+		}
+		rooms = append(rooms, *room)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate rooms rows: %w", err)
+	}
+
+	return rooms, nil
+}
+
+// FindRoomByID returns a single active room.
+func (r *SQLRepository) FindRoomByID(ctx context.Context, roomID string) (*Room, error) {
+	const query = `
+SELECT id, property_id, name, status, size, floor, room_type, facilities::text, default_rent_amount, notes, zone, created_at, updated_at
+FROM rooms
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+
+	room, err := scanRoom(r.db.QueryRowContext(ctx, query, roomID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrRoomNotFound
+		}
+		return nil, fmt.Errorf("query room by id: %w", err)
+	}
+
+	return room, nil
+}
+
 type rowScanner interface {
 	Scan(dest ...any) error
 }
@@ -135,4 +219,64 @@ func scanProperty(row rowScanner) (*Property, error) {
 	}
 
 	return &property, nil
+}
+
+func scanRoom(row rowScanner) (*Room, error) {
+	var room Room
+	var size sql.NullFloat64
+	var floor sql.NullString
+	var roomType sql.NullString
+	var facilities sql.NullString
+	var defaultRentAmount sql.NullInt64
+	var notes sql.NullString
+	var zone sql.NullString
+
+	if err := row.Scan(
+		&room.ID,
+		&room.PropertyID,
+		&room.Name,
+		&room.Status,
+		&size,
+		&floor,
+		&roomType,
+		&facilities,
+		&defaultRentAmount,
+		&notes,
+		&zone,
+		&room.CreatedAt,
+		&room.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	if size.Valid {
+		room.Size = &size.Float64
+	}
+	if floor.Valid {
+		room.Floor = &floor.String
+	}
+	if roomType.Valid {
+		room.RoomType = &roomType.String
+	}
+	if facilities.Valid {
+		var decoded map[string]interface{}
+		if err := json.Unmarshal([]byte(facilities.String), &decoded); err != nil {
+			return nil, fmt.Errorf("decode facilities: %w", err)
+		}
+		if decoded != nil {
+			room.Facilities = &decoded
+		}
+	}
+	if defaultRentAmount.Valid {
+		value := int(defaultRentAmount.Int64)
+		room.DefaultRentAmount = &value
+	}
+	if notes.Valid {
+		room.Notes = &notes.String
+	}
+	if zone.Valid {
+		room.Zone = &zone.String
+	}
+
+	return &room, nil
 }

--- a/internal/platform/database/propertyquery/repository.go
+++ b/internal/platform/database/propertyquery/repository.go
@@ -8,13 +8,12 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"stds_backend/internal/shared/apperr"
 )
 
 // ErrNotFound indicates that no active property matched the requested lookup.
 var ErrNotFound = errors.New("property query not found")
-
-// ErrRoomNotFound indicates that no active room matched the requested lookup.
-var ErrRoomNotFound = errors.New("room query not found")
 
 // Property is the read model returned by property queries.
 type Property struct {
@@ -186,7 +185,7 @@ LIMIT 1
 	room, err := scanRoom(r.db.QueryRowContext(ctx, query, roomID))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ErrRoomNotFound
+			return nil, apperr.ErrRoomNotFound
 		}
 		return nil, fmt.Errorf("query room by id: %w", err)
 	}
@@ -259,12 +258,12 @@ func scanRoom(row rowScanner) (*Room, error) {
 		room.RoomType = &roomType.String
 	}
 	if facilities.Valid {
-		var decoded map[string]interface{}
+		var decoded any
 		if err := json.Unmarshal([]byte(facilities.String), &decoded); err != nil {
 			return nil, fmt.Errorf("decode facilities: %w", err)
 		}
-		if decoded != nil {
-			room.Facilities = &decoded
+		if objectValue, ok := decoded.(map[string]interface{}); ok {
+			room.Facilities = &objectValue
 		}
 	}
 	if defaultRentAmount.Valid {

--- a/internal/platform/database/propertyquery/repository_test.go
+++ b/internal/platform/database/propertyquery/repository_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+
+	"stds_backend/internal/shared/apperr"
 )
 
 func TestListRoomsByPropertyReturnsActiveRoomsWithStatusFilterAndPagination(t *testing.T) {
@@ -85,7 +87,7 @@ LIMIT 1`)).
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if errors.Is(err, ErrRoomNotFound) {
+	if errors.Is(err, apperr.ErrRoomNotFound) {
 		t.Fatalf("expected wrapped query error, got not found")
 	}
 
@@ -114,8 +116,59 @@ LIMIT 1`)).
 		}))
 
 	_, err = repo.FindRoomByID(context.Background(), "20000000-0000-0000-0000-000000000099")
-	if !errors.Is(err, ErrRoomNotFound) {
+	if !errors.Is(err, apperr.ErrRoomNotFound) {
 		t.Fatalf("expected ErrRoomNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListRoomsByPropertyIgnoresNonObjectFacilities(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, property_id, name, status, size, floor, room_type, facilities::text, default_rent_amount, notes, zone, created_at, updated_at
+FROM rooms
+WHERE property_id = $1
+  AND deleted_at IS NULL
+ ORDER BY created_at DESC LIMIT $2 OFFSET $3`)).
+		WithArgs("10000000-0000-0000-0000-000000000001", 20, 0).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "property_id", "name", "status", "size", "floor", "room_type", "facilities", "default_rent_amount", "notes", "zone", "created_at", "updated_at",
+		}).AddRow(
+			"20000000-0000-0000-0000-000000000001",
+			"10000000-0000-0000-0000-000000000001",
+			"101 Room",
+			"vacant",
+			nil,
+			nil,
+			nil,
+			`["ac","desk"]`,
+			nil,
+			nil,
+			nil,
+			now,
+			now,
+		))
+
+	rooms, err := repo.ListRoomsByProperty(context.Background(), "10000000-0000-0000-0000-000000000001", "", 20, 0)
+	if err != nil {
+		t.Fatalf("ListRoomsByProperty: %v", err)
+	}
+
+	if len(rooms) != 1 {
+		t.Fatalf("expected 1 room, got %d", len(rooms))
+	}
+	if rooms[0].Facilities != nil {
+		t.Fatalf("expected facilities nil for non-object json, got %#v", rooms[0].Facilities)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/platform/database/propertyquery/repository_test.go
+++ b/internal/platform/database/propertyquery/repository_test.go
@@ -1,0 +1,124 @@
+package propertyquery
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestListRoomsByPropertyReturnsActiveRoomsWithStatusFilterAndPagination(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, property_id, name, status, size, floor, room_type, facilities::text, default_rent_amount, notes, zone, created_at, updated_at
+FROM rooms
+WHERE property_id = $1
+  AND deleted_at IS NULL
+ AND status = $2 ORDER BY created_at DESC LIMIT $3 OFFSET $4`)).
+		WithArgs("10000000-0000-0000-0000-000000000001", "vacant", 10, 20).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "property_id", "name", "status", "size", "floor", "room_type", "facilities", "default_rent_amount", "notes", "zone", "created_at", "updated_at",
+		}).AddRow(
+			"20000000-0000-0000-0000-000000000001",
+			"10000000-0000-0000-0000-000000000001",
+			"101 Room",
+			"vacant",
+			10.5,
+			"1F",
+			"suite",
+			`{"ac":true}`,
+			12000,
+			"Window room",
+			"A",
+			now,
+			now,
+		))
+
+	rooms, err := repo.ListRoomsByProperty(context.Background(), "10000000-0000-0000-0000-000000000001", "vacant", 10, 20)
+	if err != nil {
+		t.Fatalf("ListRoomsByProperty: %v", err)
+	}
+
+	if len(rooms) != 1 {
+		t.Fatalf("expected 1 room, got %d", len(rooms))
+	}
+	if rooms[0].Name != "101 Room" {
+		t.Fatalf("expected room name 101 Room, got %s", rooms[0].Name)
+	}
+	if rooms[0].Facilities == nil || (*rooms[0].Facilities)["ac"] != true {
+		t.Fatalf("expected facilities to include ac=true, got %#v", rooms[0].Facilities)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindRoomByIDWrapsQueryErrors(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, property_id, name, status, size, floor, room_type, facilities::text, default_rent_amount, notes, zone, created_at, updated_at
+FROM rooms
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1`)).
+		WithArgs("20000000-0000-0000-0000-000000000099").
+		WillReturnError(sqlmock.ErrCancelled)
+
+	_, err = repo.FindRoomByID(context.Background(), "20000000-0000-0000-0000-000000000099")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrRoomNotFound) {
+		t.Fatalf("expected wrapped query error, got not found")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindRoomByIDMapsNoRowsToRoomNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, property_id, name, status, size, floor, room_type, facilities::text, default_rent_amount, notes, zone, created_at, updated_at
+FROM rooms
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1`)).
+		WithArgs("20000000-0000-0000-0000-000000000099").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "property_id", "name", "status", "size", "floor", "room_type", "facilities", "default_rent_amount", "notes", "zone", "created_at", "updated_at",
+		}))
+
+	_, err = repo.FindRoomByID(context.Background(), "20000000-0000-0000-0000-000000000099")
+	if !errors.Is(err, ErrRoomNotFound) {
+		t.Fatalf("expected ErrRoomNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement `GET /properties/{id}/rooms` and `GET /rooms/{id}` in the API handler
- extend `propertyquery` with room list/detail read models and SQL queries
- add focused handler, router, and repository tests for room read behavior and error mapping

## Testing
- `go test ./internal/http/handler ./internal/http/router ./internal/platform/database/propertyquery ./internal/http/middleware`