### PR TITLE
[codex] Implement room command maintenance flow

### DIFF
--- a/internal/application/property/create_property_test.go
+++ b/internal/application/property/create_property_test.go
@@ -107,3 +107,23 @@ func (a sqlPropertyRepositoryAdapter) ListOccupiedRoomIDs(context.Context, *sql.
 func (a sqlPropertyRepositoryAdapter) SoftDelete(context.Context, *sql.Tx, string, int) error {
 	return nil
 }
+
+func (a sqlPropertyRepositoryAdapter) CreateRoom(context.Context, *sql.Tx, CreateRoomParams) (*Room, error) {
+	return nil, nil
+}
+
+func (a sqlPropertyRepositoryAdapter) FindRoomByID(context.Context, *sql.Tx, string) (*Room, error) {
+	return nil, nil
+}
+
+func (a sqlPropertyRepositoryAdapter) UpdateRoom(context.Context, *sql.Tx, UpdateRoomParams) (*Room, error) {
+	return nil, nil
+}
+
+func (a sqlPropertyRepositoryAdapter) SoftDeleteRoom(context.Context, *sql.Tx, string) error {
+	return nil
+}
+
+func (a sqlPropertyRepositoryAdapter) CreateRepairRequest(context.Context, *sql.Tx, CreateRepairRequestParams) (*RepairRequest, error) {
+	return nil, nil
+}

--- a/internal/application/property/create_room.go
+++ b/internal/application/property/create_room.go
@@ -1,0 +1,77 @@
+package property
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	domainproperty "stds_backend/internal/domain/property"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// CreateRoomInput is the command payload for creating a room.
+type CreateRoomInput struct {
+	PropertyID string
+	Name       string
+}
+
+// CreateRoomService creates rooms within a property.
+type CreateRoomService struct {
+	propertyRepo Repository
+	txRunner     *txrunner.Runner
+}
+
+// NewCreateRoomService returns a CreateRoomService.
+func NewCreateRoomService(propertyRepo Repository, txRunner *txrunner.Runner) *CreateRoomService {
+	return &CreateRoomService{
+		propertyRepo: propertyRepo,
+		txRunner:     txRunner,
+	}
+}
+
+// Execute validates input and persists a new room.
+func (s *CreateRoomService) Execute(ctx context.Context, input CreateRoomInput) (*Room, error) {
+	propertyID := strings.TrimSpace(input.PropertyID)
+	if propertyID == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "property_id"})
+	}
+
+	aggregate, err := domainproperty.NewRoom(domainproperty.RoomState{
+		PropertyID: propertyID,
+		Name:       input.Name,
+		Status:     domainproperty.RoomStatusVacant,
+	})
+	if err != nil {
+		return nil, mapDomainError(err)
+	}
+
+	var created *Room
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		if _, err := s.propertyRepo.FindByID(ctx, tx, propertyID); err != nil {
+			switch {
+			case errors.Is(err, ErrPropertyNotFound):
+				return apperr.ErrPropertyNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		room, err := s.propertyRepo.CreateRoom(ctx, tx, CreateRoomParams{
+			PropertyID: propertyID,
+			Name:       aggregate.RoomState().Name,
+		})
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		created = room
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return created, nil
+}

--- a/internal/application/property/delete_room.go
+++ b/internal/application/property/delete_room.go
@@ -1,0 +1,76 @@
+package property
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	domainproperty "stds_backend/internal/domain/property"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// DeleteRoomInput is the command payload for deleting a room.
+type DeleteRoomInput struct {
+	ID string
+}
+
+// DeleteRoomService deletes rooms while enforcing BR-08.
+type DeleteRoomService struct {
+	propertyRepo Repository
+	txRunner     *txrunner.Runner
+}
+
+// NewDeleteRoomService returns a DeleteRoomService.
+func NewDeleteRoomService(propertyRepo Repository, txRunner *txrunner.Runner) *DeleteRoomService {
+	return &DeleteRoomService{
+		propertyRepo: propertyRepo,
+		txRunner:     txRunner,
+	}
+}
+
+// Execute loads the room, checks BR-08, and soft-deletes it.
+func (s *DeleteRoomService) Execute(ctx context.Context, input DeleteRoomInput) error {
+	roomID := strings.TrimSpace(input.ID)
+	if roomID == "" {
+		return apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "id"})
+	}
+
+	return s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		current, err := s.propertyRepo.FindRoomByID(ctx, tx, roomID)
+		if err != nil {
+			switch {
+			case errors.Is(err, apperr.ErrRoomNotFound):
+				return apperr.ErrRoomNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		aggregate, err := domainproperty.RehydrateRoom(domainproperty.RoomState{
+			ID:         current.ID,
+			PropertyID: current.PropertyID,
+			Name:       current.Name,
+			Status:     current.Status,
+		})
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		if err := aggregate.EnsureRoomDeletable(); err != nil {
+			return mapDomainError(err)
+		}
+
+		if err := s.propertyRepo.SoftDeleteRoom(ctx, tx, current.ID); err != nil {
+			switch {
+			case errors.Is(err, apperr.ErrRoomNotFound):
+				return apperr.ErrRoomNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		return nil
+	})
+}

--- a/internal/application/property/errors.go
+++ b/internal/application/property/errors.go
@@ -12,6 +12,9 @@ const (
 	codeForbiddenElectricityPriceUpdate = "FORBIDDEN_ELECTRICITY_PRICE_UPDATE"
 	codeElectricityPriceMustBePositive  = "ELECTRICITY_PRICE_MUST_BE_POSITIVE"
 	codePropertyHasOccupiedRooms        = "PROPERTY_HAS_OCCUPIED_ROOMS"
+	codeValidationRoomNameRequired      = "VALIDATION_ROOM_NAME_REQUIRED"
+	codeRoomIsOccupied                  = "ROOM_IS_OCCUPIED"
+	codeRoomIsInMaintenance             = "ROOM_IS_IN_MAINTENANCE"
 )
 
 var (
@@ -29,6 +32,21 @@ var (
 		codePropertyHasOccupiedRooms,
 		http.StatusUnprocessableEntity,
 		"Property has occupied rooms.",
+	)
+	errValidationRoomNameRequired = apperr.New(
+		codeValidationRoomNameRequired,
+		http.StatusBadRequest,
+		"Room name is required.",
+	)
+	errRoomIsOccupied = apperr.New(
+		codeRoomIsOccupied,
+		http.StatusUnprocessableEntity,
+		"Room is occupied.",
+	)
+	errRoomIsInMaintenance = apperr.New(
+		codeRoomIsInMaintenance,
+		http.StatusUnprocessableEntity,
+		"Room is in maintenance.",
 	)
 )
 
@@ -52,6 +70,12 @@ func mapDomainError(err error) error {
 		return errForbiddenElectricityPriceUpdate
 	case errors.Is(err, domainproperty.ErrElectricityPriceMustBePositive):
 		return errElectricityPriceMustBePositive
+	case errors.Is(err, domainproperty.ErrRoomNameRequired):
+		return errValidationRoomNameRequired
+	case errors.Is(err, domainproperty.ErrRoomIsOccupied):
+		return errRoomIsOccupied
+	case errors.Is(err, domainproperty.ErrRoomIsInMaintenance):
+		return errRoomIsInMaintenance
 	default:
 		var occupiedErr *domainproperty.OccupiedRoomsError
 		if errors.As(err, &occupiedErr) {

--- a/internal/application/property/errors.go
+++ b/internal/application/property/errors.go
@@ -76,6 +76,8 @@ func mapDomainError(err error) error {
 		return errRoomIsOccupied
 	case errors.Is(err, domainproperty.ErrRoomIsInMaintenance):
 		return errRoomIsInMaintenance
+	case errors.Is(err, domainproperty.ErrBadRoomStatus):
+		return apperr.ErrInternalServerError.WithCause(err)
 	default:
 		var occupiedErr *domainproperty.OccupiedRoomsError
 		if errors.As(err, &occupiedErr) {

--- a/internal/application/property/property_service_test.go
+++ b/internal/application/property/property_service_test.go
@@ -28,12 +28,21 @@ type propertyRepoStub struct {
 	created         *Property
 	current         *Property
 	updated         *Property
+	room            *Room
+	createdRoom     *Room
+	updatedRoom     *Room
+	repairRequest   *RepairRequest
 	occupiedRoomIDs []string
 	createErr       error
 	findErr         error
 	updateErr       error
+	findRoomErr     error
+	createRoomErr   error
+	updateRoomErr   error
+	repairErr       error
 	listOccupiedErr error
 	deleteErr       error
+	deleteRoomErr   error
 }
 
 func (s propertyRepoStub) Create(context.Context, *sql.Tx, CreatePropertyParams) (*Property, error) {
@@ -60,6 +69,35 @@ func (s propertyRepoStub) ListOccupiedRoomIDs(context.Context, *sql.Tx, string) 
 
 func (s propertyRepoStub) SoftDelete(context.Context, *sql.Tx, string, int) error {
 	return s.deleteErr
+}
+
+func (s propertyRepoStub) CreateRoom(context.Context, *sql.Tx, CreateRoomParams) (*Room, error) {
+	return s.createdRoom, s.createRoomErr
+}
+
+func (s propertyRepoStub) FindRoomByID(context.Context, *sql.Tx, string) (*Room, error) {
+	if s.findRoomErr != nil {
+		return nil, s.findRoomErr
+	}
+	return s.room, nil
+}
+
+func (s propertyRepoStub) UpdateRoom(context.Context, *sql.Tx, UpdateRoomParams) (*Room, error) {
+	if s.updateRoomErr != nil {
+		return nil, s.updateRoomErr
+	}
+	return s.updatedRoom, nil
+}
+
+func (s propertyRepoStub) SoftDeleteRoom(context.Context, *sql.Tx, string) error {
+	return s.deleteRoomErr
+}
+
+func (s propertyRepoStub) CreateRepairRequest(context.Context, *sql.Tx, CreateRepairRequestParams) (*RepairRequest, error) {
+	if s.repairErr != nil {
+		return nil, s.repairErr
+	}
+	return s.repairRequest, nil
 }
 
 func TestCreatePropertyServicePublishesPropertyCreatedAfterCommit(t *testing.T) {

--- a/internal/application/property/repository.go
+++ b/internal/application/property/repository.go
@@ -23,6 +23,33 @@ type Property struct {
 	Version                          int
 }
 
+// Room is the application-facing room shape for room command use cases.
+type Room struct {
+	ID         string
+	PropertyID string
+	Name       string
+	Status     string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// RepairRequest is the application-facing repair request shape for maintenance entry.
+type RepairRequest struct {
+	ID          string
+	PropertyID  string
+	RoomID      string
+	SubmittedBy string
+	Title       string
+	Description string
+	Status      string
+	SubmittedAt time.Time
+	AssignedAt  *time.Time
+	AssignedTo  *string
+	CompletedAt *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
 // CreatePropertyParams contains the writable fields required to create a
 // property.
 type CreatePropertyParams struct {
@@ -45,6 +72,28 @@ type UpdatePropertyParams struct {
 	Version                          int
 }
 
+// CreateRoomParams contains the writable fields required to create a room.
+type CreateRoomParams struct {
+	PropertyID string
+	Name       string
+}
+
+// UpdateRoomParams contains the writable fields required to persist a room update.
+type UpdateRoomParams struct {
+	ID     string
+	Name   string
+	Status *string
+}
+
+// CreateRepairRequestParams contains the writable fields required to create a room-scoped repair request.
+type CreateRepairRequestParams struct {
+	PropertyID  string
+	RoomID      string
+	SubmittedBy string
+	Title       string
+	Description string
+}
+
 // Repository defines persistence needed by property application services.
 type Repository interface {
 	Create(ctx context.Context, tx *sql.Tx, params CreatePropertyParams) (*Property, error)
@@ -52,4 +101,9 @@ type Repository interface {
 	Update(ctx context.Context, tx *sql.Tx, params UpdatePropertyParams) (*Property, error)
 	ListOccupiedRoomIDs(ctx context.Context, tx *sql.Tx, propertyID string) ([]string, error)
 	SoftDelete(ctx context.Context, tx *sql.Tx, id string, version int) error
+	CreateRoom(ctx context.Context, tx *sql.Tx, params CreateRoomParams) (*Room, error)
+	FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*Room, error)
+	UpdateRoom(ctx context.Context, tx *sql.Tx, params UpdateRoomParams) (*Room, error)
+	SoftDeleteRoom(ctx context.Context, tx *sql.Tx, id string) error
+	CreateRepairRequest(ctx context.Context, tx *sql.Tx, params CreateRepairRequestParams) (*RepairRequest, error)
 }

--- a/internal/application/property/room_service_test.go
+++ b/internal/application/property/room_service_test.go
@@ -162,6 +162,18 @@ func TestUpdateRoomServiceUpdatesName(t *testing.T) {
 	}
 }
 
+func TestMapDomainErrorMapsBadRoomStatusToInternalServerError(t *testing.T) {
+	err := mapDomainError(domainproperty.ErrBadRoomStatus)
+
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected app error, got %v", err)
+	}
+	if appErr.Code != apperr.ErrInternalServerError.Code {
+		t.Fatalf("expected %s, got %s", apperr.ErrInternalServerError.Code, appErr.Code)
+	}
+}
+
 func TestSetRoomMaintenanceServicePublishesEventAfterCommit(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/application/property/room_service_test.go
+++ b/internal/application/property/room_service_test.go
@@ -1,0 +1,303 @@
+package property
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	domainevents "stds_backend/internal/domain/events"
+	domainproperty "stds_backend/internal/domain/property"
+	dbtxrunner "stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+func TestCreateRoomServiceCreatesRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	service := NewCreateRoomService(propertyRepoStub{
+		current: &Property{ID: "property-1"},
+		createdRoom: &Room{
+			ID:         "room-1",
+			PropertyID: "property-1",
+			Name:       "101 Room",
+			Status:     domainproperty.RoomStatusVacant,
+			CreatedAt:  time.Date(2026, 4, 23, 9, 0, 0, 0, time.UTC),
+			UpdatedAt:  time.Date(2026, 4, 23, 9, 0, 0, 0, time.UTC),
+		},
+	}, dbtxrunner.New(db, nil))
+
+	room, err := service.Execute(context.Background(), CreateRoomInput{
+		PropertyID: "property-1",
+		Name:       " 101 Room ",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if room.Name != "101 Room" {
+		t.Fatalf("expected normalized room name, got %q", room.Name)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestDeleteRoomServiceRejectsMaintenanceRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	service := NewDeleteRoomService(propertyRepoStub{
+		room: &Room{
+			ID:         "room-1",
+			PropertyID: "property-1",
+			Name:       "101 Room",
+			Status:     domainproperty.RoomStatusMaintenance,
+		},
+	}, dbtxrunner.New(db, nil))
+
+	err = service.Execute(context.Background(), DeleteRoomInput{ID: "room-1"})
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected app error, got %v", err)
+	}
+	if appErr.Code != codeRoomIsInMaintenance {
+		t.Fatalf("expected %s, got %s", codeRoomIsInMaintenance, appErr.Code)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestDeleteRoomServiceRejectsOccupiedRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	service := NewDeleteRoomService(propertyRepoStub{
+		room: &Room{
+			ID:         "room-1",
+			PropertyID: "property-1",
+			Name:       "101 Room",
+			Status:     domainproperty.RoomStatusOccupied,
+		},
+	}, dbtxrunner.New(db, nil))
+
+	err = service.Execute(context.Background(), DeleteRoomInput{ID: "room-1"})
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected app error, got %v", err)
+	}
+	if appErr.Code != codeRoomIsOccupied {
+		t.Fatalf("expected %s, got %s", codeRoomIsOccupied, appErr.Code)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdateRoomServiceUpdatesName(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	service := NewUpdateRoomService(propertyRepoStub{
+		room: &Room{
+			ID:         "room-1",
+			PropertyID: "property-1",
+			Name:       "101 Room",
+			Status:     domainproperty.RoomStatusVacant,
+		},
+		updatedRoom: &Room{
+			ID:         "room-1",
+			PropertyID: "property-1",
+			Name:       "101 Room Renamed",
+			Status:     domainproperty.RoomStatusVacant,
+			CreatedAt:  time.Date(2026, 4, 23, 9, 0, 0, 0, time.UTC),
+			UpdatedAt:  time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
+		},
+	}, dbtxrunner.New(db, nil))
+
+	name := " 101 Room Renamed "
+	room, err := service.Execute(context.Background(), UpdateRoomInput{
+		ID:   "room-1",
+		Name: &name,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if room.Name != "101 Room Renamed" {
+		t.Fatalf("expected normalized room name, got %q", room.Name)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestSetRoomMaintenanceServicePublishesEventAfterCommit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	publisher := &recordingPublisher{}
+	service := NewSetRoomMaintenanceService(propertyRepoStub{
+		room: &Room{
+			ID:         "room-1",
+			PropertyID: "property-1",
+			Name:       "101 Room",
+			Status:     domainproperty.RoomStatusVacant,
+		},
+		updatedRoom: &Room{
+			ID:         "room-1",
+			PropertyID: "property-1",
+			Name:       "101 Room",
+			Status:     domainproperty.RoomStatusMaintenance,
+			CreatedAt:  time.Date(2026, 4, 23, 9, 0, 0, 0, time.UTC),
+			UpdatedAt:  time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
+		},
+		repairRequest: &RepairRequest{
+			ID:          "repair-1",
+			PropertyID:  "property-1",
+			RoomID:      "room-1",
+			SubmittedBy: "user-1",
+			Title:       "Leak",
+			Description: "Bathroom leak",
+			Status:      "submitted",
+			SubmittedAt: time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
+			CreatedAt:   time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
+			UpdatedAt:   time.Date(2026, 4, 23, 10, 0, 0, 0, time.UTC),
+		},
+	}, dbtxrunner.New(db, publisher))
+
+	result, err := service.Execute(context.Background(), SetRoomMaintenanceInput{
+		RoomID:      "room-1",
+		OperatorID:  "user-1",
+		Title:       "Leak",
+		Description: "Bathroom leak",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.Room.Status != domainproperty.RoomStatusMaintenance {
+		t.Fatalf("expected maintenance status, got %q", result.Room.Status)
+	}
+	if len(publisher.events) != 1 {
+		t.Fatalf("expected 1 published event, got %d", len(publisher.events))
+	}
+	if _, ok := publisher.events[0].(domainevents.RoomSetToMaintenance); !ok {
+		t.Fatalf("expected RoomSetToMaintenance event, got %T", publisher.events[0])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestSetRoomMaintenanceServiceRejectsOccupiedRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	service := NewSetRoomMaintenanceService(propertyRepoStub{
+		room: &Room{
+			ID:         "room-1",
+			PropertyID: "property-1",
+			Name:       "101 Room",
+			Status:     domainproperty.RoomStatusOccupied,
+		},
+	}, dbtxrunner.New(db, nil))
+
+	_, err = service.Execute(context.Background(), SetRoomMaintenanceInput{
+		RoomID:      "room-1",
+		OperatorID:  "user-1",
+		Title:       "Leak",
+		Description: "Bathroom leak",
+	})
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected app error, got %v", err)
+	}
+	if appErr.Code != codeRoomIsOccupied {
+		t.Fatalf("expected %s, got %s", codeRoomIsOccupied, appErr.Code)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestSetRoomMaintenanceServiceRejectsMaintenanceRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	service := NewSetRoomMaintenanceService(propertyRepoStub{
+		room: &Room{
+			ID:         "room-1",
+			PropertyID: "property-1",
+			Name:       "101 Room",
+			Status:     domainproperty.RoomStatusMaintenance,
+		},
+	}, dbtxrunner.New(db, nil))
+
+	_, err = service.Execute(context.Background(), SetRoomMaintenanceInput{
+		RoomID:      "room-1",
+		OperatorID:  "user-1",
+		Title:       "Leak",
+		Description: "Bathroom leak",
+	})
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected app error, got %v", err)
+	}
+	if appErr.Code != codeRoomIsInMaintenance {
+		t.Fatalf("expected %s, got %s", codeRoomIsInMaintenance, appErr.Code)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}

--- a/internal/application/property/set_room_maintenance.go
+++ b/internal/application/property/set_room_maintenance.go
@@ -1,0 +1,136 @@
+package property
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	domainevents "stds_backend/internal/domain/events"
+	domainproperty "stds_backend/internal/domain/property"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// SetRoomMaintenanceInput is the command payload for entering maintenance.
+type SetRoomMaintenanceInput struct {
+	RoomID      string
+	OperatorID  string
+	Title       string
+	Description string
+}
+
+// SetRoomMaintenanceResult returns the updated room and created repair request.
+type SetRoomMaintenanceResult struct {
+	Room          *Room
+	RepairRequest *RepairRequest
+}
+
+// SetRoomMaintenanceService coordinates the composite maintenance entry flow.
+type SetRoomMaintenanceService struct {
+	propertyRepo Repository
+	txRunner     *txrunner.Runner
+	now          func() time.Time
+}
+
+// NewSetRoomMaintenanceService returns a SetRoomMaintenanceService.
+func NewSetRoomMaintenanceService(propertyRepo Repository, txRunner *txrunner.Runner) *SetRoomMaintenanceService {
+	return &SetRoomMaintenanceService{
+		propertyRepo: propertyRepo,
+		txRunner:     txRunner,
+		now:          time.Now,
+	}
+}
+
+// Execute creates a room-scoped repair request and moves the room into maintenance in one transaction.
+func (s *SetRoomMaintenanceService) Execute(ctx context.Context, input SetRoomMaintenanceInput) (*SetRoomMaintenanceResult, error) {
+	roomID := strings.TrimSpace(input.RoomID)
+	operatorID := strings.TrimSpace(input.OperatorID)
+	title := strings.TrimSpace(input.Title)
+	description := strings.TrimSpace(input.Description)
+
+	if roomID == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "id"})
+	}
+	if operatorID == "" {
+		return nil, apperr.ErrUnauthorized
+	}
+	if title == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "title"})
+	}
+	if description == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "description"})
+	}
+
+	result := &SetRoomMaintenanceResult{}
+	err := s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+		current, err := s.propertyRepo.FindRoomByID(ctx, tx, roomID)
+		if err != nil {
+			switch {
+			case errors.Is(err, apperr.ErrRoomNotFound):
+				return apperr.ErrRoomNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		aggregate, err := domainproperty.RehydrateRoom(domainproperty.RoomState{
+			ID:         current.ID,
+			PropertyID: current.PropertyID,
+			Name:       current.Name,
+			Status:     current.Status,
+		})
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		if err := aggregate.EnterMaintenance(); err != nil {
+			return mapDomainError(err)
+		}
+
+		repairRequest, err := s.propertyRepo.CreateRepairRequest(ctx, tx, CreateRepairRequestParams{
+			PropertyID:  current.PropertyID,
+			RoomID:      current.ID,
+			SubmittedBy: operatorID,
+			Title:       title,
+			Description: description,
+		})
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		room, err := s.propertyRepo.UpdateRoom(ctx, tx, UpdateRoomParams{
+			ID:     current.ID,
+			Name:   aggregate.RoomState().Name,
+			Status: ptrString(aggregate.RoomState().Status),
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, apperr.ErrRoomNotFound):
+				return apperr.ErrRoomNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		result.Room = room
+		result.RepairRequest = repairRequest
+		recorder.Record(domainevents.RoomSetToMaintenance{
+			RoomID:     current.ID,
+			PropertyID: current.PropertyID,
+			OperatorID: operatorID,
+			OccurredAt: s.now().UTC(),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func ptrString(value string) *string {
+	return &value
+}

--- a/internal/application/property/update_room.go
+++ b/internal/application/property/update_room.go
@@ -1,0 +1,93 @@
+package property
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	domainproperty "stds_backend/internal/domain/property"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// UpdateRoomInput is the command payload for updating a room.
+type UpdateRoomInput struct {
+	ID   string
+	Name *string
+}
+
+// UpdateRoomService updates room fields while enforcing mutation rules.
+type UpdateRoomService struct {
+	propertyRepo Repository
+	txRunner     *txrunner.Runner
+}
+
+// NewUpdateRoomService returns an UpdateRoomService.
+func NewUpdateRoomService(propertyRepo Repository, txRunner *txrunner.Runner) *UpdateRoomService {
+	return &UpdateRoomService{
+		propertyRepo: propertyRepo,
+		txRunner:     txRunner,
+	}
+}
+
+// Execute validates the update payload and persists the resulting room state.
+func (s *UpdateRoomService) Execute(ctx context.Context, input UpdateRoomInput) (*Room, error) {
+	roomID := strings.TrimSpace(input.ID)
+	if roomID == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "id"})
+	}
+	if input.Name == nil {
+		return nil, apperr.ErrBadRequest
+	}
+
+	var updated *Room
+	err := s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		current, err := s.propertyRepo.FindRoomByID(ctx, tx, roomID)
+		if err != nil {
+			switch {
+			case errors.Is(err, apperr.ErrRoomNotFound):
+				return apperr.ErrRoomNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		aggregate, err := domainproperty.RehydrateRoom(domainproperty.RoomState{
+			ID:         current.ID,
+			PropertyID: current.PropertyID,
+			Name:       current.Name,
+			Status:     current.Status,
+		})
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		if err := aggregate.UpdateRoom(domainproperty.RoomUpdateInput{Name: input.Name}); err != nil {
+			return mapDomainError(err)
+		}
+
+		state := aggregate.RoomState()
+		room, err := s.propertyRepo.UpdateRoom(ctx, tx, UpdateRoomParams{
+			ID:     state.ID,
+			Name:   state.Name,
+			Status: nil,
+		})
+		if err != nil {
+			switch {
+			case errors.Is(err, apperr.ErrRoomNotFound):
+				return apperr.ErrRoomNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		updated = room
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return updated, nil
+}

--- a/internal/domain/events/room_set_to_maintenance.go
+++ b/internal/domain/events/room_set_to_maintenance.go
@@ -1,0 +1,11 @@
+package events
+
+import "time"
+
+// RoomSetToMaintenance is emitted after room maintenance entry commits.
+type RoomSetToMaintenance struct {
+	RoomID     string
+	PropertyID string
+	OperatorID string
+	OccurredAt time.Time
+}

--- a/internal/domain/property/aggregate.go
+++ b/internal/domain/property/aggregate.go
@@ -5,6 +5,9 @@ import "strings"
 const (
 	BillingCadenceMonthly   = "monthly"
 	BillingCadenceBimonthly = "bimonthly"
+	RoomStatusVacant        = "vacant"
+	RoomStatusOccupied      = "occupied"
+	RoomStatusMaintenance   = "maintenance"
 )
 
 // State is the persisted property aggregate state.
@@ -16,6 +19,24 @@ type State struct {
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
 	Version                          int
+}
+
+// RoomState is the persisted room state used by room command rules.
+type RoomState struct {
+	ID         string
+	PropertyID string
+	Name       string
+	Status     string
+}
+
+// RoomUpdateInput is the aggregate patch for room mutations.
+type RoomUpdateInput struct {
+	Name *string
+}
+
+// RoomAggregate owns room command rules.
+type RoomAggregate struct {
+	state RoomState
 }
 
 // UpdateInput is the aggregate patch for property mutations.
@@ -164,5 +185,118 @@ func isValidBillingCadence(cadence string) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// NewRoom creates a room rule owner for create commands.
+func NewRoom(state RoomState) (*RoomAggregate, error) {
+	normalized, err := normalizeRoomState(state, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RoomAggregate{state: normalized}, nil
+}
+
+// RehydrateRoom reconstructs room state for mutation rules.
+func RehydrateRoom(state RoomState) (*RoomAggregate, error) {
+	normalized, err := normalizeRoomState(state, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RoomAggregate{state: normalized}, nil
+}
+
+// RoomState returns the room snapshot when the aggregate is used for room rules.
+func (a *RoomAggregate) RoomState() RoomState {
+	if a == nil {
+		return RoomState{}
+	}
+
+	return a.state
+}
+
+// UpdateRoom applies room mutation rules.
+func (a *RoomAggregate) UpdateRoom(input RoomUpdateInput) error {
+	if a == nil {
+		return nil
+	}
+
+	if input.Name != nil {
+		name := strings.TrimSpace(*input.Name)
+		if name == "" {
+			return ErrRoomNameRequired
+		}
+		a.state.Name = name
+	}
+
+	return nil
+}
+
+// EnsureRoomDeletable enforces BR-08.
+func (a *RoomAggregate) EnsureRoomDeletable() error {
+	if a == nil {
+		return nil
+	}
+
+	switch a.state.Status {
+	case RoomStatusOccupied:
+		return ErrRoomIsOccupied
+	case RoomStatusMaintenance:
+		return ErrRoomIsInMaintenance
+	default:
+		return nil
+	}
+}
+
+// EnsureCanEnterMaintenance validates room maintenance transitions.
+func (a *RoomAggregate) EnsureCanEnterMaintenance() error {
+	if a == nil {
+		return nil
+	}
+
+	switch a.state.Status {
+	case RoomStatusOccupied:
+		return ErrRoomIsOccupied
+	case RoomStatusMaintenance:
+		return ErrRoomIsInMaintenance
+	default:
+		return nil
+	}
+}
+
+// EnterMaintenance transitions the room to maintenance after validation.
+func (a *RoomAggregate) EnterMaintenance() error {
+	if err := a.EnsureCanEnterMaintenance(); err != nil {
+		return err
+	}
+
+	a.state.Status = RoomStatusMaintenance
+	return nil
+}
+
+func normalizeRoomState(state RoomState, requireStatus bool) (RoomState, error) {
+	state.ID = strings.TrimSpace(state.ID)
+	state.PropertyID = strings.TrimSpace(state.PropertyID)
+	state.Name = strings.TrimSpace(state.Name)
+	state.Status = strings.TrimSpace(state.Status)
+
+	if state.Name == "" {
+		return RoomState{}, ErrRoomNameRequired
+	}
+
+	if requireStatus && state.Status == "" {
+		state.Status = RoomStatusVacant
+	}
+	if state.Status == "" {
+		return RoomState{}, ErrBadRoomStatus
+	}
+
+	switch state.Status {
+	case RoomStatusVacant, RoomStatusOccupied, RoomStatusMaintenance:
+		return state, nil
+	default:
+		return RoomState{}, ErrBadRoomStatus
 	}
 }

--- a/internal/domain/property/errors.go
+++ b/internal/domain/property/errors.go
@@ -9,6 +9,10 @@ var (
 	ErrElectricityPriceMustBePositive  = errors.New("property electricity price must be positive")
 	ErrInvalidBillingCadence           = errors.New("property billing cadence is invalid")
 	ErrForbiddenElectricityPriceUpdate = errors.New("property electricity price update is forbidden")
+	ErrRoomNameRequired                = errors.New("room name is required")
+	ErrRoomIsOccupied                  = errors.New("room is occupied")
+	ErrRoomIsInMaintenance             = errors.New("room is in maintenance")
+	ErrBadRoomStatus                   = errors.New("room status is invalid")
 )
 
 // OccupiedRoomsError indicates that a property cannot be deleted because one or

--- a/internal/domain/property/room_aggregate_test.go
+++ b/internal/domain/property/room_aggregate_test.go
@@ -1,0 +1,93 @@
+package property
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewRoomNormalizesNameAndDefaultsVacant(t *testing.T) {
+	aggregate, err := NewRoom(RoomState{
+		PropertyID: "property-1",
+		Name:       " 101 Room ",
+	})
+	if err != nil {
+		t.Fatalf("NewRoom: %v", err)
+	}
+
+	state := aggregate.RoomState()
+	if state.Name != "101 Room" {
+		t.Fatalf("expected trimmed name, got %q", state.Name)
+	}
+	if state.Status != RoomStatusVacant {
+		t.Fatalf("expected vacant status, got %q", state.Status)
+	}
+}
+
+func TestRehydrateRoomRejectsMissingStatus(t *testing.T) {
+	_, err := RehydrateRoom(RoomState{
+		ID:         "room-1",
+		PropertyID: "property-1",
+		Name:       "101 Room",
+	})
+	if !errors.Is(err, ErrBadRoomStatus) {
+		t.Fatalf("expected ErrBadRoomStatus, got %v", err)
+	}
+}
+
+func TestRoomEnsureDeletableRejectsOccupiedAndMaintenance(t *testing.T) {
+	cases := []struct {
+		name   string
+		status string
+		want   error
+	}{
+		{name: "occupied", status: RoomStatusOccupied, want: ErrRoomIsOccupied},
+		{name: "maintenance", status: RoomStatusMaintenance, want: ErrRoomIsInMaintenance},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			aggregate, err := RehydrateRoom(RoomState{
+				ID:         "room-1",
+				PropertyID: "property-1",
+				Name:       "101 Room",
+				Status:     tc.status,
+			})
+			if err != nil {
+				t.Fatalf("RehydrateRoom: %v", err)
+			}
+
+			err = aggregate.EnsureRoomDeletable()
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("expected %v, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestRoomEnterMaintenanceRejectsInvalidStates(t *testing.T) {
+	occupied, err := RehydrateRoom(RoomState{
+		ID:         "room-1",
+		PropertyID: "property-1",
+		Name:       "101 Room",
+		Status:     RoomStatusOccupied,
+	})
+	if err != nil {
+		t.Fatalf("RehydrateRoom occupied: %v", err)
+	}
+	if err := occupied.EnterMaintenance(); !errors.Is(err, ErrRoomIsOccupied) {
+		t.Fatalf("expected ErrRoomIsOccupied, got %v", err)
+	}
+
+	maintenance, err := RehydrateRoom(RoomState{
+		ID:         "room-1",
+		PropertyID: "property-1",
+		Name:       "101 Room",
+		Status:     RoomStatusMaintenance,
+	})
+	if err != nil {
+		t.Fatalf("RehydrateRoom maintenance: %v", err)
+	}
+	if err := maintenance.EnterMaintenance(); !errors.Is(err, ErrRoomIsInMaintenance) {
+		t.Fatalf("expected ErrRoomIsInMaintenance, got %v", err)
+	}
+}

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -37,6 +37,10 @@ type APIServer struct {
 	createPropertySvc *appproperty.CreatePropertyService
 	updatePropertySvc *appproperty.UpdatePropertyService
 	deletePropertySvc *appproperty.DeletePropertyService
+	createRoomSvc     *appproperty.CreateRoomService
+	updateRoomSvc     *appproperty.UpdateRoomService
+	deleteRoomSvc     *appproperty.DeleteRoomService
+	setMaintenanceSvc *appproperty.SetRoomMaintenanceService
 }
 
 // NewAPIServer returns an API server with only the currently implemented
@@ -54,6 +58,10 @@ func NewAPIServer(
 	createPropertySvc *appproperty.CreatePropertyService,
 	updatePropertySvc *appproperty.UpdatePropertyService,
 	deletePropertySvc *appproperty.DeletePropertyService,
+	createRoomSvc *appproperty.CreateRoomService,
+	updateRoomSvc *appproperty.UpdateRoomService,
+	deleteRoomSvc *appproperty.DeleteRoomService,
+	setMaintenanceSvc *appproperty.SetRoomMaintenanceService,
 ) *APIServer {
 	return &APIServer{
 		userRepo:          userRepo,
@@ -68,6 +76,10 @@ func NewAPIServer(
 		createPropertySvc: createPropertySvc,
 		updatePropertySvc: updatePropertySvc,
 		deletePropertySvc: deletePropertySvc,
+		createRoomSvc:     createRoomSvc,
+		updateRoomSvc:     updateRoomSvc,
+		deleteRoomSvc:     deleteRoomSvc,
+		setMaintenanceSvc: setMaintenanceSvc,
 	}
 }
 
@@ -417,7 +429,24 @@ func (s *APIServer) ListPropertyRooms(c *gin.Context, id string, params api.List
 }
 
 // CreatePropertyRoom handles room creation within a property.
-func (s *APIServer) CreatePropertyRoom(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) CreatePropertyRoom(c *gin.Context, id string) {
+	var request api.CreateRoomRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	room, err := s.createRoomSvc.Execute(c.Request.Context(), appproperty.CreateRoomInput{
+		PropertyID: id,
+		Name:       request.Name,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, toCreatedRoomResponse(room))
+}
 
 // ListRepairRequests handles the repair request listing endpoint.
 func (s *APIServer) ListRepairRequests(c *gin.Context, params api.ListRepairRequestsParams) {
@@ -459,7 +488,14 @@ func (s *APIServer) CompleteRepairRequest(c *gin.Context, id string) { writeNotI
 func (s *APIServer) ProgressRepairRequest(c *gin.Context, id string) { writeNotImplemented(c) }
 
 // DeleteRoom handles room deletion.
-func (s *APIServer) DeleteRoom(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) DeleteRoom(c *gin.Context, id string) {
+	if err := s.deleteRoomSvc.Execute(c.Request.Context(), appproperty.DeleteRoomInput{ID: id}); err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
 
 // GetRoom handles room detail retrieval.
 func (s *APIServer) GetRoom(c *gin.Context, id string) {
@@ -488,10 +524,55 @@ func (s *APIServer) CreateRoomAttachment(c *gin.Context, id openapi_types.UUID) 
 }
 
 // UpdateRoom handles room updates.
-func (s *APIServer) UpdateRoom(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) UpdateRoom(c *gin.Context, id string) {
+	var request api.UpdateRoomRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	room, err := s.updateRoomSvc.Execute(c.Request.Context(), appproperty.UpdateRoomInput{
+		ID:   id,
+		Name: request.Name,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toCreatedRoomResponse(room))
+}
 
 // CreateRoomMaintenance handles setting room maintenance state.
-func (s *APIServer) CreateRoomMaintenance(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) CreateRoomMaintenance(c *gin.Context, id string) {
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	var request api.SetMaintenanceRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	result, err := s.setMaintenanceSvc.Execute(c.Request.Context(), appproperty.SetRoomMaintenanceInput{
+		RoomID:      id,
+		OperatorID:  principal.UserID,
+		Title:       request.Title,
+		Description: request.Description,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, api.SetMaintenanceResponse{
+		Room:          toCreatedRoomResponse(result.Room),
+		RepairRequest: toRepairRequestResponse(result.RepairRequest),
+	})
+}
 
 // ListRoomMeterHistory handles room meter history retrieval.
 func (s *APIServer) ListRoomMeterHistory(c *gin.Context, id string, params api.ListRoomMeterHistoryParams) {
@@ -992,6 +1073,63 @@ func toCreatedPropertyResponse(property *appproperty.Property) api.PropertyRespo
 	}
 
 	return toPropertyResponse(queryShape)
+}
+
+func toCreatedRoomResponse(room *appproperty.Room) api.RoomResponse {
+	queryShape := &dbpropertyquery.Room{
+		ID:         room.ID,
+		PropertyID: room.PropertyID,
+		Name:       room.Name,
+		Status:     room.Status,
+		CreatedAt:  room.CreatedAt,
+		UpdatedAt:  room.UpdatedAt,
+	}
+
+	return toRoomResponse(queryShape)
+}
+
+func toRepairRequestResponse(repairRequest *appproperty.RepairRequest) api.RepairRequestResponse {
+	id, ok := parseUUID(repairRequest.ID)
+	propertyID, propertyOK := parseUUID(repairRequest.PropertyID)
+	roomID, roomOK := parseUUID(repairRequest.RoomID)
+	submittedBy, submittedByOK := parseUUID(repairRequest.SubmittedBy)
+	title := repairRequest.Title
+	description := repairRequest.Description
+	status := api.RepairRequestResponseStatus(repairRequest.Status)
+	submittedAt := repairRequest.SubmittedAt
+	createdAt := repairRequest.CreatedAt
+	updatedAt := repairRequest.UpdatedAt
+
+	response := api.RepairRequestResponse{
+		AssignedAt:  repairRequest.AssignedAt,
+		CompletedAt: repairRequest.CompletedAt,
+		CreatedAt:   &createdAt,
+		Description: &description,
+		Status:      &status,
+		SubmittedAt: &submittedAt,
+		Title:       &title,
+		UpdatedAt:   &updatedAt,
+	}
+	if ok {
+		response.Id = &id
+	}
+	if propertyOK {
+		response.PropertyId = &propertyID
+	}
+	if roomOK {
+		response.RoomId = &roomID
+	}
+	if submittedByOK {
+		response.SubmittedBy = &submittedBy
+	}
+	if repairRequest.AssignedTo != nil {
+		assignedTo, assignedToOK := parseUUID(*repairRequest.AssignedTo)
+		if assignedToOK {
+			response.AssignedTo = &assignedTo
+		}
+	}
+
+	return response
 }
 
 func isSupportedRoomStatus(status string) bool {

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -56,6 +56,10 @@ func New(
 	createPropertyService *appproperty.CreatePropertyService,
 	updatePropertyService *appproperty.UpdatePropertyService,
 	deletePropertyService *appproperty.DeletePropertyService,
+	createRoomService *appproperty.CreateRoomService,
+	updateRoomService *appproperty.UpdateRoomService,
+	deleteRoomService *appproperty.DeleteRoomService,
+	setRoomMaintenanceService *appproperty.SetRoomMaintenanceService,
 ) *gin.Engine {
 	engine := gin.New()
 	engine.Use(
@@ -72,7 +76,7 @@ func New(
 	engine.GET("/openapi.yaml", docsHandler.OpenAPI)
 	engine.GET("/scalar", docsHandler.Scalar)
 
-	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, createPropertyService, updatePropertyService, deletePropertyService), api.GinServerOptions{
+	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService), api.GinServerOptions{
 		BaseURL: "/api/v1",
 		Middlewares: []api.MiddlewareFunc{
 			protectedAPIMiddleware(appCfg, authenticator, userRepo, authzRepos),

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -920,6 +920,335 @@ func TestCreatePropertyRejectsMalformedJSONAsBadRequest(t *testing.T) {
 	}
 }
 
+func TestCreatePropertyRoomReturnsCreatedRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := fakeUserRepo{}
+	propertyRepo := fakePropertyRepo{}
+	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{}, propertyRepo, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeleteRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/properties/"+testPropertyID1+"/rooms", strings.NewReader(`{"name":"101 Room"}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["name"] != "101 Room" {
+		t.Fatalf("expected room name 101 Room, got %v", payload["name"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdateRoomReturnsUpdatedRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := fakeUserRepo{}
+	propertyRepo := fakePropertyRepo{}
+	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeleteRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/rooms/"+testRoomID1, strings.NewReader(`{"name":"101 Room Renamed"}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["name"] != "101 Room Renamed" {
+		t.Fatalf("expected room name 101 Room Renamed, got %v", payload["name"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestDeleteRoomRejectsMaintenanceRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	repo := fakeUserRepo{role: "admin"}
+	propertyRepo := fakePropertyRepo{
+		roomByID: map[string]*appproperty.Room{
+			testRoomID1: {
+				ID:         testRoomID1,
+				PropertyID: testPropertyID1,
+				Name:       "101 Room",
+				Status:     "maintenance",
+			},
+		},
+	}
+	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{role: "admin"}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeleteRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/rooms/"+testRoomID1, nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestDeleteRoomRejectsOccupiedRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	repo := fakeUserRepo{role: "admin"}
+	propertyRepo := fakePropertyRepo{
+		roomByID: map[string]*appproperty.Room{
+			testRoomID1: {
+				ID:         testRoomID1,
+				PropertyID: testPropertyID1,
+				Name:       "101 Room",
+				Status:     "occupied",
+			},
+		},
+	}
+	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{role: "admin"}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeleteRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/rooms/"+testRoomID1, nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateRoomMaintenanceReturnsCompositeResponse(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := fakeUserRepo{}
+	propertyRepo := fakePropertyRepo{}
+	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeleteRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rooms/"+testRoomID1+"/maintenance", strings.NewReader(`{"title":"Leak","description":"Bathroom leak"}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	room, ok := payload["room"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected room object, got %#v", payload["room"])
+	}
+	if room["status"] != "maintenance" {
+		t.Fatalf("expected maintenance status, got %v", room["status"])
+	}
+	repairRequest, ok := payload["repair_request"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected repair_request object, got %#v", payload["repair_request"])
+	}
+	if repairRequest["status"] != "submitted" {
+		t.Fatalf("expected submitted repair request, got %v", repairRequest["status"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateRoomMaintenanceRejectsOccupiedRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	repo := fakeUserRepo{}
+	propertyRepo := fakePropertyRepo{
+		roomByID: map[string]*appproperty.Room{
+			testRoomID1: {
+				ID:         testRoomID1,
+				PropertyID: testPropertyID1,
+				Name:       "101 Room",
+				Status:     "occupied",
+			},
+		},
+	}
+	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeleteRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rooms/"+testRoomID1+"/maintenance", strings.NewReader(`{"title":"Leak","description":"Bathroom leak"}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateRoomMaintenanceRejectsMaintenanceRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	repo := fakeUserRepo{}
+	propertyRepo := fakePropertyRepo{
+		roomByID: map[string]*appproperty.Room{
+			testRoomID1: {
+				ID:         testRoomID1,
+				PropertyID: testPropertyID1,
+				Name:       "101 Room",
+				Status:     "maintenance",
+			},
+		},
+	}
+	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeleteRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/rooms/"+testRoomID1+"/maintenance", strings.NewReader(`{"title":"Leak","description":"Bathroom leak"}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func TestCreatePropertyAcceptsDecimalElectricityPrice(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -1771,6 +2100,7 @@ type fakePropertyRepo struct {
 	ownerByPropertyID map[string]string
 	propertyByID      map[string]*appproperty.Property
 	occupiedRoomIDs   map[string][]string
+	roomByID          map[string]*appproperty.Room
 }
 
 type fakePropertyQueryRepo struct {
@@ -2209,6 +2539,67 @@ func (f fakePropertyRepo) SoftDelete(_ context.Context, _ *sql.Tx, _ string, _ i
 	return nil
 }
 
+func (f fakePropertyRepo) CreateRoom(_ context.Context, _ *sql.Tx, params appproperty.CreateRoomParams) (*appproperty.Room, error) {
+	return &appproperty.Room{
+		ID:         "room-new",
+		PropertyID: params.PropertyID,
+		Name:       params.Name,
+		Status:     "vacant",
+		CreatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func (f fakePropertyRepo) FindRoomByID(_ context.Context, _ *sql.Tx, id string) (*appproperty.Room, error) {
+	if room, ok := f.roomByID[id]; ok {
+		return room, nil
+	}
+
+	return &appproperty.Room{
+		ID:         id,
+		PropertyID: testPropertyID1,
+		Name:       "101 Room",
+		Status:     "vacant",
+		CreatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func (f fakePropertyRepo) UpdateRoom(_ context.Context, _ *sql.Tx, params appproperty.UpdateRoomParams) (*appproperty.Room, error) {
+	status := "vacant"
+	if params.Status != nil {
+		status = *params.Status
+	}
+
+	return &appproperty.Room{
+		ID:         params.ID,
+		PropertyID: testPropertyID1,
+		Name:       params.Name,
+		Status:     status,
+		CreatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func (f fakePropertyRepo) SoftDeleteRoom(_ context.Context, _ *sql.Tx, _ string) error {
+	return nil
+}
+
+func (f fakePropertyRepo) CreateRepairRequest(_ context.Context, _ *sql.Tx, params appproperty.CreateRepairRequestParams) (*appproperty.RepairRequest, error) {
+	return &appproperty.RepairRequest{
+		ID:          "repair-1",
+		PropertyID:  params.PropertyID,
+		RoomID:      params.RoomID,
+		SubmittedBy: params.SubmittedBy,
+		Title:       params.Title,
+		Description: params.Description,
+		Status:      "submitted",
+		SubmittedAt: time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC),
+		CreatedAt:   time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC),
+	}, nil
+}
+
 func (a testSQLPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params appproperty.CreatePropertyParams) (*appproperty.Property, error) {
 	property, err := a.repo.Create(ctx, tx, dbproperties.CreatePropertyParams{
 		Name:                             params.Name,
@@ -2286,6 +2677,94 @@ func (a testSQLPropertyRepositoryAdapter) ListOccupiedRoomIDs(ctx context.Contex
 
 func (a testSQLPropertyRepositoryAdapter) SoftDelete(ctx context.Context, tx *sql.Tx, id string, version int) error {
 	return a.repo.SoftDelete(ctx, tx, id, version)
+}
+
+func (a testSQLPropertyRepositoryAdapter) CreateRoom(ctx context.Context, tx *sql.Tx, params appproperty.CreateRoomParams) (*appproperty.Room, error) {
+	room, err := a.repo.CreateRoom(ctx, tx, dbproperties.CreateRoomParams{
+		PropertyID: params.PropertyID,
+		Name:       params.Name,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &appproperty.Room{
+		ID:         room.ID,
+		PropertyID: room.PropertyID,
+		Name:       room.Name,
+		Status:     room.Status,
+		CreatedAt:  room.CreatedAt,
+		UpdatedAt:  room.UpdatedAt,
+	}, nil
+}
+
+func (a testSQLPropertyRepositoryAdapter) FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*appproperty.Room, error) {
+	room, err := a.repo.FindRoomByID(ctx, tx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &appproperty.Room{
+		ID:         room.ID,
+		PropertyID: room.PropertyID,
+		Name:       room.Name,
+		Status:     room.Status,
+		CreatedAt:  room.CreatedAt,
+		UpdatedAt:  room.UpdatedAt,
+	}, nil
+}
+
+func (a testSQLPropertyRepositoryAdapter) UpdateRoom(ctx context.Context, tx *sql.Tx, params appproperty.UpdateRoomParams) (*appproperty.Room, error) {
+	room, err := a.repo.UpdateRoom(ctx, tx, dbproperties.UpdateRoomParams{
+		ID:     params.ID,
+		Name:   params.Name,
+		Status: params.Status,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &appproperty.Room{
+		ID:         room.ID,
+		PropertyID: room.PropertyID,
+		Name:       room.Name,
+		Status:     room.Status,
+		CreatedAt:  room.CreatedAt,
+		UpdatedAt:  room.UpdatedAt,
+	}, nil
+}
+
+func (a testSQLPropertyRepositoryAdapter) SoftDeleteRoom(ctx context.Context, tx *sql.Tx, id string) error {
+	return a.repo.SoftDeleteRoom(ctx, tx, id)
+}
+
+func (a testSQLPropertyRepositoryAdapter) CreateRepairRequest(ctx context.Context, tx *sql.Tx, params appproperty.CreateRepairRequestParams) (*appproperty.RepairRequest, error) {
+	repairRequest, err := a.repo.CreateRepairRequest(ctx, tx, dbproperties.CreateRepairRequestParams{
+		PropertyID:  params.PropertyID,
+		RoomID:      params.RoomID,
+		SubmittedBy: params.SubmittedBy,
+		Title:       params.Title,
+		Description: params.Description,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &appproperty.RepairRequest{
+		ID:          repairRequest.ID,
+		PropertyID:  repairRequest.PropertyID,
+		RoomID:      repairRequest.RoomID,
+		SubmittedBy: repairRequest.SubmittedBy,
+		AssignedTo:  repairRequest.AssignedTo,
+		Title:       repairRequest.Title,
+		Description: repairRequest.Description,
+		Status:      repairRequest.Status,
+		SubmittedAt: repairRequest.SubmittedAt,
+		AssignedAt:  repairRequest.AssignedAt,
+		CompletedAt: repairRequest.CompletedAt,
+		CreatedAt:   repairRequest.CreatedAt,
+		UpdatedAt:   repairRequest.UpdatedAt,
+	}, nil
 }
 
 func (f fakePropertyQueryRepo) FindByID(_ context.Context, propertyID string) (*dbpropertyquery.Property, error) {
@@ -2499,18 +2978,21 @@ func newTestEngineWithPropertyQueryRepo(userRepo fakeUserRepo, authenticator fak
 }
 
 func newTestEngineWithCreatePropertyService(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, createPropertyService *appproperty.CreatePropertyService, updatePropertyService *appproperty.UpdatePropertyService, deletePropertyService *appproperty.DeletePropertyService) *gin.Engine {
-	return newTestEngineWithNotificationSender(
+	return newTestEngineWithRoomServices(
 		userRepo,
 		authenticator,
 		propertyRepo,
 		ownershipRepo,
 		schedulerKey,
 		jobRunsRepo,
-		&testNotificationSender{},
 		propertyQueryRepo,
 		createPropertyService,
 		updatePropertyService,
 		deletePropertyService,
+		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(nil, nil)),
+		appproperty.NewUpdateRoomService(propertyRepo, dbtxrunner.New(nil, nil)),
+		appproperty.NewDeleteRoomService(propertyRepo, dbtxrunner.New(nil, nil)),
+		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(nil, nil)),
 	)
 }
 
@@ -2542,6 +3024,45 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 		createPropertyService,
 		updatePropertyService,
 		deletePropertyService,
+		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(nil, nil)),
+		appproperty.NewUpdateRoomService(propertyRepo, dbtxrunner.New(nil, nil)),
+		appproperty.NewDeleteRoomService(propertyRepo, dbtxrunner.New(nil, nil)),
+		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(nil, nil)),
+	)
+}
+
+func newTestEngineWithRoomServices(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, createPropertyService *appproperty.CreatePropertyService, updatePropertyService *appproperty.UpdatePropertyService, deletePropertyService *appproperty.DeletePropertyService, createRoomService *appproperty.CreateRoomService, updateRoomService *appproperty.UpdateRoomService, deleteRoomService *appproperty.DeleteRoomService, setRoomMaintenanceService *appproperty.SetRoomMaintenanceService) *gin.Engine {
+	repo := &userRepo
+	userAccountRepo := testUserAccountRepositoryAdapter{repo: repo}
+	return New(
+		config.AppConfig{Name: "test", Env: "test", SchedulerKey: schedulerKey, ReadTimeout: time.Second, WriteTimeout: time.Second},
+		testLogger(),
+		nil,
+		authenticator,
+		repo,
+		AuthorizationRepositories{
+			Properties:        propertyRepo,
+			ResourceOwnership: ownershipRepo,
+		},
+		appiam.NewCreateUserService(userAccountRepo, authenticator, appnotification.NewService(&testNotificationSender{})),
+		appiam.NewSendUserPasswordResetService(userAccountRepo, authenticator, appnotification.NewService(&testNotificationSender{})),
+		appiam.NewSyncAuthService(userAccountRepo, appiam.NewCustomClaimsService(authenticator)),
+		appiam.NewUpdateCurrentUserService(repo),
+		appiam.NewUpdateUserService(userAccountRepo, appiam.NewCustomClaimsService(authenticator)),
+		appiam.NewAssignUserPropertiesService(
+			testManagedUserRepositoryAdapter{repo: repo},
+			testPropertyExistenceChecker{repo: fakePropertyQueryRepo{}},
+			appiam.NewCustomClaimsService(authenticator),
+		),
+		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
+		propertyQueryRepo,
+		createPropertyService,
+		updatePropertyService,
+		deletePropertyService,
+		createRoomService,
+		updateRoomService,
+		deleteRoomService,
+		setRoomMaintenanceService,
 	)
 }
 

--- a/internal/platform/database/properties/repository.go
+++ b/internal/platform/database/properties/repository.go
@@ -23,6 +23,11 @@ type CommandRepository interface {
 	Update(ctx context.Context, tx *sql.Tx, params UpdatePropertyParams) (*Property, error)
 	ListOccupiedRoomIDs(ctx context.Context, tx *sql.Tx, propertyID string) ([]string, error)
 	SoftDelete(ctx context.Context, tx *sql.Tx, id string, version int) error
+	CreateRoom(ctx context.Context, tx *sql.Tx, params CreateRoomParams) (*Room, error)
+	FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*Room, error)
+	UpdateRoom(ctx context.Context, tx *sql.Tx, params UpdateRoomParams) (*Room, error)
+	SoftDeleteRoom(ctx context.Context, tx *sql.Tx, id string) error
+	CreateRepairRequest(ctx context.Context, tx *sql.Tx, params CreateRepairRequestParams) (*RepairRequest, error)
 }
 
 // Property is the persisted property aggregate state used by write flows.
@@ -36,6 +41,33 @@ type Property struct {
 	CreatedAt                        time.Time
 	UpdatedAt                        time.Time
 	Version                          int
+}
+
+// Room is the persisted room state used by write flows.
+type Room struct {
+	ID         string
+	PropertyID string
+	Name       string
+	Status     string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// RepairRequest is the persisted repair request state used by write flows.
+type RepairRequest struct {
+	ID          string
+	PropertyID  string
+	RoomID      string
+	SubmittedBy string
+	AssignedTo  *string
+	Title       string
+	Description string
+	Status      string
+	SubmittedAt time.Time
+	AssignedAt  *time.Time
+	CompletedAt *time.Time
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 // CreatePropertyParams contains the writable fields required to persist a property.
@@ -56,6 +88,28 @@ type UpdatePropertyParams struct {
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
 	Version                          int
+}
+
+// CreateRoomParams contains the writable fields required to persist a room.
+type CreateRoomParams struct {
+	PropertyID string
+	Name       string
+}
+
+// UpdateRoomParams contains the writable fields required to persist a room update.
+type UpdateRoomParams struct {
+	ID     string
+	Name   string
+	Status *string
+}
+
+// CreateRepairRequestParams contains the writable fields required to persist a repair request.
+type CreateRepairRequestParams struct {
+	PropertyID  string
+	RoomID      string
+	SubmittedBy string
+	Title       string
+	Description string
 }
 
 // SQLRepository loads property ownership data from PostgreSQL.
@@ -250,6 +304,151 @@ WHERE id = $1
 	return nil
 }
 
+// CreateRoom persists a new room row within the provided transaction.
+func (r *SQLRepository) CreateRoom(ctx context.Context, tx *sql.Tx, params CreateRoomParams) (*Room, error) {
+	const query = `
+INSERT INTO rooms (
+	property_id,
+	name
+) VALUES ($1, $2)
+RETURNING
+	id,
+	property_id,
+	name,
+	status,
+	created_at,
+	updated_at
+`
+
+	room, err := scanRoom(tx.QueryRowContext(ctx, query, params.PropertyID, params.Name))
+	if err != nil {
+		return nil, fmt.Errorf("create room: %w", err)
+	}
+
+	return room, nil
+}
+
+// FindRoomByID loads a single active room inside the provided transaction.
+func (r *SQLRepository) FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*Room, error) {
+	const query = `
+SELECT
+	id,
+	property_id,
+	name,
+	status,
+	created_at,
+	updated_at
+FROM rooms
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+
+	room, err := scanRoom(tx.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find room by id: %w", err)
+	}
+
+	return room, nil
+}
+
+// UpdateRoom persists a room mutation inside the provided transaction.
+func (r *SQLRepository) UpdateRoom(ctx context.Context, tx *sql.Tx, params UpdateRoomParams) (*Room, error) {
+	status := ""
+	if params.Status != nil {
+		status = *params.Status
+	}
+
+	const query = `
+UPDATE rooms
+SET name = $2,
+	status = CASE WHEN $3 = '' THEN status ELSE $3 END,
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	property_id,
+	name,
+	status,
+	created_at,
+	updated_at
+`
+
+	room, err := scanRoom(tx.QueryRowContext(ctx, query, params.ID, params.Name, status))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update room: %w", err)
+	}
+
+	return room, nil
+}
+
+// SoftDeleteRoom marks an active room as deleted inside the provided transaction.
+func (r *SQLRepository) SoftDeleteRoom(ctx context.Context, tx *sql.Tx, id string) error {
+	const query = `
+UPDATE rooms
+SET deleted_at = now(),
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+`
+
+	result, err := tx.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("soft delete room: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("soft delete room rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+
+	return nil
+}
+
+// CreateRepairRequest persists a new room-scoped repair request within the provided transaction.
+func (r *SQLRepository) CreateRepairRequest(ctx context.Context, tx *sql.Tx, params CreateRepairRequestParams) (*RepairRequest, error) {
+	const query = `
+INSERT INTO repair_requests (
+	property_id,
+	room_id,
+	submitted_by,
+	title,
+	description
+) VALUES ($1, $2, $3, $4, $5)
+RETURNING
+	id,
+	property_id,
+	room_id,
+	submitted_by,
+	assigned_to,
+	title,
+	description,
+	status,
+	submitted_at,
+	assigned_at,
+	completed_at,
+	created_at,
+	updated_at
+`
+
+	repairRequest, err := scanRepairRequest(tx.QueryRowContext(ctx, query, params.PropertyID, params.RoomID, params.SubmittedBy, params.Title, params.Description))
+	if err != nil {
+		return nil, fmt.Errorf("create repair request: %w", err)
+	}
+
+	return repairRequest, nil
+}
+
 type rowScanner interface {
 	Scan(dest ...any) error
 }
@@ -275,4 +474,57 @@ func scanProperty(row rowScanner) (*Property, error) {
 	}
 
 	return &property, nil
+}
+
+func scanRoom(row rowScanner) (*Room, error) {
+	var room Room
+	if err := row.Scan(
+		&room.ID,
+		&room.PropertyID,
+		&room.Name,
+		&room.Status,
+		&room.CreatedAt,
+		&room.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	return &room, nil
+}
+
+func scanRepairRequest(row rowScanner) (*RepairRequest, error) {
+	var repairRequest RepairRequest
+	var assignedTo sql.NullString
+	var assignedAt sql.NullTime
+	var completedAt sql.NullTime
+
+	if err := row.Scan(
+		&repairRequest.ID,
+		&repairRequest.PropertyID,
+		&repairRequest.RoomID,
+		&repairRequest.SubmittedBy,
+		&assignedTo,
+		&repairRequest.Title,
+		&repairRequest.Description,
+		&repairRequest.Status,
+		&repairRequest.SubmittedAt,
+		&assignedAt,
+		&completedAt,
+		&repairRequest.CreatedAt,
+		&repairRequest.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	if assignedTo.Valid {
+		repairRequest.AssignedTo = &assignedTo.String
+	}
+	if assignedAt.Valid {
+		repairRequest.AssignedAt = &assignedAt.Time
+	}
+	if completedAt.Valid {
+		repairRequest.CompletedAt = &completedAt.Time
+	}
+
+	return &repairRequest, nil
 }

--- a/internal/server/property_adapters.go
+++ b/internal/server/property_adapters.go
@@ -7,6 +7,7 @@ import (
 	appproperty "stds_backend/internal/application/property"
 	dbproperties "stds_backend/internal/platform/database/properties"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
+	"stds_backend/internal/shared/apperr"
 )
 
 type propertyExistenceCheckerAdapter struct {
@@ -88,6 +89,69 @@ func (a propertyRepositoryAdapter) SoftDelete(ctx context.Context, tx *sql.Tx, i
 	return err
 }
 
+func (a propertyRepositoryAdapter) CreateRoom(ctx context.Context, tx *sql.Tx, params appproperty.CreateRoomParams) (*appproperty.Room, error) {
+	room, err := a.repo.CreateRoom(ctx, tx, dbproperties.CreateRoomParams{
+		PropertyID: params.PropertyID,
+		Name:       params.Name,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toApplicationRoom(room), nil
+}
+
+func (a propertyRepositoryAdapter) FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*appproperty.Room, error) {
+	room, err := a.repo.FindRoomByID(ctx, tx, id)
+	if err != nil {
+		if err == dbproperties.ErrNotFound {
+			return nil, apperr.ErrRoomNotFound
+		}
+		return nil, err
+	}
+
+	return toApplicationRoom(room), nil
+}
+
+func (a propertyRepositoryAdapter) UpdateRoom(ctx context.Context, tx *sql.Tx, params appproperty.UpdateRoomParams) (*appproperty.Room, error) {
+	room, err := a.repo.UpdateRoom(ctx, tx, dbproperties.UpdateRoomParams{
+		ID:     params.ID,
+		Name:   params.Name,
+		Status: params.Status,
+	})
+	if err != nil {
+		if err == dbproperties.ErrNotFound {
+			return nil, apperr.ErrRoomNotFound
+		}
+		return nil, err
+	}
+
+	return toApplicationRoom(room), nil
+}
+
+func (a propertyRepositoryAdapter) SoftDeleteRoom(ctx context.Context, tx *sql.Tx, id string) error {
+	err := a.repo.SoftDeleteRoom(ctx, tx, id)
+	if err == dbproperties.ErrNotFound {
+		return apperr.ErrRoomNotFound
+	}
+	return err
+}
+
+func (a propertyRepositoryAdapter) CreateRepairRequest(ctx context.Context, tx *sql.Tx, params appproperty.CreateRepairRequestParams) (*appproperty.RepairRequest, error) {
+	repairRequest, err := a.repo.CreateRepairRequest(ctx, tx, dbproperties.CreateRepairRequestParams{
+		PropertyID:  params.PropertyID,
+		RoomID:      params.RoomID,
+		SubmittedBy: params.SubmittedBy,
+		Title:       params.Title,
+		Description: params.Description,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toApplicationRepairRequest(repairRequest), nil
+}
+
 func toApplicationProperty(property *dbproperties.Property) *appproperty.Property {
 	return &appproperty.Property{
 		ID:                               property.ID,
@@ -99,5 +163,34 @@ func toApplicationProperty(property *dbproperties.Property) *appproperty.Propert
 		CreatedAt:                        property.CreatedAt,
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,
+	}
+}
+
+func toApplicationRoom(room *dbproperties.Room) *appproperty.Room {
+	return &appproperty.Room{
+		ID:         room.ID,
+		PropertyID: room.PropertyID,
+		Name:       room.Name,
+		Status:     room.Status,
+		CreatedAt:  room.CreatedAt,
+		UpdatedAt:  room.UpdatedAt,
+	}
+}
+
+func toApplicationRepairRequest(repairRequest *dbproperties.RepairRequest) *appproperty.RepairRequest {
+	return &appproperty.RepairRequest{
+		ID:          repairRequest.ID,
+		PropertyID:  repairRequest.PropertyID,
+		RoomID:      repairRequest.RoomID,
+		SubmittedBy: repairRequest.SubmittedBy,
+		AssignedTo:  repairRequest.AssignedTo,
+		Title:       repairRequest.Title,
+		Description: repairRequest.Description,
+		Status:      repairRequest.Status,
+		SubmittedAt: repairRequest.SubmittedAt,
+		AssignedAt:  repairRequest.AssignedAt,
+		CompletedAt: repairRequest.CompletedAt,
+		CreatedAt:   repairRequest.CreatedAt,
+		UpdatedAt:   repairRequest.UpdatedAt,
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -81,12 +81,16 @@ func New(cfg *config.Config) (*Server, error) {
 	createPropertyService := appproperty.NewCreatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	updatePropertyService := appproperty.NewUpdatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	deletePropertyService := appproperty.NewDeletePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
+	createRoomService := appproperty.NewCreateRoomService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
+	updateRoomService := appproperty.NewUpdateRoomService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
+	deleteRoomService := appproperty.NewDeleteRoomService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
+	setRoomMaintenanceService := appproperty.NewSetRoomMaintenanceService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	jobTriggerService := appjobs.NewTriggerService(jobRunStoreAdapter{repo: jobRunsRepo}, nil, cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)
 
 	engine := router.New(cfg.App, logger, db, authenticator, userRepo, router.AuthorizationRepositories{
 		Properties:        propertyRepo,
 		ResourceOwnership: resourceOwnershipRepo,
-	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, createPropertyService, updatePropertyService, deletePropertyService)
+	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService)
 
 	return &Server{
 		httpServer: &http.Server{


### PR DESCRIPTION
## Summary
- implement Property room command flows for create, update, delete, and maintenance entry
- enforce room mutation business rules in the room aggregate and application services
- create a room-scoped repair request and publish `RoomSetToMaintenance` after commit when entering maintenance
- add router, application, and domain coverage for the room command acceptance paths and rejection cases

## Why
Issue #13 requires the remaining Property command APIs for room mutations, including the composite maintenance flow that atomically creates a repair request and transitions the room to `maintenance`.

## Validation
- `go test ./internal/domain/property ./internal/application/property ./internal/http/router`
- `go test ./...`

Closes #13