### PR TITLE
Implement lease replacement flow

### DIFF
--- a/internal/application/lease/create_lease_test.go
+++ b/internal/application/lease/create_lease_test.go
@@ -356,9 +356,12 @@ type leaseRepositoryStub struct {
 	lockedRentBills    bool
 	voidRentDueDate    *time.Time
 	createLeaseParams  *CreateLeaseParams
+	terminateCalls     int
+	voidBillsBoundary  *time.Time
 	updateLeaseCalls   int
 	settleDepositCalls int
 	createdBills       []CreateBillParams
+	replacementBills   []Bill
 }
 
 func (s *leaseRepositoryStub) FindTenantByID(context.Context, *sql.Tx, string) (*Tenant, error) {
@@ -422,12 +425,32 @@ func (s *leaseRepositoryStub) SettleDeposit(_ context.Context, _ *sql.Tx, params
 	return s.lease, nil
 }
 
+func (s *leaseRepositoryStub) TerminateLease(_ context.Context, _ *sql.Tx, params TerminateLeaseParams) (*Lease, error) {
+	s.terminateCalls++
+	if s.lease == nil {
+		return nil, ErrLeaseNotFound
+	}
+	s.lease.Status = "terminated"
+	s.lease.EndDate = params.EndDate
+	s.lease.TerminationReason = &params.TerminationReason
+	return s.lease, nil
+}
+
+func (s *leaseRepositoryStub) ListBillsByLeaseIDForUpdate(context.Context, *sql.Tx, string) ([]Bill, error) {
+	return s.replacementBills, nil
+}
+
 func (s *leaseRepositoryStub) HasLockedRentBillsFromDueDate(context.Context, *sql.Tx, string, time.Time) (bool, error) {
 	return s.lockedRentBills, nil
 }
 
 func (s *leaseRepositoryStub) VoidRentBillsFromDueDate(_ context.Context, _ *sql.Tx, _ string, dueDate time.Time) error {
 	s.voidRentDueDate = &dueDate
+	return nil
+}
+
+func (s *leaseRepositoryStub) VoidBillsOverlappingOrAfter(_ context.Context, _ *sql.Tx, _ string, boundary time.Time) error {
+	s.voidBillsBoundary = &boundary
 	return nil
 }
 

--- a/internal/application/lease/errors.go
+++ b/internal/application/lease/errors.go
@@ -9,21 +9,25 @@ import (
 )
 
 const (
-	codeValidationTenantIDRequired  = "VALIDATION_TENANT_ID_REQUIRED"
-	codeValidationRoomIDRequired    = "VALIDATION_ROOM_ID_REQUIRED"
-	codeValidationStartDateRequired = "VALIDATION_START_DATE_REQUIRED"
-	codeValidationEndDateRequired   = "VALIDATION_END_DATE_REQUIRED"
-	codeLeaseInvalidDateRange       = "LEASE_INVALID_DATE_RANGE"
-	codeLeaseRentAmountNonPositive  = "LEASE_RENT_AMOUNT_NON_POSITIVE"
-	codeLeaseDepositNegative        = "LEASE_DEPOSIT_NEGATIVE"
-	codeSettlementNegative          = "LEASE_SETTLEMENT_NEGATIVE"
-	codeLeaseUnsupportedUpdate      = "LEASE_UNSUPPORTED_UPDATE"
-	codeDepositDeductionReason      = "DEPOSIT_DEDUCTION_REASON_REQUIRED"
-	codeDepositSettlementMismatch   = "DEPOSIT_SETTLEMENT_AMOUNT_MISMATCH"
-	codeDepositNotHeld              = "DEPOSIT_NOT_HELD"
-	codeLeaseUpdateLockedBills      = "LEASE_UPDATE_HAS_LOCKED_FUTURE_BILLS"
-	codeLeaseNotActive              = "LEASE_NOT_ACTIVE"
-	codeRoomNotVacant               = "ROOM_NOT_VACANT"
+	codeValidationTenantIDRequired    = "VALIDATION_TENANT_ID_REQUIRED"
+	codeValidationRoomIDRequired      = "VALIDATION_ROOM_ID_REQUIRED"
+	codeValidationStartDateRequired   = "VALIDATION_START_DATE_REQUIRED"
+	codeValidationEndDateRequired     = "VALIDATION_END_DATE_REQUIRED"
+	codeLeaseInvalidDateRange         = "LEASE_INVALID_DATE_RANGE"
+	codeLeaseRentAmountNonPositive    = "LEASE_RENT_AMOUNT_NON_POSITIVE"
+	codeLeaseDepositNegative          = "LEASE_DEPOSIT_NEGATIVE"
+	codeSettlementNegative            = "LEASE_SETTLEMENT_NEGATIVE"
+	codeLeaseUnsupportedUpdate        = "LEASE_UNSUPPORTED_UPDATE"
+	codeDepositDeductionReason        = "DEPOSIT_DEDUCTION_REASON_REQUIRED"
+	codeDepositSettlementMismatch     = "DEPOSIT_SETTLEMENT_AMOUNT_MISMATCH"
+	codeDepositNotHeld                = "DEPOSIT_NOT_HELD"
+	codeLeaseUpdateLockedBills        = "LEASE_UPDATE_HAS_LOCKED_FUTURE_BILLS"
+	codeLeaseNotActive                = "LEASE_NOT_ACTIVE"
+	codeRoomNotVacant                 = "ROOM_NOT_VACANT"
+	codeReplacementNotBoundary        = "LEASE_REPLACEMENT_NOT_AT_BILLING_BOUNDARY"
+	codeReplacementUnsettledBills     = "LEASE_REPLACEMENT_HAS_UNSETTLED_BILLS"
+	codeReplacementScopeMismatch      = "LEASE_REPLACEMENT_SCOPE_MISMATCH"
+	codeReplacementDepositUnsupported = "LEASE_REPLACEMENT_DEPOSIT_HANDLING_UNSUPPORTED"
 )
 
 var (
@@ -101,6 +105,26 @@ var (
 		codeRoomNotVacant,
 		http.StatusUnprocessableEntity,
 		"Room is not vacant.",
+	)
+	errReplacementNotAtBillingBoundary = apperr.New(
+		codeReplacementNotBoundary,
+		http.StatusUnprocessableEntity,
+		"Lease replacement is allowed only at a complete billing period boundary.",
+	)
+	errReplacementHasUnsettledBills = apperr.New(
+		codeReplacementUnsettledBills,
+		http.StatusUnprocessableEntity,
+		"Lease replacement has unsettled bills before the boundary.",
+	)
+	errReplacementScopeMismatch = apperr.New(
+		codeReplacementScopeMismatch,
+		http.StatusUnprocessableEntity,
+		"Lease replacement supports only the same tenant, room, and property.",
+	)
+	errReplacementDepositHandlingUnsupported = apperr.New(
+		codeReplacementDepositUnsupported,
+		http.StatusUnprocessableEntity,
+		"Lease replacement v1 supports only deposit carry_over.",
 	)
 )
 

--- a/internal/application/lease/replace_lease.go
+++ b/internal/application/lease/replace_lease.go
@@ -1,0 +1,300 @@
+package lease
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	domainevents "stds_backend/internal/domain/events"
+	domainlease "stds_backend/internal/domain/lease"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+const (
+	replacementDepositCarryOver = "carry_over"
+	billStatusPaid              = "paid"
+)
+
+// ReplaceLeaseInput is the command payload for lease replacement.
+type ReplaceLeaseInput struct {
+	ActorRole           string
+	AssignedPropertyIDs []string
+	LeaseID             string
+	Reason              string
+	EffectiveStartDate  time.Time
+	DepositHandling     string
+	NewEndDate          time.Time
+	NewRentAmount       int
+	NewCadence          string
+	NewNotes            *string
+}
+
+// ReplaceLeaseResult contains predecessor, successor, and replacement metadata.
+type ReplaceLeaseResult struct {
+	OldLease           *Lease
+	NewLease           *Lease
+	Reason             string
+	EffectiveStartDate time.Time
+	DepositHandling    string
+	ChangedFields      []string
+}
+
+// ReplaceLeaseService replaces a lease by terminating the predecessor and creating a successor.
+type ReplaceLeaseService struct {
+	repo     Repository
+	txRunner *txrunner.Runner
+}
+
+// NewReplaceLeaseService returns a ReplaceLeaseService.
+func NewReplaceLeaseService(repo Repository, txRunner *txrunner.Runner) *ReplaceLeaseService {
+	return &ReplaceLeaseService{repo: repo, txRunner: txRunner}
+}
+
+// Execute validates replacement rules and coordinates predecessor/successor writes.
+func (s *ReplaceLeaseService) Execute(ctx context.Context, input ReplaceLeaseInput) (*ReplaceLeaseResult, error) {
+	leaseID := strings.TrimSpace(input.LeaseID)
+	if leaseID == "" || leaseID == zeroUUID {
+		return nil, apperr.ErrLeaseNotFound
+	}
+	if _, err := uuid.Parse(leaseID); err != nil {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "lease_id"})
+	}
+	if input.EffectiveStartDate.IsZero() {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "effective_start_date"})
+	}
+	if input.NewEndDate.IsZero() {
+		return nil, errValidationEndDateRequired
+	}
+	if strings.TrimSpace(input.DepositHandling) != replacementDepositCarryOver {
+		return nil, errReplacementDepositHandlingUnsupported
+	}
+
+	actorRole := strings.ToLower(strings.TrimSpace(input.ActorRole))
+	switch actorRole {
+	case "admin", "organizer", "staff":
+	default:
+		return nil, apperr.ErrForbidden
+	}
+
+	reason := strings.TrimSpace(input.Reason)
+	switch reason {
+	case "cadence_change", "renewal", "contract_reissue", "other_exception":
+	default:
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "reason"})
+	}
+	cadence := strings.TrimSpace(input.NewCadence)
+	effectiveStart := normalizeDate(input.EffectiveStartDate)
+	newEndDate := normalizeDate(input.NewEndDate)
+
+	var result *ReplaceLeaseResult
+	err := s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+		current, err := s.repo.FindLeaseByIDForUpdate(ctx, tx, leaseID)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrLeaseNotFound):
+				return apperr.ErrLeaseNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+		if (actorRole == "organizer" || actorRole == "staff") && !containsAssignedProperty(input.AssignedPropertyIDs, current.PropertyID) {
+			return apperr.ErrForbidden
+		}
+		if current.Status != domainlease.StatusActive {
+			return errLeaseNotActive
+		}
+		if current.DepositStatus != domainlease.DepositStatusHeld {
+			return errReplacementDepositHandlingUnsupported.WithDetails(map[string]interface{}{"field": "deposit_status"})
+		}
+
+		if _, err := s.repo.FindTenantByID(ctx, tx, current.TenantID); err != nil {
+			switch {
+			case errors.Is(err, ErrTenantNotFound):
+				return apperr.ErrTenantNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+		room, err := s.repo.FindRoomByIDForUpdate(ctx, tx, current.RoomID)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrRoomNotFound):
+				return apperr.ErrRoomNotFound
+			default:
+				return apperr.ErrInternalServerError.WithCause(err)
+			}
+		}
+		if room.ID != current.RoomID || room.PropertyID != current.PropertyID {
+			return errReplacementScopeMismatch
+		}
+
+		bills, err := s.repo.ListBillsByLeaseIDForUpdate(ctx, tx, leaseID)
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+		if !isReplacementBoundary(bills, effectiveStart) {
+			return errReplacementNotAtBillingBoundary
+		}
+		if unsettledBillIDs := unsettledBeforeBoundary(bills, effectiveStart); len(unsettledBillIDs) > 0 {
+			return errReplacementHasUnsettledBills.WithDetails(map[string]interface{}{"bill_ids": unsettledBillIDs})
+		}
+
+		successorAggregate, err := domainlease.New(domainlease.State{
+			TenantID:                  current.TenantID,
+			RoomID:                    current.RoomID,
+			PropertyID:                current.PropertyID,
+			RentAmount:                input.NewRentAmount,
+			StartDate:                 effectiveStart,
+			EndDate:                   newEndDate,
+			ElectricityBillingCadence: cadence,
+			DepositAmount:             current.DepositAmount,
+		})
+		if err != nil {
+			return mapDomainError(err)
+		}
+
+		oldEndDate := effectiveStart.AddDate(0, 0, -1)
+		if oldEndDate.Before(normalizeDate(current.StartDate)) {
+			return errReplacementNotAtBillingBoundary
+		}
+		terminated, err := s.repo.TerminateLease(ctx, tx, TerminateLeaseParams{
+			LeaseID:           leaseID,
+			EndDate:           oldEndDate,
+			TerminationReason: "lease replacement: " + reason,
+		})
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+		if err := s.repo.VoidBillsOverlappingOrAfter(ctx, tx, leaseID, effectiveStart); err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		state := successorAggregate.State()
+		successor, err := s.repo.CreateLease(ctx, tx, CreateLeaseParams{
+			TenantID:                  state.TenantID,
+			RoomID:                    state.RoomID,
+			PropertyID:                state.PropertyID,
+			RentAmount:                state.RentAmount,
+			StartDate:                 state.StartDate,
+			EndDate:                   state.EndDate,
+			ElectricityBillingCadence: state.ElectricityBillingCadence,
+			DepositAmount:             state.DepositAmount,
+			Notes:                     input.NewNotes,
+		})
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		rentPeriods, err := domainlease.BuildBillingPeriods(state.StartDate, state.EndDate, domainlease.BillingCadenceMonthly)
+		if err != nil {
+			return mapDomainError(err)
+		}
+		electricityPeriods, err := domainlease.BuildBillingPeriods(state.StartDate, state.EndDate, state.ElectricityBillingCadence)
+		if err != nil {
+			return mapDomainError(err)
+		}
+		if err := s.repo.CreateBills(ctx, tx, buildBillSeeds(successor, rentPeriods, electricityPeriods)); err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		changedFields := replacementChangedFields(current, successor)
+		now := time.Now().UTC()
+		recorder.Record(domainevents.LeaseTerminated{
+			LeaseID:       terminated.ID,
+			RoomID:        terminated.RoomID,
+			PropertyID:    terminated.PropertyID,
+			TenantID:      terminated.TenantID,
+			Forced:        false,
+			IsReplacement: true,
+			OccurredAt:    now,
+		})
+		recorder.Record(domainevents.LeaseCreated{
+			LeaseID:                   successor.ID,
+			RoomID:                    successor.RoomID,
+			PropertyID:                successor.PropertyID,
+			TenantID:                  successor.TenantID,
+			StartDate:                 successor.StartDate,
+			EndDate:                   successor.EndDate,
+			ElectricityBillingCadence: successor.ElectricityBillingCadence,
+			OccurredAt:                now,
+		})
+		recorder.Record(domainevents.LeaseReplaced{
+			OldLeaseID:      terminated.ID,
+			NewLeaseID:      successor.ID,
+			RoomID:          successor.RoomID,
+			PropertyID:      successor.PropertyID,
+			TenantID:        successor.TenantID,
+			Reason:          reason,
+			EffectiveDate:   effectiveStart,
+			ChangedFields:   changedFields,
+			DepositHandling: replacementDepositCarryOver,
+			OccurredAt:      now,
+		})
+
+		result = &ReplaceLeaseResult{
+			OldLease:           terminated,
+			NewLease:           successor,
+			Reason:             reason,
+			EffectiveStartDate: effectiveStart,
+			DepositHandling:    replacementDepositCarryOver,
+			ChangedFields:      changedFields,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func isReplacementBoundary(bills []Bill, effectiveStart time.Time) bool {
+	for _, bill := range bills {
+		if bill.Type != billTypeElectricity {
+			continue
+		}
+		if normalizeDate(bill.PeriodEnd).AddDate(0, 0, 1).Equal(effectiveStart) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func unsettledBeforeBoundary(bills []Bill, effectiveStart time.Time) []string {
+	ids := make([]string, 0)
+	for _, bill := range bills {
+		if !normalizeDate(bill.PeriodEnd).Before(effectiveStart) {
+			continue
+		}
+		if bill.Status != billStatusPaid {
+			ids = append(ids, bill.ID)
+		}
+	}
+
+	return ids
+}
+
+func replacementChangedFields(oldLease *Lease, newLease *Lease) []string {
+	fields := make([]string, 0, 3)
+	if oldLease.RentAmount != newLease.RentAmount {
+		fields = append(fields, "rent_amount")
+	}
+	if !normalizeDate(oldLease.EndDate).Equal(normalizeDate(newLease.EndDate)) {
+		fields = append(fields, "end_date")
+	}
+	if oldLease.ElectricityBillingCadence != newLease.ElectricityBillingCadence {
+		fields = append(fields, "electricity_billing_cadence")
+	}
+
+	return fields
+}
+
+func normalizeDate(value time.Time) time.Time {
+	return time.Date(value.Year(), value.Month(), value.Day(), 0, 0, 0, 0, value.Location())
+}

--- a/internal/application/lease/replace_lease.go
+++ b/internal/application/lease/replace_lease.go
@@ -129,7 +129,7 @@ func (s *ReplaceLeaseService) Execute(ctx context.Context, input ReplaceLeaseInp
 				return apperr.ErrInternalServerError.WithCause(err)
 			}
 		}
-		if room.ID != current.RoomID || room.PropertyID != current.PropertyID {
+		if room.PropertyID != current.PropertyID {
 			return errReplacementScopeMismatch
 		}
 

--- a/internal/application/lease/replace_lease_test.go
+++ b/internal/application/lease/replace_lease_test.go
@@ -135,6 +135,26 @@ func TestReplaceLeaseServiceRejectsUnsupportedDepositHandling(t *testing.T) {
 	}
 }
 
+func TestReplaceLeaseServiceRejectsScopeMismatch(t *testing.T) {
+	repo := replacementRepoStub()
+	repo.room.PropertyID = "property-2"
+	service := NewReplaceLeaseService(repo, txRunnerForRollback(t))
+
+	_, err := service.Execute(context.Background(), ReplaceLeaseInput{
+		ActorRole:          "admin",
+		LeaseID:            replaceLeaseTestLeaseID,
+		Reason:             "cadence_change",
+		EffectiveStartDate: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		DepositHandling:    "carry_over",
+		NewEndDate:         time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+		NewRentAmount:      20000,
+		NewCadence:         "bimonthly",
+	})
+	if !errors.Is(err, errReplacementScopeMismatch) {
+		t.Fatalf("expected errReplacementScopeMismatch, got %v", err)
+	}
+}
+
 func TestReplaceLeaseServiceVoidsBillsOverlappingBoundary(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -241,6 +261,9 @@ func txRunnerForRollback(t *testing.T) *dbtxrunner.Runner {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
 	t.Cleanup(func() {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("ExpectationsWereMet: %v", err)
+		}
 		_ = db.Close()
 	})
 	mock.ExpectBegin()

--- a/internal/application/lease/replace_lease_test.go
+++ b/internal/application/lease/replace_lease_test.go
@@ -1,0 +1,250 @@
+package lease
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	domainevents "stds_backend/internal/domain/events"
+	dbtxrunner "stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+const replaceLeaseTestLeaseID = "40000000-0000-0000-0000-000000000001"
+
+func TestReplaceLeaseServiceCreatesSuccessorAndPublishesEvents(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	publisher := &recordingPublisher{}
+	repo := replacementRepoStub()
+	service := NewReplaceLeaseService(repo, dbtxrunner.New(db, publisher))
+
+	result, err := service.Execute(context.Background(), ReplaceLeaseInput{
+		ActorRole:           "staff",
+		AssignedPropertyIDs: []string{"property-1"},
+		LeaseID:             replaceLeaseTestLeaseID,
+		Reason:              "cadence_change",
+		EffectiveStartDate:  time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		DepositHandling:     "carry_over",
+		NewEndDate:          time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+		NewRentAmount:       20000,
+		NewCadence:          "bimonthly",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.OldLease.Status != "terminated" {
+		t.Fatalf("old status = %q, want terminated", result.OldLease.Status)
+	}
+	if repo.createLeaseParams == nil || repo.createLeaseParams.TenantID != repo.lease.TenantID || repo.createLeaseParams.RoomID != repo.lease.RoomID {
+		t.Fatalf("successor did not inherit scope: %+v", repo.createLeaseParams)
+	}
+	if repo.voidBillsBoundary == nil || !repo.voidBillsBoundary.Equal(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("voidBillsBoundary = %v, want 2026-06-01", repo.voidBillsBoundary)
+	}
+	if len(repo.createdBills) != 11 {
+		t.Fatalf("created bills = %d, want 11", len(repo.createdBills))
+	}
+	if len(publisher.events) != 3 {
+		t.Fatalf("events = %d, want 3", len(publisher.events))
+	}
+	terminated, ok := publisher.events[0].(domainevents.LeaseTerminated)
+	if !ok || !terminated.IsReplacement {
+		t.Fatalf("first event = %+v, want replacement LeaseTerminated", publisher.events[0])
+	}
+	if _, ok := publisher.events[1].(domainevents.LeaseCreated); !ok {
+		t.Fatalf("second event = %T, want LeaseCreated", publisher.events[1])
+	}
+	replaced, ok := publisher.events[2].(domainevents.LeaseReplaced)
+	if !ok {
+		t.Fatalf("third event = %T, want LeaseReplaced", publisher.events[2])
+	}
+	if replaced.OldLeaseID != replaceLeaseTestLeaseID || replaced.NewLeaseID != "lease-successor" || replaced.DepositHandling != "carry_over" {
+		t.Fatalf("unexpected LeaseReplaced event: %+v", replaced)
+	}
+}
+
+func TestReplaceLeaseServiceRejectsNonBoundaryDate(t *testing.T) {
+	service := NewReplaceLeaseService(replacementRepoStub(), txRunnerForRollback(t))
+
+	_, err := service.Execute(context.Background(), ReplaceLeaseInput{
+		ActorRole:          "admin",
+		LeaseID:            replaceLeaseTestLeaseID,
+		Reason:             "cadence_change",
+		EffectiveStartDate: time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
+		DepositHandling:    "carry_over",
+		NewEndDate:         time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+		NewRentAmount:      20000,
+		NewCadence:         "bimonthly",
+	})
+	if !errors.Is(err, errReplacementNotAtBillingBoundary) {
+		t.Fatalf("expected errReplacementNotAtBillingBoundary, got %v", err)
+	}
+}
+
+func TestReplaceLeaseServiceRejectsUnsettledBoundaryBeforeBills(t *testing.T) {
+	repo := replacementRepoStub()
+	repo.replacementBills = append(repo.replacementBills, Bill{
+		ID:          "bill-unsettled",
+		Type:        "rent",
+		Status:      "pending_payment",
+		PeriodStart: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:   time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+	})
+	service := NewReplaceLeaseService(repo, txRunnerForRollback(t))
+
+	_, err := service.Execute(context.Background(), ReplaceLeaseInput{
+		ActorRole:          "admin",
+		LeaseID:            replaceLeaseTestLeaseID,
+		Reason:             "cadence_change",
+		EffectiveStartDate: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		DepositHandling:    "carry_over",
+		NewEndDate:         time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+		NewRentAmount:      20000,
+		NewCadence:         "bimonthly",
+	})
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) || appErr.Code != codeReplacementUnsettledBills {
+		t.Fatalf("expected errReplacementHasUnsettledBills, got %v", err)
+	}
+}
+
+func TestReplaceLeaseServiceRejectsUnsupportedDepositHandling(t *testing.T) {
+	service := NewReplaceLeaseService(nil, nil)
+
+	_, err := service.Execute(context.Background(), ReplaceLeaseInput{
+		LeaseID:            replaceLeaseTestLeaseID,
+		EffectiveStartDate: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		DepositHandling:    "refund",
+		NewEndDate:         time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+		NewRentAmount:      20000,
+		NewCadence:         "bimonthly",
+	})
+	if !errors.Is(err, errReplacementDepositHandlingUnsupported) {
+		t.Fatalf("expected errReplacementDepositHandlingUnsupported, got %v", err)
+	}
+}
+
+func TestReplaceLeaseServiceVoidsBillsOverlappingBoundary(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := replacementRepoStub()
+	repo.replacementBills = append(repo.replacementBills, Bill{
+		ID:          "bill-electricity-paid-second",
+		Type:        "electricity",
+		Status:      "paid",
+		PeriodStart: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:   time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
+	}, Bill{
+		ID:          "bill-rent-overlap",
+		Type:        "rent",
+		Status:      "pending_payment",
+		PeriodStart: time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:   time.Date(2026, 7, 14, 0, 0, 0, 0, time.UTC),
+	})
+	service := NewReplaceLeaseService(repo, dbtxrunner.New(db, nil))
+
+	_, err = service.Execute(context.Background(), ReplaceLeaseInput{
+		ActorRole:          "admin",
+		LeaseID:            replaceLeaseTestLeaseID,
+		Reason:             "cadence_change",
+		EffectiveStartDate: time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+		DepositHandling:    "carry_over",
+		NewEndDate:         time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+		NewRentAmount:      20000,
+		NewCadence:         "bimonthly",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if repo.voidBillsBoundary == nil || !repo.voidBillsBoundary.Equal(time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("voidBillsBoundary = %v, want 2026-07-01", repo.voidBillsBoundary)
+	}
+}
+
+func replacementRepoStub() *leaseRepositoryStub {
+	return &leaseRepositoryStub{
+		tenant: &Tenant{ID: "tenant-1", Status: "active"},
+		room: &Room{
+			ID:                               "room-1",
+			PropertyID:                       "property-1",
+			Status:                           "occupied",
+			DefaultElectricityBillingCadence: "monthly",
+		},
+		lease: &Lease{
+			ID:                        replaceLeaseTestLeaseID,
+			TenantID:                  "tenant-1",
+			PropertyID:                "property-1",
+			RoomID:                    "room-1",
+			RentAmount:                18000,
+			StartDate:                 time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:                   time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+			ElectricityBillingCadence: "monthly",
+			Status:                    "active",
+			DepositAmount:             36000,
+			DepositStatus:             "held",
+		},
+		createdLease: &Lease{
+			ID:                        "lease-successor",
+			TenantID:                  "tenant-1",
+			PropertyID:                "property-1",
+			RoomID:                    "room-1",
+			RentAmount:                20000,
+			StartDate:                 time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:                   time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+			ElectricityBillingCadence: "bimonthly",
+			Status:                    "active",
+			DepositAmount:             36000,
+			DepositStatus:             "held",
+		},
+		replacementBills: []Bill{
+			{
+				ID:          "bill-electricity-paid",
+				Type:        "electricity",
+				Status:      "paid",
+				PeriodStart: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+				PeriodEnd:   time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+			},
+			{
+				ID:          "bill-rent-paid",
+				Type:        "rent",
+				Status:      "paid",
+				PeriodStart: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+				PeriodEnd:   time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+}
+
+func txRunnerForRollback(t *testing.T) *dbtxrunner.Runner {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	return dbtxrunner.New(db, nil)
+}

--- a/internal/application/lease/repository.go
+++ b/internal/application/lease/repository.go
@@ -61,6 +61,7 @@ type CreateLeaseParams struct {
 	EndDate                   time.Time
 	ElectricityBillingCadence string
 	DepositAmount             int
+	Notes                     *string
 }
 
 // CreateBillParams contains the pre-generated bill fields.
@@ -77,6 +78,15 @@ type CreateBillParams struct {
 	Status      string
 }
 
+// Bill captures bill state required by replacement rules.
+type Bill struct {
+	ID          string
+	Type        string
+	Status      string
+	PeriodStart time.Time
+	PeriodEnd   time.Time
+}
+
 // UpdateLeaseParams contains supported normal lease-condition updates.
 type UpdateLeaseParams struct {
 	LeaseID    string
@@ -91,6 +101,13 @@ type SettleDepositParams struct {
 	DepositDeductionReason *string
 }
 
+// TerminateLeaseParams contains fields for predecessor termination.
+type TerminateLeaseParams struct {
+	LeaseID           string
+	EndDate           time.Time
+	TerminationReason string
+}
+
 // Repository defines persistence required by lease use cases and subscribers.
 type Repository interface {
 	FindTenantByID(ctx context.Context, tx *sql.Tx, tenantID string) (*Tenant, error)
@@ -99,8 +116,11 @@ type Repository interface {
 	CreateLease(ctx context.Context, tx *sql.Tx, params CreateLeaseParams) (*Lease, error)
 	UpdateLeaseConditions(ctx context.Context, tx *sql.Tx, params UpdateLeaseParams) (*Lease, error)
 	SettleDeposit(ctx context.Context, tx *sql.Tx, params SettleDepositParams) (*Lease, error)
+	TerminateLease(ctx context.Context, tx *sql.Tx, params TerminateLeaseParams) (*Lease, error)
+	ListBillsByLeaseIDForUpdate(ctx context.Context, tx *sql.Tx, leaseID string) ([]Bill, error)
 	HasLockedRentBillsFromDueDate(ctx context.Context, tx *sql.Tx, leaseID string, dueDate time.Time) (bool, error)
 	VoidRentBillsFromDueDate(ctx context.Context, tx *sql.Tx, leaseID string, dueDate time.Time) error
+	VoidBillsOverlappingOrAfter(ctx context.Context, tx *sql.Tx, leaseID string, boundary time.Time) error
 	CreateBills(ctx context.Context, tx *sql.Tx, params []CreateBillParams) error
 	MarkRoomOccupied(ctx context.Context, tx *sql.Tx, roomID string) error
 	ActivateTenant(ctx context.Context, tx *sql.Tx, tenantID string) error

--- a/internal/domain/events/lease_replaced.go
+++ b/internal/domain/events/lease_replaced.go
@@ -1,0 +1,17 @@
+package events
+
+import "time"
+
+// LeaseReplaced is emitted after a replacement creates a successor lease.
+type LeaseReplaced struct {
+	OldLeaseID      string
+	NewLeaseID      string
+	RoomID          string
+	PropertyID      string
+	TenantID        string
+	Reason          string
+	EffectiveDate   time.Time
+	ChangedFields   []string
+	DepositHandling string
+	OccurredAt      time.Time
+}

--- a/internal/domain/events/lease_terminated.go
+++ b/internal/domain/events/lease_terminated.go
@@ -4,10 +4,11 @@ import "time"
 
 // LeaseTerminated is emitted after a lease termination use case succeeds.
 type LeaseTerminated struct {
-	LeaseID    string
-	RoomID     string
-	PropertyID string
-	TenantID   string
-	Forced     bool
-	OccurredAt time.Time
+	LeaseID       string
+	RoomID        string
+	PropertyID    string
+	TenantID      string
+	Forced        bool
+	IsReplacement bool
+	OccurredAt    time.Time
 }

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -447,7 +447,9 @@ func (s *APIServer) ReplaceLease(c *gin.Context, id string) {
 	var notes *string
 	if request.NewLease.Notes != nil {
 		value := strings.TrimSpace(*request.NewLease.Notes)
-		notes = &value
+		if value != "" {
+			notes = &value
+		}
 	}
 
 	result, err := s.replaceLeaseSvc.Execute(c.Request.Context(), applease.ReplaceLeaseInput{

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -53,12 +54,14 @@ type APIServer struct {
 	createLeaseSvc    *applease.CreateLeaseService
 	updateLeaseSvc    *applease.UpdateLeaseService
 	updateDepositSvc  *applease.UpdateDepositService
+	replaceLeaseSvc   *applease.ReplaceLeaseService
 }
 
 // LeaseCommandServices groups optional lease command services beyond creation.
 type LeaseCommandServices struct {
 	UpdateLease   *applease.UpdateLeaseService
 	UpdateDeposit *applease.UpdateDepositService
+	ReplaceLease  *applease.ReplaceLeaseService
 }
 
 // NewAPIServer returns an API server with only the currently implemented
@@ -113,6 +116,7 @@ func NewAPIServer(
 	if len(leaseCommands) > 0 {
 		server.updateLeaseSvc = leaseCommands[0].UpdateLease
 		server.updateDepositSvc = leaseCommands[0].UpdateDeposit
+		server.replaceLeaseSvc = leaseCommands[0].ReplaceLease
 	}
 
 	return server
@@ -422,7 +426,49 @@ func (s *APIServer) UpdateLeaseDeposit(c *gin.Context, id string) {
 }
 
 // ReplaceLease handles lease replacement.
-func (s *APIServer) ReplaceLease(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) ReplaceLease(c *gin.Context, id string) {
+	if s.replaceLeaseSvc == nil {
+		writeNotImplemented(c)
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	var request api.LeaseReplaceRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	var notes *string
+	if request.NewLease.Notes != nil {
+		value := strings.TrimSpace(*request.NewLease.Notes)
+		notes = &value
+	}
+
+	result, err := s.replaceLeaseSvc.Execute(c.Request.Context(), applease.ReplaceLeaseInput{
+		ActorRole:           principal.Role,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		LeaseID:             id,
+		Reason:              string(request.Reason),
+		EffectiveStartDate:  request.EffectiveStartDate.Time,
+		DepositHandling:     string(request.DepositHandling),
+		NewEndDate:          request.NewLease.EndDate.Time,
+		NewRentAmount:       request.NewLease.RentAmount,
+		NewCadence:          string(request.NewLease.ElectricityBillingCadence),
+		NewNotes:            notes,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toLeaseReplaceResponse(result))
+}
 
 // ForceTerminateLease handles forced lease termination.
 func (s *APIServer) ForceTerminateLease(c *gin.Context, id string) { writeNotImplemented(c) }
@@ -1566,6 +1612,31 @@ func toCreatedLeaseResponse(lease *applease.Lease) api.LeaseResponse {
 		UpdatedAt:                 lease.UpdatedAt,
 		Version:                   lease.Version,
 	})
+}
+
+func toLeaseReplaceResponse(result *applease.ReplaceLeaseResult) api.LeaseReplaceResponse {
+	effectiveStart := openapi_types.Date{Time: result.EffectiveStartDate}
+	depositHandling := api.LeaseReplaceResponseReplacementDepositHandling(result.DepositHandling)
+	changedFields := append([]string(nil), result.ChangedFields...)
+	reason := result.Reason
+	oldLease := toCreatedLeaseResponse(result.OldLease)
+	newLease := toCreatedLeaseResponse(result.NewLease)
+
+	return api.LeaseReplaceResponse{
+		OldLease: &oldLease,
+		NewLease: &newLease,
+		Replacement: &struct {
+			ChangedFields      *[]string                                           `json:"changed_fields,omitempty"`
+			DepositHandling    *api.LeaseReplaceResponseReplacementDepositHandling `json:"deposit_handling,omitempty"`
+			EffectiveStartDate *openapi_types.Date                                 `json:"effective_start_date,omitempty"`
+			Reason             *string                                             `json:"reason,omitempty"`
+		}{
+			ChangedFields:      &changedFields,
+			DepositHandling:    &depositHandling,
+			EffectiveStartDate: &effectiveStart,
+			Reason:             &reason,
+		},
+	}
 }
 
 func toRepairRequestResponse(repairRequest *appproperty.RepairRequest) api.RepairRequestResponse {

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -3807,11 +3807,38 @@ func (f fakeLeaseRepo) SettleDeposit(_ context.Context, _ *sql.Tx, params applea
 	return lease, nil
 }
 
+func (f fakeLeaseRepo) TerminateLease(_ context.Context, _ *sql.Tx, params applease.TerminateLeaseParams) (*applease.Lease, error) {
+	lease, err := f.FindLeaseByIDForUpdate(context.Background(), nil, params.LeaseID)
+	if err != nil {
+		return nil, err
+	}
+	lease.Status = "terminated"
+	lease.EndDate = params.EndDate
+	lease.TerminationReason = &params.TerminationReason
+	return lease, nil
+}
+
+func (f fakeLeaseRepo) ListBillsByLeaseIDForUpdate(_ context.Context, _ *sql.Tx, _ string) ([]applease.Bill, error) {
+	return []applease.Bill{
+		{
+			ID:          "50000000-0000-0000-0000-000000000001",
+			Type:        "electricity",
+			Status:      "paid",
+			PeriodStart: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			PeriodEnd:   time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+		},
+	}, nil
+}
+
 func (f fakeLeaseRepo) HasLockedRentBillsFromDueDate(_ context.Context, _ *sql.Tx, _ string, _ time.Time) (bool, error) {
 	return false, nil
 }
 
 func (f fakeLeaseRepo) VoidRentBillsFromDueDate(_ context.Context, _ *sql.Tx, _ string, _ time.Time) error {
+	return nil
+}
+
+func (f fakeLeaseRepo) VoidBillsOverlappingOrAfter(_ context.Context, _ *sql.Tx, _ string, _ time.Time) error {
 	return nil
 }
 

--- a/internal/platform/database/leases/repository.go
+++ b/internal/platform/database/leases/repository.go
@@ -24,8 +24,11 @@ type CommandRepository interface {
 	CreateLease(ctx context.Context, tx *sql.Tx, params CreateLeaseParams) (*Lease, error)
 	UpdateLeaseConditions(ctx context.Context, tx *sql.Tx, params UpdateLeaseParams) (*Lease, error)
 	SettleDeposit(ctx context.Context, tx *sql.Tx, params SettleDepositParams) (*Lease, error)
+	TerminateLease(ctx context.Context, tx *sql.Tx, params TerminateLeaseParams) (*Lease, error)
+	ListBillsByLeaseIDForUpdate(ctx context.Context, tx *sql.Tx, leaseID string) ([]Bill, error)
 	HasLockedRentBillsFromDueDate(ctx context.Context, tx *sql.Tx, leaseID string, dueDate time.Time) (bool, error)
 	VoidRentBillsFromDueDate(ctx context.Context, tx *sql.Tx, leaseID string, dueDate time.Time) error
+	VoidBillsOverlappingOrAfter(ctx context.Context, tx *sql.Tx, leaseID string, boundary time.Time) error
 	CreateBills(ctx context.Context, tx *sql.Tx, params []CreateBillParams) error
 	MarkRoomOccupied(ctx context.Context, tx *sql.Tx, roomID string) error
 	ActivateTenant(ctx context.Context, tx *sql.Tx, tenantID string) error
@@ -79,6 +82,7 @@ type CreateLeaseParams struct {
 	EndDate                   time.Time
 	ElectricityBillingCadence string
 	DepositAmount             int
+	Notes                     *string
 }
 
 // CreateBillParams contains the writable fields required to pre-generate a bill.
@@ -95,6 +99,15 @@ type CreateBillParams struct {
 	Status      string
 }
 
+// Bill is the persisted bill state required by replacement rules.
+type Bill struct {
+	ID          string
+	Type        string
+	Status      string
+	PeriodStart time.Time
+	PeriodEnd   time.Time
+}
+
 // UpdateLeaseParams contains supported normal lease-condition update fields.
 type UpdateLeaseParams struct {
 	LeaseID    string
@@ -107,6 +120,13 @@ type SettleDepositParams struct {
 	RefundAmount           int
 	DeductionAmount        int
 	DepositDeductionReason *string
+}
+
+// TerminateLeaseParams contains fields for predecessor termination.
+type TerminateLeaseParams struct {
+	LeaseID           string
+	EndDate           time.Time
+	TerminationReason string
 }
 
 // SQLRepository persists lease writes in PostgreSQL.
@@ -221,8 +241,9 @@ INSERT INTO leases (
 	end_date,
 	electricity_billing_cadence,
 	deposit_amount,
-	deposit_status
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'held')
+	deposit_status,
+	notes
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'held', $9)
 RETURNING
 	id,
 	tenant_id,
@@ -255,12 +276,90 @@ RETURNING
 		params.EndDate,
 		params.ElectricityBillingCadence,
 		params.DepositAmount,
+		params.Notes,
 	))
 	if err != nil {
 		return nil, fmt.Errorf("create lease: %w", err)
 	}
 
 	return lease, nil
+}
+
+func (r *SQLRepository) TerminateLease(ctx context.Context, tx *sql.Tx, params TerminateLeaseParams) (*Lease, error) {
+	const query = `
+UPDATE leases
+SET status = 'terminated',
+	end_date = $2,
+	termination_reason = $3,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	tenant_id,
+	property_id,
+	room_id,
+	rent_amount,
+	start_date,
+	end_date,
+	electricity_billing_cadence,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	deposit_deduction_reason,
+	notes,
+	termination_reason,
+	settlement_detail::text,
+	created_at,
+	updated_at,
+	version
+`
+
+	lease, err := scanLease(tx.QueryRowContext(ctx, query, params.LeaseID, params.EndDate, params.TerminationReason))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrLeaseNotFound
+		}
+		return nil, fmt.Errorf("terminate lease: %w", err)
+	}
+
+	return lease, nil
+}
+
+func (r *SQLRepository) ListBillsByLeaseIDForUpdate(ctx context.Context, tx *sql.Tx, leaseID string) ([]Bill, error) {
+	const query = `
+SELECT id, type, status, period_start, period_end
+FROM bills
+WHERE lease_id = $1
+  AND deleted_at IS NULL
+ORDER BY period_start ASC, type ASC
+FOR UPDATE
+`
+
+	rows, err := tx.QueryContext(ctx, query, leaseID)
+	if err != nil {
+		return nil, fmt.Errorf("list bills by lease id for update: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	bills := make([]Bill, 0)
+	for rows.Next() {
+		var bill Bill
+		if err := rows.Scan(&bill.ID, &bill.Type, &bill.Status, &bill.PeriodStart, &bill.PeriodEnd); err != nil {
+			return nil, fmt.Errorf("scan replacement bill: %w", err)
+		}
+		bills = append(bills, bill)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate replacement bills: %w", err)
+	}
+
+	return bills, nil
 }
 
 func (r *SQLRepository) UpdateLeaseConditions(ctx context.Context, tx *sql.Tx, params UpdateLeaseParams) (*Lease, error) {
@@ -395,6 +494,25 @@ WHERE lease_id = $1
 
 	if _, err := tx.ExecContext(ctx, query, leaseID, dueDate); err != nil {
 		return fmt.Errorf("void rent bills from due date: %w", err)
+	}
+
+	return nil
+}
+
+func (r *SQLRepository) VoidBillsOverlappingOrAfter(ctx context.Context, tx *sql.Tx, leaseID string, boundary time.Time) error {
+	const query = `
+UPDATE bills
+SET status = 'voided',
+	updated_at = now(),
+	version = version + 1
+WHERE lease_id = $1
+  AND period_end >= $2
+  AND status IN ('pending_payment', 'pending_meter')
+  AND deleted_at IS NULL
+`
+
+	if _, err := tx.ExecContext(ctx, query, leaseID, boundary); err != nil {
+		return fmt.Errorf("void bills overlapping or after boundary: %w", err)
 	}
 
 	return nil

--- a/internal/server/lease_adapters.go
+++ b/internal/server/lease_adapters.go
@@ -73,12 +73,51 @@ func (a leaseRepositoryAdapter) CreateLease(ctx context.Context, tx *sql.Tx, par
 		EndDate:                   params.EndDate,
 		ElectricityBillingCadence: params.ElectricityBillingCadence,
 		DepositAmount:             params.DepositAmount,
+		Notes:                     params.Notes,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return toApplicationLease(lease), nil
+}
+
+func (a leaseRepositoryAdapter) TerminateLease(ctx context.Context, tx *sql.Tx, params applease.TerminateLeaseParams) (*applease.Lease, error) {
+	lease, err := a.repo.TerminateLease(ctx, tx, dbleases.TerminateLeaseParams{
+		LeaseID:           params.LeaseID,
+		EndDate:           params.EndDate,
+		TerminationReason: params.TerminationReason,
+	})
+	if err != nil {
+		switch err {
+		case dbleases.ErrLeaseNotFound:
+			return nil, applease.ErrLeaseNotFound
+		default:
+			return nil, err
+		}
+	}
+
+	return toApplicationLease(lease), nil
+}
+
+func (a leaseRepositoryAdapter) ListBillsByLeaseIDForUpdate(ctx context.Context, tx *sql.Tx, leaseID string) ([]applease.Bill, error) {
+	bills, err := a.repo.ListBillsByLeaseIDForUpdate(ctx, tx, leaseID)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]applease.Bill, 0, len(bills))
+	for _, bill := range bills {
+		items = append(items, applease.Bill{
+			ID:          bill.ID,
+			Type:        bill.Type,
+			Status:      bill.Status,
+			PeriodStart: bill.PeriodStart,
+			PeriodEnd:   bill.PeriodEnd,
+		})
+	}
+
+	return items, nil
 }
 
 func (a leaseRepositoryAdapter) UpdateLeaseConditions(ctx context.Context, tx *sql.Tx, params applease.UpdateLeaseParams) (*applease.Lease, error) {
@@ -123,6 +162,10 @@ func (a leaseRepositoryAdapter) HasLockedRentBillsFromDueDate(ctx context.Contex
 
 func (a leaseRepositoryAdapter) VoidRentBillsFromDueDate(ctx context.Context, tx *sql.Tx, leaseID string, dueDate time.Time) error {
 	return a.repo.VoidRentBillsFromDueDate(ctx, tx, leaseID, dueDate)
+}
+
+func (a leaseRepositoryAdapter) VoidBillsOverlappingOrAfter(ctx context.Context, tx *sql.Tx, leaseID string, boundary time.Time) error {
+	return a.repo.VoidBillsOverlappingOrAfter(ctx, tx, leaseID, boundary)
 }
 
 func (a leaseRepositoryAdapter) CreateBills(ctx context.Context, tx *sql.Tx, params []applease.CreateBillParams) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -101,6 +101,7 @@ func New(cfg *config.Config) (*Server, error) {
 	createLeaseService := applease.NewCreateLeaseService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	updateLeaseService := applease.NewUpdateLeaseService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	updateDepositService := applease.NewUpdateDepositService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
+	replaceLeaseService := applease.NewReplaceLeaseService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	occupyRoomOnLeaseCreated := applease.NewOccupyRoomOnLeaseCreatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	activateTenantOnLeaseCreated := applease.NewActivateTenantOnLeaseCreatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	jobTriggerService := appjobs.NewTriggerService(jobRunStoreAdapter{repo: jobRunsRepo}, nil, cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)
@@ -113,6 +114,7 @@ func New(cfg *config.Config) (*Server, error) {
 	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, handler.LeaseCommandServices{
 		UpdateLease:   updateLeaseService,
 		UpdateDeposit: updateDepositService,
+		ReplaceLease:  replaceLeaseService,
 	})
 
 	return &Server{


### PR DESCRIPTION
Closes #24

## Summary

Implements `POST /leases/{id}/replace` as a dedicated structural replacement flow: terminate the predecessor lease, create a successor lease, regenerate successor bills, and publish replacement-related events after commit.

## Reviewer Notes

- BR-20 uses persisted electricity bill `period_start` / `period_end` as the replacement boundary source of truth.
- BR-21 uses the conservative settlement rule confirmed in #24: only `paid` bills before the boundary count as settled; `voided` and `written_off` do not.
- Successor lease inherits predecessor tenant, room, property, and deposit amount. The current OpenAPI request does not expose scope-changing fields.
- Predecessor pending bills that overlap or follow the replacement boundary are voided so old bills do not cover the successor period.
- Legacy backfilled bill periods are accepted as persisted truth for v1. If a legacy lease has incorrect periods, repair its bill periods before replacement.

## Validation

- `env GOCACHE=/tmp/go-cache go test ./...`