### PR TITLE
[codex] Implement lease list detail create APIs

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -2343,7 +2343,7 @@ paths:
         x-required-role: admin, organizer, staff
         觸發 LeaseCreated event → Property BC（Room 改 occupied）+ Billing BC（預產帳單）
         BR-01：起始日不得晚於終止日
-        BR-02：租金不得為零
+        BR-02：租金必須大於零
         BR-03：押金不得為負
         BR-12：目標房間必須為 vacant（取悲觀鎖後檢查）
         electricity_billing_cadence 可於建約時覆寫，未提供時套用 Property 預設值
@@ -2458,11 +2458,11 @@ paths:
                   value:
                     error_code: LEASE_INVALID_DATE_RANGE
                     message: 租約起始日不得晚於終止日
-                rent_amount_zero:
-                  summary: BR-02 租金不得為零
+                rent_amount_non_positive:
+                  summary: BR-02 租金必須大於零
                   value:
-                    error_code: LEASE_RENT_AMOUNT_ZERO
-                    message: 租金不得為零
+                    error_code: LEASE_RENT_AMOUNT_NON_POSITIVE
+                    message: 租金必須大於零
                 deposit_negative:
                   summary: BR-03 押金不得為負
                   value:
@@ -2639,11 +2639,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
               examples:
-                rent_amount_zero:
-                  summary: BR-02 租金不得為零
+                rent_amount_non_positive:
+                  summary: BR-02 租金必須大於零
                   value:
-                    error_code: LEASE_RENT_AMOUNT_ZERO
-                    message: 租金不得為零
+                    error_code: LEASE_RENT_AMOUNT_NON_POSITIVE
+                    message: 租金必須大於零
     delete:
       operationId: deleteLease
       summary: 刪除租約（軟刪除）

--- a/docs/spec/src/paths/tenancy/leases.yaml
+++ b/docs/spec/src/paths/tenancy/leases.yaml
@@ -79,7 +79,7 @@ post:
     x-required-role: admin, organizer, staff
     觸發 LeaseCreated event → Property BC（Room 改 occupied）+ Billing BC（預產帳單）
     BR-01：起始日不得晚於終止日
-    BR-02：租金不得為零
+    BR-02：租金必須大於零
     BR-03：押金不得為負
     BR-12：目標房間必須為 vacant（取悲觀鎖後檢查）
     electricity_billing_cadence 可於建約時覆寫，未提供時套用 Property 預設值
@@ -194,11 +194,11 @@ post:
               value:
                 error_code: LEASE_INVALID_DATE_RANGE
                 message: 租約起始日不得晚於終止日
-            rent_amount_zero:
-              summary: BR-02 租金不得為零
+            rent_amount_non_positive:
+              summary: BR-02 租金必須大於零
               value:
-                error_code: LEASE_RENT_AMOUNT_ZERO
-                message: 租金不得為零
+                error_code: LEASE_RENT_AMOUNT_NON_POSITIVE
+                message: 租金必須大於零
             deposit_negative:
               summary: BR-03 押金不得為負
               value:

--- a/docs/spec/src/paths/tenancy/leases_{id}.yaml
+++ b/docs/spec/src/paths/tenancy/leases_{id}.yaml
@@ -166,11 +166,11 @@ patch:
           schema:
             $ref: ../../components/schemas/shared/ErrorResponse.yaml
           examples:
-            rent_amount_zero:
-              summary: BR-02 租金不得為零
+            rent_amount_non_positive:
+              summary: BR-02 租金必須大於零
               value:
-                error_code: LEASE_RENT_AMOUNT_ZERO
-                message: 租金不得為零
+                error_code: LEASE_RENT_AMOUNT_NON_POSITIVE
+                message: 租金必須大於零
 delete:
   operationId: deleteLease
   summary: 刪除租約（軟刪除）

--- a/internal/application/lease/create_lease.go
+++ b/internal/application/lease/create_lease.go
@@ -1,0 +1,193 @@
+package lease
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+
+	domainevents "stds_backend/internal/domain/events"
+	domainlease "stds_backend/internal/domain/lease"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+const (
+	billTypeRent        = "rent"
+	billTypeElectricity = "electricity"
+
+	billStatusPendingPayment = "pending_payment"
+	billStatusPendingMeter   = "pending_meter"
+)
+
+// CreateLeaseInput is the command payload for creating a lease.
+type CreateLeaseInput struct {
+	ActorRole                 string
+	AssignedPropertyIDs       []string
+	TenantID                  string
+	RoomID                    string
+	RentAmount                int
+	StartDate                 time.Time
+	EndDate                   time.Time
+	DepositAmount             int
+	ElectricityBillingCadence *string
+}
+
+// CreateLeaseService creates a lease and pre-generates bills.
+type CreateLeaseService struct {
+	repo     Repository
+	txRunner *txrunner.Runner
+}
+
+// NewCreateLeaseService returns a CreateLeaseService.
+func NewCreateLeaseService(repo Repository, txRunner *txrunner.Runner) *CreateLeaseService {
+	return &CreateLeaseService{repo: repo, txRunner: txRunner}
+}
+
+// Execute validates input, creates the lease, pre-generates bills, and records LeaseCreated.
+func (s *CreateLeaseService) Execute(ctx context.Context, input CreateLeaseInput) (*Lease, error) {
+	tenantID := strings.TrimSpace(input.TenantID)
+	if tenantID == "" {
+		return nil, errValidationTenantIDRequired
+	}
+
+	roomID := strings.TrimSpace(input.RoomID)
+	if roomID == "" {
+		return nil, errValidationRoomIDRequired
+	}
+
+	var created *Lease
+	err := s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+		if _, err := s.repo.FindTenantByID(ctx, tx, tenantID); err != nil {
+			switch err {
+			case ErrTenantNotFound:
+				return apperr.ErrTenantNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+
+		room, err := s.repo.FindRoomByIDForUpdate(ctx, tx, roomID)
+		if err != nil {
+			switch err {
+			case ErrRoomNotFound:
+				return apperr.ErrRoomNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+		if room.Status != "vacant" {
+			return errRoomNotVacant
+		}
+		if (input.ActorRole == "organizer" || input.ActorRole == "staff") && !containsAssignedProperty(input.AssignedPropertyIDs, room.PropertyID) {
+			return apperr.ErrForbidden
+		}
+
+		cadence := room.DefaultElectricityBillingCadence
+		if input.ElectricityBillingCadence != nil {
+			cadence = strings.TrimSpace(*input.ElectricityBillingCadence)
+		}
+
+		aggregate, err := domainlease.New(domainlease.State{
+			TenantID:                  tenantID,
+			RoomID:                    roomID,
+			PropertyID:                room.PropertyID,
+			RentAmount:                input.RentAmount,
+			StartDate:                 input.StartDate,
+			EndDate:                   input.EndDate,
+			ElectricityBillingCadence: cadence,
+			DepositAmount:             input.DepositAmount,
+		})
+		if err != nil {
+			return mapDomainError(err)
+		}
+
+		state := aggregate.State()
+		createdLease, err := s.repo.CreateLease(ctx, tx, CreateLeaseParams{
+			TenantID:                  state.TenantID,
+			RoomID:                    state.RoomID,
+			PropertyID:                state.PropertyID,
+			RentAmount:                state.RentAmount,
+			StartDate:                 state.StartDate,
+			EndDate:                   state.EndDate,
+			ElectricityBillingCadence: state.ElectricityBillingCadence,
+			DepositAmount:             state.DepositAmount,
+		})
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		periods, err := domainlease.BuildBillingPeriods(state.StartDate, state.EndDate, state.ElectricityBillingCadence)
+		if err != nil {
+			return mapDomainError(err)
+		}
+
+		if err := s.repo.CreateBills(ctx, tx, buildBillSeeds(createdLease, periods)); err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		recorder.Record(domainevents.LeaseCreated{
+			LeaseID:                   createdLease.ID,
+			RoomID:                    createdLease.RoomID,
+			PropertyID:                createdLease.PropertyID,
+			TenantID:                  createdLease.TenantID,
+			StartDate:                 createdLease.StartDate,
+			EndDate:                   createdLease.EndDate,
+			ElectricityBillingCadence: createdLease.ElectricityBillingCadence,
+			OccurredAt:                time.Now().UTC(),
+		})
+
+		created = createdLease
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return created, nil
+}
+
+func containsAssignedProperty(assignedPropertyIDs []string, propertyID string) bool {
+	for _, assignedID := range assignedPropertyIDs {
+		if strings.TrimSpace(assignedID) == propertyID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func buildBillSeeds(lease *Lease, periods []domainlease.BillingPeriod) []CreateBillParams {
+	bills := make([]CreateBillParams, 0, len(periods)*2)
+	for _, period := range periods {
+		rentAmount := lease.RentAmount
+		bills = append(bills,
+			CreateBillParams{
+				LeaseID:     lease.ID,
+				TenantID:    lease.TenantID,
+				RoomID:      lease.RoomID,
+				PropertyID:  lease.PropertyID,
+				Type:        billTypeRent,
+				Amount:      &rentAmount,
+				PeriodStart: period.PeriodStart,
+				PeriodEnd:   period.PeriodEnd,
+				DueDate:     period.DueDate,
+				Status:      billStatusPendingPayment,
+			},
+			CreateBillParams{
+				LeaseID:     lease.ID,
+				TenantID:    lease.TenantID,
+				RoomID:      lease.RoomID,
+				PropertyID:  lease.PropertyID,
+				Type:        billTypeElectricity,
+				Amount:      nil,
+				PeriodStart: period.PeriodStart,
+				PeriodEnd:   period.PeriodEnd,
+				DueDate:     period.DueDate,
+				Status:      billStatusPendingMeter,
+			},
+		)
+	}
+
+	return bills
+}

--- a/internal/application/lease/create_lease.go
+++ b/internal/application/lease/create_lease.go
@@ -18,6 +18,8 @@ const (
 
 	billStatusPendingPayment = "pending_payment"
 	billStatusPendingMeter   = "pending_meter"
+
+	zeroUUID = "00000000-0000-0000-0000-000000000000"
 )
 
 // CreateLeaseInput is the command payload for creating a lease.
@@ -47,13 +49,19 @@ func NewCreateLeaseService(repo Repository, txRunner *txrunner.Runner) *CreateLe
 // Execute validates input, creates the lease, pre-generates bills, and records LeaseCreated.
 func (s *CreateLeaseService) Execute(ctx context.Context, input CreateLeaseInput) (*Lease, error) {
 	tenantID := strings.TrimSpace(input.TenantID)
-	if tenantID == "" {
+	if tenantID == "" || tenantID == zeroUUID {
 		return nil, errValidationTenantIDRequired
 	}
 
 	roomID := strings.TrimSpace(input.RoomID)
-	if roomID == "" {
+	if roomID == "" || roomID == zeroUUID {
 		return nil, errValidationRoomIDRequired
+	}
+	if input.StartDate.IsZero() {
+		return nil, errValidationStartDateRequired
+	}
+	if input.EndDate.IsZero() {
+		return nil, errValidationEndDateRequired
 	}
 
 	var created *Lease
@@ -117,12 +125,17 @@ func (s *CreateLeaseService) Execute(ctx context.Context, input CreateLeaseInput
 			return apperr.ErrInternalServerError.WithCause(err)
 		}
 
-		periods, err := domainlease.BuildBillingPeriods(state.StartDate, state.EndDate, state.ElectricityBillingCadence)
+		rentPeriods, err := domainlease.BuildBillingPeriods(state.StartDate, state.EndDate, domainlease.BillingCadenceMonthly)
 		if err != nil {
 			return mapDomainError(err)
 		}
 
-		if err := s.repo.CreateBills(ctx, tx, buildBillSeeds(createdLease, periods)); err != nil {
+		electricityPeriods, err := domainlease.BuildBillingPeriods(state.StartDate, state.EndDate, state.ElectricityBillingCadence)
+		if err != nil {
+			return mapDomainError(err)
+		}
+
+		if err := s.repo.CreateBills(ctx, tx, buildBillSeeds(createdLease, rentPeriods, electricityPeriods)); err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)
 		}
 
@@ -157,36 +170,36 @@ func containsAssignedProperty(assignedPropertyIDs []string, propertyID string) b
 	return false
 }
 
-func buildBillSeeds(lease *Lease, periods []domainlease.BillingPeriod) []CreateBillParams {
-	bills := make([]CreateBillParams, 0, len(periods)*2)
-	for _, period := range periods {
+func buildBillSeeds(lease *Lease, rentPeriods []domainlease.BillingPeriod, electricityPeriods []domainlease.BillingPeriod) []CreateBillParams {
+	bills := make([]CreateBillParams, 0, len(rentPeriods)+len(electricityPeriods))
+	for _, period := range rentPeriods {
 		rentAmount := lease.RentAmount
-		bills = append(bills,
-			CreateBillParams{
-				LeaseID:     lease.ID,
-				TenantID:    lease.TenantID,
-				RoomID:      lease.RoomID,
-				PropertyID:  lease.PropertyID,
-				Type:        billTypeRent,
-				Amount:      &rentAmount,
-				PeriodStart: period.PeriodStart,
-				PeriodEnd:   period.PeriodEnd,
-				DueDate:     period.DueDate,
-				Status:      billStatusPendingPayment,
-			},
-			CreateBillParams{
-				LeaseID:     lease.ID,
-				TenantID:    lease.TenantID,
-				RoomID:      lease.RoomID,
-				PropertyID:  lease.PropertyID,
-				Type:        billTypeElectricity,
-				Amount:      nil,
-				PeriodStart: period.PeriodStart,
-				PeriodEnd:   period.PeriodEnd,
-				DueDate:     period.DueDate,
-				Status:      billStatusPendingMeter,
-			},
-		)
+		bills = append(bills, CreateBillParams{
+			LeaseID:     lease.ID,
+			TenantID:    lease.TenantID,
+			RoomID:      lease.RoomID,
+			PropertyID:  lease.PropertyID,
+			Type:        billTypeRent,
+			Amount:      &rentAmount,
+			PeriodStart: period.PeriodStart,
+			PeriodEnd:   period.PeriodEnd,
+			DueDate:     period.DueDate,
+			Status:      billStatusPendingPayment,
+		})
+	}
+	for _, period := range electricityPeriods {
+		bills = append(bills, CreateBillParams{
+			LeaseID:     lease.ID,
+			TenantID:    lease.TenantID,
+			RoomID:      lease.RoomID,
+			PropertyID:  lease.PropertyID,
+			Type:        billTypeElectricity,
+			Amount:      nil,
+			PeriodStart: period.PeriodStart,
+			PeriodEnd:   period.PeriodEnd,
+			DueDate:     period.DueDate,
+			Status:      billStatusPendingMeter,
+		})
 	}
 
 	return bills

--- a/internal/application/lease/create_lease.go
+++ b/internal/application/lease/create_lease.go
@@ -65,6 +65,13 @@ func (s *CreateLeaseService) Execute(ctx context.Context, input CreateLeaseInput
 		return nil, errValidationEndDateRequired
 	}
 
+	actorRole := strings.ToLower(strings.TrimSpace(input.ActorRole))
+	switch actorRole {
+	case "admin", "organizer", "staff":
+	default:
+		return nil, apperr.ErrForbidden
+	}
+
 	var created *Lease
 	err := s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
 		if _, err := s.repo.FindTenantByID(ctx, tx, tenantID); err != nil {
@@ -88,7 +95,7 @@ func (s *CreateLeaseService) Execute(ctx context.Context, input CreateLeaseInput
 		if room.Status != "vacant" {
 			return errRoomNotVacant
 		}
-		if (input.ActorRole == "organizer" || input.ActorRole == "staff") && !containsAssignedProperty(input.AssignedPropertyIDs, room.PropertyID) {
+		if (actorRole == "organizer" || actorRole == "staff") && !containsAssignedProperty(input.AssignedPropertyIDs, room.PropertyID) {
 			return apperr.ErrForbidden
 		}
 

--- a/internal/application/lease/create_lease.go
+++ b/internal/application/lease/create_lease.go
@@ -3,6 +3,7 @@ package lease
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"strings"
 	"time"
 
@@ -67,8 +68,8 @@ func (s *CreateLeaseService) Execute(ctx context.Context, input CreateLeaseInput
 	var created *Lease
 	err := s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
 		if _, err := s.repo.FindTenantByID(ctx, tx, tenantID); err != nil {
-			switch err {
-			case ErrTenantNotFound:
+			switch {
+			case errors.Is(err, ErrTenantNotFound):
 				return apperr.ErrTenantNotFound
 			default:
 				return apperr.ErrInternalServerError.WithCause(err)
@@ -77,8 +78,8 @@ func (s *CreateLeaseService) Execute(ctx context.Context, input CreateLeaseInput
 
 		room, err := s.repo.FindRoomByIDForUpdate(ctx, tx, roomID)
 		if err != nil {
-			switch err {
-			case ErrRoomNotFound:
+			switch {
+			case errors.Is(err, ErrRoomNotFound):
 				return apperr.ErrRoomNotFound
 			default:
 				return apperr.ErrInternalServerError.WithCause(err)

--- a/internal/application/lease/create_lease_test.go
+++ b/internal/application/lease/create_lease_test.go
@@ -1,0 +1,298 @@
+package lease
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	domainevents "stds_backend/internal/domain/events"
+	dbtxrunner "stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+func TestCreateLeaseServiceCreatesLeaseAndPreGeneratesBills(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	publisher := &recordingPublisher{}
+	repo := &leaseRepositoryStub{
+		tenant: &Tenant{ID: "tenant-1", Status: "inactive"},
+		room: &Room{
+			ID:                               "room-1",
+			PropertyID:                       "property-1",
+			Status:                           "vacant",
+			DefaultElectricityBillingCadence: "monthly",
+		},
+		createdLease: &Lease{
+			ID:                        "lease-1",
+			TenantID:                  "tenant-1",
+			PropertyID:                "property-1",
+			RoomID:                    "room-1",
+			RentAmount:                18000,
+			StartDate:                 time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+			EndDate:                   time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
+			ElectricityBillingCadence: "monthly",
+			Status:                    "active",
+			DepositAmount:             36000,
+			DepositStatus:             "held",
+			CreatedAt:                 time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+			UpdatedAt:                 time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+			Version:                   1,
+		},
+	}
+
+	service := NewCreateLeaseService(repo, dbtxrunner.New(db, publisher))
+	lease, err := service.Execute(context.Background(), CreateLeaseInput{
+		TenantID:      "tenant-1",
+		RoomID:        "room-1",
+		RentAmount:    18000,
+		StartDate:     time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+		EndDate:       time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
+		DepositAmount: 36000,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if lease.ID != "lease-1" {
+		t.Fatalf("expected lease-1, got %q", lease.ID)
+	}
+	if len(repo.createdBills) != 6 {
+		t.Fatalf("expected 6 created bills, got %d", len(repo.createdBills))
+	}
+
+	firstRent := repo.createdBills[0]
+	if firstRent.Type != billTypeRent || firstRent.Status != billStatusPendingPayment || firstRent.Amount == nil || *firstRent.Amount != 18000 {
+		t.Fatalf("unexpected first rent bill: %+v", firstRent)
+	}
+	if !firstRent.PeriodStart.Equal(time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)) || !firstRent.PeriodEnd.Equal(time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)) || !firstRent.DueDate.Equal(time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("unexpected first rent bill period: %+v", firstRent)
+	}
+
+	lastElectricity := repo.createdBills[len(repo.createdBills)-1]
+	if lastElectricity.Type != billTypeElectricity || lastElectricity.Status != billStatusPendingMeter || lastElectricity.Amount != nil {
+		t.Fatalf("unexpected last electricity bill: %+v", lastElectricity)
+	}
+	if !lastElectricity.PeriodStart.Equal(time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)) || !lastElectricity.PeriodEnd.Equal(time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC)) || !lastElectricity.DueDate.Equal(time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("unexpected last electricity period: %+v", lastElectricity)
+	}
+
+	if len(publisher.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(publisher.events))
+	}
+	event, ok := publisher.events[0].(domainevents.LeaseCreated)
+	if !ok {
+		t.Fatalf("expected LeaseCreated event, got %T", publisher.events[0])
+	}
+	if event.LeaseID != "lease-1" || event.RoomID != "room-1" || event.TenantID != "tenant-1" || event.ElectricityBillingCadence != "monthly" {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateLeaseServiceUsesExplicitCadenceOverride(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	override := "bimonthly"
+	repo := &leaseRepositoryStub{
+		tenant: &Tenant{ID: "tenant-1", Status: "active"},
+		room: &Room{
+			ID:                               "room-1",
+			PropertyID:                       "property-1",
+			Status:                           "vacant",
+			DefaultElectricityBillingCadence: "monthly",
+		},
+		createdLease: &Lease{
+			ID:                        "lease-1",
+			TenantID:                  "tenant-1",
+			PropertyID:                "property-1",
+			RoomID:                    "room-1",
+			RentAmount:                18000,
+			StartDate:                 time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+			EndDate:                   time.Date(2026, 10, 20, 0, 0, 0, 0, time.UTC),
+			ElectricityBillingCadence: "bimonthly",
+			Status:                    "active",
+			DepositAmount:             36000,
+			DepositStatus:             "held",
+		},
+	}
+
+	service := NewCreateLeaseService(repo, dbtxrunner.New(db, nil))
+	_, err = service.Execute(context.Background(), CreateLeaseInput{
+		TenantID:                  "tenant-1",
+		RoomID:                    "room-1",
+		RentAmount:                18000,
+		StartDate:                 time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+		EndDate:                   time.Date(2026, 10, 20, 0, 0, 0, 0, time.UTC),
+		DepositAmount:             36000,
+		ElectricityBillingCadence: &override,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if repo.createLeaseParams == nil || repo.createLeaseParams.ElectricityBillingCadence != "bimonthly" {
+		t.Fatalf("expected bimonthly cadence, got %+v", repo.createLeaseParams)
+	}
+	if len(repo.createdBills) != 6 {
+		t.Fatalf("expected 6 bills for 3 bimonthly periods, got %d", len(repo.createdBills))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateLeaseServiceRejectsBusinessRuleViolationsAndMissingReferences(t *testing.T) {
+	t.Run("missing tenant id", func(t *testing.T) {
+		service := NewCreateLeaseService(nil, nil)
+		_, err := service.Execute(context.Background(), CreateLeaseInput{RoomID: "room-1"})
+		if !errors.Is(err, errValidationTenantIDRequired) {
+			t.Fatalf("expected errValidationTenantIDRequired, got %v", err)
+		}
+	})
+
+	t.Run("missing room id", func(t *testing.T) {
+		service := NewCreateLeaseService(nil, nil)
+		_, err := service.Execute(context.Background(), CreateLeaseInput{TenantID: "tenant-1"})
+		if !errors.Is(err, errValidationRoomIDRequired) {
+			t.Fatalf("expected errValidationRoomIDRequired, got %v", err)
+		}
+	})
+
+	t.Run("tenant not found", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		defer db.Close()
+		mock.ExpectBegin()
+		mock.ExpectRollback()
+
+		service := NewCreateLeaseService(&leaseRepositoryStub{tenantErr: ErrTenantNotFound}, dbtxrunner.New(db, nil))
+		_, err = service.Execute(context.Background(), CreateLeaseInput{
+			TenantID:      "tenant-1",
+			RoomID:        "room-1",
+			RentAmount:    18000,
+			StartDate:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:       time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+			DepositAmount: 36000,
+		})
+		if !errors.Is(err, apperr.ErrTenantNotFound) {
+			t.Fatalf("expected tenant not found, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("ExpectationsWereMet: %v", err)
+		}
+	})
+
+	t.Run("room not vacant", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		defer db.Close()
+		mock.ExpectBegin()
+		mock.ExpectRollback()
+
+		service := NewCreateLeaseService(&leaseRepositoryStub{
+			tenant: &Tenant{ID: "tenant-1", Status: "active"},
+			room: &Room{
+				ID:                               "room-1",
+				PropertyID:                       "property-1",
+				Status:                           "occupied",
+				DefaultElectricityBillingCadence: "monthly",
+			},
+		}, dbtxrunner.New(db, nil))
+		_, err = service.Execute(context.Background(), CreateLeaseInput{
+			TenantID:      "tenant-1",
+			RoomID:        "room-1",
+			RentAmount:    18000,
+			StartDate:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:       time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+			DepositAmount: 36000,
+		})
+		if !errors.Is(err, errRoomNotVacant) {
+			t.Fatalf("expected errRoomNotVacant, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("ExpectationsWereMet: %v", err)
+		}
+	})
+}
+
+type leaseRepositoryStub struct {
+	tenant            *Tenant
+	tenantErr         error
+	room              *Room
+	roomErr           error
+	createdLease      *Lease
+	createLeaseErr    error
+	createBillsErr    error
+	createLeaseParams *CreateLeaseParams
+	createdBills      []CreateBillParams
+}
+
+func (s *leaseRepositoryStub) FindTenantByID(context.Context, *sql.Tx, string) (*Tenant, error) {
+	if s.tenantErr != nil {
+		return nil, s.tenantErr
+	}
+	return s.tenant, nil
+}
+
+func (s *leaseRepositoryStub) FindRoomByIDForUpdate(context.Context, *sql.Tx, string) (*Room, error) {
+	if s.roomErr != nil {
+		return nil, s.roomErr
+	}
+	return s.room, nil
+}
+
+func (s *leaseRepositoryStub) CreateLease(_ context.Context, _ *sql.Tx, params CreateLeaseParams) (*Lease, error) {
+	s.createLeaseParams = &params
+	if s.createLeaseErr != nil {
+		return nil, s.createLeaseErr
+	}
+	return s.createdLease, nil
+}
+
+func (s *leaseRepositoryStub) CreateBills(_ context.Context, _ *sql.Tx, params []CreateBillParams) error {
+	s.createdBills = append([]CreateBillParams(nil), params...)
+	return s.createBillsErr
+}
+
+func (s *leaseRepositoryStub) MarkRoomOccupied(context.Context, *sql.Tx, string) error {
+	return nil
+}
+
+func (s *leaseRepositoryStub) ActivateTenant(context.Context, *sql.Tx, string) error {
+	return nil
+}
+
+type recordingPublisher struct {
+	events []any
+}
+
+func (p *recordingPublisher) Publish(_ context.Context, event any) error {
+	p.events = append(p.events, event)
+	return nil
+}

--- a/internal/application/lease/create_lease_test.go
+++ b/internal/application/lease/create_lease_test.go
@@ -296,8 +296,8 @@ func TestCreateLeaseServiceRejectsBusinessRuleViolationsAndMissingReferences(t *
 			EndDate:       time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
 			DepositAmount: 36000,
 		})
-		if !errors.Is(err, errLeaseRentAmountZero) {
-			t.Fatalf("expected errLeaseRentAmountZero, got %v", err)
+		if !errors.Is(err, errLeaseRentAmountNonPositive) {
+			t.Fatalf("expected errLeaseRentAmountNonPositive, got %v", err)
 		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("ExpectationsWereMet: %v", err)

--- a/internal/application/lease/create_lease_test.go
+++ b/internal/application/lease/create_lease_test.go
@@ -59,6 +59,7 @@ func TestCreateLeaseServiceCreatesLeaseAndPreGeneratesBills(t *testing.T) {
 		StartDate:     time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
 		EndDate:       time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
 		DepositAmount: 36000,
+		ActorRole:     "admin",
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -146,6 +147,7 @@ func TestCreateLeaseServiceUsesExplicitCadenceOverride(t *testing.T) {
 		EndDate:                   time.Date(2026, 10, 20, 0, 0, 0, 0, time.UTC),
 		DepositAmount:             36000,
 		ElectricityBillingCadence: &override,
+		ActorRole:                 "admin",
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -227,6 +229,7 @@ func TestCreateLeaseServiceRejectsBusinessRuleViolationsAndMissingReferences(t *
 			StartDate:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
 			EndDate:       time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
 			DepositAmount: 36000,
+			ActorRole:     "admin",
 		})
 		if !errors.Is(err, apperr.ErrTenantNotFound) {
 			t.Fatalf("expected tenant not found, got %v", err)
@@ -261,6 +264,7 @@ func TestCreateLeaseServiceRejectsBusinessRuleViolationsAndMissingReferences(t *
 			StartDate:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
 			EndDate:       time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
 			DepositAmount: 36000,
+			ActorRole:     "admin",
 		})
 		if !errors.Is(err, errRoomNotVacant) {
 			t.Fatalf("expected errRoomNotVacant, got %v", err)
@@ -295,12 +299,44 @@ func TestCreateLeaseServiceRejectsBusinessRuleViolationsAndMissingReferences(t *
 			StartDate:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
 			EndDate:       time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
 			DepositAmount: 36000,
+			ActorRole:     "admin",
 		})
 		if !errors.Is(err, errLeaseRentAmountNonPositive) {
 			t.Fatalf("expected errLeaseRentAmountNonPositive, got %v", err)
 		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("ExpectationsWereMet: %v", err)
+		}
+	})
+
+	t.Run("empty actor role", func(t *testing.T) {
+		service := NewCreateLeaseService(nil, nil)
+		_, err := service.Execute(context.Background(), CreateLeaseInput{
+			TenantID:      "tenant-1",
+			RoomID:        "room-1",
+			RentAmount:    18000,
+			StartDate:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:       time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+			DepositAmount: 36000,
+		})
+		if !errors.Is(err, apperr.ErrForbidden) {
+			t.Fatalf("expected forbidden, got %v", err)
+		}
+	})
+
+	t.Run("unknown actor role", func(t *testing.T) {
+		service := NewCreateLeaseService(nil, nil)
+		_, err := service.Execute(context.Background(), CreateLeaseInput{
+			TenantID:      "tenant-1",
+			RoomID:        "room-1",
+			RentAmount:    18000,
+			StartDate:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:       time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+			DepositAmount: 36000,
+			ActorRole:     "superuser",
+		})
+		if !errors.Is(err, apperr.ErrForbidden) {
+			t.Fatalf("expected forbidden, got %v", err)
 		}
 	})
 }

--- a/internal/application/lease/create_lease_test.go
+++ b/internal/application/lease/create_lease_test.go
@@ -154,8 +154,15 @@ func TestCreateLeaseServiceUsesExplicitCadenceOverride(t *testing.T) {
 	if repo.createLeaseParams == nil || repo.createLeaseParams.ElectricityBillingCadence != "bimonthly" {
 		t.Fatalf("expected bimonthly cadence, got %+v", repo.createLeaseParams)
 	}
-	if len(repo.createdBills) != 6 {
-		t.Fatalf("expected 6 bills for 3 bimonthly periods, got %d", len(repo.createdBills))
+	if len(repo.createdBills) != 9 {
+		t.Fatalf("expected 9 bills for 6 rent periods and 3 electricity periods, got %d", len(repo.createdBills))
+	}
+	firstElectricity := repo.createdBills[6]
+	if firstElectricity.Type != billTypeElectricity || firstElectricity.Status != billStatusPendingMeter || firstElectricity.Amount != nil {
+		t.Fatalf("unexpected first electricity bill: %+v", firstElectricity)
+	}
+	if !firstElectricity.PeriodStart.Equal(time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC)) || !firstElectricity.PeriodEnd.Equal(time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("unexpected first electricity period: %+v", firstElectricity)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -177,6 +184,29 @@ func TestCreateLeaseServiceRejectsBusinessRuleViolationsAndMissingReferences(t *
 		_, err := service.Execute(context.Background(), CreateLeaseInput{TenantID: "tenant-1"})
 		if !errors.Is(err, errValidationRoomIDRequired) {
 			t.Fatalf("expected errValidationRoomIDRequired, got %v", err)
+		}
+	})
+
+	t.Run("zero tenant id", func(t *testing.T) {
+		service := NewCreateLeaseService(nil, nil)
+		_, err := service.Execute(context.Background(), CreateLeaseInput{
+			TenantID: "00000000-0000-0000-0000-000000000000",
+			RoomID:   "room-1",
+		})
+		if !errors.Is(err, errValidationTenantIDRequired) {
+			t.Fatalf("expected errValidationTenantIDRequired, got %v", err)
+		}
+	})
+
+	t.Run("zero start date", func(t *testing.T) {
+		service := NewCreateLeaseService(nil, nil)
+		_, err := service.Execute(context.Background(), CreateLeaseInput{
+			TenantID: "tenant-1",
+			RoomID:   "room-1",
+			EndDate:  time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+		})
+		if !errors.Is(err, errValidationStartDateRequired) {
+			t.Fatalf("expected errValidationStartDateRequired, got %v", err)
 		}
 	})
 
@@ -234,6 +264,40 @@ func TestCreateLeaseServiceRejectsBusinessRuleViolationsAndMissingReferences(t *
 		})
 		if !errors.Is(err, errRoomNotVacant) {
 			t.Fatalf("expected errRoomNotVacant, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("ExpectationsWereMet: %v", err)
+		}
+	})
+
+	t.Run("negative rent", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		if err != nil {
+			t.Fatalf("sqlmock.New: %v", err)
+		}
+		defer db.Close()
+		mock.ExpectBegin()
+		mock.ExpectRollback()
+
+		service := NewCreateLeaseService(&leaseRepositoryStub{
+			tenant: &Tenant{ID: "tenant-1", Status: "active"},
+			room: &Room{
+				ID:                               "room-1",
+				PropertyID:                       "property-1",
+				Status:                           "vacant",
+				DefaultElectricityBillingCadence: "monthly",
+			},
+		}, dbtxrunner.New(db, nil))
+		_, err = service.Execute(context.Background(), CreateLeaseInput{
+			TenantID:      "tenant-1",
+			RoomID:        "room-1",
+			RentAmount:    -1,
+			StartDate:     time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:       time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+			DepositAmount: 36000,
+		})
+		if !errors.Is(err, errLeaseRentAmountZero) {
+			t.Fatalf("expected errLeaseRentAmountZero, got %v", err)
 		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("ExpectationsWereMet: %v", err)

--- a/internal/application/lease/errors.go
+++ b/internal/application/lease/errors.go
@@ -1,0 +1,72 @@
+package lease
+
+import (
+	"errors"
+	"net/http"
+
+	domainlease "stds_backend/internal/domain/lease"
+	"stds_backend/internal/shared/apperr"
+)
+
+const (
+	codeValidationTenantIDRequired = "VALIDATION_TENANT_ID_REQUIRED"
+	codeValidationRoomIDRequired   = "VALIDATION_ROOM_ID_REQUIRED"
+	codeLeaseInvalidDateRange      = "LEASE_INVALID_DATE_RANGE"
+	codeLeaseRentAmountZero        = "LEASE_RENT_AMOUNT_ZERO"
+	codeLeaseDepositNegative       = "LEASE_DEPOSIT_NEGATIVE"
+	codeRoomNotVacant              = "ROOM_NOT_VACANT"
+)
+
+var (
+	errValidationTenantIDRequired = apperr.New(
+		codeValidationTenantIDRequired,
+		http.StatusBadRequest,
+		"tenant_id is required.",
+	)
+	errValidationRoomIDRequired = apperr.New(
+		codeValidationRoomIDRequired,
+		http.StatusBadRequest,
+		"room_id is required.",
+	)
+	errLeaseInvalidDateRange = apperr.New(
+		codeLeaseInvalidDateRange,
+		http.StatusUnprocessableEntity,
+		"Lease start date must not be later than end date.",
+	)
+	errLeaseRentAmountZero = apperr.New(
+		codeLeaseRentAmountZero,
+		http.StatusUnprocessableEntity,
+		"Lease rent amount must not be zero.",
+	)
+	errLeaseDepositNegative = apperr.New(
+		codeLeaseDepositNegative,
+		http.StatusUnprocessableEntity,
+		"Lease deposit amount must not be negative.",
+	)
+	errRoomNotVacant = apperr.New(
+		codeRoomNotVacant,
+		http.StatusUnprocessableEntity,
+		"Room is not vacant.",
+	)
+)
+
+func mapDomainError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, domainlease.ErrInvalidDateRange):
+		return errLeaseInvalidDateRange
+	case errors.Is(err, domainlease.ErrRentAmountZero):
+		return errLeaseRentAmountZero
+	case errors.Is(err, domainlease.ErrDepositNegative):
+		return errLeaseDepositNegative
+	case errors.Is(err, domainlease.ErrInvalidCadence):
+		return apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field": "electricity_billing_cadence",
+		})
+	default:
+		return err
+	}
+}

--- a/internal/application/lease/errors.go
+++ b/internal/application/lease/errors.go
@@ -79,6 +79,6 @@ func mapDomainError(err error) error {
 			"field": "electricity_billing_cadence",
 		})
 	default:
-		return err
+		return apperr.ErrInternalServerError.WithCause(err)
 	}
 }

--- a/internal/application/lease/errors.go
+++ b/internal/application/lease/errors.go
@@ -14,7 +14,7 @@ const (
 	codeValidationStartDateRequired = "VALIDATION_START_DATE_REQUIRED"
 	codeValidationEndDateRequired   = "VALIDATION_END_DATE_REQUIRED"
 	codeLeaseInvalidDateRange       = "LEASE_INVALID_DATE_RANGE"
-	codeLeaseRentAmountZero         = "LEASE_RENT_AMOUNT_ZERO"
+	codeLeaseRentAmountNonPositive  = "LEASE_RENT_AMOUNT_NON_POSITIVE"
 	codeLeaseDepositNegative        = "LEASE_DEPOSIT_NEGATIVE"
 	codeRoomNotVacant               = "ROOM_NOT_VACANT"
 )
@@ -45,10 +45,10 @@ var (
 		http.StatusUnprocessableEntity,
 		"Lease start date must not be later than end date.",
 	)
-	errLeaseRentAmountZero = apperr.New(
-		codeLeaseRentAmountZero,
+	errLeaseRentAmountNonPositive = apperr.New(
+		codeLeaseRentAmountNonPositive,
 		http.StatusUnprocessableEntity,
-		"Lease rent amount must not be zero.",
+		"Lease rent amount must be greater than zero.",
 	)
 	errLeaseDepositNegative = apperr.New(
 		codeLeaseDepositNegative,
@@ -70,8 +70,8 @@ func mapDomainError(err error) error {
 	switch {
 	case errors.Is(err, domainlease.ErrInvalidDateRange):
 		return errLeaseInvalidDateRange
-	case errors.Is(err, domainlease.ErrRentAmountZero):
-		return errLeaseRentAmountZero
+	case errors.Is(err, domainlease.ErrRentAmountNonPositive):
+		return errLeaseRentAmountNonPositive
 	case errors.Is(err, domainlease.ErrDepositNegative):
 		return errLeaseDepositNegative
 	case errors.Is(err, domainlease.ErrInvalidCadence):

--- a/internal/application/lease/errors.go
+++ b/internal/application/lease/errors.go
@@ -9,12 +9,14 @@ import (
 )
 
 const (
-	codeValidationTenantIDRequired = "VALIDATION_TENANT_ID_REQUIRED"
-	codeValidationRoomIDRequired   = "VALIDATION_ROOM_ID_REQUIRED"
-	codeLeaseInvalidDateRange      = "LEASE_INVALID_DATE_RANGE"
-	codeLeaseRentAmountZero        = "LEASE_RENT_AMOUNT_ZERO"
-	codeLeaseDepositNegative       = "LEASE_DEPOSIT_NEGATIVE"
-	codeRoomNotVacant              = "ROOM_NOT_VACANT"
+	codeValidationTenantIDRequired  = "VALIDATION_TENANT_ID_REQUIRED"
+	codeValidationRoomIDRequired    = "VALIDATION_ROOM_ID_REQUIRED"
+	codeValidationStartDateRequired = "VALIDATION_START_DATE_REQUIRED"
+	codeValidationEndDateRequired   = "VALIDATION_END_DATE_REQUIRED"
+	codeLeaseInvalidDateRange       = "LEASE_INVALID_DATE_RANGE"
+	codeLeaseRentAmountZero         = "LEASE_RENT_AMOUNT_ZERO"
+	codeLeaseDepositNegative        = "LEASE_DEPOSIT_NEGATIVE"
+	codeRoomNotVacant               = "ROOM_NOT_VACANT"
 )
 
 var (
@@ -27,6 +29,16 @@ var (
 		codeValidationRoomIDRequired,
 		http.StatusBadRequest,
 		"room_id is required.",
+	)
+	errValidationStartDateRequired = apperr.New(
+		codeValidationStartDateRequired,
+		http.StatusBadRequest,
+		"start_date is required.",
+	)
+	errValidationEndDateRequired = apperr.New(
+		codeValidationEndDateRequired,
+		http.StatusBadRequest,
+		"end_date is required.",
 	)
 	errLeaseInvalidDateRange = apperr.New(
 		codeLeaseInvalidDateRange,

--- a/internal/application/lease/repository.go
+++ b/internal/application/lease/repository.go
@@ -1,0 +1,88 @@
+package lease
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+var (
+	ErrLeaseNotFound  = errors.New("lease not found")
+	ErrTenantNotFound = errors.New("tenant not found")
+	ErrRoomNotFound   = errors.New("room not found")
+)
+
+// Lease is the application-facing lease shape.
+type Lease struct {
+	ID                        string
+	TenantID                  string
+	PropertyID                string
+	RoomID                    string
+	RentAmount                int
+	StartDate                 time.Time
+	EndDate                   time.Time
+	ElectricityBillingCadence string
+	Status                    string
+	DepositAmount             int
+	DepositRefundAmount       *int
+	DepositDeductionAmount    *int
+	DepositStatus             string
+	DepositDeductionReason    *string
+	Notes                     *string
+	TerminationReason         *string
+	SettlementDetail          *map[string]interface{}
+	CreatedAt                 time.Time
+	UpdatedAt                 time.Time
+	Version                   int
+}
+
+// Tenant captures tenant state required by lease workflows.
+type Tenant struct {
+	ID     string
+	Status string
+}
+
+// Room captures locked room state plus property defaults required by lease workflows.
+type Room struct {
+	ID                               string
+	PropertyID                       string
+	Status                           string
+	DefaultElectricityBillingCadence string
+}
+
+// CreateLeaseParams contains the writable lease fields.
+type CreateLeaseParams struct {
+	TenantID                  string
+	RoomID                    string
+	PropertyID                string
+	RentAmount                int
+	StartDate                 time.Time
+	EndDate                   time.Time
+	ElectricityBillingCadence string
+	DepositAmount             int
+}
+
+// CreateBillParams contains the pre-generated bill fields.
+type CreateBillParams struct {
+	LeaseID     string
+	TenantID    string
+	RoomID      string
+	PropertyID  string
+	Type        string
+	Amount      *int
+	PeriodStart time.Time
+	PeriodEnd   time.Time
+	DueDate     time.Time
+	Status      string
+}
+
+// Repository defines persistence required by lease use cases and subscribers.
+type Repository interface {
+	FindTenantByID(ctx context.Context, tx *sql.Tx, tenantID string) (*Tenant, error)
+	FindRoomByIDForUpdate(ctx context.Context, tx *sql.Tx, roomID string) (*Room, error)
+	CreateLease(ctx context.Context, tx *sql.Tx, params CreateLeaseParams) (*Lease, error)
+	CreateBills(ctx context.Context, tx *sql.Tx, params []CreateBillParams) error
+	MarkRoomOccupied(ctx context.Context, tx *sql.Tx, roomID string) error
+	ActivateTenant(ctx context.Context, tx *sql.Tx, tenantID string) error
+}

--- a/internal/application/lease/subscribers.go
+++ b/internal/application/lease/subscribers.go
@@ -1,0 +1,45 @@
+package lease
+
+import (
+	"context"
+	"database/sql"
+
+	domainevents "stds_backend/internal/domain/events"
+	"stds_backend/internal/platform/database/txrunner"
+)
+
+// OccupyRoomOnLeaseCreatedHandler updates room occupancy after lease creation.
+type OccupyRoomOnLeaseCreatedHandler struct {
+	repo     Repository
+	txRunner *txrunner.Runner
+}
+
+// NewOccupyRoomOnLeaseCreatedHandler returns an occupancy handler.
+func NewOccupyRoomOnLeaseCreatedHandler(repo Repository, txRunner *txrunner.Runner) *OccupyRoomOnLeaseCreatedHandler {
+	return &OccupyRoomOnLeaseCreatedHandler{repo: repo, txRunner: txRunner}
+}
+
+// HandleLeaseCreated marks the leased room as occupied.
+func (h *OccupyRoomOnLeaseCreatedHandler) HandleLeaseCreated(ctx context.Context, event domainevents.LeaseCreated) error {
+	return h.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		return h.repo.MarkRoomOccupied(ctx, tx, event.RoomID)
+	})
+}
+
+// ActivateTenantOnLeaseCreatedHandler reactivates inactive tenants after lease creation.
+type ActivateTenantOnLeaseCreatedHandler struct {
+	repo     Repository
+	txRunner *txrunner.Runner
+}
+
+// NewActivateTenantOnLeaseCreatedHandler returns a tenant activation handler.
+func NewActivateTenantOnLeaseCreatedHandler(repo Repository, txRunner *txrunner.Runner) *ActivateTenantOnLeaseCreatedHandler {
+	return &ActivateTenantOnLeaseCreatedHandler{repo: repo, txRunner: txRunner}
+}
+
+// HandleLeaseCreated marks the tenant active when needed.
+func (h *ActivateTenantOnLeaseCreatedHandler) HandleLeaseCreated(ctx context.Context, event domainevents.LeaseCreated) error {
+	return h.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		return h.repo.ActivateTenant(ctx, tx, event.TenantID)
+	})
+}

--- a/internal/domain/events/lease_created.go
+++ b/internal/domain/events/lease_created.go
@@ -1,0 +1,15 @@
+package events
+
+import "time"
+
+// LeaseCreated is emitted after a lease creation use case succeeds.
+type LeaseCreated struct {
+	LeaseID                   string
+	RoomID                    string
+	PropertyID                string
+	TenantID                  string
+	StartDate                 time.Time
+	EndDate                   time.Time
+	ElectricityBillingCadence string
+	OccurredAt                time.Time
+}

--- a/internal/domain/lease/aggregate.go
+++ b/internal/domain/lease/aggregate.go
@@ -78,7 +78,7 @@ func normalizeState(state State, creating bool) (State, error) {
 	if state.StartDate.After(state.EndDate) {
 		return State{}, ErrInvalidDateRange
 	}
-	if state.RentAmount == 0 {
+	if state.RentAmount <= 0 {
 		return State{}, ErrRentAmountZero
 	}
 	if state.DepositAmount < 0 {

--- a/internal/domain/lease/aggregate.go
+++ b/internal/domain/lease/aggregate.go
@@ -79,7 +79,7 @@ func normalizeState(state State, creating bool) (State, error) {
 		return State{}, ErrInvalidDateRange
 	}
 	if state.RentAmount <= 0 {
-		return State{}, ErrRentAmountZero
+		return State{}, ErrRentAmountNonPositive
 	}
 	if state.DepositAmount < 0 {
 		return State{}, ErrDepositNegative

--- a/internal/domain/lease/aggregate.go
+++ b/internal/domain/lease/aggregate.go
@@ -1,0 +1,110 @@
+package lease
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	StatusActive          = "active"
+	StatusExpired         = "expired"
+	StatusTerminated      = "terminated"
+	StatusForceTerminated = "force_terminated"
+
+	DepositStatusHeld       = "held"
+	DepositStatusSettled    = "settled"
+	DepositStatusWrittenOff = "written_off"
+
+	BillingCadenceMonthly   = "monthly"
+	BillingCadenceBimonthly = "bimonthly"
+)
+
+// State is the persisted lease aggregate snapshot.
+type State struct {
+	ID                        string
+	TenantID                  string
+	RoomID                    string
+	PropertyID                string
+	RentAmount                int
+	StartDate                 time.Time
+	EndDate                   time.Time
+	ElectricityBillingCadence string
+	Status                    string
+	DepositAmount             int
+	DepositStatus             string
+	Version                   int
+}
+
+// Aggregate owns lease create-time business rules.
+type Aggregate struct {
+	state State
+}
+
+// New creates a lease aggregate for create commands.
+func New(state State) (*Aggregate, error) {
+	normalized, err := normalizeState(state, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Aggregate{state: normalized}, nil
+}
+
+// Rehydrate reconstructs an existing lease aggregate.
+func Rehydrate(state State) (*Aggregate, error) {
+	normalized, err := normalizeState(state, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Aggregate{state: normalized}, nil
+}
+
+// State returns the normalized aggregate snapshot.
+func (a *Aggregate) State() State {
+	if a == nil {
+		return State{}
+	}
+
+	return a.state
+}
+
+func normalizeState(state State, creating bool) (State, error) {
+	state.TenantID = strings.TrimSpace(state.TenantID)
+	state.RoomID = strings.TrimSpace(state.RoomID)
+	state.PropertyID = strings.TrimSpace(state.PropertyID)
+	state.ElectricityBillingCadence = strings.TrimSpace(state.ElectricityBillingCadence)
+
+	if state.StartDate.After(state.EndDate) {
+		return State{}, ErrInvalidDateRange
+	}
+	if state.RentAmount == 0 {
+		return State{}, ErrRentAmountZero
+	}
+	if state.DepositAmount < 0 {
+		return State{}, ErrDepositNegative
+	}
+	if !isValidCadence(state.ElectricityBillingCadence) {
+		return State{}, ErrInvalidCadence
+	}
+
+	if creating {
+		if state.Status == "" {
+			state.Status = StatusActive
+		}
+		if state.DepositStatus == "" {
+			state.DepositStatus = DepositStatusHeld
+		}
+	}
+
+	return state, nil
+}
+
+func isValidCadence(cadence string) bool {
+	switch cadence {
+	case BillingCadenceMonthly, BillingCadenceBimonthly:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/domain/lease/aggregate_test.go
+++ b/internal/domain/lease/aggregate_test.go
@@ -54,6 +54,22 @@ func TestNewRejectsNegativeDeposit(t *testing.T) {
 	}
 }
 
+func TestNewRejectsInvalidCadence(t *testing.T) {
+	_, err := New(State{
+		TenantID:                  "tenant-1",
+		RoomID:                    "room-1",
+		PropertyID:                "property-1",
+		RentAmount:                18000,
+		StartDate:                 date(2026, 5, 1),
+		EndDate:                   date(2026, 5, 31),
+		ElectricityBillingCadence: "weekly",
+		DepositAmount:             36000,
+	})
+	if !errors.Is(err, ErrInvalidCadence) {
+		t.Fatalf("expected ErrInvalidCadence, got %v", err)
+	}
+}
+
 func TestBuildBillingPeriodsMonthlyDetailedCases(t *testing.T) {
 	t.Run("general monthly periods stay anchored to start day", func(t *testing.T) {
 		periods, err := BuildBillingPeriods(date(2026, 5, 15), date(2026, 9, 20), BillingCadenceMonthly)

--- a/internal/domain/lease/aggregate_test.go
+++ b/internal/domain/lease/aggregate_test.go
@@ -22,7 +22,7 @@ func TestNewRejectsInvalidDateRange(t *testing.T) {
 	}
 }
 
-func TestNewRejectsZeroRent(t *testing.T) {
+func TestNewRejectsNonPositiveRent(t *testing.T) {
 	_, err := New(State{
 		TenantID:                  "tenant-1",
 		RoomID:                    "room-1",
@@ -33,8 +33,8 @@ func TestNewRejectsZeroRent(t *testing.T) {
 		ElectricityBillingCadence: BillingCadenceMonthly,
 		DepositAmount:             36000,
 	})
-	if !errors.Is(err, ErrRentAmountZero) {
-		t.Fatalf("expected ErrRentAmountZero, got %v", err)
+	if !errors.Is(err, ErrRentAmountNonPositive) {
+		t.Fatalf("expected ErrRentAmountNonPositive, got %v", err)
 	}
 }
 

--- a/internal/domain/lease/aggregate_test.go
+++ b/internal/domain/lease/aggregate_test.go
@@ -1,0 +1,157 @@
+package lease
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNewRejectsInvalidDateRange(t *testing.T) {
+	_, err := New(State{
+		TenantID:                  "tenant-1",
+		RoomID:                    "room-1",
+		PropertyID:                "property-1",
+		RentAmount:                18000,
+		StartDate:                 date(2026, 6, 1),
+		EndDate:                   date(2026, 5, 31),
+		ElectricityBillingCadence: BillingCadenceMonthly,
+		DepositAmount:             36000,
+	})
+	if !errors.Is(err, ErrInvalidDateRange) {
+		t.Fatalf("expected ErrInvalidDateRange, got %v", err)
+	}
+}
+
+func TestNewRejectsZeroRent(t *testing.T) {
+	_, err := New(State{
+		TenantID:                  "tenant-1",
+		RoomID:                    "room-1",
+		PropertyID:                "property-1",
+		RentAmount:                0,
+		StartDate:                 date(2026, 5, 1),
+		EndDate:                   date(2026, 5, 31),
+		ElectricityBillingCadence: BillingCadenceMonthly,
+		DepositAmount:             36000,
+	})
+	if !errors.Is(err, ErrRentAmountZero) {
+		t.Fatalf("expected ErrRentAmountZero, got %v", err)
+	}
+}
+
+func TestNewRejectsNegativeDeposit(t *testing.T) {
+	_, err := New(State{
+		TenantID:                  "tenant-1",
+		RoomID:                    "room-1",
+		PropertyID:                "property-1",
+		RentAmount:                18000,
+		StartDate:                 date(2026, 5, 1),
+		EndDate:                   date(2026, 5, 31),
+		ElectricityBillingCadence: BillingCadenceMonthly,
+		DepositAmount:             -1,
+	})
+	if !errors.Is(err, ErrDepositNegative) {
+		t.Fatalf("expected ErrDepositNegative, got %v", err)
+	}
+}
+
+func TestBuildBillingPeriodsMonthlyDetailedCases(t *testing.T) {
+	t.Run("general monthly periods stay anchored to start day", func(t *testing.T) {
+		periods, err := BuildBillingPeriods(date(2026, 5, 15), date(2026, 9, 20), BillingCadenceMonthly)
+		if err != nil {
+			t.Fatalf("BuildBillingPeriods: %v", err)
+		}
+
+		assertPeriods(t, periods, []BillingPeriod{
+			{PeriodStart: date(2026, 5, 15), PeriodEnd: date(2026, 6, 14), DueDate: date(2026, 5, 15)},
+			{PeriodStart: date(2026, 6, 15), PeriodEnd: date(2026, 7, 14), DueDate: date(2026, 6, 15)},
+			{PeriodStart: date(2026, 7, 15), PeriodEnd: date(2026, 8, 14), DueDate: date(2026, 7, 15)},
+			{PeriodStart: date(2026, 8, 15), PeriodEnd: date(2026, 9, 14), DueDate: date(2026, 8, 15)},
+			{PeriodStart: date(2026, 9, 15), PeriodEnd: date(2026, 9, 20), DueDate: date(2026, 9, 15)},
+		})
+	})
+
+	t.Run("month-end anchor clamps backward and keeps detailed boundaries", func(t *testing.T) {
+		periods, err := BuildBillingPeriods(date(2026, 1, 31), date(2026, 4, 29), BillingCadenceMonthly)
+		if err != nil {
+			t.Fatalf("BuildBillingPeriods: %v", err)
+		}
+
+		assertPeriods(t, periods, []BillingPeriod{
+			{PeriodStart: date(2026, 1, 31), PeriodEnd: date(2026, 2, 27), DueDate: date(2026, 1, 31)},
+			{PeriodStart: date(2026, 2, 28), PeriodEnd: date(2026, 3, 30), DueDate: date(2026, 2, 28)},
+			{PeriodStart: date(2026, 3, 31), PeriodEnd: date(2026, 4, 29), DueDate: date(2026, 3, 31)},
+		})
+	})
+
+	t.Run("leap year february uses month end for backward due date", func(t *testing.T) {
+		periods, err := BuildBillingPeriods(date(2028, 1, 31), date(2028, 3, 30), BillingCadenceMonthly)
+		if err != nil {
+			t.Fatalf("BuildBillingPeriods: %v", err)
+		}
+
+		assertPeriods(t, periods, []BillingPeriod{
+			{PeriodStart: date(2028, 1, 31), PeriodEnd: date(2028, 2, 28), DueDate: date(2028, 1, 31)},
+			{PeriodStart: date(2028, 2, 29), PeriodEnd: date(2028, 3, 30), DueDate: date(2028, 2, 29)},
+		})
+	})
+}
+
+func TestBuildBillingPeriodsNaturalBimonthlyDetailedCases(t *testing.T) {
+	t.Run("odd month start uses remaining natural two-month window", func(t *testing.T) {
+		periods, err := BuildBillingPeriods(date(2026, 5, 15), date(2026, 10, 20), BillingCadenceBimonthly)
+		if err != nil {
+			t.Fatalf("BuildBillingPeriods: %v", err)
+		}
+
+		assertPeriods(t, periods, []BillingPeriod{
+			{PeriodStart: date(2026, 5, 15), PeriodEnd: date(2026, 6, 30), DueDate: date(2026, 5, 15)},
+			{PeriodStart: date(2026, 7, 1), PeriodEnd: date(2026, 8, 31), DueDate: date(2026, 7, 15)},
+			{PeriodStart: date(2026, 9, 1), PeriodEnd: date(2026, 10, 20), DueDate: date(2026, 9, 15)},
+		})
+	})
+
+	t.Run("even month start keeps natural window and clamps due date backward in current month", func(t *testing.T) {
+		periods, err := BuildBillingPeriods(date(2026, 6, 10), date(2026, 9, 25), BillingCadenceBimonthly)
+		if err != nil {
+			t.Fatalf("BuildBillingPeriods: %v", err)
+		}
+
+		assertPeriods(t, periods, []BillingPeriod{
+			{PeriodStart: date(2026, 6, 10), PeriodEnd: date(2026, 6, 30), DueDate: date(2026, 6, 10)},
+			{PeriodStart: date(2026, 7, 1), PeriodEnd: date(2026, 8, 31), DueDate: date(2026, 7, 10)},
+			{PeriodStart: date(2026, 9, 1), PeriodEnd: date(2026, 9, 25), DueDate: date(2026, 9, 10)},
+		})
+	})
+
+	t.Run("month-end anchor in bimonthly still uses backward due date in start month", func(t *testing.T) {
+		periods, err := BuildBillingPeriods(date(2026, 6, 30), date(2026, 12, 5), BillingCadenceBimonthly)
+		if err != nil {
+			t.Fatalf("BuildBillingPeriods: %v", err)
+		}
+
+		assertPeriods(t, periods, []BillingPeriod{
+			{PeriodStart: date(2026, 6, 30), PeriodEnd: date(2026, 6, 30), DueDate: date(2026, 6, 30)},
+			{PeriodStart: date(2026, 7, 1), PeriodEnd: date(2026, 8, 31), DueDate: date(2026, 7, 30)},
+			{PeriodStart: date(2026, 9, 1), PeriodEnd: date(2026, 10, 31), DueDate: date(2026, 9, 30)},
+			{PeriodStart: date(2026, 11, 1), PeriodEnd: date(2026, 12, 5), DueDate: date(2026, 11, 30)},
+		})
+	})
+}
+
+func date(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+func assertPeriods(t *testing.T, got []BillingPeriod, want []BillingPeriod) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d periods, got %d", len(want), len(got))
+	}
+
+	for i := range want {
+		if !got[i].PeriodStart.Equal(want[i].PeriodStart) || !got[i].PeriodEnd.Equal(want[i].PeriodEnd) || !got[i].DueDate.Equal(want[i].DueDate) {
+			t.Fatalf("period %d mismatch: got %+v want %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/domain/lease/billing.go
+++ b/internal/domain/lease/billing.go
@@ -1,0 +1,95 @@
+package lease
+
+import "time"
+
+// BillingPeriod describes one pre-generated billing interval.
+type BillingPeriod struct {
+	PeriodStart time.Time
+	PeriodEnd   time.Time
+	DueDate     time.Time
+}
+
+// BuildBillingPeriods expands a lease date range into billing periods.
+func BuildBillingPeriods(startDate time.Time, endDate time.Time, cadence string) ([]BillingPeriod, error) {
+	if startDate.After(endDate) {
+		return nil, ErrInvalidDateRange
+	}
+
+	anchorDay := startDate.Day()
+	switch cadence {
+	case BillingCadenceMonthly:
+		return buildMonthlyPeriods(startDate, endDate, anchorDay), nil
+	case BillingCadenceBimonthly:
+		return buildNaturalBimonthlyPeriods(startDate, endDate, anchorDay), nil
+	default:
+		return nil, ErrInvalidCadence
+	}
+}
+
+func buildMonthlyPeriods(startDate time.Time, endDate time.Time, anchorDay int) []BillingPeriod {
+	currentStart := normalizeDate(startDate)
+	finalEnd := normalizeDate(endDate)
+	periods := make([]BillingPeriod, 0)
+
+	for !currentStart.After(finalEnd) {
+		nextStart := clampedMonthDate(currentStart.Year(), currentStart.Month()+1, anchorDay, currentStart.Location())
+		periodEnd := nextStart.AddDate(0, 0, -1)
+		if periodEnd.After(finalEnd) {
+			periodEnd = finalEnd
+		}
+
+		periods = append(periods, BillingPeriod{
+			PeriodStart: currentStart,
+			PeriodEnd:   periodEnd,
+			DueDate:     clampedMonthDate(currentStart.Year(), currentStart.Month(), anchorDay, currentStart.Location()),
+		})
+
+		currentStart = nextStart
+	}
+
+	return periods
+}
+
+func buildNaturalBimonthlyPeriods(startDate time.Time, endDate time.Time, anchorDay int) []BillingPeriod {
+	currentStart := normalizeDate(startDate)
+	finalEnd := normalizeDate(endDate)
+	periods := make([]BillingPeriod, 0)
+
+	for !currentStart.After(finalEnd) {
+		windowStartMonth := currentStart.Month()
+		if windowStartMonth%2 == 0 {
+			windowStartMonth--
+		}
+
+		windowStart := time.Date(currentStart.Year(), windowStartMonth, 1, 0, 0, 0, 0, currentStart.Location())
+		windowEnd := clampedMonthDate(windowStart.Year(), windowStartMonth+2, 1, currentStart.Location()).AddDate(0, 0, -1)
+		periodEnd := windowEnd
+		if periodEnd.After(finalEnd) {
+			periodEnd = finalEnd
+		}
+
+		periods = append(periods, BillingPeriod{
+			PeriodStart: currentStart,
+			PeriodEnd:   periodEnd,
+			DueDate:     clampedMonthDate(currentStart.Year(), currentStart.Month(), anchorDay, currentStart.Location()),
+		})
+
+		currentStart = windowEnd.AddDate(0, 0, 1)
+	}
+
+	return periods
+}
+
+func normalizeDate(value time.Time) time.Time {
+	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, value.Location())
+}
+
+func clampedMonthDate(year int, month time.Month, day int, location *time.Location) time.Time {
+	firstOfNextMonth := time.Date(year, month+1, 1, 0, 0, 0, 0, location)
+	lastDay := firstOfNextMonth.AddDate(0, 0, -1).Day()
+	if day > lastDay {
+		day = lastDay
+	}
+
+	return time.Date(year, month, day, 0, 0, 0, 0, location)
+}

--- a/internal/domain/lease/errors.go
+++ b/internal/domain/lease/errors.go
@@ -1,0 +1,10 @@
+package lease
+
+import "errors"
+
+var (
+	ErrInvalidDateRange = errors.New("lease date range is invalid")
+	ErrRentAmountZero   = errors.New("lease rent amount must not be zero")
+	ErrDepositNegative  = errors.New("lease deposit amount must not be negative")
+	ErrInvalidCadence   = errors.New("lease billing cadence is invalid")
+)

--- a/internal/domain/lease/errors.go
+++ b/internal/domain/lease/errors.go
@@ -3,8 +3,8 @@ package lease
 import "errors"
 
 var (
-	ErrInvalidDateRange = errors.New("lease date range is invalid")
-	ErrRentAmountZero   = errors.New("lease rent amount must not be zero")
-	ErrDepositNegative  = errors.New("lease deposit amount must not be negative")
-	ErrInvalidCadence   = errors.New("lease billing cadence is invalid")
+	ErrInvalidDateRange      = errors.New("lease date range is invalid")
+	ErrRentAmountNonPositive = errors.New("lease rent amount must be greater than zero")
+	ErrDepositNegative       = errors.New("lease deposit amount must not be negative")
+	ErrInvalidCadence        = errors.New("lease billing cadence is invalid")
 )

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -10,12 +10,14 @@ import (
 
 	appiam "stds_backend/internal/application/iam"
 	appjobs "stds_backend/internal/application/jobs"
+	applease "stds_backend/internal/application/lease"
 	appproperty "stds_backend/internal/application/property"
 	apptenant "stds_backend/internal/application/tenant"
 	domainusers "stds_backend/internal/domain/users"
 	"stds_backend/internal/http/api"
 	"stds_backend/internal/http/queryparams"
 	"stds_backend/internal/http/requestctx"
+	dbleasequery "stds_backend/internal/platform/database/leasequery"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
 	dbtenantquery "stds_backend/internal/platform/database/tenantquery"
 	"stds_backend/internal/platform/database/users"
@@ -36,6 +38,7 @@ type APIServer struct {
 	assignProperties  *appiam.AssignUserPropertiesService
 	jobTriggerService *appjobs.TriggerService
 	propertyQueryRepo dbpropertyquery.Repository
+	leaseQueryRepo    dbleasequery.Repository
 	tenantQueryRepo   dbtenantquery.Repository
 	createPropertySvc *appproperty.CreatePropertyService
 	updatePropertySvc *appproperty.UpdatePropertyService
@@ -46,6 +49,7 @@ type APIServer struct {
 	setMaintenanceSvc *appproperty.SetRoomMaintenanceService
 	createTenantSvc   *apptenant.CreateTenantService
 	updateTenantSvc   *apptenant.UpdateTenantService
+	createLeaseSvc    *applease.CreateLeaseService
 }
 
 // NewAPIServer returns an API server with only the currently implemented
@@ -60,6 +64,7 @@ func NewAPIServer(
 	assignProperties *appiam.AssignUserPropertiesService,
 	jobTriggerService *appjobs.TriggerService,
 	propertyQueryRepo dbpropertyquery.Repository,
+	leaseQueryRepo dbleasequery.Repository,
 	tenantQueryRepo dbtenantquery.Repository,
 	createPropertySvc *appproperty.CreatePropertyService,
 	updatePropertySvc *appproperty.UpdatePropertyService,
@@ -70,6 +75,7 @@ func NewAPIServer(
 	setMaintenanceSvc *appproperty.SetRoomMaintenanceService,
 	createTenantSvc *apptenant.CreateTenantService,
 	updateTenantSvc *apptenant.UpdateTenantService,
+	createLeaseSvc *applease.CreateLeaseService,
 ) *APIServer {
 	return &APIServer{
 		userRepo:          userRepo,
@@ -81,6 +87,7 @@ func NewAPIServer(
 		assignProperties:  assignProperties,
 		jobTriggerService: jobTriggerService,
 		propertyQueryRepo: propertyQueryRepo,
+		leaseQueryRepo:    leaseQueryRepo,
 		tenantQueryRepo:   tenantQueryRepo,
 		createPropertySvc: createPropertySvc,
 		updatePropertySvc: updatePropertySvc,
@@ -91,6 +98,7 @@ func NewAPIServer(
 		setMaintenanceSvc: setMaintenanceSvc,
 		createTenantSvc:   createTenantSvc,
 		updateTenantSvc:   updateTenantSvc,
+		createLeaseSvc:    createLeaseSvc,
 	}
 }
 
@@ -209,10 +217,83 @@ func (s *APIServer) GetJournalLog(c *gin.Context, id string) { writeNotImplement
 func (s *APIServer) UpdateJournalLog(c *gin.Context, id string) { writeNotImplemented(c) }
 
 // ListLeases handles the lease listing endpoint.
-func (s *APIServer) ListLeases(c *gin.Context, params api.ListLeasesParams) { writeNotImplemented(c) }
+func (s *APIServer) ListLeases(c *gin.Context, params api.ListLeasesParams) {
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	pagination, err := queryparams.NormalizePagination(params.Page, params.Limit)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	status := ""
+	if params.Status != nil {
+		status = string(*params.Status)
+	}
+
+	leases, err := s.leaseQueryRepo.ListAccessible(c.Request.Context(), principal.Role, principal.AssignedPropertyIDs, dbleasequery.ListParams{
+		PropertyID: params.PropertyId,
+		RoomID:     params.RoomId,
+		TenantID:   params.TenantId,
+		Status:     status,
+		Limit:      pagination.Limit,
+		Offset:     pagination.Offset,
+	})
+	if err != nil {
+		c.Error(apperr.ErrInternalServerError.WithCause(err))
+		return
+	}
+
+	items := make([]api.LeaseResponse, 0, len(leases))
+	for _, lease := range leases {
+		items = append(items, toLeaseResponse(&lease))
+	}
+
+	c.JSON(http.StatusOK, api.LeaseListResponse{Data: &items})
+}
 
 // CreateLease handles lease creation.
-func (s *APIServer) CreateLease(c *gin.Context) { writeNotImplemented(c) }
+func (s *APIServer) CreateLease(c *gin.Context) {
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	var request api.CreateLeaseRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	var cadence *string
+	if request.ElectricityBillingCadence != nil {
+		value := string(*request.ElectricityBillingCadence)
+		cadence = &value
+	}
+
+	lease, err := s.createLeaseSvc.Execute(c.Request.Context(), applease.CreateLeaseInput{
+		ActorRole:                 principal.Role,
+		AssignedPropertyIDs:       principal.AssignedPropertyIDs,
+		TenantID:                  request.TenantId.String(),
+		RoomID:                    request.RoomId.String(),
+		RentAmount:                request.RentAmount,
+		StartDate:                 request.StartDate.Time,
+		EndDate:                   request.EndDate.Time,
+		DepositAmount:             request.DepositAmount,
+		ElectricityBillingCadence: cadence,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, toCreatedLeaseResponse(lease))
+}
 
 // ListLeaseAttachments handles lease attachment listing.
 func (s *APIServer) ListLeaseAttachments(c *gin.Context, id openapi_types.UUID) {
@@ -228,7 +309,26 @@ func (s *APIServer) CreateLeaseAttachment(c *gin.Context, id openapi_types.UUID)
 func (s *APIServer) DeleteLease(c *gin.Context, id string) { writeNotImplemented(c) }
 
 // GetLease handles lease detail retrieval.
-func (s *APIServer) GetLease(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) GetLease(c *gin.Context, id string) {
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	lease, err := s.leaseQueryRepo.FindByIDAccessible(c.Request.Context(), id, principal.Role, principal.AssignedPropertyIDs)
+	if err != nil {
+		switch {
+		case errors.Is(err, dbleasequery.ErrNotFound):
+			c.Error(apperr.ErrLeaseNotFound)
+		default:
+			c.Error(apperr.ErrInternalServerError.WithCause(err))
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, toLeaseResponse(lease))
+}
 
 // UpdateLease handles lease updates.
 func (s *APIServer) UpdateLease(c *gin.Context, id string) { writeNotImplemented(c) }
@@ -1329,6 +1429,58 @@ func toTenantLeaseResponse(lease *dbtenantquery.Lease) api.LeaseResponse {
 	}
 
 	return response
+}
+
+func toLeaseResponse(lease *dbleasequery.Lease) api.LeaseResponse {
+	tenantLease := &dbtenantquery.Lease{
+		ID:                        lease.ID,
+		TenantID:                  lease.TenantID,
+		PropertyID:                lease.PropertyID,
+		RoomID:                    lease.RoomID,
+		RentAmount:                lease.RentAmount,
+		StartDate:                 lease.StartDate,
+		EndDate:                   lease.EndDate,
+		ElectricityBillingCadence: lease.ElectricityBillingCadence,
+		Status:                    lease.Status,
+		DepositAmount:             lease.DepositAmount,
+		DepositRefundAmount:       lease.DepositRefundAmount,
+		DepositDeductionAmount:    lease.DepositDeductionAmount,
+		DepositStatus:             lease.DepositStatus,
+		DepositDeductionReason:    lease.DepositDeductionReason,
+		Notes:                     lease.Notes,
+		TerminationReason:         lease.TerminationReason,
+		SettlementDetail:          lease.SettlementDetail,
+		CreatedAt:                 lease.CreatedAt,
+		UpdatedAt:                 lease.UpdatedAt,
+		Version:                   lease.Version,
+	}
+
+	return toTenantLeaseResponse(tenantLease)
+}
+
+func toCreatedLeaseResponse(lease *applease.Lease) api.LeaseResponse {
+	return toLeaseResponse(&dbleasequery.Lease{
+		ID:                        lease.ID,
+		TenantID:                  lease.TenantID,
+		PropertyID:                lease.PropertyID,
+		RoomID:                    lease.RoomID,
+		RentAmount:                lease.RentAmount,
+		StartDate:                 lease.StartDate,
+		EndDate:                   lease.EndDate,
+		ElectricityBillingCadence: lease.ElectricityBillingCadence,
+		Status:                    lease.Status,
+		DepositAmount:             lease.DepositAmount,
+		DepositRefundAmount:       lease.DepositRefundAmount,
+		DepositDeductionAmount:    lease.DepositDeductionAmount,
+		DepositStatus:             lease.DepositStatus,
+		DepositDeductionReason:    lease.DepositDeductionReason,
+		Notes:                     lease.Notes,
+		TerminationReason:         lease.TerminationReason,
+		SettlementDetail:          lease.SettlementDetail,
+		CreatedAt:                 lease.CreatedAt,
+		UpdatedAt:                 lease.UpdatedAt,
+		Version:                   lease.Version,
+	})
 }
 
 func toRepairRequestResponse(repairRequest *appproperty.RepairRequest) api.RepairRequestResponse {

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -8,12 +8,14 @@ import (
 
 	appiam "stds_backend/internal/application/iam"
 	appjobs "stds_backend/internal/application/jobs"
+	applease "stds_backend/internal/application/lease"
 	appproperty "stds_backend/internal/application/property"
 	apptenant "stds_backend/internal/application/tenant"
 	"stds_backend/internal/config"
 	"stds_backend/internal/http/api"
 	"stds_backend/internal/http/handler"
 	"stds_backend/internal/http/middleware"
+	dbleasequery "stds_backend/internal/platform/database/leasequery"
 	dbproperties "stds_backend/internal/platform/database/properties"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
 	dbresourceownership "stds_backend/internal/platform/database/resourceownership"
@@ -55,6 +57,7 @@ func New(
 	assignUserPropertiesService *appiam.AssignUserPropertiesService,
 	jobTriggerService *appjobs.TriggerService,
 	propertyQueryRepo dbpropertyquery.Repository,
+	leaseQueryRepo dbleasequery.Repository,
 	tenantQueryRepo dbtenantquery.Repository,
 	createPropertyService *appproperty.CreatePropertyService,
 	updatePropertyService *appproperty.UpdatePropertyService,
@@ -65,6 +68,7 @@ func New(
 	setRoomMaintenanceService *appproperty.SetRoomMaintenanceService,
 	createTenantService *apptenant.CreateTenantService,
 	updateTenantService *apptenant.UpdateTenantService,
+	createLeaseService *applease.CreateLeaseService,
 ) *gin.Engine {
 	engine := gin.New()
 	engine.Use(
@@ -81,7 +85,7 @@ func New(
 	engine.GET("/openapi.yaml", docsHandler.OpenAPI)
 	engine.GET("/scalar", docsHandler.Scalar)
 
-	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService), api.GinServerOptions{
+	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService), api.GinServerOptions{
 		BaseURL: "/api/v1",
 		Middlewares: []api.MiddlewareFunc{
 			protectedAPIMiddleware(appCfg, authenticator, userRepo, authzRepos),

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -204,7 +204,7 @@ func routePolicies(authzRepos AuthorizationRepositories) []routePolicy {
 		{method: "GET", path: "/api/v1/journal-logs/:id", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByJournalLogID, apperr.ErrJournalLogNotFound)},
 		{method: "PATCH", path: "/api/v1/journal-logs/:id", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByJournalLogID, apperr.ErrJournalLogNotFound)},
 
-		{method: "GET", path: "/api/v1/leases", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
+		{method: "GET", path: "/api/v1/leases", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.QueryPropertyID("property_id")},
 		{method: "POST", path: "/api/v1/leases", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "GET", path: "/api/v1/leases/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByLeaseID, apperr.ErrLeaseNotFound)},
 		{method: "POST", path: "/api/v1/leases/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByLeaseID, apperr.ErrLeaseNotFound)},

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -678,6 +678,7 @@ func TestListLeasesRejectsUnassignedPropertyFilter(t *testing.T) {
 }
 
 func TestGetLeaseReturnsAccessibleLease(t *testing.T) {
+	findCall := &findLeaseCall{}
 	engine := newTestEngineWithAllQueryRepos(
 		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
 		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
@@ -691,6 +692,7 @@ func TestGetLeaseReturnsAccessibleLease(t *testing.T) {
 		fakeJobRunsRepo{},
 		fakePropertyQueryRepo{},
 		fakeLeaseQueryRepo{
+			findCall: findCall,
 			lease: &dbleasequery.Lease{
 				ID:                        "40000000-0000-0000-0000-000000000001",
 				TenantID:                  "30000000-0000-0000-0000-000000000001",
@@ -728,6 +730,9 @@ func TestGetLeaseReturnsAccessibleLease(t *testing.T) {
 	if payload["id"] != "40000000-0000-0000-0000-000000000001" {
 		t.Fatalf("expected lease id, got %v", payload["id"])
 	}
+	if findCall.leaseID != "40000000-0000-0000-0000-000000000001" {
+		t.Fatalf("expected lease lookup id, got %q", findCall.leaseID)
+	}
 }
 
 func TestCreateLeaseReturnsCreatedLease(t *testing.T) {
@@ -739,6 +744,10 @@ func TestCreateLeaseReturnsCreatedLease(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectCommit()
+
+	var findTenantID string
+	var findRoomID string
+	createParams := applease.CreateLeaseParams{}
 
 	engine := newTestEngineWithAllServices(
 		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
@@ -752,7 +761,11 @@ func TestCreateLeaseReturnsCreatedLease(t *testing.T) {
 		fakeTenantQueryRepo{},
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(db, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(db, nil)),
-		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(db, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{
+			findTenantID: &findTenantID,
+			findRoomID:   &findRoomID,
+			createParams: &createParams,
+		}, dbtxrunner.New(db, nil)),
 	)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/leases", strings.NewReader(`{
@@ -782,6 +795,30 @@ func TestCreateLeaseReturnsCreatedLease(t *testing.T) {
 	}
 	if payload["status"] != "active" {
 		t.Fatalf("expected active status, got %v", payload["status"])
+	}
+	if findTenantID != "30000000-0000-0000-0000-000000000001" {
+		t.Fatalf("expected tenant lookup id, got %q", findTenantID)
+	}
+	if findRoomID != "20000000-0000-0000-0000-000000000001" {
+		t.Fatalf("expected room lookup id, got %q", findRoomID)
+	}
+	if createParams.TenantID != "30000000-0000-0000-0000-000000000001" {
+		t.Fatalf("expected tenant_id, got %q", createParams.TenantID)
+	}
+	if createParams.RoomID != "20000000-0000-0000-0000-000000000001" {
+		t.Fatalf("expected room_id, got %q", createParams.RoomID)
+	}
+	if createParams.RentAmount != 18000 {
+		t.Fatalf("expected rent_amount 18000, got %d", createParams.RentAmount)
+	}
+	if createParams.DepositAmount != 36000 {
+		t.Fatalf("expected deposit_amount 36000, got %d", createParams.DepositAmount)
+	}
+	if !createParams.StartDate.Equal(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected start_date 2026-05-01, got %s", createParams.StartDate)
+	}
+	if !createParams.EndDate.Equal(time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("expected end_date 2026-12-31, got %s", createParams.EndDate)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -2791,8 +2828,11 @@ type fakeTenantQueryRepo struct {
 type fakeLeaseRepo struct {
 	tenant       *applease.Tenant
 	tenantErr    error
+	findTenantID *string
 	room         *applease.Room
 	roomErr      error
+	findRoomID   *string
+	createParams *applease.CreateLeaseParams
 	createdLease *applease.Lease
 	createErr    error
 	billsErr     error
@@ -2803,6 +2843,7 @@ type fakeLeaseQueryRepo struct {
 	leaseErr error
 	leases   []dbleasequery.Lease
 	listCall *listLeasesCall
+	findCall *findLeaseCall
 }
 
 type listRoomsCall struct {
@@ -2832,6 +2873,12 @@ type listLeasesCall struct {
 	role                string
 	assignedPropertyIDs []string
 	params              dbleasequery.ListParams
+}
+
+type findLeaseCall struct {
+	leaseID             string
+	role                string
+	assignedPropertyIDs []string
 }
 
 type fakeResourceOwnershipRepo struct {
@@ -3658,7 +3705,10 @@ func (f fakeTenantRepo) Update(_ context.Context, _ *sql.Tx, _ apptenant.UpdateT
 	}, nil
 }
 
-func (f fakeLeaseRepo) FindTenantByID(_ context.Context, _ *sql.Tx, _ string) (*applease.Tenant, error) {
+func (f fakeLeaseRepo) FindTenantByID(_ context.Context, _ *sql.Tx, tenantID string) (*applease.Tenant, error) {
+	if f.findTenantID != nil {
+		*f.findTenantID = tenantID
+	}
 	if f.tenantErr != nil {
 		return nil, f.tenantErr
 	}
@@ -3669,7 +3719,10 @@ func (f fakeLeaseRepo) FindTenantByID(_ context.Context, _ *sql.Tx, _ string) (*
 	return &applease.Tenant{ID: "tenant-1", Status: "active"}, nil
 }
 
-func (f fakeLeaseRepo) FindRoomByIDForUpdate(_ context.Context, _ *sql.Tx, _ string) (*applease.Room, error) {
+func (f fakeLeaseRepo) FindRoomByIDForUpdate(_ context.Context, _ *sql.Tx, roomID string) (*applease.Room, error) {
+	if f.findRoomID != nil {
+		*f.findRoomID = roomID
+	}
 	if f.roomErr != nil {
 		return nil, f.roomErr
 	}
@@ -3685,7 +3738,10 @@ func (f fakeLeaseRepo) FindRoomByIDForUpdate(_ context.Context, _ *sql.Tx, _ str
 	}, nil
 }
 
-func (f fakeLeaseRepo) CreateLease(_ context.Context, _ *sql.Tx, _ applease.CreateLeaseParams) (*applease.Lease, error) {
+func (f fakeLeaseRepo) CreateLease(_ context.Context, _ *sql.Tx, params applease.CreateLeaseParams) (*applease.Lease, error) {
+	if f.createParams != nil {
+		*f.createParams = params
+	}
 	if f.createErr != nil {
 		return nil, f.createErr
 	}
@@ -3794,7 +3850,12 @@ func (f fakeLeaseQueryRepo) ListAccessible(_ context.Context, role string, assig
 	return []dbleasequery.Lease{}, nil
 }
 
-func (f fakeLeaseQueryRepo) FindByIDAccessible(_ context.Context, _ string, _ string, _ []string) (*dbleasequery.Lease, error) {
+func (f fakeLeaseQueryRepo) FindByIDAccessible(_ context.Context, id string, role string, assignedPropertyIDs []string) (*dbleasequery.Lease, error) {
+	if f.findCall != nil {
+		f.findCall.leaseID = id
+		f.findCall.role = role
+		f.findCall.assignedPropertyIDs = assignedPropertyIDs
+	}
 	if f.leaseErr != nil {
 		return nil, f.leaseErr
 	}

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -753,6 +753,45 @@ func TestCreateLeaseReturnsCreatedLease(t *testing.T) {
 	}
 }
 
+func TestCreateLeaseRejectsMissingTenantID(t *testing.T) {
+	engine := newTestEngineWithAllQueryRepos(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
+		fakeTenantQueryRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/leases", strings.NewReader(`{
+		"room_id":"20000000-0000-0000-0000-000000000001",
+		"rent_amount":18000,
+		"start_date":"2026-05-01",
+		"end_date":"2026-12-31",
+		"deposit_amount":36000
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["error_code"] != "VALIDATION_TENANT_ID_REQUIRED" {
+		t.Fatalf("expected VALIDATION_TENANT_ID_REQUIRED, got %v", payload["error_code"])
+	}
+}
+
 func TestCreateLeaseRejectsUnassignedRoomProperty(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -18,11 +18,13 @@ import (
 
 	appiam "stds_backend/internal/application/iam"
 	appjobs "stds_backend/internal/application/jobs"
+	applease "stds_backend/internal/application/lease"
 	appnotification "stds_backend/internal/application/notification"
 	appproperty "stds_backend/internal/application/property"
 	apptenant "stds_backend/internal/application/tenant"
 	"stds_backend/internal/config"
 	domainusers "stds_backend/internal/domain/users"
+	dbleasequery "stds_backend/internal/platform/database/leasequery"
 	dbproperties "stds_backend/internal/platform/database/properties"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
 	dbresourceownership "stds_backend/internal/platform/database/resourceownership"
@@ -570,6 +572,240 @@ func TestListTenantLeasesReturnsLeaseHistory(t *testing.T) {
 	data, ok := payload["data"].([]any)
 	if !ok || len(data) != 1 {
 		t.Fatalf("expected one lease entry, got %#v", payload["data"])
+	}
+}
+
+func TestListLeasesReturnsAccessibleLeases(t *testing.T) {
+	leaseCall := &listLeasesCall{}
+	engine := newTestEngineWithAllQueryRepos(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{
+			listCall: leaseCall,
+			leases: []dbleasequery.Lease{
+				{
+					ID:                        "40000000-0000-0000-0000-000000000001",
+					TenantID:                  "30000000-0000-0000-0000-000000000001",
+					PropertyID:                testPropertyID1,
+					RoomID:                    testRoomID1,
+					RentAmount:                18000,
+					StartDate:                 time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+					EndDate:                   time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+					ElectricityBillingCadence: "monthly",
+					Status:                    "active",
+					DepositAmount:             36000,
+					DepositStatus:             "held",
+					CreatedAt:                 time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+					UpdatedAt:                 time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+					Version:                   1,
+				},
+			},
+		},
+		fakeTenantQueryRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/leases?status=active&page=2&limit=5&property_id="+testPropertyID1+"&room_id="+testRoomID1, nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	data, ok := payload["data"].([]any)
+	if !ok || len(data) != 1 {
+		t.Fatalf("expected one lease entry, got %#v", payload["data"])
+	}
+	if leaseCall.params.Status != "active" {
+		t.Fatalf("expected status active, got %q", leaseCall.params.Status)
+	}
+	if leaseCall.params.PropertyID == nil || *leaseCall.params.PropertyID != testPropertyID1 {
+		t.Fatalf("expected property filter %s, got %#v", testPropertyID1, leaseCall.params.PropertyID)
+	}
+	if leaseCall.params.RoomID == nil || *leaseCall.params.RoomID != testRoomID1 {
+		t.Fatalf("expected room filter %s, got %#v", testRoomID1, leaseCall.params.RoomID)
+	}
+	if leaseCall.params.Limit != 5 || leaseCall.params.Offset != 5 {
+		t.Fatalf("expected pagination 5/5, got limit=%d offset=%d", leaseCall.params.Limit, leaseCall.params.Offset)
+	}
+}
+
+func TestGetLeaseReturnsAccessibleLease(t *testing.T) {
+	engine := newTestEngineWithAllQueryRepos(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{
+			propertyByLeaseID: map[string]string{
+				"40000000-0000-0000-0000-000000000001": testPropertyID1,
+			},
+		},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{
+			lease: &dbleasequery.Lease{
+				ID:                        "40000000-0000-0000-0000-000000000001",
+				TenantID:                  "30000000-0000-0000-0000-000000000001",
+				PropertyID:                testPropertyID1,
+				RoomID:                    testRoomID1,
+				RentAmount:                18000,
+				StartDate:                 time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+				EndDate:                   time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+				ElectricityBillingCadence: "monthly",
+				Status:                    "active",
+				DepositAmount:             36000,
+				DepositStatus:             "held",
+				CreatedAt:                 time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+				UpdatedAt:                 time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+				Version:                   1,
+			},
+		},
+		fakeTenantQueryRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/leases/40000000-0000-0000-0000-000000000001", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["id"] != "40000000-0000-0000-0000-000000000001" {
+		t.Fatalf("expected lease id, got %v", payload["id"])
+	}
+}
+
+func TestCreateLeaseReturnsCreatedLease(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	engine := newTestEngineWithAllServices(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
+		fakeTenantQueryRepo{},
+		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(db, nil)),
+		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(db, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/leases", strings.NewReader(`{
+		"tenant_id":"30000000-0000-0000-0000-000000000001",
+		"room_id":"20000000-0000-0000-0000-000000000001",
+		"rent_amount":18000,
+		"start_date":"2026-05-01",
+		"end_date":"2026-12-31",
+		"deposit_amount":36000
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["id"] != "40000000-0000-0000-0000-000000000001" {
+		t.Fatalf("expected created lease id, got %v", payload["id"])
+	}
+	if payload["status"] != "active" {
+		t.Fatalf("expected active status, got %v", payload["status"])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateLeaseRejectsUnassignedRoomProperty(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	engine := newTestEngineWithAllServices(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID2}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
+		fakeTenantQueryRepo{},
+		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(db, nil)),
+		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(db, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{
+			tenant: &applease.Tenant{ID: "tenant-1", Status: "active"},
+			room: &applease.Room{
+				ID:                               "room-1",
+				PropertyID:                       testPropertyID1,
+				Status:                           "vacant",
+				DefaultElectricityBillingCadence: "monthly",
+			},
+		}, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/leases", strings.NewReader(`{
+		"tenant_id":"30000000-0000-0000-0000-000000000001",
+		"room_id":"20000000-0000-0000-0000-000000000001",
+		"rent_amount":18000,
+		"start_date":"2026-05-01",
+		"end_date":"2026-12-31",
+		"deposit_amount":36000
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
 	}
 }
 
@@ -2477,6 +2713,23 @@ type fakeTenantQueryRepo struct {
 	leasesCall *listTenantLeasesCall
 }
 
+type fakeLeaseRepo struct {
+	tenant       *applease.Tenant
+	tenantErr    error
+	room         *applease.Room
+	roomErr      error
+	createdLease *applease.Lease
+	createErr    error
+	billsErr     error
+}
+
+type fakeLeaseQueryRepo struct {
+	lease    *dbleasequery.Lease
+	leaseErr error
+	leases   []dbleasequery.Lease
+	listCall *listLeasesCall
+}
+
 type listRoomsCall struct {
 	propertyID string
 	status     string
@@ -2498,6 +2751,12 @@ type listTenantLeasesCall struct {
 	role                string
 	assignedPropertyIDs []string
 	status              string
+}
+
+type listLeasesCall struct {
+	role                string
+	assignedPropertyIDs []string
+	params              dbleasequery.ListParams
 }
 
 type fakeResourceOwnershipRepo struct {
@@ -3324,6 +3583,71 @@ func (f fakeTenantRepo) Update(_ context.Context, _ *sql.Tx, _ apptenant.UpdateT
 	}, nil
 }
 
+func (f fakeLeaseRepo) FindTenantByID(_ context.Context, _ *sql.Tx, _ string) (*applease.Tenant, error) {
+	if f.tenantErr != nil {
+		return nil, f.tenantErr
+	}
+	if f.tenant != nil {
+		return f.tenant, nil
+	}
+
+	return &applease.Tenant{ID: "tenant-1", Status: "active"}, nil
+}
+
+func (f fakeLeaseRepo) FindRoomByIDForUpdate(_ context.Context, _ *sql.Tx, _ string) (*applease.Room, error) {
+	if f.roomErr != nil {
+		return nil, f.roomErr
+	}
+	if f.room != nil {
+		return f.room, nil
+	}
+
+	return &applease.Room{
+		ID:                               "room-1",
+		PropertyID:                       testPropertyID1,
+		Status:                           "vacant",
+		DefaultElectricityBillingCadence: "monthly",
+	}, nil
+}
+
+func (f fakeLeaseRepo) CreateLease(_ context.Context, _ *sql.Tx, _ applease.CreateLeaseParams) (*applease.Lease, error) {
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	if f.createdLease != nil {
+		return f.createdLease, nil
+	}
+
+	return &applease.Lease{
+		ID:                        "40000000-0000-0000-0000-000000000001",
+		TenantID:                  "30000000-0000-0000-0000-000000000001",
+		PropertyID:                testPropertyID1,
+		RoomID:                    testRoomID1,
+		RentAmount:                18000,
+		StartDate:                 time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:                   time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+		ElectricityBillingCadence: "monthly",
+		Status:                    "active",
+		DepositAmount:             36000,
+		DepositStatus:             "held",
+		CreatedAt:                 time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:                 time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+		Version:                   1,
+	}, nil
+}
+
+func (f fakeLeaseRepo) CreateBills(_ context.Context, _ *sql.Tx, _ []applease.CreateBillParams) error {
+	return f.billsErr
+}
+
+func (f fakeLeaseRepo) MarkRoomOccupied(_ context.Context, _ *sql.Tx, _ string) error {
+	return nil
+}
+
+func (f fakeLeaseRepo) ActivateTenant(_ context.Context, _ *sql.Tx, _ string) error {
+	return nil
+}
+
 func (f fakeTenantQueryRepo) ListAccessible(_ context.Context, role string, assignedPropertyIDs []string, propertyID *string, status string, limit int, offset int) ([]dbtenantquery.Tenant, error) {
 	if f.listCall != nil {
 		f.listCall.role = role
@@ -3377,6 +3701,48 @@ func (f fakeTenantQueryRepo) ListLeasesByTenantAccessible(_ context.Context, ten
 	}
 
 	return []dbtenantquery.Lease{}, nil
+}
+
+func (f fakeLeaseQueryRepo) ListAccessible(_ context.Context, role string, assignedPropertyIDs []string, params dbleasequery.ListParams) ([]dbleasequery.Lease, error) {
+	if f.listCall != nil {
+		f.listCall.role = role
+		f.listCall.assignedPropertyIDs = assignedPropertyIDs
+		f.listCall.params = params
+	}
+	if f.leaseErr != nil {
+		return nil, f.leaseErr
+	}
+	if f.leases != nil {
+		return f.leases, nil
+	}
+
+	return []dbleasequery.Lease{}, nil
+}
+
+func (f fakeLeaseQueryRepo) FindByIDAccessible(_ context.Context, _ string, _ string, _ []string) (*dbleasequery.Lease, error) {
+	if f.leaseErr != nil {
+		return nil, f.leaseErr
+	}
+	if f.lease != nil {
+		return f.lease, nil
+	}
+
+	return &dbleasequery.Lease{
+		ID:                        "40000000-0000-0000-0000-000000000001",
+		TenantID:                  "30000000-0000-0000-0000-000000000001",
+		PropertyID:                testPropertyID1,
+		RoomID:                    testRoomID1,
+		RentAmount:                18000,
+		StartDate:                 time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		EndDate:                   time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+		ElectricityBillingCadence: "monthly",
+		Status:                    "active",
+		DepositAmount:             36000,
+		DepositStatus:             "held",
+		CreatedAt:                 time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:                 time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC),
+		Version:                   1,
+	}, nil
 }
 
 func (f fakeResourceOwnershipRepo) FindPropertyIDByRoomID(_ context.Context, roomID string) (string, error) {
@@ -3442,7 +3808,7 @@ func (fakeJobRunsRepo) Fail(_ context.Context, _ string, _ string) error     { r
 func (fakeJobRunsRepo) Skip(_ context.Context, _ string, _ string) error     { return nil }
 
 func newTestEngine(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo) *gin.Engine {
-	return newTestEngineWithQueryRepos(
+	return newTestEngineWithAllQueryRepos(
 		userRepo,
 		authenticator,
 		propertyRepo,
@@ -3450,16 +3816,17 @@ func newTestEngine(userRepo fakeUserRepo, authenticator fakeAuthenticator, prope
 		schedulerKey,
 		jobRunsRepo,
 		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
 		fakeTenantQueryRepo{},
 	)
 }
 
 func newTestEngineWithPropertyQueryRepo(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository) *gin.Engine {
-	return newTestEngineWithQueryRepos(userRepo, authenticator, propertyRepo, ownershipRepo, schedulerKey, jobRunsRepo, propertyQueryRepo, fakeTenantQueryRepo{})
+	return newTestEngineWithAllQueryRepos(userRepo, authenticator, propertyRepo, ownershipRepo, schedulerKey, jobRunsRepo, propertyQueryRepo, fakeLeaseQueryRepo{}, fakeTenantQueryRepo{})
 }
 
 func newTestEngineWithQueryRepos(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, tenantQueryRepo dbtenantquery.Repository) *gin.Engine {
-	return newTestEngineWithTenantServices(
+	return newTestEngineWithAllQueryRepos(
 		userRepo,
 		authenticator,
 		propertyRepo,
@@ -3467,13 +3834,46 @@ func newTestEngineWithQueryRepos(userRepo fakeUserRepo, authenticator fakeAuthen
 		schedulerKey,
 		jobRunsRepo,
 		propertyQueryRepo,
+		fakeLeaseQueryRepo{},
+		tenantQueryRepo,
+	)
+}
+
+func newTestEngineWithAllQueryRepos(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, leaseQueryRepo dbleasequery.Repository, tenantQueryRepo dbtenantquery.Repository) *gin.Engine {
+	return newTestEngineWithAllServices(
+		userRepo,
+		authenticator,
+		propertyRepo,
+		ownershipRepo,
+		schedulerKey,
+		jobRunsRepo,
+		propertyQueryRepo,
+		leaseQueryRepo,
 		tenantQueryRepo,
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
 	)
 }
 
 func newTestEngineWithTenantServices(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, tenantQueryRepo dbtenantquery.Repository, createTenantService *apptenant.CreateTenantService, updateTenantService *apptenant.UpdateTenantService) *gin.Engine {
+	return newTestEngineWithAllServices(
+		userRepo,
+		authenticator,
+		propertyRepo,
+		ownershipRepo,
+		schedulerKey,
+		jobRunsRepo,
+		propertyQueryRepo,
+		fakeLeaseQueryRepo{},
+		tenantQueryRepo,
+		createTenantService,
+		updateTenantService,
+		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+	)
+}
+
+func newTestEngineWithAllServices(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, leaseQueryRepo dbleasequery.Repository, tenantQueryRepo dbtenantquery.Repository, createTenantService *apptenant.CreateTenantService, updateTenantService *apptenant.UpdateTenantService, createLeaseService *applease.CreateLeaseService) *gin.Engine {
 	repo := &userRepo
 	userAccountRepo := testUserAccountRepositoryAdapter{repo: repo}
 	return New(
@@ -3498,6 +3898,7 @@ func newTestEngineWithTenantServices(userRepo fakeUserRepo, authenticator fakeAu
 		),
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		propertyQueryRepo,
+		leaseQueryRepo,
 		tenantQueryRepo,
 		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
 		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
@@ -3508,6 +3909,7 @@ func newTestEngineWithTenantServices(userRepo fakeUserRepo, authenticator fakeAu
 		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(nil, nil)),
 		createTenantService,
 		updateTenantService,
+		createLeaseService,
 	)
 }
 
@@ -3555,6 +3957,7 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 		),
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		propertyQueryRepo,
+		fakeLeaseQueryRepo{},
 		fakeTenantQueryRepo{},
 		createPropertyService,
 		updatePropertyService,
@@ -3565,6 +3968,7 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(nil, nil)),
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
 	)
 }
 
@@ -3593,6 +3997,7 @@ func newTestEngineWithRoomServices(userRepo fakeUserRepo, authenticator fakeAuth
 		),
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		propertyQueryRepo,
+		fakeLeaseQueryRepo{},
 		fakeTenantQueryRepo{},
 		createPropertyService,
 		updatePropertyService,
@@ -3603,6 +4008,7 @@ func newTestEngineWithRoomServices(userRepo fakeUserRepo, authenticator fakeAuth
 		setRoomMaintenanceService,
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
 	)
 }
 

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -641,6 +641,42 @@ func TestListLeasesReturnsAccessibleLeases(t *testing.T) {
 	}
 }
 
+func TestListLeasesRejectsUnassignedPropertyFilter(t *testing.T) {
+	engine := newTestEngineWithAllQueryRepos(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID2}},
+		fakePropertyRepo{
+			ownerByPropertyID: map[string]string{
+				testPropertyID1: "owner-1",
+			},
+		},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
+		fakeTenantQueryRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/leases?property_id="+testPropertyID1, nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["error_code"] != apperr.CodeForbidden {
+		t.Fatalf("expected FORBIDDEN, got %v", payload["error_code"])
+	}
+}
+
 func TestGetLeaseReturnsAccessibleLease(t *testing.T) {
 	engine := newTestEngineWithAllQueryRepos(
 		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},

--- a/internal/platform/database/leasequery/repository.go
+++ b/internal/platform/database/leasequery/repository.go
@@ -1,0 +1,279 @@
+package leasequery
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ErrNotFound indicates that no lease matched the requested accessible lookup.
+var ErrNotFound = errors.New("lease query not found")
+
+// Lease is the read model returned by lease queries.
+type Lease struct {
+	ID                        string
+	TenantID                  string
+	PropertyID                string
+	RoomID                    string
+	RentAmount                int
+	StartDate                 time.Time
+	EndDate                   time.Time
+	ElectricityBillingCadence string
+	Status                    string
+	DepositAmount             int
+	DepositRefundAmount       *int
+	DepositDeductionAmount    *int
+	DepositStatus             string
+	DepositDeductionReason    *string
+	Notes                     *string
+	TerminationReason         *string
+	SettlementDetail          *map[string]interface{}
+	CreatedAt                 time.Time
+	UpdatedAt                 time.Time
+	Version                   int
+}
+
+// ListParams captures supported filters for lease listing.
+type ListParams struct {
+	PropertyID *string
+	RoomID     *string
+	TenantID   *string
+	Status     string
+	Limit      int
+	Offset     int
+}
+
+// Repository serves read-model queries for leases.
+type Repository interface {
+	ListAccessible(ctx context.Context, role string, assignedPropertyIDs []string, params ListParams) ([]Lease, error)
+	FindByIDAccessible(ctx context.Context, leaseID string, role string, assignedPropertyIDs []string) (*Lease, error)
+}
+
+// SQLRepository reads lease data from PostgreSQL.
+type SQLRepository struct {
+	db *sql.DB
+}
+
+// NewRepository returns a Repository backed by the provided DB.
+func NewRepository(db *sql.DB) *SQLRepository {
+	return &SQLRepository{db: db}
+}
+
+func (r *SQLRepository) ListAccessible(ctx context.Context, role string, assignedPropertyIDs []string, params ListParams) ([]Lease, error) {
+	base := `
+SELECT
+	l.id,
+	l.tenant_id,
+	l.property_id,
+	l.room_id,
+	l.rent_amount,
+	l.start_date,
+	l.end_date,
+	l.electricity_billing_cadence,
+	l.status,
+	l.deposit_amount,
+	l.deposit_refund_amount,
+	l.deposit_deduction_amount,
+	l.deposit_status,
+	l.deposit_deduction_reason,
+	l.notes,
+	l.termination_reason,
+	l.settlement_detail::text,
+	l.created_at,
+	l.updated_at,
+	l.version
+FROM leases l
+WHERE l.deleted_at IS NULL
+`
+
+	args := make([]any, 0)
+	role = strings.TrimSpace(role)
+	switch role {
+	case "organizer", "staff":
+		if len(assignedPropertyIDs) == 0 {
+			return []Lease{}, nil
+		}
+		placeholders := make([]string, 0, len(assignedPropertyIDs))
+		for _, id := range assignedPropertyIDs {
+			args = append(args, id)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		base += "\n  AND l.property_id IN (" + strings.Join(placeholders, ", ") + ")"
+	case "admin":
+	default:
+		return []Lease{}, nil
+	}
+
+	if params.PropertyID != nil && strings.TrimSpace(*params.PropertyID) != "" {
+		args = append(args, strings.TrimSpace(*params.PropertyID))
+		base += fmt.Sprintf("\n  AND l.property_id = $%d", len(args))
+	}
+	if params.RoomID != nil && strings.TrimSpace(*params.RoomID) != "" {
+		args = append(args, strings.TrimSpace(*params.RoomID))
+		base += fmt.Sprintf("\n  AND l.room_id = $%d", len(args))
+	}
+	if params.TenantID != nil && strings.TrimSpace(*params.TenantID) != "" {
+		args = append(args, strings.TrimSpace(*params.TenantID))
+		base += fmt.Sprintf("\n  AND l.tenant_id = $%d", len(args))
+	}
+	if strings.TrimSpace(params.Status) != "" {
+		args = append(args, strings.TrimSpace(params.Status))
+		base += fmt.Sprintf("\n  AND l.status = $%d", len(args))
+	}
+
+	args = append(args, params.Limit, params.Offset)
+	base += fmt.Sprintf("\nORDER BY l.created_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
+
+	rows, err := r.db.QueryContext(ctx, base, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list accessible leases: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	leases := make([]Lease, 0)
+	for rows.Next() {
+		lease, err := scanLease(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan lease row: %w", err)
+		}
+		leases = append(leases, *lease)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate lease rows: %w", err)
+	}
+
+	return leases, nil
+}
+
+func (r *SQLRepository) FindByIDAccessible(ctx context.Context, leaseID string, role string, assignedPropertyIDs []string) (*Lease, error) {
+	base := `
+SELECT
+	l.id,
+	l.tenant_id,
+	l.property_id,
+	l.room_id,
+	l.rent_amount,
+	l.start_date,
+	l.end_date,
+	l.electricity_billing_cadence,
+	l.status,
+	l.deposit_amount,
+	l.deposit_refund_amount,
+	l.deposit_deduction_amount,
+	l.deposit_status,
+	l.deposit_deduction_reason,
+	l.notes,
+	l.termination_reason,
+	l.settlement_detail::text,
+	l.created_at,
+	l.updated_at,
+	l.version
+FROM leases l
+WHERE l.id = $1
+  AND l.deleted_at IS NULL
+`
+
+	args := []any{leaseID}
+	switch strings.TrimSpace(role) {
+	case "organizer", "staff":
+		if len(assignedPropertyIDs) == 0 {
+			return nil, ErrNotFound
+		}
+		placeholders := make([]string, 0, len(assignedPropertyIDs))
+		for _, id := range assignedPropertyIDs {
+			args = append(args, id)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		base += "\n  AND l.property_id IN (" + strings.Join(placeholders, ", ") + ")"
+	case "admin":
+	default:
+		return nil, ErrNotFound
+	}
+
+	base += "\nLIMIT 1"
+	lease, err := scanLease(r.db.QueryRowContext(ctx, base, args...))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("query accessible lease by id: %w", err)
+	}
+
+	return lease, nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanLease(row rowScanner) (*Lease, error) {
+	var lease Lease
+	var depositRefundAmount sql.NullInt64
+	var depositDeductionAmount sql.NullInt64
+	var depositDeductionReason sql.NullString
+	var notes sql.NullString
+	var terminationReason sql.NullString
+	var settlementDetail sql.NullString
+
+	if err := row.Scan(
+		&lease.ID,
+		&lease.TenantID,
+		&lease.PropertyID,
+		&lease.RoomID,
+		&lease.RentAmount,
+		&lease.StartDate,
+		&lease.EndDate,
+		&lease.ElectricityBillingCadence,
+		&lease.Status,
+		&lease.DepositAmount,
+		&depositRefundAmount,
+		&depositDeductionAmount,
+		&lease.DepositStatus,
+		&depositDeductionReason,
+		&notes,
+		&terminationReason,
+		&settlementDetail,
+		&lease.CreatedAt,
+		&lease.UpdatedAt,
+		&lease.Version,
+	); err != nil {
+		return nil, err
+	}
+
+	lease.DepositRefundAmount = nullIntPtr(depositRefundAmount)
+	lease.DepositDeductionAmount = nullIntPtr(depositDeductionAmount)
+	lease.DepositDeductionReason = nullStringPtr(depositDeductionReason)
+	lease.Notes = nullStringPtr(notes)
+	lease.TerminationReason = nullStringPtr(terminationReason)
+	if settlementDetail.Valid && strings.TrimSpace(settlementDetail.String) != "" && settlementDetail.String != "null" {
+		payload := map[string]interface{}{}
+		if err := json.Unmarshal([]byte(settlementDetail.String), &payload); err != nil {
+			return nil, fmt.Errorf("decode settlement detail: %w", err)
+		}
+		lease.SettlementDetail = &payload
+	}
+
+	return &lease, nil
+}
+
+func nullStringPtr(value sql.NullString) *string {
+	if !value.Valid {
+		return nil
+	}
+	result := value.String
+	return &result
+}
+
+func nullIntPtr(value sql.NullInt64) *int {
+	if !value.Valid {
+		return nil
+	}
+	result := int(value.Int64)
+	return &result
+}

--- a/internal/platform/database/leases/repository.go
+++ b/internal/platform/database/leases/repository.go
@@ -1,0 +1,360 @@
+package leases
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var (
+	ErrLeaseNotFound  = errors.New("lease not found")
+	ErrTenantNotFound = errors.New("tenant not found")
+	ErrRoomNotFound   = errors.New("room not found")
+)
+
+// CommandRepository defines lease write persistence used by application services.
+type CommandRepository interface {
+	FindTenantByID(ctx context.Context, tx *sql.Tx, tenantID string) (*Tenant, error)
+	FindRoomByIDForUpdate(ctx context.Context, tx *sql.Tx, roomID string) (*Room, error)
+	CreateLease(ctx context.Context, tx *sql.Tx, params CreateLeaseParams) (*Lease, error)
+	CreateBills(ctx context.Context, tx *sql.Tx, params []CreateBillParams) error
+	MarkRoomOccupied(ctx context.Context, tx *sql.Tx, roomID string) error
+	ActivateTenant(ctx context.Context, tx *sql.Tx, tenantID string) error
+}
+
+// Lease is the persisted lease state used by write flows.
+type Lease struct {
+	ID                        string
+	TenantID                  string
+	PropertyID                string
+	RoomID                    string
+	RentAmount                int
+	StartDate                 time.Time
+	EndDate                   time.Time
+	ElectricityBillingCadence string
+	Status                    string
+	DepositAmount             int
+	DepositRefundAmount       *int
+	DepositDeductionAmount    *int
+	DepositStatus             string
+	DepositDeductionReason    *string
+	Notes                     *string
+	TerminationReason         *string
+	SettlementDetail          *map[string]interface{}
+	CreatedAt                 time.Time
+	UpdatedAt                 time.Time
+	Version                   int
+}
+
+// Tenant is the minimal tenant shape needed by lease writes.
+type Tenant struct {
+	ID     string
+	Status string
+}
+
+// Room is the minimal locked room shape needed by lease writes.
+type Room struct {
+	ID                               string
+	PropertyID                       string
+	Status                           string
+	DefaultElectricityBillingCadence string
+}
+
+// CreateLeaseParams contains the writable fields required to persist a lease.
+type CreateLeaseParams struct {
+	TenantID                  string
+	RoomID                    string
+	PropertyID                string
+	RentAmount                int
+	StartDate                 time.Time
+	EndDate                   time.Time
+	ElectricityBillingCadence string
+	DepositAmount             int
+}
+
+// CreateBillParams contains the writable fields required to pre-generate a bill.
+type CreateBillParams struct {
+	LeaseID     string
+	TenantID    string
+	RoomID      string
+	PropertyID  string
+	Type        string
+	Amount      *int
+	PeriodStart time.Time
+	PeriodEnd   time.Time
+	DueDate     time.Time
+	Status      string
+}
+
+// SQLRepository persists lease writes in PostgreSQL.
+type SQLRepository struct {
+	db *sql.DB
+}
+
+// NewRepository returns a CommandRepository backed by the provided database handle.
+func NewRepository(db *sql.DB) *SQLRepository {
+	return &SQLRepository{db: db}
+}
+
+func (r *SQLRepository) FindTenantByID(ctx context.Context, tx *sql.Tx, tenantID string) (*Tenant, error) {
+	const query = `
+SELECT id, status
+FROM tenants
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+
+	var tenant Tenant
+	if err := tx.QueryRowContext(ctx, query, tenantID).Scan(&tenant.ID, &tenant.Status); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrTenantNotFound
+		}
+		return nil, fmt.Errorf("find tenant by id: %w", err)
+	}
+
+	return &tenant, nil
+}
+
+func (r *SQLRepository) FindRoomByIDForUpdate(ctx context.Context, tx *sql.Tx, roomID string) (*Room, error) {
+	const query = `
+SELECT
+	r.id,
+	r.property_id,
+	r.status,
+	p.default_electricity_billing_cadence
+FROM rooms r
+JOIN properties p ON p.id = r.property_id
+WHERE r.id = $1
+  AND r.deleted_at IS NULL
+  AND p.deleted_at IS NULL
+FOR UPDATE
+`
+
+	var room Room
+	if err := tx.QueryRowContext(ctx, query, roomID).Scan(
+		&room.ID,
+		&room.PropertyID,
+		&room.Status,
+		&room.DefaultElectricityBillingCadence,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrRoomNotFound
+		}
+		return nil, fmt.Errorf("find room by id for update: %w", err)
+	}
+
+	return &room, nil
+}
+
+func (r *SQLRepository) CreateLease(ctx context.Context, tx *sql.Tx, params CreateLeaseParams) (*Lease, error) {
+	const query = `
+INSERT INTO leases (
+	tenant_id,
+	room_id,
+	property_id,
+	rent_amount,
+	start_date,
+	end_date,
+	electricity_billing_cadence,
+	deposit_amount,
+	deposit_status
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'held')
+RETURNING
+	id,
+	tenant_id,
+	property_id,
+	room_id,
+	rent_amount,
+	start_date,
+	end_date,
+	electricity_billing_cadence,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	deposit_deduction_reason,
+	notes,
+	termination_reason,
+	settlement_detail::text,
+	created_at,
+	updated_at,
+	version
+`
+
+	lease, err := scanLease(tx.QueryRowContext(ctx, query,
+		params.TenantID,
+		params.RoomID,
+		params.PropertyID,
+		params.RentAmount,
+		params.StartDate,
+		params.EndDate,
+		params.ElectricityBillingCadence,
+		params.DepositAmount,
+	))
+	if err != nil {
+		return nil, fmt.Errorf("create lease: %w", err)
+	}
+
+	return lease, nil
+}
+
+func (r *SQLRepository) CreateBills(ctx context.Context, tx *sql.Tx, params []CreateBillParams) error {
+	if len(params) == 0 {
+		return nil
+	}
+
+	const query = `
+INSERT INTO bills (
+	lease_id,
+	tenant_id,
+	room_id,
+	property_id,
+	type,
+	amount,
+	period_start,
+	period_end,
+	due_date,
+	status
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+`
+
+	stmt, err := tx.PrepareContext(ctx, query)
+	if err != nil {
+		return fmt.Errorf("prepare create bills: %w", err)
+	}
+	defer func() {
+		_ = stmt.Close()
+	}()
+
+	for _, bill := range params {
+		var amount any
+		if bill.Amount != nil {
+			amount = *bill.Amount
+		}
+		if _, err := stmt.ExecContext(ctx,
+			bill.LeaseID,
+			bill.TenantID,
+			bill.RoomID,
+			bill.PropertyID,
+			bill.Type,
+			amount,
+			bill.PeriodStart,
+			bill.PeriodEnd,
+			bill.DueDate,
+			bill.Status,
+		); err != nil {
+			return fmt.Errorf("create bill for lease %s period %s-%s: %w", bill.LeaseID, bill.PeriodStart.Format("2006-01-02"), bill.PeriodEnd.Format("2006-01-02"), err)
+		}
+	}
+
+	return nil
+}
+
+func (r *SQLRepository) MarkRoomOccupied(ctx context.Context, tx *sql.Tx, roomID string) error {
+	const query = `
+UPDATE rooms
+SET status = 'occupied',
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+`
+
+	if _, err := tx.ExecContext(ctx, query, roomID); err != nil {
+		return fmt.Errorf("mark room occupied: %w", err)
+	}
+
+	return nil
+}
+
+func (r *SQLRepository) ActivateTenant(ctx context.Context, tx *sql.Tx, tenantID string) error {
+	const query = `
+UPDATE tenants
+SET status = 'active',
+	updated_at = now()
+WHERE id = $1
+  AND status = 'inactive'
+  AND deleted_at IS NULL
+`
+
+	if _, err := tx.ExecContext(ctx, query, tenantID); err != nil {
+		return fmt.Errorf("activate tenant: %w", err)
+	}
+
+	return nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanLease(row rowScanner) (*Lease, error) {
+	var lease Lease
+	var depositRefundAmount sql.NullInt64
+	var depositDeductionAmount sql.NullInt64
+	var depositDeductionReason sql.NullString
+	var notes sql.NullString
+	var terminationReason sql.NullString
+	var settlementDetail sql.NullString
+
+	if err := row.Scan(
+		&lease.ID,
+		&lease.TenantID,
+		&lease.PropertyID,
+		&lease.RoomID,
+		&lease.RentAmount,
+		&lease.StartDate,
+		&lease.EndDate,
+		&lease.ElectricityBillingCadence,
+		&lease.Status,
+		&lease.DepositAmount,
+		&depositRefundAmount,
+		&depositDeductionAmount,
+		&lease.DepositStatus,
+		&depositDeductionReason,
+		&notes,
+		&terminationReason,
+		&settlementDetail,
+		&lease.CreatedAt,
+		&lease.UpdatedAt,
+		&lease.Version,
+	); err != nil {
+		return nil, err
+	}
+
+	lease.DepositRefundAmount = nullIntPtr(depositRefundAmount)
+	lease.DepositDeductionAmount = nullIntPtr(depositDeductionAmount)
+	lease.DepositDeductionReason = nullStringPtr(depositDeductionReason)
+	lease.Notes = nullStringPtr(notes)
+	lease.TerminationReason = nullStringPtr(terminationReason)
+	if settlementDetail.Valid && strings.TrimSpace(settlementDetail.String) != "" && settlementDetail.String != "null" {
+		payload := map[string]interface{}{}
+		if err := json.Unmarshal([]byte(settlementDetail.String), &payload); err != nil {
+			return nil, fmt.Errorf("decode settlement detail: %w", err)
+		}
+		lease.SettlementDetail = &payload
+	}
+
+	return &lease, nil
+}
+
+func nullStringPtr(value sql.NullString) *string {
+	if !value.Valid {
+		return nil
+	}
+	result := value.String
+	return &result
+}
+
+func nullIntPtr(value sql.NullInt64) *int {
+	if !value.Valid {
+		return nil
+	}
+	result := int(value.Int64)
+	return &result
+}

--- a/internal/server/lease_adapters.go
+++ b/internal/server/lease_adapters.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+
+	applease "stds_backend/internal/application/lease"
+	dbleases "stds_backend/internal/platform/database/leases"
+)
+
+type leaseRepositoryAdapter struct {
+	repo dbleases.CommandRepository
+}
+
+func (a leaseRepositoryAdapter) FindTenantByID(ctx context.Context, tx *sql.Tx, tenantID string) (*applease.Tenant, error) {
+	tenant, err := a.repo.FindTenantByID(ctx, tx, tenantID)
+	if err != nil {
+		switch err {
+		case dbleases.ErrTenantNotFound:
+			return nil, applease.ErrTenantNotFound
+		default:
+			return nil, err
+		}
+	}
+
+	return &applease.Tenant{
+		ID:     tenant.ID,
+		Status: tenant.Status,
+	}, nil
+}
+
+func (a leaseRepositoryAdapter) FindRoomByIDForUpdate(ctx context.Context, tx *sql.Tx, roomID string) (*applease.Room, error) {
+	room, err := a.repo.FindRoomByIDForUpdate(ctx, tx, roomID)
+	if err != nil {
+		switch err {
+		case dbleases.ErrRoomNotFound:
+			return nil, applease.ErrRoomNotFound
+		default:
+			return nil, err
+		}
+	}
+
+	return &applease.Room{
+		ID:                               room.ID,
+		PropertyID:                       room.PropertyID,
+		Status:                           room.Status,
+		DefaultElectricityBillingCadence: room.DefaultElectricityBillingCadence,
+	}, nil
+}
+
+func (a leaseRepositoryAdapter) CreateLease(ctx context.Context, tx *sql.Tx, params applease.CreateLeaseParams) (*applease.Lease, error) {
+	lease, err := a.repo.CreateLease(ctx, tx, dbleases.CreateLeaseParams{
+		TenantID:                  params.TenantID,
+		RoomID:                    params.RoomID,
+		PropertyID:                params.PropertyID,
+		RentAmount:                params.RentAmount,
+		StartDate:                 params.StartDate,
+		EndDate:                   params.EndDate,
+		ElectricityBillingCadence: params.ElectricityBillingCadence,
+		DepositAmount:             params.DepositAmount,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toApplicationLease(lease), nil
+}
+
+func (a leaseRepositoryAdapter) CreateBills(ctx context.Context, tx *sql.Tx, params []applease.CreateBillParams) error {
+	items := make([]dbleases.CreateBillParams, 0, len(params))
+	for _, item := range params {
+		items = append(items, dbleases.CreateBillParams{
+			LeaseID:     item.LeaseID,
+			TenantID:    item.TenantID,
+			RoomID:      item.RoomID,
+			PropertyID:  item.PropertyID,
+			Type:        item.Type,
+			Amount:      item.Amount,
+			PeriodStart: item.PeriodStart,
+			PeriodEnd:   item.PeriodEnd,
+			DueDate:     item.DueDate,
+			Status:      item.Status,
+		})
+	}
+
+	return a.repo.CreateBills(ctx, tx, items)
+}
+
+func (a leaseRepositoryAdapter) MarkRoomOccupied(ctx context.Context, tx *sql.Tx, roomID string) error {
+	return a.repo.MarkRoomOccupied(ctx, tx, roomID)
+}
+
+func (a leaseRepositoryAdapter) ActivateTenant(ctx context.Context, tx *sql.Tx, tenantID string) error {
+	return a.repo.ActivateTenant(ctx, tx, tenantID)
+}
+
+func toApplicationLease(lease *dbleases.Lease) *applease.Lease {
+	return &applease.Lease{
+		ID:                        lease.ID,
+		TenantID:                  lease.TenantID,
+		PropertyID:                lease.PropertyID,
+		RoomID:                    lease.RoomID,
+		RentAmount:                lease.RentAmount,
+		StartDate:                 lease.StartDate,
+		EndDate:                   lease.EndDate,
+		ElectricityBillingCadence: lease.ElectricityBillingCadence,
+		Status:                    lease.Status,
+		DepositAmount:             lease.DepositAmount,
+		DepositRefundAmount:       lease.DepositRefundAmount,
+		DepositDeductionAmount:    lease.DepositDeductionAmount,
+		DepositStatus:             lease.DepositStatus,
+		DepositDeductionReason:    lease.DepositDeductionReason,
+		Notes:                     lease.Notes,
+		TerminationReason:         lease.TerminationReason,
+		SettlementDetail:          lease.SettlementDetail,
+		CreatedAt:                 lease.CreatedAt,
+		UpdatedAt:                 lease.UpdatedAt,
+		Version:                   lease.Version,
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 
 	appiam "stds_backend/internal/application/iam"
 	appjobs "stds_backend/internal/application/jobs"
+	applease "stds_backend/internal/application/lease"
 	appnotification "stds_backend/internal/application/notification"
 	appproperty "stds_backend/internal/application/property"
 	apptenant "stds_backend/internal/application/tenant"
@@ -16,6 +17,8 @@ import (
 	"stds_backend/internal/http/router"
 	"stds_backend/internal/platform/database"
 	dbjobruns "stds_backend/internal/platform/database/jobruns"
+	dbleasequery "stds_backend/internal/platform/database/leasequery"
+	dbleases "stds_backend/internal/platform/database/leases"
 	dbproperties "stds_backend/internal/platform/database/properties"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
 	dbresourceownership "stds_backend/internal/platform/database/resourceownership"
@@ -54,7 +57,9 @@ func New(cfg *config.Config) (*Server, error) {
 
 	userRepo := dbusers.NewRepository(db)
 	propertyRepo := dbproperties.NewRepository(db)
+	leaseRepo := dbleases.NewRepository(db)
 	propertyQueryRepo := dbpropertyquery.NewRepository(db)
+	leaseQueryRepo := dbleasequery.NewRepository(db)
 	tenantRepo := dbtenants.NewRepository(db)
 	tenantQueryRepo := dbtenantquery.NewRepository(db)
 	resourceOwnershipRepo := dbresourceownership.NewRepository(db)
@@ -92,12 +97,17 @@ func New(cfg *config.Config) (*Server, error) {
 	setRoomMaintenanceService := appproperty.NewSetRoomMaintenanceService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	createTenantService := apptenant.NewCreateTenantService(tenantRepositoryAdapter{repo: tenantRepo}, txRunner)
 	updateTenantService := apptenant.NewUpdateTenantService(tenantRepositoryAdapter{repo: tenantRepo}, txRunner)
+	createLeaseService := applease.NewCreateLeaseService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
+	occupyRoomOnLeaseCreated := applease.NewOccupyRoomOnLeaseCreatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
+	activateTenantOnLeaseCreated := applease.NewActivateTenantOnLeaseCreatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	jobTriggerService := appjobs.NewTriggerService(jobRunStoreAdapter{repo: jobRunsRepo}, nil, cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)
+	eventbus.Subscribe(bus, occupyRoomOnLeaseCreated.HandleLeaseCreated)
+	eventbus.Subscribe(bus, activateTenantOnLeaseCreated.HandleLeaseCreated)
 
 	engine := router.New(cfg.App, logger, db, authenticator, userRepo, router.AuthorizationRepositories{
 		Properties:        propertyRepo,
 		ResourceOwnership: resourceOwnershipRepo,
-	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService)
+	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService)
 
 	return &Server{
 		httpServer: &http.Server{


### PR DESCRIPTION
Closes #15

## Summary
- Implemented lease list, detail, and create endpoints for the Leasing slice.
- Added lease creation orchestration with vacant-room locking, cadence resolution, lease persistence, bill pre-generation, and `LeaseCreated` recording.
- Added lease read query repository, server wiring, and route coverage for authorization/access behavior.
- Fixed create-time bill generation so rent bills remain monthly while electricity bills follow `electricity_billing_cadence`.
- Added validation coverage for missing/zero create fields and non-positive rent amounts.

## Transaction / Event Consistency Note
`CreateLease` intentionally keeps the create transaction scoped to:
- creating the lease
- pre-generating bills
- recording `LeaseCreated`

Room occupancy (`room -> occupied`) and tenant activation (`inactive -> active`) are handled by `LeaseCreated` subscribers after the transaction commits. This is not an ignored risk. It follows the current infrastructure model: `txrunner` commits first, then synchronously publishes events. Therefore, if post-commit publish or a subscriber fails, the lease and bills can already be persisted while room/tenant status has not synchronized yet.

Given the current project scale, in-process event bus, and non-distributed architecture, this is an accepted low-but-nonzero tradeoff for this PR rather than a ticket-specific omission.

## Validation
- `go test ./internal/domain/lease ./internal/application/lease ./internal/http/router`
- `go test ./...`