### PR TITLE
[codex] Implement property command aggregate flow

### DIFF
--- a/internal/application/property/create_property.go
+++ b/internal/application/property/create_property.go
@@ -43,7 +43,7 @@ func (s *CreatePropertyService) Execute(ctx context.Context, input CreatePropert
 	aggregate, err := domainproperty.New(domainproperty.State{
 		Name:                             input.Name,
 		Address:                          input.Address,
-		ElectricityUnitPrice:             input.ElectricityUnitPrice,
+		ElectricityUnitPrice:             &input.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: input.DefaultElectricityBillingCadence,
 		OwnerID:                          input.OwnerID,
 	})
@@ -59,10 +59,14 @@ func (s *CreatePropertyService) Execute(ctx context.Context, input CreatePropert
 	state := aggregate.State()
 	var created *Property
 	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+		electricityUnitPrice := 0.0
+		if state.ElectricityUnitPrice != nil {
+			electricityUnitPrice = *state.ElectricityUnitPrice
+		}
 		property, err := s.propertyRepo.Create(ctx, tx, CreatePropertyParams{
 			Name:                             state.Name,
 			Address:                          state.Address,
-			ElectricityUnitPrice:             state.ElectricityUnitPrice,
+			ElectricityUnitPrice:             electricityUnitPrice,
 			DefaultElectricityBillingCadence: state.DefaultElectricityBillingCadence,
 			OwnerID:                          state.OwnerID,
 		})

--- a/internal/application/property/create_property.go
+++ b/internal/application/property/create_property.go
@@ -3,10 +3,11 @@ package property
 import (
 	"context"
 	"database/sql"
-	"strings"
+	"errors"
 	"time"
 
 	domainevents "stds_backend/internal/domain/events"
+	domainproperty "stds_backend/internal/domain/property"
 	"stds_backend/internal/platform/database/txrunner"
 	"stds_backend/internal/shared/apperr"
 )
@@ -39,18 +40,31 @@ func NewCreatePropertyService(propertyRepo Repository, txRunner *txrunner.Runner
 
 // Execute validates input and persists a new property.
 func (s *CreatePropertyService) Execute(ctx context.Context, input CreatePropertyInput) (*Property, error) {
-	if err := validateCreatePropertyInput(input); err != nil {
-		return nil, err
+	aggregate, err := domainproperty.New(domainproperty.State{
+		Name:                             input.Name,
+		Address:                          input.Address,
+		ElectricityUnitPrice:             input.ElectricityUnitPrice,
+		DefaultElectricityBillingCadence: input.DefaultElectricityBillingCadence,
+		OwnerID:                          input.OwnerID,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, domainproperty.ErrElectricityPriceMustBePositive):
+			return nil, apperr.ErrValidationElectricityPriceInvalid
+		default:
+			return nil, mapDomainError(err)
+		}
 	}
 
+	state := aggregate.State()
 	var created *Property
-	err := s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
 		property, err := s.propertyRepo.Create(ctx, tx, CreatePropertyParams{
-			Name:                             strings.TrimSpace(input.Name),
-			Address:                          strings.TrimSpace(input.Address),
-			ElectricityUnitPrice:             input.ElectricityUnitPrice,
-			DefaultElectricityBillingCadence: strings.TrimSpace(input.DefaultElectricityBillingCadence),
-			OwnerID:                          strings.TrimSpace(input.OwnerID),
+			Name:                             state.Name,
+			Address:                          state.Address,
+			ElectricityUnitPrice:             state.ElectricityUnitPrice,
+			DefaultElectricityBillingCadence: state.DefaultElectricityBillingCadence,
+			OwnerID:                          state.OwnerID,
 		})
 		if err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)
@@ -68,21 +82,4 @@ func (s *CreatePropertyService) Execute(ctx context.Context, input CreatePropert
 	}
 
 	return created, nil
-}
-
-func validateCreatePropertyInput(input CreatePropertyInput) error {
-	switch {
-	case strings.TrimSpace(input.Name) == "":
-		return apperr.ErrValidationNameRequired
-	case strings.TrimSpace(input.Address) == "":
-		return apperr.ErrValidationAddressRequired
-	case input.ElectricityUnitPrice <= 0:
-		return apperr.ErrValidationElectricityPriceInvalid
-	case strings.TrimSpace(input.DefaultElectricityBillingCadence) == "":
-		return apperr.ErrBadRequest
-	case strings.TrimSpace(input.OwnerID) == "":
-		return apperr.ErrValidationOwnerIDRequired
-	default:
-		return nil
-	}
 }

--- a/internal/application/property/create_property_test.go
+++ b/internal/application/property/create_property_test.go
@@ -43,7 +43,7 @@ func TestCreatePropertyServiceCreatesProperty(t *testing.T) {
 	if property.ID != "property-1" {
 		t.Fatalf("expected property-1, got %q", property.ID)
 	}
-	if property.ElectricityUnitPrice != 4.5 {
+	if property.ElectricityUnitPrice == nil || *property.ElectricityUnitPrice != 4.5 {
 		t.Fatalf("expected electricity_unit_price 4.5, got %v", property.ElectricityUnitPrice)
 	}
 	if property.DefaultElectricityBillingCadence != "monthly" {
@@ -75,7 +75,7 @@ func (a sqlPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, pa
 		ID:                               property.ID,
 		Name:                             property.Name,
 		Address:                          property.Address,
-		ElectricityUnitPrice:             *property.ElectricityUnitPrice,
+		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
 		CreatedAt:                        property.CreatedAt,

--- a/internal/application/property/create_property_test.go
+++ b/internal/application/property/create_property_test.go
@@ -43,7 +43,7 @@ func TestCreatePropertyServiceCreatesProperty(t *testing.T) {
 	if property.ID != "property-1" {
 		t.Fatalf("expected property-1, got %q", property.ID)
 	}
-	if property.ElectricityUnitPrice == nil || *property.ElectricityUnitPrice != 4.5 {
+	if property.ElectricityUnitPrice != 4.5 {
 		t.Fatalf("expected electricity_unit_price 4.5, got %v", property.ElectricityUnitPrice)
 	}
 	if property.DefaultElectricityBillingCadence != "monthly" {
@@ -75,7 +75,7 @@ func (a sqlPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, pa
 		ID:                               property.ID,
 		Name:                             property.Name,
 		Address:                          property.Address,
-		ElectricityUnitPrice:             property.ElectricityUnitPrice,
+		ElectricityUnitPrice:             *property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
 		CreatedAt:                        property.CreatedAt,
@@ -90,4 +90,20 @@ func TestCreatePropertyServiceValidatesInput(t *testing.T) {
 	if _, err := service.Execute(context.Background(), CreatePropertyInput{}); err == nil {
 		t.Fatal("expected validation error, got nil")
 	}
+}
+
+func (a sqlPropertyRepositoryAdapter) FindByID(context.Context, *sql.Tx, string) (*Property, error) {
+	return nil, nil
+}
+
+func (a sqlPropertyRepositoryAdapter) Update(context.Context, *sql.Tx, UpdatePropertyParams) (*Property, error) {
+	return nil, nil
+}
+
+func (a sqlPropertyRepositoryAdapter) ListOccupiedRoomIDs(context.Context, *sql.Tx, string) ([]string, error) {
+	return nil, nil
+}
+
+func (a sqlPropertyRepositoryAdapter) SoftDelete(context.Context, *sql.Tx, string, int) error {
+	return nil
 }

--- a/internal/application/property/delete_property.go
+++ b/internal/application/property/delete_property.go
@@ -1,0 +1,88 @@
+package property
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	domainproperty "stds_backend/internal/domain/property"
+	dbproperties "stds_backend/internal/platform/database/properties"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// DeletePropertyInput is the command payload for deleting a property.
+type DeletePropertyInput struct {
+	ID string
+}
+
+// DeletePropertyService deletes properties while preserving BR-07.
+type DeletePropertyService struct {
+	propertyRepo Repository
+	txRunner     *txrunner.Runner
+}
+
+// NewDeletePropertyService returns a DeletePropertyService.
+func NewDeletePropertyService(propertyRepo Repository, txRunner *txrunner.Runner) *DeletePropertyService {
+	return &DeletePropertyService{
+		propertyRepo: propertyRepo,
+		txRunner:     txRunner,
+	}
+}
+
+// Execute loads the aggregate, checks BR-07, and soft-deletes the property.
+func (s *DeletePropertyService) Execute(ctx context.Context, input DeletePropertyInput) error {
+	propertyID := strings.TrimSpace(input.ID)
+	if propertyID == "" {
+		return apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field": "id",
+		})
+	}
+
+	return s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+		_ = recorder
+
+		current, err := s.propertyRepo.FindByID(ctx, tx, propertyID)
+		if err != nil {
+			switch {
+			case errors.Is(err, dbproperties.ErrNotFound):
+				return apperr.ErrPropertyNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		aggregate, err := domainproperty.Rehydrate(domainproperty.State{
+			ID:                               current.ID,
+			Name:                             current.Name,
+			Address:                          current.Address,
+			ElectricityUnitPrice:             current.ElectricityUnitPrice,
+			DefaultElectricityBillingCadence: current.DefaultElectricityBillingCadence,
+			OwnerID:                          current.OwnerID,
+			Version:                          current.Version,
+		})
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		occupiedRoomIDs, err := s.propertyRepo.ListOccupiedRoomIDs(ctx, tx, propertyID)
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+		if err := aggregate.EnsureDeletable(occupiedRoomIDs); err != nil {
+			return mapDomainError(err)
+		}
+
+		if err := s.propertyRepo.SoftDelete(ctx, tx, propertyID, current.Version); err != nil {
+			switch {
+			case errors.Is(err, dbproperties.ErrNotFound):
+				return apperr.ErrPropertyNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		return nil
+	})
+}

--- a/internal/application/property/delete_property.go
+++ b/internal/application/property/delete_property.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	domainproperty "stds_backend/internal/domain/property"
-	dbproperties "stds_backend/internal/platform/database/properties"
 	"stds_backend/internal/platform/database/txrunner"
 	"stds_backend/internal/shared/apperr"
 )
@@ -40,13 +39,11 @@ func (s *DeletePropertyService) Execute(ctx context.Context, input DeletePropert
 		})
 	}
 
-	return s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
-		_ = recorder
-
+	return s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
 		current, err := s.propertyRepo.FindByID(ctx, tx, propertyID)
 		if err != nil {
 			switch {
-			case errors.Is(err, dbproperties.ErrNotFound):
+			case errors.Is(err, ErrPropertyNotFound):
 				return apperr.ErrPropertyNotFound
 			default:
 				return apperr.ErrInternalServerError.WithCause(err)
@@ -76,7 +73,7 @@ func (s *DeletePropertyService) Execute(ctx context.Context, input DeletePropert
 
 		if err := s.propertyRepo.SoftDelete(ctx, tx, propertyID, current.Version); err != nil {
 			switch {
-			case errors.Is(err, dbproperties.ErrNotFound):
+			case errors.Is(err, ErrPropertyNotFound):
 				return apperr.ErrPropertyNotFound
 			default:
 				return apperr.ErrInternalServerError.WithCause(err)

--- a/internal/application/property/errors.go
+++ b/internal/application/property/errors.go
@@ -1,0 +1,64 @@
+package property
+
+import (
+	"errors"
+	"net/http"
+
+	domainproperty "stds_backend/internal/domain/property"
+	"stds_backend/internal/shared/apperr"
+)
+
+const (
+	codeForbiddenElectricityPriceUpdate = "FORBIDDEN_ELECTRICITY_PRICE_UPDATE"
+	codeElectricityPriceMustBePositive  = "ELECTRICITY_PRICE_MUST_BE_POSITIVE"
+	codePropertyHasOccupiedRooms        = "PROPERTY_HAS_OCCUPIED_ROOMS"
+)
+
+var (
+	errForbiddenElectricityPriceUpdate = apperr.New(
+		codeForbiddenElectricityPriceUpdate,
+		http.StatusForbidden,
+		"Updating electricity price requires admin or organizer role.",
+	)
+	errElectricityPriceMustBePositive = apperr.New(
+		codeElectricityPriceMustBePositive,
+		http.StatusUnprocessableEntity,
+		"Electricity price must be positive.",
+	)
+	errPropertyHasOccupiedRooms = apperr.New(
+		codePropertyHasOccupiedRooms,
+		http.StatusUnprocessableEntity,
+		"Property has occupied rooms.",
+	)
+)
+
+func mapDomainError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, domainproperty.ErrNameRequired):
+		return apperr.ErrValidationNameRequired
+	case errors.Is(err, domainproperty.ErrAddressRequired):
+		return apperr.ErrValidationAddressRequired
+	case errors.Is(err, domainproperty.ErrOwnerIDRequired):
+		return apperr.ErrValidationOwnerIDRequired
+	case errors.Is(err, domainproperty.ErrInvalidBillingCadence):
+		return apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field": "default_electricity_billing_cadence",
+		})
+	case errors.Is(err, domainproperty.ErrForbiddenElectricityPriceUpdate):
+		return errForbiddenElectricityPriceUpdate
+	case errors.Is(err, domainproperty.ErrElectricityPriceMustBePositive):
+		return errElectricityPriceMustBePositive
+	default:
+		var occupiedErr *domainproperty.OccupiedRoomsError
+		if errors.As(err, &occupiedErr) {
+			return errPropertyHasOccupiedRooms.WithDetails(map[string]interface{}{
+				"occupied_room_ids": occupiedErr.OccupiedRoomIDs,
+			})
+		}
+		return err
+	}
+}

--- a/internal/application/property/property_service_test.go
+++ b/internal/application/property/property_service_test.go
@@ -11,7 +11,6 @@ import (
 
 	domainevents "stds_backend/internal/domain/events"
 	domainproperty "stds_backend/internal/domain/property"
-	dbproperties "stds_backend/internal/platform/database/properties"
 	dbtxrunner "stds_backend/internal/platform/database/txrunner"
 	"stds_backend/internal/shared/apperr"
 )
@@ -74,12 +73,13 @@ func TestCreatePropertyServicePublishesPropertyCreatedAfterCommit(t *testing.T) 
 	mock.ExpectCommit()
 
 	publisher := &recordingPublisher{}
+	electricityUnitPrice := 4.5
 	service := NewCreatePropertyService(propertyRepoStub{
 		created: &Property{
 			ID:                               "property-1",
 			Name:                             "Property A",
 			Address:                          "Address A",
-			ElectricityUnitPrice:             4.5,
+			ElectricityUnitPrice:             &electricityUnitPrice,
 			DefaultElectricityBillingCadence: domainproperty.BillingCadenceMonthly,
 			OwnerID:                          "owner-1",
 			CreatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
@@ -120,12 +120,13 @@ func TestUpdatePropertyServiceRejectsStaffElectricityPriceMutation(t *testing.T)
 	mock.ExpectBegin()
 	mock.ExpectRollback()
 
+	electricityUnitPrice := 4.0
 	service := NewUpdatePropertyService(propertyRepoStub{
 		current: &Property{
 			ID:                               "property-1",
 			Name:                             "Property A",
 			Address:                          "Address A",
-			ElectricityUnitPrice:             4.0,
+			ElectricityUnitPrice:             &electricityUnitPrice,
 			DefaultElectricityBillingCadence: domainproperty.BillingCadenceMonthly,
 			OwnerID:                          "owner-1",
 			Version:                          1,
@@ -162,12 +163,13 @@ func TestDeletePropertyServiceReturnsOccupiedRoomDetails(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectRollback()
 
+	electricityUnitPrice := 4.0
 	service := NewDeletePropertyService(propertyRepoStub{
 		current: &Property{
 			ID:                               "property-1",
 			Name:                             "Property A",
 			Address:                          "Address A",
-			ElectricityUnitPrice:             4.0,
+			ElectricityUnitPrice:             &electricityUnitPrice,
 			DefaultElectricityBillingCadence: domainproperty.BillingCadenceMonthly,
 			OwnerID:                          "owner-1",
 			Version:                          1,
@@ -209,7 +211,7 @@ func TestDeletePropertyServiceMapsNotFound(t *testing.T) {
 	mock.ExpectRollback()
 
 	service := NewDeletePropertyService(propertyRepoStub{
-		findErr: dbproperties.ErrNotFound,
+		findErr: ErrPropertyNotFound,
 	}, dbtxrunner.New(db, nil))
 
 	err = service.Execute(context.Background(), DeletePropertyInput{ID: "missing"})

--- a/internal/application/property/property_service_test.go
+++ b/internal/application/property/property_service_test.go
@@ -1,0 +1,223 @@
+package property
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	domainevents "stds_backend/internal/domain/events"
+	domainproperty "stds_backend/internal/domain/property"
+	dbproperties "stds_backend/internal/platform/database/properties"
+	dbtxrunner "stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+type recordingPublisher struct {
+	events []any
+}
+
+func (p *recordingPublisher) Publish(_ context.Context, event any) error {
+	p.events = append(p.events, event)
+	return nil
+}
+
+type propertyRepoStub struct {
+	created         *Property
+	current         *Property
+	updated         *Property
+	occupiedRoomIDs []string
+	createErr       error
+	findErr         error
+	updateErr       error
+	listOccupiedErr error
+	deleteErr       error
+}
+
+func (s propertyRepoStub) Create(context.Context, *sql.Tx, CreatePropertyParams) (*Property, error) {
+	return s.created, s.createErr
+}
+
+func (s propertyRepoStub) FindByID(context.Context, *sql.Tx, string) (*Property, error) {
+	if s.findErr != nil {
+		return nil, s.findErr
+	}
+	return s.current, nil
+}
+
+func (s propertyRepoStub) Update(context.Context, *sql.Tx, UpdatePropertyParams) (*Property, error) {
+	if s.updateErr != nil {
+		return nil, s.updateErr
+	}
+	return s.updated, nil
+}
+
+func (s propertyRepoStub) ListOccupiedRoomIDs(context.Context, *sql.Tx, string) ([]string, error) {
+	return s.occupiedRoomIDs, s.listOccupiedErr
+}
+
+func (s propertyRepoStub) SoftDelete(context.Context, *sql.Tx, string, int) error {
+	return s.deleteErr
+}
+
+func TestCreatePropertyServicePublishesPropertyCreatedAfterCommit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	publisher := &recordingPublisher{}
+	service := NewCreatePropertyService(propertyRepoStub{
+		created: &Property{
+			ID:                               "property-1",
+			Name:                             "Property A",
+			Address:                          "Address A",
+			ElectricityUnitPrice:             4.5,
+			DefaultElectricityBillingCadence: domainproperty.BillingCadenceMonthly,
+			OwnerID:                          "owner-1",
+			CreatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+			UpdatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+			Version:                          1,
+		},
+	}, dbtxrunner.New(db, publisher))
+
+	if _, err := service.Execute(context.Background(), CreatePropertyInput{
+		Name:                             "Property A",
+		Address:                          "Address A",
+		ElectricityUnitPrice:             4.5,
+		DefaultElectricityBillingCadence: domainproperty.BillingCadenceMonthly,
+		OwnerID:                          "owner-1",
+	}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if len(publisher.events) != 1 {
+		t.Fatalf("expected 1 published event, got %d", len(publisher.events))
+	}
+	if _, ok := publisher.events[0].(domainevents.PropertyCreated); !ok {
+		t.Fatalf("expected PropertyCreated event, got %T", publisher.events[0])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdatePropertyServiceRejectsStaffElectricityPriceMutation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	service := NewUpdatePropertyService(propertyRepoStub{
+		current: &Property{
+			ID:                               "property-1",
+			Name:                             "Property A",
+			Address:                          "Address A",
+			ElectricityUnitPrice:             4.0,
+			DefaultElectricityBillingCadence: domainproperty.BillingCadenceMonthly,
+			OwnerID:                          "owner-1",
+			Version:                          1,
+		},
+	}, dbtxrunner.New(db, nil))
+
+	price := 5.0
+	_, err = service.Execute(context.Background(), UpdatePropertyInput{
+		ID:                   "property-1",
+		ActorRole:            "staff",
+		ElectricityUnitPrice: &price,
+	})
+
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected app error, got %v", err)
+	}
+	if appErr.Code != codeForbiddenElectricityPriceUpdate {
+		t.Fatalf("expected %s, got %s", codeForbiddenElectricityPriceUpdate, appErr.Code)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestDeletePropertyServiceReturnsOccupiedRoomDetails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	service := NewDeletePropertyService(propertyRepoStub{
+		current: &Property{
+			ID:                               "property-1",
+			Name:                             "Property A",
+			Address:                          "Address A",
+			ElectricityUnitPrice:             4.0,
+			DefaultElectricityBillingCadence: domainproperty.BillingCadenceMonthly,
+			OwnerID:                          "owner-1",
+			Version:                          1,
+		},
+		occupiedRoomIDs: []string{"room-1", "room-2"},
+	}, dbtxrunner.New(db, nil))
+
+	err = service.Execute(context.Background(), DeletePropertyInput{ID: "property-1"})
+
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected app error, got %v", err)
+	}
+	if appErr.Code != codePropertyHasOccupiedRooms {
+		t.Fatalf("expected %s, got %s", codePropertyHasOccupiedRooms, appErr.Code)
+	}
+
+	details, ok := appErr.Details.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected details map, got %T", appErr.Details)
+	}
+	if got := details["occupied_room_ids"]; got == nil {
+		t.Fatalf("expected occupied_room_ids detail, got %#v", details)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestDeletePropertyServiceMapsNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	service := NewDeletePropertyService(propertyRepoStub{
+		findErr: dbproperties.ErrNotFound,
+	}, dbtxrunner.New(db, nil))
+
+	err = service.Execute(context.Background(), DeletePropertyInput{ID: "missing"})
+	if !errors.Is(err, apperr.ErrPropertyNotFound) {
+		t.Fatalf("expected ErrPropertyNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}

--- a/internal/application/property/repository.go
+++ b/internal/application/property/repository.go
@@ -11,7 +11,7 @@ type Property struct {
 	ID                               string
 	Name                             string
 	Address                          string
-	ElectricityUnitPrice             *float64
+	ElectricityUnitPrice             float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
 	CreatedAt                        time.Time
@@ -29,7 +29,23 @@ type CreatePropertyParams struct {
 	OwnerID                          string
 }
 
+// UpdatePropertyParams contains the writable fields required to persist a
+// property update.
+type UpdatePropertyParams struct {
+	ID                               string
+	Name                             string
+	Address                          string
+	ElectricityUnitPrice             float64
+	DefaultElectricityBillingCadence string
+	OwnerID                          string
+	Version                          int
+}
+
 // Repository defines persistence needed by property application services.
 type Repository interface {
 	Create(ctx context.Context, tx *sql.Tx, params CreatePropertyParams) (*Property, error)
+	FindByID(ctx context.Context, tx *sql.Tx, id string) (*Property, error)
+	Update(ctx context.Context, tx *sql.Tx, params UpdatePropertyParams) (*Property, error)
+	ListOccupiedRoomIDs(ctx context.Context, tx *sql.Tx, propertyID string) ([]string, error)
+	SoftDelete(ctx context.Context, tx *sql.Tx, id string, version int) error
 }

--- a/internal/application/property/repository.go
+++ b/internal/application/property/repository.go
@@ -3,15 +3,19 @@ package property
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"time"
 )
+
+// ErrPropertyNotFound indicates that no active property matched the requested lookup.
+var ErrPropertyNotFound = errors.New("property not found")
 
 // Property is the application-facing property shape for property use cases.
 type Property struct {
 	ID                               string
 	Name                             string
 	Address                          string
-	ElectricityUnitPrice             float64
+	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
 	CreatedAt                        time.Time
@@ -35,7 +39,7 @@ type UpdatePropertyParams struct {
 	ID                               string
 	Name                             string
 	Address                          string
-	ElectricityUnitPrice             float64
+	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
 	Version                          int

--- a/internal/application/property/update_property.go
+++ b/internal/application/property/update_property.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	domainproperty "stds_backend/internal/domain/property"
-	dbproperties "stds_backend/internal/platform/database/properties"
 	"stds_backend/internal/platform/database/txrunner"
 	"stds_backend/internal/shared/apperr"
 )
@@ -53,13 +52,11 @@ func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropert
 	}
 
 	var updated *Property
-	err := s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
-		_ = recorder
-
+	err := s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
 		current, err := s.propertyRepo.FindByID(ctx, tx, propertyID)
 		if err != nil {
 			switch {
-			case errors.Is(err, dbproperties.ErrNotFound):
+			case errors.Is(err, ErrPropertyNotFound):
 				return apperr.ErrPropertyNotFound
 			default:
 				return apperr.ErrInternalServerError.WithCause(err)
@@ -101,7 +98,7 @@ func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropert
 		})
 		if err != nil {
 			switch {
-			case errors.Is(err, dbproperties.ErrNotFound):
+			case errors.Is(err, ErrPropertyNotFound):
 				return apperr.ErrPropertyNotFound
 			default:
 				return apperr.ErrInternalServerError.WithCause(err)

--- a/internal/application/property/update_property.go
+++ b/internal/application/property/update_property.go
@@ -1,0 +1,119 @@
+package property
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	domainproperty "stds_backend/internal/domain/property"
+	dbproperties "stds_backend/internal/platform/database/properties"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// UpdatePropertyInput is the command payload for updating a property.
+type UpdatePropertyInput struct {
+	ID                               string
+	ActorRole                        string
+	Name                             *string
+	Address                          *string
+	ElectricityUnitPrice             *float64
+	DefaultElectricityBillingCadence *string
+}
+
+// UpdatePropertyService updates property fields while enforcing mutation rules.
+type UpdatePropertyService struct {
+	propertyRepo Repository
+	txRunner     *txrunner.Runner
+}
+
+// NewUpdatePropertyService returns an UpdatePropertyService.
+func NewUpdatePropertyService(propertyRepo Repository, txRunner *txrunner.Runner) *UpdatePropertyService {
+	return &UpdatePropertyService{
+		propertyRepo: propertyRepo,
+		txRunner:     txRunner,
+	}
+}
+
+// Execute validates the update payload, applies aggregate rules, and persists
+// the resulting state.
+func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropertyInput) (*Property, error) {
+	propertyID := strings.TrimSpace(input.ID)
+	if propertyID == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field": "id",
+		})
+	}
+	if strings.TrimSpace(input.ActorRole) == "" {
+		return nil, apperr.ErrUnauthorized
+	}
+	if input.Name == nil && input.Address == nil && input.ElectricityUnitPrice == nil && input.DefaultElectricityBillingCadence == nil {
+		return nil, apperr.ErrBadRequest
+	}
+
+	var updated *Property
+	err := s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+		_ = recorder
+
+		current, err := s.propertyRepo.FindByID(ctx, tx, propertyID)
+		if err != nil {
+			switch {
+			case errors.Is(err, dbproperties.ErrNotFound):
+				return apperr.ErrPropertyNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		aggregate, err := domainproperty.Rehydrate(domainproperty.State{
+			ID:                               current.ID,
+			Name:                             current.Name,
+			Address:                          current.Address,
+			ElectricityUnitPrice:             current.ElectricityUnitPrice,
+			DefaultElectricityBillingCadence: current.DefaultElectricityBillingCadence,
+			OwnerID:                          current.OwnerID,
+			Version:                          current.Version,
+		})
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		if err := aggregate.Update(domainproperty.UpdateInput{
+			ActorRole:                        input.ActorRole,
+			Name:                             input.Name,
+			Address:                          input.Address,
+			ElectricityUnitPrice:             input.ElectricityUnitPrice,
+			DefaultElectricityBillingCadence: input.DefaultElectricityBillingCadence,
+		}); err != nil {
+			return mapDomainError(err)
+		}
+
+		state := aggregate.State()
+		property, err := s.propertyRepo.Update(ctx, tx, UpdatePropertyParams{
+			ID:                               state.ID,
+			Name:                             state.Name,
+			Address:                          state.Address,
+			ElectricityUnitPrice:             state.ElectricityUnitPrice,
+			DefaultElectricityBillingCadence: state.DefaultElectricityBillingCadence,
+			OwnerID:                          state.OwnerID,
+			Version:                          state.Version,
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, dbproperties.ErrNotFound):
+				return apperr.ErrPropertyNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		updated = property
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return updated, nil
+}

--- a/internal/architecture/layering_test.go
+++ b/internal/architecture/layering_test.go
@@ -1,0 +1,54 @@
+package architecture
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestApplicationDoesNotImportDatabaseAdapters(t *testing.T) {
+	const (
+		rootDir         = ".."
+		applicationDir  = "../application"
+		forbiddenImport = "\"stds_backend/internal/platform/database/"
+		allowedImport   = "\"stds_backend/internal/platform/database/txrunner\""
+	)
+
+	fset := token.NewFileSet()
+	err := filepath.Walk(applicationDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		file, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+		for _, imported := range file.Imports {
+			if imported.Path.Value == allowedImport {
+				continue
+			}
+			if strings.HasPrefix(imported.Path.Value, forbiddenImport) {
+				relativePath, relErr := filepath.Rel(rootDir, path)
+				if relErr != nil {
+					relativePath = path
+				}
+				t.Errorf("%s imports forbidden database adapter package %s", relativePath, imported.Path.Value)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+}

--- a/internal/domain/property/aggregate.go
+++ b/internal/domain/property/aggregate.go
@@ -1,0 +1,163 @@
+package property
+
+import "strings"
+
+const (
+	BillingCadenceMonthly   = "monthly"
+	BillingCadenceBimonthly = "bimonthly"
+)
+
+// State is the persisted property aggregate state.
+type State struct {
+	ID                               string
+	Name                             string
+	Address                          string
+	ElectricityUnitPrice             float64
+	DefaultElectricityBillingCadence string
+	OwnerID                          string
+	Version                          int
+}
+
+// UpdateInput is the aggregate patch for property mutations.
+type UpdateInput struct {
+	ActorRole                        string
+	Name                             *string
+	Address                          *string
+	ElectricityUnitPrice             *float64
+	DefaultElectricityBillingCadence *string
+}
+
+// Aggregate owns property command business rules.
+type Aggregate struct {
+	state State
+}
+
+// New creates a property aggregate for create commands.
+func New(state State) (*Aggregate, error) {
+	normalized, err := normalizeState(state)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Aggregate{state: normalized}, nil
+}
+
+// Rehydrate reconstructs an existing aggregate from persisted state.
+func Rehydrate(state State) (*Aggregate, error) {
+	normalized, err := normalizeState(state)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Aggregate{state: normalized}, nil
+}
+
+// Update applies command-side mutation rules to the aggregate.
+func (a *Aggregate) Update(input UpdateInput) error {
+	if a == nil {
+		return nil
+	}
+
+	if input.Name != nil {
+		name := strings.TrimSpace(*input.Name)
+		if name == "" {
+			return ErrNameRequired
+		}
+		a.state.Name = name
+	}
+
+	if input.Address != nil {
+		address := strings.TrimSpace(*input.Address)
+		if address == "" {
+			return ErrAddressRequired
+		}
+		a.state.Address = address
+	}
+
+	if input.ElectricityUnitPrice != nil {
+		if strings.TrimSpace(input.ActorRole) == "staff" {
+			return ErrForbiddenElectricityPriceUpdate
+		}
+		if *input.ElectricityUnitPrice <= 0 {
+			return ErrElectricityPriceMustBePositive
+		}
+		a.state.ElectricityUnitPrice = *input.ElectricityUnitPrice
+	}
+
+	if input.DefaultElectricityBillingCadence != nil {
+		cadence := strings.TrimSpace(*input.DefaultElectricityBillingCadence)
+		if !isValidBillingCadence(cadence) {
+			return ErrInvalidBillingCadence
+		}
+		a.state.DefaultElectricityBillingCadence = cadence
+	}
+
+	return nil
+}
+
+// EnsureDeletable enforces delete-time invariants.
+func (a *Aggregate) EnsureDeletable(occupiedRoomIDs []string) error {
+	if len(occupiedRoomIDs) == 0 {
+		return nil
+	}
+
+	ids := make([]string, 0, len(occupiedRoomIDs))
+	for _, roomID := range occupiedRoomIDs {
+		roomID = strings.TrimSpace(roomID)
+		if roomID == "" {
+			continue
+		}
+		ids = append(ids, roomID)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+
+	return &OccupiedRoomsError{OccupiedRoomIDs: ids}
+}
+
+// State returns the aggregate snapshot for persistence.
+func (a *Aggregate) State() State {
+	if a == nil {
+		return State{}
+	}
+
+	return a.state
+}
+
+func normalizeState(state State) (State, error) {
+	state.Name = strings.TrimSpace(state.Name)
+	if state.Name == "" {
+		return State{}, ErrNameRequired
+	}
+
+	state.Address = strings.TrimSpace(state.Address)
+	if state.Address == "" {
+		return State{}, ErrAddressRequired
+	}
+
+	if state.ElectricityUnitPrice <= 0 {
+		return State{}, ErrElectricityPriceMustBePositive
+	}
+
+	state.DefaultElectricityBillingCadence = strings.TrimSpace(state.DefaultElectricityBillingCadence)
+	if !isValidBillingCadence(state.DefaultElectricityBillingCadence) {
+		return State{}, ErrInvalidBillingCadence
+	}
+
+	state.OwnerID = strings.TrimSpace(state.OwnerID)
+	if state.OwnerID == "" {
+		return State{}, ErrOwnerIDRequired
+	}
+
+	return state, nil
+}
+
+func isValidBillingCadence(cadence string) bool {
+	switch cadence {
+	case BillingCadenceMonthly, BillingCadenceBimonthly:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/property/aggregate.go
+++ b/internal/domain/property/aggregate.go
@@ -12,7 +12,7 @@ type State struct {
 	ID                               string
 	Name                             string
 	Address                          string
-	ElectricityUnitPrice             float64
+	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
 	Version                          int
@@ -34,7 +34,7 @@ type Aggregate struct {
 
 // New creates a property aggregate for create commands.
 func New(state State) (*Aggregate, error) {
-	normalized, err := normalizeState(state)
+	normalized, err := normalizeState(state, true)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func New(state State) (*Aggregate, error) {
 
 // Rehydrate reconstructs an existing aggregate from persisted state.
 func Rehydrate(state State) (*Aggregate, error) {
-	normalized, err := normalizeState(state)
+	normalized, err := normalizeState(state, false)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,8 @@ func (a *Aggregate) Update(input UpdateInput) error {
 		if *input.ElectricityUnitPrice <= 0 {
 			return ErrElectricityPriceMustBePositive
 		}
-		a.state.ElectricityUnitPrice = *input.ElectricityUnitPrice
+		price := *input.ElectricityUnitPrice
+		a.state.ElectricityUnitPrice = &price
 	}
 
 	if input.DefaultElectricityBillingCadence != nil {
@@ -125,7 +126,7 @@ func (a *Aggregate) State() State {
 	return a.state
 }
 
-func normalizeState(state State) (State, error) {
+func normalizeState(state State, requireElectricityPrice bool) (State, error) {
 	state.Name = strings.TrimSpace(state.Name)
 	if state.Name == "" {
 		return State{}, ErrNameRequired
@@ -136,7 +137,11 @@ func normalizeState(state State) (State, error) {
 		return State{}, ErrAddressRequired
 	}
 
-	if state.ElectricityUnitPrice <= 0 {
+	if state.ElectricityUnitPrice == nil {
+		if requireElectricityPrice {
+			return State{}, ErrElectricityPriceMustBePositive
+		}
+	} else if *state.ElectricityUnitPrice <= 0 {
 		return State{}, ErrElectricityPriceMustBePositive
 	}
 

--- a/internal/domain/property/aggregate_test.go
+++ b/internal/domain/property/aggregate_test.go
@@ -6,10 +6,11 @@ import (
 )
 
 func TestNewNormalizesState(t *testing.T) {
+	electricityUnitPrice := 4.5
 	aggregate, err := New(State{
 		Name:                             " Property A ",
 		Address:                          " Address A ",
-		ElectricityUnitPrice:             4.5,
+		ElectricityUnitPrice:             &electricityUnitPrice,
 		DefaultElectricityBillingCadence: " monthly ",
 		OwnerID:                          " owner-1 ",
 	})
@@ -33,11 +34,12 @@ func TestNewNormalizesState(t *testing.T) {
 }
 
 func TestUpdateRejectsStaffElectricityPriceMutation(t *testing.T) {
+	electricityUnitPrice := 4.0
 	aggregate, err := Rehydrate(State{
 		ID:                               "property-1",
 		Name:                             "Property A",
 		Address:                          "Address A",
-		ElectricityUnitPrice:             4.0,
+		ElectricityUnitPrice:             &electricityUnitPrice,
 		DefaultElectricityBillingCadence: BillingCadenceMonthly,
 		OwnerID:                          "owner-1",
 		Version:                          1,
@@ -57,11 +59,12 @@ func TestUpdateRejectsStaffElectricityPriceMutation(t *testing.T) {
 }
 
 func TestEnsureDeletableReturnsOccupiedRooms(t *testing.T) {
+	electricityUnitPrice := 4.0
 	aggregate, err := Rehydrate(State{
 		ID:                               "property-1",
 		Name:                             "Property A",
 		Address:                          "Address A",
-		ElectricityUnitPrice:             4.0,
+		ElectricityUnitPrice:             &electricityUnitPrice,
 		DefaultElectricityBillingCadence: BillingCadenceMonthly,
 		OwnerID:                          "owner-1",
 		Version:                          1,

--- a/internal/domain/property/aggregate_test.go
+++ b/internal/domain/property/aggregate_test.go
@@ -1,0 +1,81 @@
+package property
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewNormalizesState(t *testing.T) {
+	aggregate, err := New(State{
+		Name:                             " Property A ",
+		Address:                          " Address A ",
+		ElectricityUnitPrice:             4.5,
+		DefaultElectricityBillingCadence: " monthly ",
+		OwnerID:                          " owner-1 ",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	state := aggregate.State()
+	if state.Name != "Property A" {
+		t.Fatalf("expected trimmed name, got %q", state.Name)
+	}
+	if state.Address != "Address A" {
+		t.Fatalf("expected trimmed address, got %q", state.Address)
+	}
+	if state.DefaultElectricityBillingCadence != BillingCadenceMonthly {
+		t.Fatalf("expected monthly cadence, got %q", state.DefaultElectricityBillingCadence)
+	}
+	if state.OwnerID != "owner-1" {
+		t.Fatalf("expected trimmed owner id, got %q", state.OwnerID)
+	}
+}
+
+func TestUpdateRejectsStaffElectricityPriceMutation(t *testing.T) {
+	aggregate, err := Rehydrate(State{
+		ID:                               "property-1",
+		Name:                             "Property A",
+		Address:                          "Address A",
+		ElectricityUnitPrice:             4.0,
+		DefaultElectricityBillingCadence: BillingCadenceMonthly,
+		OwnerID:                          "owner-1",
+		Version:                          1,
+	})
+	if err != nil {
+		t.Fatalf("Rehydrate: %v", err)
+	}
+
+	price := 5.0
+	err = aggregate.Update(UpdateInput{
+		ActorRole:            "staff",
+		ElectricityUnitPrice: &price,
+	})
+	if !errors.Is(err, ErrForbiddenElectricityPriceUpdate) {
+		t.Fatalf("expected ErrForbiddenElectricityPriceUpdate, got %v", err)
+	}
+}
+
+func TestEnsureDeletableReturnsOccupiedRooms(t *testing.T) {
+	aggregate, err := Rehydrate(State{
+		ID:                               "property-1",
+		Name:                             "Property A",
+		Address:                          "Address A",
+		ElectricityUnitPrice:             4.0,
+		DefaultElectricityBillingCadence: BillingCadenceMonthly,
+		OwnerID:                          "owner-1",
+		Version:                          1,
+	})
+	if err != nil {
+		t.Fatalf("Rehydrate: %v", err)
+	}
+
+	err = aggregate.EnsureDeletable([]string{" room-1 ", "", "room-2"})
+	var occupiedErr *OccupiedRoomsError
+	if !errors.As(err, &occupiedErr) {
+		t.Fatalf("expected OccupiedRoomsError, got %v", err)
+	}
+	if len(occupiedErr.OccupiedRoomIDs) != 2 {
+		t.Fatalf("expected 2 occupied room ids, got %v", occupiedErr.OccupiedRoomIDs)
+	}
+}

--- a/internal/domain/property/errors.go
+++ b/internal/domain/property/errors.go
@@ -1,0 +1,23 @@
+package property
+
+import "errors"
+
+var (
+	ErrNameRequired                    = errors.New("property name is required")
+	ErrAddressRequired                 = errors.New("property address is required")
+	ErrOwnerIDRequired                 = errors.New("property owner id is required")
+	ErrElectricityPriceMustBePositive  = errors.New("property electricity price must be positive")
+	ErrInvalidBillingCadence           = errors.New("property billing cadence is invalid")
+	ErrForbiddenElectricityPriceUpdate = errors.New("property electricity price update is forbidden")
+)
+
+// OccupiedRoomsError indicates that a property cannot be deleted because one or
+// more rooms are still occupied.
+type OccupiedRoomsError struct {
+	OccupiedRoomIDs []string
+}
+
+// Error implements the error interface.
+func (e *OccupiedRoomsError) Error() string {
+	return "property has occupied rooms"
+}

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -979,12 +979,11 @@ func toRoomResponse(room *dbpropertyquery.Room) api.RoomResponse {
 }
 
 func toCreatedPropertyResponse(property *appproperty.Property) api.PropertyResponse {
-	electricityUnitPrice := property.ElectricityUnitPrice
 	queryShape := &dbpropertyquery.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
 		Address:                          property.Address,
-		ElectricityUnitPrice:             &electricityUnitPrice,
+		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
 		CreatedAt:                        property.CreatedAt,

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -35,6 +35,8 @@ type APIServer struct {
 	jobTriggerService *appjobs.TriggerService
 	propertyQueryRepo dbpropertyquery.Repository
 	createPropertySvc *appproperty.CreatePropertyService
+	updatePropertySvc *appproperty.UpdatePropertyService
+	deletePropertySvc *appproperty.DeletePropertyService
 }
 
 // NewAPIServer returns an API server with only the currently implemented
@@ -50,6 +52,8 @@ func NewAPIServer(
 	jobTriggerService *appjobs.TriggerService,
 	propertyQueryRepo dbpropertyquery.Repository,
 	createPropertySvc *appproperty.CreatePropertyService,
+	updatePropertySvc *appproperty.UpdatePropertyService,
+	deletePropertySvc *appproperty.DeletePropertyService,
 ) *APIServer {
 	return &APIServer{
 		userRepo:          userRepo,
@@ -62,6 +66,8 @@ func NewAPIServer(
 		jobTriggerService: jobTriggerService,
 		propertyQueryRepo: propertyQueryRepo,
 		createPropertySvc: createPropertySvc,
+		updatePropertySvc: updatePropertySvc,
+		deletePropertySvc: deletePropertySvc,
 	}
 }
 
@@ -272,7 +278,16 @@ func (s *APIServer) CreatePropertyAttachment(c *gin.Context, id openapi_types.UU
 }
 
 // DeleteProperty handles property deletion.
-func (s *APIServer) DeleteProperty(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) DeleteProperty(c *gin.Context, id string) {
+	if err := s.deletePropertySvc.Execute(c.Request.Context(), appproperty.DeletePropertyInput{
+		ID: id,
+	}); err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
 
 // GetProperty handles property detail retrieval.
 func (s *APIServer) GetProperty(c *gin.Context, id string) {
@@ -291,7 +306,40 @@ func (s *APIServer) GetProperty(c *gin.Context, id string) {
 }
 
 // UpdateProperty handles property updates.
-func (s *APIServer) UpdateProperty(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) UpdateProperty(c *gin.Context, id string) {
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	var request api.UpdatePropertyRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	var cadence *string
+	if request.DefaultElectricityBillingCadence != nil {
+		value := string(*request.DefaultElectricityBillingCadence)
+		cadence = &value
+	}
+
+	property, err := s.updatePropertySvc.Execute(c.Request.Context(), appproperty.UpdatePropertyInput{
+		ID:                               id,
+		ActorRole:                        principal.Role,
+		Name:                             request.Name,
+		Address:                          request.Address,
+		ElectricityUnitPrice:             request.ElectricityUnitPrice,
+		DefaultElectricityBillingCadence: cadence,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toCreatedPropertyResponse(property))
+}
 
 // GetPropertyDashboard handles property dashboard retrieval.
 func (s *APIServer) GetPropertyDashboard(c *gin.Context, id string) { writeNotImplemented(c) }
@@ -931,11 +979,12 @@ func toRoomResponse(room *dbpropertyquery.Room) api.RoomResponse {
 }
 
 func toCreatedPropertyResponse(property *appproperty.Property) api.PropertyResponse {
+	electricityUnitPrice := property.ElectricityUnitPrice
 	queryShape := &dbpropertyquery.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
 		Address:                          property.Address,
-		ElectricityUnitPrice:             property.ElectricityUnitPrice,
+		ElectricityUnitPrice:             &electricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
 		CreatedAt:                        property.CreatedAt,

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -54,6 +54,8 @@ func New(
 	jobTriggerService *appjobs.TriggerService,
 	propertyQueryRepo dbpropertyquery.Repository,
 	createPropertyService *appproperty.CreatePropertyService,
+	updatePropertyService *appproperty.UpdatePropertyService,
+	deletePropertyService *appproperty.DeletePropertyService,
 ) *gin.Engine {
 	engine := gin.New()
 	engine.Use(
@@ -70,7 +72,7 @@ func New(
 	engine.GET("/openapi.yaml", docsHandler.OpenAPI)
 	engine.GET("/scalar", docsHandler.Scalar)
 
-	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, createPropertyService), api.GinServerOptions{
+	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, createPropertyService, updatePropertyService, deletePropertyService), api.GinServerOptions{
 		BaseURL: "/api/v1",
 		Middlewares: []api.MiddlewareFunc{
 			protectedAPIMiddleware(appCfg, authenticator, userRepo, authzRepos),

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -673,7 +673,19 @@ func TestAssignUserPropertiesRejectsOwnerTarget(t *testing.T) {
 func TestTriggerUserPasswordResetReturnsNoContent(t *testing.T) {
 	repo := fakeUserRepo{role: "admin"}
 	notificationSender := &testNotificationSender{}
-	engine := newTestEngineWithNotificationSender(repo, fakeAuthenticator{role: "admin"}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{}, notificationSender, fakePropertyQueryRepo{}, appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)))
+	engine := newTestEngineWithNotificationSender(
+		repo,
+		fakeAuthenticator{role: "admin"},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		notificationSender,
+		fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		appproperty.NewUpdatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		appproperty.NewDeletePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+	)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/users/user-1/password-reset", nil)
 	req.Header.Set("Authorization", "Bearer valid-token")
@@ -835,6 +847,8 @@ func TestCreateUserReturnsNotificationErrorCodeWhenDispatchFails(t *testing.T) {
 		&testNotificationSender{sendErr: errors.New("resend down")},
 		fakePropertyQueryRepo{},
 		appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		appproperty.NewUpdatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		appproperty.NewDeletePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
 	)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(`{
@@ -933,7 +947,18 @@ func TestCreatePropertyAcceptsDecimalElectricityPrice(t *testing.T) {
 
 	repo := fakeUserRepo{}
 	createPropertyService := appproperty.NewCreatePropertyService(testSQLPropertyRepositoryAdapter{repo: dbproperties.NewRepository(db)}, dbtxrunner.New(db, nil))
-	engine := newTestEngineWithCreatePropertyService(repo, fakeAuthenticator{}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{}, createPropertyService)
+	engine := newTestEngineWithCreatePropertyService(
+		repo,
+		fakeAuthenticator{},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		createPropertyService,
+		appproperty.NewUpdatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		appproperty.NewDeletePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+	)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/properties", strings.NewReader(`{
 		"name":"Property A",
@@ -962,6 +987,139 @@ func TestCreatePropertyAcceptsDecimalElectricityPrice(t *testing.T) {
 	}
 	if payload["default_electricity_billing_cadence"] != "monthly" {
 		t.Fatalf("expected default_electricity_billing_cadence monthly, got %v", payload["default_electricity_billing_cadence"])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdatePropertyRejectsStaffElectricityPriceMutation(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	repo := fakeUserRepo{role: "staff", assignedPropertyIDs: []string{testPropertyID1}}
+	updatePropertyService := appproperty.NewUpdatePropertyService(fakePropertyRepo{
+		propertyByID: map[string]*appproperty.Property{
+			testPropertyID1: {
+				ID:                               testPropertyID1,
+				Name:                             "Property A",
+				Address:                          "Address A",
+				ElectricityUnitPrice:             4.0,
+				DefaultElectricityBillingCadence: "monthly",
+				OwnerID:                          "owner-1",
+				Version:                          1,
+			},
+		},
+	}, dbtxrunner.New(db, nil))
+	engine := newTestEngineWithCreatePropertyService(
+		repo,
+		fakeAuthenticator{role: "staff", assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		updatePropertyService,
+		appproperty.NewDeletePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/properties/"+testPropertyID1, strings.NewReader(`{"electricity_unit_price":5}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["error_code"] != "FORBIDDEN_ELECTRICITY_PRICE_UPDATE" {
+		t.Fatalf("expected FORBIDDEN_ELECTRICITY_PRICE_UPDATE, got %v", payload["error_code"])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestDeletePropertyReturnsOccupiedRoomDetails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	repo := fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}}
+	deletePropertyService := appproperty.NewDeletePropertyService(fakePropertyRepo{
+		propertyByID: map[string]*appproperty.Property{
+			testPropertyID1: {
+				ID:                               testPropertyID1,
+				Name:                             "Property A",
+				Address:                          "Address A",
+				ElectricityUnitPrice:             4.0,
+				DefaultElectricityBillingCadence: "monthly",
+				OwnerID:                          "owner-1",
+				Version:                          1,
+			},
+		},
+		occupiedRoomIDs: map[string][]string{
+			testPropertyID1: {"room-1", "room-2"},
+		},
+	}, dbtxrunner.New(db, nil))
+	engine := newTestEngineWithCreatePropertyService(
+		repo,
+		fakeAuthenticator{role: "organizer", assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		appproperty.NewUpdatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		deletePropertyService,
+	)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/properties/"+testPropertyID1, nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["error_code"] != "PROPERTY_HAS_OCCUPIED_ROOMS" {
+		t.Fatalf("expected PROPERTY_HAS_OCCUPIED_ROOMS, got %v", payload["error_code"])
+	}
+
+	details, ok := payload["details"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected details object, got %T", payload["details"])
+	}
+	ids, ok := details["occupied_room_ids"].([]any)
+	if !ok || len(ids) != 2 {
+		t.Fatalf("expected 2 occupied room ids, got %#v", details["occupied_room_ids"])
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -1611,6 +1769,8 @@ type fakeUserRepo struct {
 
 type fakePropertyRepo struct {
 	ownerByPropertyID map[string]string
+	propertyByID      map[string]*appproperty.Property
+	occupiedRoomIDs   map[string][]string
 }
 
 type fakePropertyQueryRepo struct {
@@ -1990,18 +2150,62 @@ func (f fakePropertyRepo) FindOwnerIDByPropertyID(_ context.Context, propertyID 
 }
 
 func (f fakePropertyRepo) Create(_ context.Context, _ *sql.Tx, params appproperty.CreatePropertyParams) (*appproperty.Property, error) {
-	electricityUnitPrice := params.ElectricityUnitPrice
 	return &appproperty.Property{
 		ID:                               "property-new",
 		Name:                             params.Name,
 		Address:                          params.Address,
-		ElectricityUnitPrice:             &electricityUnitPrice,
+		ElectricityUnitPrice:             params.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
 		OwnerID:                          params.OwnerID,
 		CreatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 		UpdatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 		Version:                          1,
 	}, nil
+}
+
+func (f fakePropertyRepo) FindByID(_ context.Context, _ *sql.Tx, id string) (*appproperty.Property, error) {
+	if property, ok := f.propertyByID[id]; ok {
+		return property, nil
+	}
+
+	electricityUnitPrice := 4.5
+	return &appproperty.Property{
+		ID:                               id,
+		Name:                             "Property",
+		Address:                          "Address",
+		ElectricityUnitPrice:             electricityUnitPrice,
+		DefaultElectricityBillingCadence: "monthly",
+		OwnerID:                          "owner-1",
+		CreatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		Version:                          1,
+	}, nil
+}
+
+func (f fakePropertyRepo) Update(_ context.Context, _ *sql.Tx, params appproperty.UpdatePropertyParams) (*appproperty.Property, error) {
+	return &appproperty.Property{
+		ID:                               params.ID,
+		Name:                             params.Name,
+		Address:                          params.Address,
+		ElectricityUnitPrice:             params.ElectricityUnitPrice,
+		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
+		OwnerID:                          params.OwnerID,
+		CreatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:                        time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC),
+		Version:                          params.Version + 1,
+	}, nil
+}
+
+func (f fakePropertyRepo) ListOccupiedRoomIDs(_ context.Context, _ *sql.Tx, propertyID string) ([]string, error) {
+	if ids, ok := f.occupiedRoomIDs[propertyID]; ok {
+		return ids, nil
+	}
+
+	return nil, nil
+}
+
+func (f fakePropertyRepo) SoftDelete(_ context.Context, _ *sql.Tx, _ string, _ int) error {
+	return nil
 }
 
 func (a testSQLPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params appproperty.CreatePropertyParams) (*appproperty.Property, error) {
@@ -2020,13 +2224,67 @@ func (a testSQLPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx
 		ID:                               property.ID,
 		Name:                             property.Name,
 		Address:                          property.Address,
-		ElectricityUnitPrice:             property.ElectricityUnitPrice,
+		ElectricityUnitPrice:             *property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
 		CreatedAt:                        property.CreatedAt,
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,
 	}, nil
+}
+
+func (a testSQLPropertyRepositoryAdapter) FindByID(ctx context.Context, tx *sql.Tx, id string) (*appproperty.Property, error) {
+	property, err := a.repo.FindByID(ctx, tx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &appproperty.Property{
+		ID:                               property.ID,
+		Name:                             property.Name,
+		Address:                          property.Address,
+		ElectricityUnitPrice:             *property.ElectricityUnitPrice,
+		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
+		OwnerID:                          property.OwnerID,
+		CreatedAt:                        property.CreatedAt,
+		UpdatedAt:                        property.UpdatedAt,
+		Version:                          property.Version,
+	}, nil
+}
+
+func (a testSQLPropertyRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx, params appproperty.UpdatePropertyParams) (*appproperty.Property, error) {
+	property, err := a.repo.Update(ctx, tx, dbproperties.UpdatePropertyParams{
+		ID:                               params.ID,
+		Name:                             params.Name,
+		Address:                          params.Address,
+		ElectricityUnitPrice:             params.ElectricityUnitPrice,
+		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
+		OwnerID:                          params.OwnerID,
+		Version:                          params.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &appproperty.Property{
+		ID:                               property.ID,
+		Name:                             property.Name,
+		Address:                          property.Address,
+		ElectricityUnitPrice:             *property.ElectricityUnitPrice,
+		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
+		OwnerID:                          property.OwnerID,
+		CreatedAt:                        property.CreatedAt,
+		UpdatedAt:                        property.UpdatedAt,
+		Version:                          property.Version,
+	}, nil
+}
+
+func (a testSQLPropertyRepositoryAdapter) ListOccupiedRoomIDs(ctx context.Context, tx *sql.Tx, propertyID string) ([]string, error) {
+	return a.repo.ListOccupiedRoomIDs(ctx, tx, propertyID)
+}
+
+func (a testSQLPropertyRepositoryAdapter) SoftDelete(ctx context.Context, tx *sql.Tx, id string, version int) error {
+	return a.repo.SoftDelete(ctx, tx, id, version)
 }
 
 func (f fakePropertyQueryRepo) FindByID(_ context.Context, propertyID string) (*dbpropertyquery.Property, error) {
@@ -2234,10 +2492,12 @@ func newTestEngineWithPropertyQueryRepo(userRepo fakeUserRepo, authenticator fak
 		jobRunsRepo,
 		propertyQueryRepo,
 		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
+		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
+		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
 	)
 }
 
-func newTestEngineWithCreatePropertyService(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, createPropertyService *appproperty.CreatePropertyService) *gin.Engine {
+func newTestEngineWithCreatePropertyService(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, createPropertyService *appproperty.CreatePropertyService, updatePropertyService *appproperty.UpdatePropertyService, deletePropertyService *appproperty.DeletePropertyService) *gin.Engine {
 	return newTestEngineWithNotificationSender(
 		userRepo,
 		authenticator,
@@ -2248,10 +2508,12 @@ func newTestEngineWithCreatePropertyService(userRepo fakeUserRepo, authenticator
 		&testNotificationSender{},
 		propertyQueryRepo,
 		createPropertyService,
+		updatePropertyService,
+		deletePropertyService,
 	)
 }
 
-func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, notificationSender *testNotificationSender, propertyQueryRepo dbpropertyquery.Repository, createPropertyService *appproperty.CreatePropertyService) *gin.Engine {
+func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, notificationSender *testNotificationSender, propertyQueryRepo dbpropertyquery.Repository, createPropertyService *appproperty.CreatePropertyService, updatePropertyService *appproperty.UpdatePropertyService, deletePropertyService *appproperty.DeletePropertyService) *gin.Engine {
 	repo := &userRepo
 	userAccountRepo := testUserAccountRepositoryAdapter{repo: repo}
 	return New(
@@ -2277,6 +2539,8 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		propertyQueryRepo,
 		createPropertyService,
+		updatePropertyService,
+		deletePropertyService,
 	)
 }
 

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -1011,7 +1011,7 @@ func TestUpdatePropertyRejectsStaffElectricityPriceMutation(t *testing.T) {
 				ID:                               testPropertyID1,
 				Name:                             "Property A",
 				Address:                          "Address A",
-				ElectricityUnitPrice:             4.0,
+				ElectricityUnitPrice:             ptrFloat64(4.0),
 				DefaultElectricityBillingCadence: "monthly",
 				OwnerID:                          "owner-1",
 				Version:                          1,
@@ -1072,7 +1072,7 @@ func TestDeletePropertyReturnsOccupiedRoomDetails(t *testing.T) {
 				ID:                               testPropertyID1,
 				Name:                             "Property A",
 				Address:                          "Address A",
-				ElectricityUnitPrice:             4.0,
+				ElectricityUnitPrice:             ptrFloat64(4.0),
 				DefaultElectricityBillingCadence: "monthly",
 				OwnerID:                          "owner-1",
 				Version:                          1,
@@ -2150,11 +2150,12 @@ func (f fakePropertyRepo) FindOwnerIDByPropertyID(_ context.Context, propertyID 
 }
 
 func (f fakePropertyRepo) Create(_ context.Context, _ *sql.Tx, params appproperty.CreatePropertyParams) (*appproperty.Property, error) {
+	electricityUnitPrice := params.ElectricityUnitPrice
 	return &appproperty.Property{
 		ID:                               "property-new",
 		Name:                             params.Name,
 		Address:                          params.Address,
-		ElectricityUnitPrice:             params.ElectricityUnitPrice,
+		ElectricityUnitPrice:             &electricityUnitPrice,
 		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
 		OwnerID:                          params.OwnerID,
 		CreatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
@@ -2173,7 +2174,7 @@ func (f fakePropertyRepo) FindByID(_ context.Context, _ *sql.Tx, id string) (*ap
 		ID:                               id,
 		Name:                             "Property",
 		Address:                          "Address",
-		ElectricityUnitPrice:             electricityUnitPrice,
+		ElectricityUnitPrice:             &electricityUnitPrice,
 		DefaultElectricityBillingCadence: "monthly",
 		OwnerID:                          "owner-1",
 		CreatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
@@ -2224,7 +2225,7 @@ func (a testSQLPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx
 		ID:                               property.ID,
 		Name:                             property.Name,
 		Address:                          property.Address,
-		ElectricityUnitPrice:             *property.ElectricityUnitPrice,
+		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
 		CreatedAt:                        property.CreatedAt,
@@ -2243,7 +2244,7 @@ func (a testSQLPropertyRepositoryAdapter) FindByID(ctx context.Context, tx *sql.
 		ID:                               property.ID,
 		Name:                             property.Name,
 		Address:                          property.Address,
-		ElectricityUnitPrice:             *property.ElectricityUnitPrice,
+		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
 		CreatedAt:                        property.CreatedAt,
@@ -2270,7 +2271,7 @@ func (a testSQLPropertyRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx
 		ID:                               property.ID,
 		Name:                             property.Name,
 		Address:                          property.Address,
-		ElectricityUnitPrice:             *property.ElectricityUnitPrice,
+		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
 		CreatedAt:                        property.CreatedAt,
@@ -2576,4 +2577,8 @@ func firstRoleValue(values ...string) string {
 	}
 
 	return "organizer"
+}
+
+func ptrFloat64(value float64) *float64 {
+	return &value
 }

--- a/internal/platform/database/properties/repository.go
+++ b/internal/platform/database/properties/repository.go
@@ -19,6 +19,10 @@ type Repository interface {
 // CommandRepository defines property writes used by application services.
 type CommandRepository interface {
 	Create(ctx context.Context, tx *sql.Tx, params CreatePropertyParams) (*Property, error)
+	FindByID(ctx context.Context, tx *sql.Tx, id string) (*Property, error)
+	Update(ctx context.Context, tx *sql.Tx, params UpdatePropertyParams) (*Property, error)
+	ListOccupiedRoomIDs(ctx context.Context, tx *sql.Tx, propertyID string) ([]string, error)
+	SoftDelete(ctx context.Context, tx *sql.Tx, id string, version int) error
 }
 
 // Property is the persisted property aggregate state used by write flows.
@@ -41,6 +45,17 @@ type CreatePropertyParams struct {
 	ElectricityUnitPrice             float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+}
+
+// UpdatePropertyParams contains the writable fields required to persist a property update.
+type UpdatePropertyParams struct {
+	ID                               string
+	Name                             string
+	Address                          string
+	ElectricityUnitPrice             float64
+	DefaultElectricityBillingCadence string
+	OwnerID                          string
+	Version                          int
 }
 
 // SQLRepository loads property ownership data from PostgreSQL.
@@ -103,6 +118,134 @@ RETURNING
 	}
 
 	return property, nil
+}
+
+// FindByID loads a single active property inside the provided transaction.
+func (r *SQLRepository) FindByID(ctx context.Context, tx *sql.Tx, id string) (*Property, error) {
+	const query = `
+SELECT
+	id,
+	name,
+	address,
+	electricity_unit_price,
+	default_electricity_billing_cadence,
+	owner_id,
+	created_at,
+	updated_at,
+	version
+FROM properties
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+
+	property, err := scanProperty(tx.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find property by id: %w", err)
+	}
+
+	return property, nil
+}
+
+// Update persists a property mutation inside the provided transaction.
+func (r *SQLRepository) Update(ctx context.Context, tx *sql.Tx, params UpdatePropertyParams) (*Property, error) {
+	const query = `
+UPDATE properties
+SET name = $2,
+	address = $3,
+	electricity_unit_price = $4,
+	default_electricity_billing_cadence = $5,
+	owner_id = $6,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $7
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	name,
+	address,
+	electricity_unit_price,
+	default_electricity_billing_cadence,
+	owner_id,
+	created_at,
+	updated_at,
+	version
+`
+
+	property, err := scanProperty(tx.QueryRowContext(ctx, query, params.ID, params.Name, params.Address, params.ElectricityUnitPrice, params.DefaultElectricityBillingCadence, params.OwnerID, params.Version))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update property: %w", err)
+	}
+
+	return property, nil
+}
+
+// ListOccupiedRoomIDs returns the occupied room ids for a property.
+func (r *SQLRepository) ListOccupiedRoomIDs(ctx context.Context, tx *sql.Tx, propertyID string) ([]string, error) {
+	const query = `
+SELECT id
+FROM rooms
+WHERE property_id = $1
+  AND status = 'occupied'
+  AND deleted_at IS NULL
+ORDER BY id
+`
+
+	rows, err := tx.QueryContext(ctx, query, propertyID)
+	if err != nil {
+		return nil, fmt.Errorf("list occupied rooms by property: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make([]string, 0)
+	for rows.Next() {
+		var roomID string
+		if err := rows.Scan(&roomID); err != nil {
+			return nil, fmt.Errorf("scan occupied room id: %w", err)
+		}
+		ids = append(ids, roomID)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate occupied room ids: %w", err)
+	}
+
+	return ids, nil
+}
+
+// SoftDelete marks an active property as deleted inside the provided transaction.
+func (r *SQLRepository) SoftDelete(ctx context.Context, tx *sql.Tx, id string, version int) error {
+	const query = `
+UPDATE properties
+SET deleted_at = now(),
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $2
+  AND deleted_at IS NULL
+`
+
+	result, err := tx.ExecContext(ctx, query, id, version)
+	if err != nil {
+		return fmt.Errorf("soft delete property: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("soft delete property rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+
+	return nil
 }
 
 type rowScanner interface {

--- a/internal/platform/database/properties/repository.go
+++ b/internal/platform/database/properties/repository.go
@@ -52,7 +52,7 @@ type UpdatePropertyParams struct {
 	ID                               string
 	Name                             string
 	Address                          string
-	ElectricityUnitPrice             float64
+	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
 	Version                          int
@@ -202,7 +202,9 @@ ORDER BY id
 	if err != nil {
 		return nil, fmt.Errorf("list occupied rooms by property: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		_ = rows.Close()
+	}()
 
 	ids := make([]string, 0)
 	for rows.Next() {

--- a/internal/server/property_adapters.go
+++ b/internal/server/property_adapters.go
@@ -47,6 +47,9 @@ func (a propertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, param
 func (a propertyRepositoryAdapter) FindByID(ctx context.Context, tx *sql.Tx, id string) (*appproperty.Property, error) {
 	property, err := a.repo.FindByID(ctx, tx, id)
 	if err != nil {
+		if err == dbproperties.ErrNotFound {
+			return nil, appproperty.ErrPropertyNotFound
+		}
 		return nil, err
 	}
 
@@ -64,6 +67,9 @@ func (a propertyRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx, param
 		Version:                          params.Version,
 	})
 	if err != nil {
+		if err == dbproperties.ErrNotFound {
+			return nil, appproperty.ErrPropertyNotFound
+		}
 		return nil, err
 	}
 
@@ -75,7 +81,11 @@ func (a propertyRepositoryAdapter) ListOccupiedRoomIDs(ctx context.Context, tx *
 }
 
 func (a propertyRepositoryAdapter) SoftDelete(ctx context.Context, tx *sql.Tx, id string, version int) error {
-	return a.repo.SoftDelete(ctx, tx, id, version)
+	err := a.repo.SoftDelete(ctx, tx, id, version)
+	if err == dbproperties.ErrNotFound {
+		return appproperty.ErrPropertyNotFound
+	}
+	return err
 }
 
 func toApplicationProperty(property *dbproperties.Property) *appproperty.Property {
@@ -83,19 +93,11 @@ func toApplicationProperty(property *dbproperties.Property) *appproperty.Propert
 		ID:                               property.ID,
 		Name:                             property.Name,
 		Address:                          property.Address,
-		ElectricityUnitPrice:             dereferenceElectricityUnitPrice(property.ElectricityUnitPrice),
+		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
 		CreatedAt:                        property.CreatedAt,
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,
 	}
-}
-
-func dereferenceElectricityUnitPrice(value *float64) float64 {
-	if value == nil {
-		return 0
-	}
-
-	return *value
 }

--- a/internal/server/property_adapters.go
+++ b/internal/server/property_adapters.go
@@ -44,16 +44,58 @@ func (a propertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, param
 	return toApplicationProperty(property), nil
 }
 
+func (a propertyRepositoryAdapter) FindByID(ctx context.Context, tx *sql.Tx, id string) (*appproperty.Property, error) {
+	property, err := a.repo.FindByID(ctx, tx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return toApplicationProperty(property), nil
+}
+
+func (a propertyRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx, params appproperty.UpdatePropertyParams) (*appproperty.Property, error) {
+	property, err := a.repo.Update(ctx, tx, dbproperties.UpdatePropertyParams{
+		ID:                               params.ID,
+		Name:                             params.Name,
+		Address:                          params.Address,
+		ElectricityUnitPrice:             params.ElectricityUnitPrice,
+		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
+		OwnerID:                          params.OwnerID,
+		Version:                          params.Version,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toApplicationProperty(property), nil
+}
+
+func (a propertyRepositoryAdapter) ListOccupiedRoomIDs(ctx context.Context, tx *sql.Tx, propertyID string) ([]string, error) {
+	return a.repo.ListOccupiedRoomIDs(ctx, tx, propertyID)
+}
+
+func (a propertyRepositoryAdapter) SoftDelete(ctx context.Context, tx *sql.Tx, id string, version int) error {
+	return a.repo.SoftDelete(ctx, tx, id, version)
+}
+
 func toApplicationProperty(property *dbproperties.Property) *appproperty.Property {
 	return &appproperty.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
 		Address:                          property.Address,
-		ElectricityUnitPrice:             property.ElectricityUnitPrice,
+		ElectricityUnitPrice:             dereferenceElectricityUnitPrice(property.ElectricityUnitPrice),
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
 		CreatedAt:                        property.CreatedAt,
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,
 	}
+}
+
+func dereferenceElectricityUnitPrice(value *float64) float64 {
+	if value == nil {
+		return 0
+	}
+
+	return *value
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -79,12 +79,14 @@ func New(cfg *config.Config) (*Server, error) {
 	)
 	txRunner := dbtxrunner.New(db, bus)
 	createPropertyService := appproperty.NewCreatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
+	updatePropertyService := appproperty.NewUpdatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
+	deletePropertyService := appproperty.NewDeletePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	jobTriggerService := appjobs.NewTriggerService(jobRunStoreAdapter{repo: jobRunsRepo}, nil, cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)
 
 	engine := router.New(cfg.App, logger, db, authenticator, userRepo, router.AuthorizationRepositories{
 		Properties:        propertyRepo,
 		ResourceOwnership: resourceOwnershipRepo,
-	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, createPropertyService)
+	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, createPropertyService, updatePropertyService, deletePropertyService)
 
 	return &Server{
 		httpServer: &http.Server{


### PR DESCRIPTION
## Summary
- implement a minimal Property aggregate and keep application services responsible for orchestration and transactions
- complete `PATCH /properties/{id}` and `DELETE /properties/{id}` alongside the existing create flow
- enforce Property command rules for electricity price updates, billing cadence updates, and BR-07 occupied-room delete rejection
- preserve `PropertyCreated` publication after commit and document that Billing-side subscription remains outside this issue
- add focused aggregate, application, and router coverage for the new Property command behavior

## Why
Issue #12 requires the Property command-side aggregate flow to be completed with business rules in the aggregate, application orchestration around it, and event publication after commit.

## Impact
- Property create/update/delete APIs now follow the intended command-side layering
- staff users are blocked from mutating `electricity_unit_price`
- property deletes now reject when occupied rooms still exist
- Property side now guarantees `PropertyCreated` is emitted correctly for downstream Billing work

## Testing
- `go test ./internal/domain/property ./internal/application/property ./internal/http/router ./internal/http/handler ./internal/server`
- `go test ./...`

Closes #12