### PR TITLE
[codex] implement billing bill meter payment APIs

### DIFF
--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -61,6 +61,7 @@ Lease 於建立時決定 `electricityBillingCadence`（`monthly | bimonthly`）�
 每日排程任務掃描逾期帳單（`due_date < today AND status = pending_payment`），批次更新為 `overdue`。允許 `overdue → paid` 轉換（逾期帳單仍可收款）。
 
 收款確認後產生 `AccountingEntry`，透過 `BillPaid` event 寫入 `PropertyAccount`。
+收款金額必須等於帳單金額；系統不支援部分收款或溢收。可收款狀態限 `pending_payment` 與 `overdue`，其中 `overdue → paid` 明確允許。
 
 **LeaseTerminated 後的處理**：Billing BC 訂閱 `LeaseTerminated` 後，void 該租約所有剩餘 `pending_payment` 和 `pending_meter` 狀態的預產帳單（狀態改為 `voided`）。正常終止時帳單應已全清；強制終止時已到期未結清帳單在 command 內同步標記 `written_off`，此步驟只處理仍不應收取的剩餘預產帳單。
 
@@ -172,6 +173,7 @@ Lease 於建立時決定 `electricityBillingCadence`（`monthly | bimonthly`）�
   - 電費帳單：`pending_meter → pending_payment → paid | overdue | voided | written_off`
   - 補充轉換：`overdue → paid`（逾期帳單仍可收款）
 - **一致性邊界**：收款確認後產生 `AccountingEntry`，不可重複收款
+- **收款規則**：`paidAmount` 必須等於帳單 `amount`；不支援部分收款或溢收
 - **金額儲存**：台幣整數（無小數）
 - **電費換算規則**：`rawAmount = usage × MeterReading.unitPrice`，`amount = round(rawAmount)`（四捨五入為最終帳單金額）
 - **併發策略**：樂觀鎖（逾期掃描與付款衝突時，樂觀鎖讓一方失敗，付款方優先，批次任務跳過衝突帳單）

--- a/docs/spec/error-codes.md
+++ b/docs/spec/error-codes.md
@@ -60,6 +60,19 @@ Go 層共用型別：
 
 ## 後續擴充規則
 
+## Billing error code decisions
+
+Issue #18 實作帳單讀取、抄表與收款時，Billing BC 需新增下列業務錯誤：
+
+| Code | HTTP Status | 用途 |
+|------|-------------|------|
+| `BILL_ALREADY_PAID` | `422` | 帳單已收款，拒絕重複收款 |
+| `BILL_STATUS_NOT_PAYABLE` | `422` | 帳單狀態不是 `pending_payment` 或 `overdue`，不可收款 |
+| `BILL_PAID_AMOUNT_MISMATCH` | `422` | `paid_amount` 不等於帳單 `amount`；不支援部分收款或溢收 |
+| `METER_READING_LESS_THAN_PREVIOUS` | `422` | 抄表讀數小於上一個已完成 billing period 的讀數 |
+| `BILL_NOT_ELECTRICITY_TYPE` | `422` | 非電費帳單不可抄表 |
+| `BILL_STATUS_NOT_RECORDABLE` | `422` | 電費帳單狀態不是 `pending_meter`，不可抄表 |
+
 ### 可以先放進 shared 的錯誤
 
 - auth / middleware / transport 層共用
@@ -83,4 +96,3 @@ Go 層共用型別：
 2. 建立 HTTP error mapping middleware / helper
 3. 各 BC 開始實作時，再新增各自的 `errors.go`
 4. 新增 BC error 時，同步對齊 OpenAPI `error_code` 與 task 驗收條件
-

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -3592,6 +3592,7 @@ paths:
         BR-16：金額由系統計算（usage × unitPrice），並四捨五入為整數 amount，不由員工輸入
         MeterRecorded event → 帳單金額更新，狀態從 pending_meter 改為 pending_payment
         抄表是針對 bill 所代表的 billing period，而不是固定自然月
+        僅 electricity 且 pending_meter 狀態的帳單可抄表。
       tags:
         - Billing
       x-required-role:
@@ -3709,6 +3710,11 @@ paths:
                   value:
                     error_code: BILL_NOT_ELECTRICITY_TYPE
                     message: 此帳單非電費帳單，無法執行抄錄
+                status_not_recordable:
+                  summary: 帳單狀態不可抄表
+                  value:
+                    error_code: BILL_STATUS_NOT_RECORDABLE
+                    message: 此帳單目前狀態不可抄表
   /bills/{id}/payment:
     post:
       operationId: recordBillPayment
@@ -3716,8 +3722,9 @@ paths:
       description: |
         x-required-role: admin, organizer, staff
         BR-05：帳單不得重複收款（已 paid 狀態拒絕）
+        paid_amount 必須等於帳單 amount；不支援部分收款或溢收。
+        僅 pending_payment / overdue 狀態可收款，允許 overdue → paid 轉換。
         觸發 BillPaid event → PropertyAccount 新增 AccountingEntry
-        允許 overdue → paid 轉換
       tags:
         - Billing
       x-required-role:
@@ -3824,6 +3831,19 @@ paths:
                   value:
                     error_code: BILL_ALREADY_PAID
                     message: 此帳單已完成收款，不得重複收款
+                status_not_payable:
+                  summary: 帳單狀態不可收款
+                  value:
+                    error_code: BILL_STATUS_NOT_PAYABLE
+                    message: 此帳單目前狀態不可收款
+                amount_mismatch:
+                  summary: 收款金額必須等於帳單金額
+                  value:
+                    error_code: BILL_PAID_AMOUNT_MISMATCH
+                    message: 收款金額必須等於帳單金額
+                    details:
+                      expected_amount: 18000
+                      submitted_amount: 17000
   /properties/{id}/pending-meter:
     get:
       operationId: listPropertyPendingMeters
@@ -6806,6 +6826,7 @@ components:
             - other
         paid_amount:
           type: integer
+          description: 收款金額，必須等於帳單 amount；不支援部分收款或溢收。
         paid_at:
           type: string
           format: date-time

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -3714,7 +3714,7 @@ paths:
                   summary: 帳單狀態不可抄表
                   value:
                     error_code: BILL_STATUS_NOT_RECORDABLE
-                    message: 此帳單目前狀態不可抄表
+                    message: Bill status is not recordable.
   /bills/{id}/payment:
     post:
       operationId: recordBillPayment
@@ -3835,12 +3835,12 @@ paths:
                   summary: 帳單狀態不可收款
                   value:
                     error_code: BILL_STATUS_NOT_PAYABLE
-                    message: 此帳單目前狀態不可收款
+                    message: Bill status is not payable.
                 amount_mismatch:
                   summary: 收款金額必須等於帳單金額
                   value:
                     error_code: BILL_PAID_AMOUNT_MISMATCH
-                    message: 收款金額必須等於帳單金額
+                    message: Paid amount must equal bill amount.
                     details:
                       expected_amount: 18000
                       submitted_amount: 17000
@@ -6826,11 +6826,11 @@ components:
             - other
         paid_amount:
           type: integer
-          description: 收款金額，必須等於帳單 amount；不支援部分收款或溢收。
+          description: Payment amount. Must exactly equal the bill amount; partial or overpayments are not supported.
         paid_at:
           type: string
           format: date-time
-          description: 付款時間（選填，預設為伺服器時間）
+          description: Payment timestamp. Optional; defaults to the server time.
     FinancialReportSummaryItem:
       type: object
       properties:

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -3830,7 +3830,7 @@ paths:
                   summary: BR-05 帳單已收款不得重複
                   value:
                     error_code: BILL_ALREADY_PAID
-                    message: 此帳單已完成收款，不得重複收款
+                    message: Bill is already paid.
                 status_not_payable:
                   summary: 帳單狀態不可收款
                   value:

--- a/docs/spec/src/components/schemas/billing/RecordPaymentRequest.yaml
+++ b/docs/spec/src/components/schemas/billing/RecordPaymentRequest.yaml
@@ -11,8 +11,8 @@ properties:
       - other
   paid_amount:
     type: integer
-    description: 收款金額，必須等於帳單 amount；不支援部分收款或溢收。
+    description: Payment amount. Must exactly equal the bill amount; partial or overpayments are not supported.
   paid_at:
     type: string
     format: date-time
-    description: 付款時間（選填，預設為伺服器時間）
+    description: Payment timestamp. Optional; defaults to the server time.

--- a/docs/spec/src/components/schemas/billing/RecordPaymentRequest.yaml
+++ b/docs/spec/src/components/schemas/billing/RecordPaymentRequest.yaml
@@ -11,6 +11,7 @@ properties:
       - other
   paid_amount:
     type: integer
+    description: 收款金額，必須等於帳單 amount；不支援部分收款或溢收。
   paid_at:
     type: string
     format: date-time

--- a/docs/spec/src/paths/billing/bills_{id}_meter.yaml
+++ b/docs/spec/src/paths/billing/bills_{id}_meter.yaml
@@ -7,6 +7,7 @@ post:
     BR-16：金額由系統計算（usage × unitPrice），並四捨五入為整數 amount，不由員工輸入
     MeterRecorded event → 帳單金額更新，狀態從 pending_meter 改為 pending_payment
     抄表是針對 bill 所代表的 billing period，而不是固定自然月
+    僅 electricity 且 pending_meter 狀態的帳單可抄表。
   tags:
     - Billing
   x-required-role:
@@ -124,3 +125,8 @@ post:
               value:
                 error_code: BILL_NOT_ELECTRICITY_TYPE
                 message: 此帳單非電費帳單，無法執行抄錄
+            status_not_recordable:
+              summary: 帳單狀態不可抄表
+              value:
+                error_code: BILL_STATUS_NOT_RECORDABLE
+                message: 此帳單目前狀態不可抄表

--- a/docs/spec/src/paths/billing/bills_{id}_meter.yaml
+++ b/docs/spec/src/paths/billing/bills_{id}_meter.yaml
@@ -129,4 +129,4 @@ post:
               summary: 帳單狀態不可抄表
               value:
                 error_code: BILL_STATUS_NOT_RECORDABLE
-                message: 此帳單目前狀態不可抄表
+                message: Bill status is not recordable.

--- a/docs/spec/src/paths/billing/bills_{id}_payment.yaml
+++ b/docs/spec/src/paths/billing/bills_{id}_payment.yaml
@@ -117,12 +117,12 @@ post:
               summary: 帳單狀態不可收款
               value:
                 error_code: BILL_STATUS_NOT_PAYABLE
-                message: 此帳單目前狀態不可收款
+                message: Bill status is not payable.
             amount_mismatch:
               summary: 收款金額必須等於帳單金額
               value:
                 error_code: BILL_PAID_AMOUNT_MISMATCH
-                message: 收款金額必須等於帳單金額
+                message: Paid amount must equal bill amount.
                 details:
                   expected_amount: 18000
                   submitted_amount: 17000

--- a/docs/spec/src/paths/billing/bills_{id}_payment.yaml
+++ b/docs/spec/src/paths/billing/bills_{id}_payment.yaml
@@ -4,8 +4,9 @@ post:
   description: |
     x-required-role: admin, organizer, staff
     BR-05：帳單不得重複收款（已 paid 狀態拒絕）
+    paid_amount 必須等於帳單 amount；不支援部分收款或溢收。
+    僅 pending_payment / overdue 狀態可收款，允許 overdue → paid 轉換。
     觸發 BillPaid event → PropertyAccount 新增 AccountingEntry
-    允許 overdue → paid 轉換
   tags:
     - Billing
   x-required-role:
@@ -112,3 +113,16 @@ post:
               value:
                 error_code: BILL_ALREADY_PAID
                 message: 此帳單已完成收款，不得重複收款
+            status_not_payable:
+              summary: 帳單狀態不可收款
+              value:
+                error_code: BILL_STATUS_NOT_PAYABLE
+                message: 此帳單目前狀態不可收款
+            amount_mismatch:
+              summary: 收款金額必須等於帳單金額
+              value:
+                error_code: BILL_PAID_AMOUNT_MISMATCH
+                message: 收款金額必須等於帳單金額
+                details:
+                  expected_amount: 18000
+                  submitted_amount: 17000

--- a/docs/spec/src/paths/billing/bills_{id}_payment.yaml
+++ b/docs/spec/src/paths/billing/bills_{id}_payment.yaml
@@ -112,7 +112,7 @@ post:
               summary: BR-05 帳單已收款不得重複
               value:
                 error_code: BILL_ALREADY_PAID
-                message: 此帳單已完成收款，不得重複收款
+                message: Bill is already paid.
             status_not_payable:
               summary: 帳單狀態不可收款
               value:

--- a/internal/application/billing/errors.go
+++ b/internal/application/billing/errors.go
@@ -1,0 +1,121 @@
+package billing
+
+import (
+	"errors"
+	"net/http"
+
+	domainbilling "stds_backend/internal/domain/billing"
+	"stds_backend/internal/shared/apperr"
+)
+
+const (
+	CodeBillAlreadyPaid              = "BILL_ALREADY_PAID"
+	CodeMeterReadingLessThanPrevious = "METER_READING_LESS_THAN_PREVIOUS"
+	CodeBillNotElectricityType       = "BILL_NOT_ELECTRICITY_TYPE"
+	CodeBillStatusNotRecordable      = "BILL_STATUS_NOT_RECORDABLE"
+	CodeBillStatusNotPayable         = "BILL_STATUS_NOT_PAYABLE"
+	CodeBillPaidAmountMismatch       = "BILL_PAID_AMOUNT_MISMATCH"
+)
+
+var (
+	ErrBillAlreadyPaid = apperr.New(
+		CodeBillAlreadyPaid,
+		http.StatusUnprocessableEntity,
+		"Bill is already paid.",
+	)
+	ErrMeterReadingLessThanPrevious = apperr.New(
+		CodeMeterReadingLessThanPrevious,
+		http.StatusUnprocessableEntity,
+		"Current reading must not be less than previous reading.",
+	)
+	ErrBillNotElectricityType = apperr.New(
+		CodeBillNotElectricityType,
+		http.StatusUnprocessableEntity,
+		"Bill is not an electricity bill.",
+	)
+	ErrBillStatusNotRecordable = apperr.New(
+		CodeBillStatusNotRecordable,
+		http.StatusUnprocessableEntity,
+		"Bill status is not recordable.",
+	)
+	ErrBillStatusNotPayable = apperr.New(
+		CodeBillStatusNotPayable,
+		http.StatusUnprocessableEntity,
+		"Bill status is not payable.",
+	)
+	ErrBillPaidAmountMismatch = apperr.New(
+		CodeBillPaidAmountMismatch,
+		http.StatusUnprocessableEntity,
+		"Paid amount must equal bill amount.",
+	)
+)
+
+func mapRepositoryError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, ErrBillNotFound):
+		return apperr.ErrBillNotFound
+	case errors.Is(err, ErrConcurrentUpdateConflict):
+		return apperr.ErrConcurrentUpdateConflict
+	default:
+		return apperr.ErrInternalServerError.WithCause(err)
+	}
+}
+
+func mapAccountingRepositoryError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, ErrPropertyAccountNotFound):
+		return apperr.ErrInternalServerError.WithCause(err).WithDetails(map[string]interface{}{
+			"dependency": "property_account",
+		})
+	default:
+		return apperr.ErrInternalServerError.WithCause(err)
+	}
+}
+
+func mapDomainError(err error, bill *Bill, submittedAmount int) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, domainbilling.ErrBillAlreadyPaid):
+		return ErrBillAlreadyPaid
+	case errors.Is(err, domainbilling.ErrMeterReadingLessThanPrevious):
+		return ErrMeterReadingLessThanPrevious
+	case errors.Is(err, domainbilling.ErrBillNotElectricityType):
+		return ErrBillNotElectricityType
+	case errors.Is(err, domainbilling.ErrBillStatusNotRecordable):
+		return ErrBillStatusNotRecordable
+	case errors.Is(err, domainbilling.ErrBillStatusNotPayable):
+		return ErrBillStatusNotPayable
+	case errors.Is(err, domainbilling.ErrBillPaidAmountMismatch):
+		details := map[string]interface{}{
+			"submitted_amount": submittedAmount,
+		}
+		if bill != nil && bill.Amount != nil {
+			details["expected_amount"] = *bill.Amount
+		}
+		return ErrBillPaidAmountMismatch.WithDetails(details)
+	default:
+		return apperr.ErrInternalServerError.WithCause(err)
+	}
+}
+
+func mapMeterDomainError(err error, previousReading int, submittedReading int) error {
+	if errors.Is(err, domainbilling.ErrMeterReadingLessThanPrevious) {
+		return ErrMeterReadingLessThanPrevious.WithDetails(map[string]interface{}{
+			"previous_reading":  previousReading,
+			"submitted_reading": submittedReading,
+		})
+	}
+
+	return mapDomainError(err, nil, 0)
+}

--- a/internal/application/billing/errors.go
+++ b/internal/application/billing/errors.go
@@ -60,6 +60,10 @@ func mapRepositoryError(err error) error {
 		return apperr.ErrBillNotFound
 	case errors.Is(err, ErrConcurrentUpdateConflict):
 		return apperr.ErrConcurrentUpdateConflict
+	case errors.Is(err, ErrPropertyElectricityUnitPriceNotFound):
+		return apperr.ErrInternalServerError.WithCause(err).WithDetails(map[string]interface{}{
+			"dependency": "electricity_unit_price",
+		})
 	default:
 		return apperr.ErrInternalServerError.WithCause(err)
 	}
@@ -95,6 +99,8 @@ func mapDomainError(err error, bill *Bill, submittedAmount int) error {
 	case errors.Is(err, domainbilling.ErrBillStatusNotRecordable):
 		return ErrBillStatusNotRecordable
 	case errors.Is(err, domainbilling.ErrBillStatusNotPayable):
+		return ErrBillStatusNotPayable
+	case errors.Is(err, domainbilling.ErrBillAmountMissing):
 		return ErrBillStatusNotPayable
 	case errors.Is(err, domainbilling.ErrBillPaidAmountMismatch):
 		details := map[string]interface{}{

--- a/internal/application/billing/get_bill.go
+++ b/internal/application/billing/get_bill.go
@@ -1,0 +1,55 @@
+package billing
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+// GetBillInput is the use-case input for bill detail retrieval.
+type GetBillInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	BillID              string
+}
+
+// GetBillService retrieves one bill read model.
+type GetBillService struct {
+	repo Repository
+}
+
+// NewGetBillService returns a GetBillService.
+func NewGetBillService(repo Repository) *GetBillService {
+	return &GetBillService{repo: repo}
+}
+
+// Execute validates the bill id and loads the bill.
+func (s *GetBillService) Execute(ctx context.Context, input GetBillInput) (*Bill, error) {
+	actorRole, err := normalizeReadRole(input.ActorRole)
+	if err != nil {
+		return nil, err
+	}
+	billID := strings.TrimSpace(input.BillID)
+	if billID == "" {
+		return nil, apperr.ErrBillNotFound
+	}
+	if _, err := uuid.Parse(billID); err != nil {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "id"})
+	}
+
+	bill, err := s.repo.FindBillByID(ctx, GetBillQuery{
+		ActorRole:           actorRole,
+		ActorUserID:         strings.TrimSpace(input.ActorUserID),
+		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
+		BillID:              billID,
+	})
+	if err != nil {
+		return nil, mapRepositoryError(err)
+	}
+
+	return bill, nil
+}

--- a/internal/application/billing/list_bills.go
+++ b/internal/application/billing/list_bills.go
@@ -10,6 +10,8 @@ import (
 	"stds_backend/internal/shared/apperr"
 )
 
+const maxListBillsLimit = 100
+
 // ListBillsInput is the use-case input for bill listing.
 type ListBillsInput struct {
 	ActorRole           string
@@ -62,10 +64,10 @@ func (s *ListBillsService) Execute(ctx context.Context, input ListBillsInput) ([
 		return nil, err
 	}
 
-	if input.Limit < 0 {
+	if input.Limit < 1 || input.Limit > maxListBillsLimit {
 		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
 			"field":  "limit",
-			"reason": "must be greater than or equal to 0",
+			"reason": "must be between 1 and 100",
 		})
 	}
 	if input.Offset < 0 {

--- a/internal/application/billing/list_bills.go
+++ b/internal/application/billing/list_bills.go
@@ -62,6 +62,19 @@ func (s *ListBillsService) Execute(ctx context.Context, input ListBillsInput) ([
 		return nil, err
 	}
 
+	if input.Limit < 0 {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "limit",
+			"reason": "must be greater than or equal to 0",
+		})
+	}
+	if input.Offset < 0 {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "offset",
+			"reason": "must be greater than or equal to 0",
+		})
+	}
+
 	bills, err := s.repo.ListBills(ctx, ListBillsQuery{
 		ActorRole:           actorRole,
 		ActorUserID:         strings.TrimSpace(input.ActorUserID),

--- a/internal/application/billing/list_bills.go
+++ b/internal/application/billing/list_bills.go
@@ -1,0 +1,155 @@
+package billing
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+// ListBillsInput is the use-case input for bill listing.
+type ListBillsInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          *string
+	LeaseID             *string
+	TenantID            *string
+	Status              *string
+	Month               *string
+	Limit               int
+	Offset              int
+}
+
+// ListBillsService lists bills with application-owned visibility semantics.
+type ListBillsService struct {
+	repo Repository
+}
+
+// NewListBillsService returns a ListBillsService.
+func NewListBillsService(repo Repository) *ListBillsService {
+	return &ListBillsService{repo: repo}
+}
+
+// Execute validates filters and delegates role scoping to the repository query contract.
+func (s *ListBillsService) Execute(ctx context.Context, input ListBillsInput) ([]Bill, error) {
+	actorRole, err := normalizeReadRole(input.ActorRole)
+	if err != nil {
+		return nil, err
+	}
+
+	propertyID, err := normalizeOptionalUUID(input.PropertyID, "property_id")
+	if err != nil {
+		return nil, err
+	}
+	leaseID, err := normalizeOptionalUUID(input.LeaseID, "lease_id")
+	if err != nil {
+		return nil, err
+	}
+	tenantID, err := normalizeOptionalUUID(input.TenantID, "tenant_id")
+	if err != nil {
+		return nil, err
+	}
+	status, err := normalizeOptionalStatus(input.Status)
+	if err != nil {
+		return nil, err
+	}
+	month, err := normalizeOptionalMonth(input.Month)
+	if err != nil {
+		return nil, err
+	}
+
+	bills, err := s.repo.ListBills(ctx, ListBillsQuery{
+		ActorRole:           actorRole,
+		ActorUserID:         strings.TrimSpace(input.ActorUserID),
+		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
+		PropertyID:          propertyID,
+		LeaseID:             leaseID,
+		TenantID:            tenantID,
+		Status:              status,
+		Month:               month,
+		Limit:               input.Limit,
+		Offset:              input.Offset,
+	})
+	if err != nil {
+		return nil, mapRepositoryError(err)
+	}
+
+	return bills, nil
+}
+
+func normalizeReadRole(role string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(role))
+	switch normalized {
+	case "admin", "organizer", "staff", "owner":
+		return normalized, nil
+	default:
+		return "", apperr.ErrForbidden
+	}
+}
+
+func normalizeWriteRole(role string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(role))
+	switch normalized {
+	case "admin", "organizer", "staff":
+		return normalized, nil
+	default:
+		return "", apperr.ErrForbidden
+	}
+}
+
+func normalizeOptionalUUID(value *string, field string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+	}
+
+	return &trimmed, nil
+}
+
+func normalizeOptionalStatus(value *string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	status := strings.TrimSpace(*value)
+	switch status {
+	case "pending_meter", "pending_payment", "paid", "overdue", "voided", "written_off":
+		return &status, nil
+	default:
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "status"})
+	}
+}
+
+func normalizeOptionalMonth(value *string) (*time.Time, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	month, err := time.Parse("2006-01", strings.TrimSpace(*value))
+	if err != nil {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "month"})
+	}
+
+	return &month, nil
+}
+
+func cloneStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+
+	cloned := make([]string, len(values))
+	copy(cloned, values)
+	return cloned
+}

--- a/internal/application/billing/record_commands_test.go
+++ b/internal/application/billing/record_commands_test.go
@@ -152,7 +152,7 @@ func TestRecordMeterServiceRecordsMeterAndPublishesEventAfterCommit(t *testing.T
 	if repo.updateMeterParams == nil {
 		t.Fatal("expected UpdateBillMeter call")
 	}
-	if repo.updateMeterParams.PreviousReading != 1250 || repo.updateMeterParams.CurrentReading != 1380 || repo.updateMeterParams.Amount != 585 || repo.updateMeterParams.Status != domainbilling.StatusPendingPayment {
+	if repo.updateMeterParams.PreviousReading != 1250 || repo.updateMeterParams.CurrentReading != 1380 || repo.updateMeterParams.Amount != 585 {
 		t.Fatalf("unexpected meter update params: %+v", repo.updateMeterParams)
 	}
 	if len(publisher.events) != 1 {
@@ -318,7 +318,7 @@ func TestRecordPaymentServiceRecordsPaymentAndPublishesEventAfterCommit(t *testi
 	if bill == nil || bill.Status != domainbilling.StatusPaid {
 		t.Fatalf("unexpected bill: %+v", bill)
 	}
-	if repo.updatePaymentParams == nil || repo.updatePaymentParams.PaidAmount != 12000 || repo.updatePaymentParams.PaymentMethod != "transfer" || repo.updatePaymentParams.Status != domainbilling.StatusPaid {
+	if repo.updatePaymentParams == nil || repo.updatePaymentParams.PaidAmount != 12000 || repo.updatePaymentParams.PaymentMethod != "transfer" {
 		t.Fatalf("unexpected payment update params: %+v", repo.updatePaymentParams)
 	}
 	if len(publisher.events) != 1 {

--- a/internal/application/billing/record_commands_test.go
+++ b/internal/application/billing/record_commands_test.go
@@ -1,0 +1,575 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	domainbilling "stds_backend/internal/domain/billing"
+	domainevents "stds_backend/internal/domain/events"
+	dbtxrunner "stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+const (
+	testBillID     = "30000000-0000-0000-0000-000000000001"
+	testLeaseID    = "40000000-0000-0000-0000-000000000001"
+	testTenantID   = "50000000-0000-0000-0000-000000000001"
+	testRoomID     = "20000000-0000-0000-0000-000000000001"
+	testPropertyID = "10000000-0000-0000-0000-000000000001"
+)
+
+func TestGetBillServicePassesActorScopeToRepository(t *testing.T) {
+	repo := &billingRepositoryStub{bill: billForCommand(domainbilling.TypeRent, domainbilling.StatusPendingPayment, intPtr(12000))}
+	service := NewGetBillService(repo)
+
+	bill, err := service.Execute(context.Background(), GetBillInput{
+		ActorRole:           "staff",
+		ActorUserID:         "user-1",
+		AssignedPropertyIDs: []string{testPropertyID},
+		BillID:              testBillID,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if bill == nil || bill.ID != testBillID {
+		t.Fatalf("unexpected bill: %+v", bill)
+	}
+	if repo.getBillQuery == nil {
+		t.Fatal("expected FindBillByID query")
+	}
+	if repo.getBillQuery.ActorRole != "staff" || repo.getBillQuery.ActorUserID != "user-1" || repo.getBillQuery.BillID != testBillID {
+		t.Fatalf("unexpected query: %+v", repo.getBillQuery)
+	}
+	if len(repo.getBillQuery.AssignedPropertyIDs) != 1 || repo.getBillQuery.AssignedPropertyIDs[0] != testPropertyID {
+		t.Fatalf("unexpected assigned properties: %+v", repo.getBillQuery.AssignedPropertyIDs)
+	}
+}
+
+func TestRecordMeterServiceRecordsMeterAndPublishesEventAfterCommit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	recordedAt := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	repo := &billingRepositoryStub{
+		billForUpdate:        billForCommand(domainbilling.TypeElectricity, domainbilling.StatusPendingMeter, nil),
+		previousReading:      1250,
+		electricityUnitPrice: floatPtr(4.5),
+		updatedMeterBill:     billForCommand(domainbilling.TypeElectricity, domainbilling.StatusPendingPayment, intPtr(585)),
+	}
+	publisher := &recordingPublisher{}
+	service := NewRecordMeterService(repo, dbtxrunner.New(db, publisher))
+
+	bill, err := service.Execute(context.Background(), RecordMeterInput{
+		ActorRole:      "staff",
+		BillID:         testBillID,
+		CurrentReading: 1380,
+		RecordedAt:     &recordedAt,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if bill == nil || bill.Status != domainbilling.StatusPendingPayment || bill.Amount == nil || *bill.Amount != 585 {
+		t.Fatalf("unexpected bill: %+v", bill)
+	}
+	if repo.previousLookupRoomID != testRoomID || !repo.previousLookupBeforePeriodStart.Equal(repo.billForUpdate.PeriodStart) {
+		t.Fatalf("previous lookup = room %q before %v, want room %q before %v", repo.previousLookupRoomID, repo.previousLookupBeforePeriodStart, testRoomID, repo.billForUpdate.PeriodStart)
+	}
+	if repo.previousLookupTx == nil {
+		t.Fatal("expected previous reading lookup to receive transaction")
+	}
+	if repo.unitPriceLookupTx == nil {
+		t.Fatal("expected unit price lookup to receive transaction")
+	}
+	if repo.updateMeterParams == nil {
+		t.Fatal("expected UpdateBillMeter call")
+	}
+	if repo.updateMeterParams.PreviousReading != 1250 || repo.updateMeterParams.CurrentReading != 1380 || repo.updateMeterParams.Amount != 585 || repo.updateMeterParams.Status != domainbilling.StatusPendingPayment {
+		t.Fatalf("unexpected meter update params: %+v", repo.updateMeterParams)
+	}
+	if len(publisher.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(publisher.events))
+	}
+	event, ok := publisher.events[0].(domainevents.MeterRecorded)
+	if !ok {
+		t.Fatalf("expected MeterRecorded event, got %T", publisher.events[0])
+	}
+	if event.BillID != testBillID || event.PreviousReading != 1250 || event.CurrentReading != 1380 || event.Amount != 585 {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestRecordMeterServiceRejectsBusinessRulesAndRollsBackWithoutEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		bill           *Bill
+		previous       int
+		current        int
+		expectedCode   string
+		expectedDetail map[string]any
+	}{
+		{
+			name:         "lower than previous",
+			bill:         billForCommand(domainbilling.TypeElectricity, domainbilling.StatusPendingMeter, nil),
+			previous:     1380,
+			current:      1250,
+			expectedCode: CodeMeterReadingLessThanPrevious,
+			expectedDetail: map[string]any{
+				"previous_reading":  1380,
+				"submitted_reading": 1250,
+			},
+		},
+		{
+			name:         "non electricity bill",
+			bill:         billForCommand(domainbilling.TypeRent, domainbilling.StatusPendingPayment, intPtr(12000)),
+			previous:     0,
+			current:      1250,
+			expectedCode: CodeBillNotElectricityType,
+		},
+		{
+			name:         "electricity bill not pending meter",
+			bill:         billForCommand(domainbilling.TypeElectricity, domainbilling.StatusPendingPayment, nil),
+			previous:     0,
+			current:      1250,
+			expectedCode: CodeBillStatusNotRecordable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+
+			mock.ExpectBegin()
+			mock.ExpectRollback()
+
+			repo := &billingRepositoryStub{
+				billForUpdate:        tt.bill,
+				previousReading:      tt.previous,
+				electricityUnitPrice: floatPtr(4.5),
+				updatedMeterBill:     billForCommand(domainbilling.TypeElectricity, domainbilling.StatusPendingPayment, intPtr(585)),
+			}
+			publisher := &recordingPublisher{}
+			service := NewRecordMeterService(repo, dbtxrunner.New(db, publisher))
+
+			_, err = service.Execute(context.Background(), RecordMeterInput{
+				ActorRole:      "staff",
+				BillID:         testBillID,
+				CurrentReading: tt.current,
+			})
+			assertAppErrorCode(t, err, tt.expectedCode)
+			if tt.expectedDetail != nil {
+				assertAppErrorDetails(t, err, tt.expectedDetail)
+			}
+			if repo.updateMeterParams != nil {
+				t.Fatalf("unexpected UpdateBillMeter call: %+v", repo.updateMeterParams)
+			}
+			if len(publisher.events) != 0 {
+				t.Fatalf("expected no events, got %d", len(publisher.events))
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
+
+func TestRecordPaymentServiceRecordsPaymentAndPublishesEventAfterCommit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	paidAt := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
+	repo := &billingRepositoryStub{
+		billForUpdate:      billForCommand(domainbilling.TypeRent, domainbilling.StatusPendingPayment, intPtr(12000)),
+		updatedPaymentBill: billForCommand(domainbilling.TypeRent, domainbilling.StatusPaid, intPtr(12000)),
+	}
+	accountingRepo := &accountingRepositoryStub{}
+	publisher := &recordingPublisher{}
+	service := NewRecordPaymentService(repo, accountingRepo, dbtxrunner.New(db, publisher))
+
+	bill, err := service.Execute(context.Background(), RecordPaymentInput{
+		ActorRole:     "organizer",
+		BillID:        testBillID,
+		PaidAmount:    12000,
+		PaymentMethod: "transfer",
+		PaidAt:        &paidAt,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if bill == nil || bill.Status != domainbilling.StatusPaid {
+		t.Fatalf("unexpected bill: %+v", bill)
+	}
+	if repo.updatePaymentParams == nil || repo.updatePaymentParams.PaidAmount != 12000 || repo.updatePaymentParams.PaymentMethod != "transfer" || repo.updatePaymentParams.Status != domainbilling.StatusPaid {
+		t.Fatalf("unexpected payment update params: %+v", repo.updatePaymentParams)
+	}
+	if len(publisher.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(publisher.events))
+	}
+	event, ok := publisher.events[0].(domainevents.BillPaid)
+	if !ok {
+		t.Fatalf("expected BillPaid event, got %T", publisher.events[0])
+	}
+	if event.BillID != testBillID || event.Amount != 12000 || event.PaidAmount != 12000 || event.PaymentMethod != "transfer" {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+	if accountingRepo.entry == nil {
+		t.Fatal("expected accounting entry")
+	}
+	if accountingRepo.entry.PropertyID != testPropertyID || accountingRepo.entry.Category != AccountingCategoryRentPayment || accountingRepo.entry.Amount != 12000 {
+		t.Fatalf("unexpected accounting entry: %+v", accountingRepo.entry)
+	}
+	if accountingRepo.entry.SourceRef["type"] != "BillPaid" || accountingRepo.entry.SourceRef["bill_id"] != testBillID {
+		t.Fatalf("unexpected source ref: %+v", accountingRepo.entry.SourceRef)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestRecordPaymentServiceAllowsOverdueBill(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := &billingRepositoryStub{
+		billForUpdate:      billForCommand(domainbilling.TypeRent, domainbilling.StatusOverdue, intPtr(12000)),
+		updatedPaymentBill: billForCommand(domainbilling.TypeRent, domainbilling.StatusPaid, intPtr(12000)),
+	}
+	service := NewRecordPaymentService(repo, &accountingRepositoryStub{}, dbtxrunner.New(db, nil))
+
+	_, err = service.Execute(context.Background(), RecordPaymentInput{
+		ActorRole:     "staff",
+		BillID:        testBillID,
+		PaidAmount:    12000,
+		PaymentMethod: "cash",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestRecordPaymentServiceRejectsBusinessRulesAndRollsBackWithoutEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		bill           *Bill
+		paidAmount     int
+		expectedCode   string
+		expectedDetail map[string]any
+	}{
+		{
+			name:         "already paid",
+			bill:         billForCommand(domainbilling.TypeRent, domainbilling.StatusPaid, intPtr(12000)),
+			paidAmount:   12000,
+			expectedCode: CodeBillAlreadyPaid,
+		},
+		{
+			name:         "pending meter",
+			bill:         billForCommand(domainbilling.TypeElectricity, domainbilling.StatusPendingMeter, nil),
+			paidAmount:   12000,
+			expectedCode: CodeBillStatusNotPayable,
+		},
+		{
+			name:         "voided",
+			bill:         billForCommand(domainbilling.TypeRent, domainbilling.StatusVoided, intPtr(12000)),
+			paidAmount:   12000,
+			expectedCode: CodeBillStatusNotPayable,
+		},
+		{
+			name:         "written off",
+			bill:         billForCommand(domainbilling.TypeRent, domainbilling.StatusWrittenOff, intPtr(12000)),
+			paidAmount:   12000,
+			expectedCode: CodeBillStatusNotPayable,
+		},
+		{
+			name:         "missing amount",
+			bill:         billForCommand(domainbilling.TypeRent, domainbilling.StatusPendingPayment, nil),
+			paidAmount:   12000,
+			expectedCode: CodeBillStatusNotPayable,
+		},
+		{
+			name:         "amount mismatch",
+			bill:         billForCommand(domainbilling.TypeRent, domainbilling.StatusPendingPayment, intPtr(12000)),
+			paidAmount:   11000,
+			expectedCode: CodeBillPaidAmountMismatch,
+			expectedDetail: map[string]any{
+				"expected_amount":  12000,
+				"submitted_amount": 11000,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("sqlmock.New: %v", err)
+			}
+			defer db.Close()
+
+			mock.ExpectBegin()
+			mock.ExpectRollback()
+
+			repo := &billingRepositoryStub{
+				billForUpdate:      tt.bill,
+				updatedPaymentBill: billForCommand(domainbilling.TypeRent, domainbilling.StatusPaid, intPtr(12000)),
+			}
+			publisher := &recordingPublisher{}
+			accountingRepo := &accountingRepositoryStub{}
+			service := NewRecordPaymentService(repo, accountingRepo, dbtxrunner.New(db, publisher))
+
+			_, err = service.Execute(context.Background(), RecordPaymentInput{
+				ActorRole:     "staff",
+				BillID:        testBillID,
+				PaidAmount:    tt.paidAmount,
+				PaymentMethod: "cash",
+			})
+			assertAppErrorCode(t, err, tt.expectedCode)
+			if tt.expectedDetail != nil {
+				assertAppErrorDetails(t, err, tt.expectedDetail)
+			}
+			if repo.updatePaymentParams != nil {
+				t.Fatalf("unexpected UpdateBillPayment call: %+v", repo.updatePaymentParams)
+			}
+			if len(publisher.events) != 0 {
+				t.Fatalf("expected no events, got %d", len(publisher.events))
+			}
+			if accountingRepo.entry != nil {
+				t.Fatalf("unexpected accounting entry: %+v", accountingRepo.entry)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
+
+func TestRecordPaymentServiceRollsBackWhenAccountingEntryFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	paidAt := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
+	repo := &billingRepositoryStub{
+		billForUpdate:      billForCommand(domainbilling.TypeElectricity, domainbilling.StatusPendingPayment, intPtr(585)),
+		updatedPaymentBill: billForCommand(domainbilling.TypeElectricity, domainbilling.StatusPaid, intPtr(585)),
+	}
+	accountingRepo := &accountingRepositoryStub{err: errors.New("insert accounting entry")}
+	publisher := &recordingPublisher{}
+	service := NewRecordPaymentService(repo, accountingRepo, dbtxrunner.New(db, publisher))
+
+	_, err = service.Execute(context.Background(), RecordPaymentInput{
+		ActorRole:     "staff",
+		BillID:        testBillID,
+		PaidAmount:    585,
+		PaymentMethod: "cash",
+		PaidAt:        &paidAt,
+	})
+	assertAppErrorCode(t, err, apperr.CodeInternalServerError)
+	if repo.updatePaymentParams == nil {
+		t.Fatal("expected bill payment update before accounting failure")
+	}
+	if accountingRepo.entry == nil {
+		t.Fatal("expected attempted accounting entry")
+	}
+	if accountingRepo.entry.Category != AccountingCategoryElectricityPayment || accountingRepo.entry.Amount != 585 {
+		t.Fatalf("unexpected accounting entry: %+v", accountingRepo.entry)
+	}
+	if len(publisher.events) != 0 {
+		t.Fatalf("expected no committed events, got %d", len(publisher.events))
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+type billingRepositoryStub struct {
+	bills                           []Bill
+	bill                            *Bill
+	getBillQuery                    *GetBillQuery
+	billForUpdate                   *Bill
+	billErr                         error
+	previousReading                 int
+	previousErr                     error
+	previousLookupTx                *sql.Tx
+	previousLookupRoomID            string
+	previousLookupBeforePeriodStart time.Time
+	electricityUnitPrice            *float64
+	unitPriceLookupTx               *sql.Tx
+	unitPriceErr                    error
+	updatedMeterBill                *Bill
+	updateMeterParams               *UpdateMeterParams
+	updateMeterErr                  error
+	updatedPaymentBill              *Bill
+	updatePaymentParams             *UpdatePaymentParams
+	updatePaymentErr                error
+}
+
+func (s *billingRepositoryStub) ListBills(_ context.Context, _ ListBillsQuery) ([]Bill, error) {
+	return s.bills, nil
+}
+
+func (s *billingRepositoryStub) FindBillByID(_ context.Context, query GetBillQuery) (*Bill, error) {
+	s.getBillQuery = &query
+	if s.billErr != nil {
+		return nil, s.billErr
+	}
+	return s.bill, nil
+}
+
+func (s *billingRepositoryStub) FindBillByIDForUpdate(_ context.Context, _ *sql.Tx, _ string) (*Bill, error) {
+	if s.billErr != nil {
+		return nil, s.billErr
+	}
+	return s.billForUpdate, nil
+}
+
+func (s *billingRepositoryStub) FindPreviousElectricityReading(_ context.Context, tx *sql.Tx, roomID string, beforePeriodStart time.Time) (int, error) {
+	s.previousLookupTx = tx
+	s.previousLookupRoomID = roomID
+	s.previousLookupBeforePeriodStart = beforePeriodStart
+	if s.previousErr != nil {
+		return 0, s.previousErr
+	}
+	return s.previousReading, nil
+}
+
+func (s *billingRepositoryStub) FindPropertyElectricityUnitPrice(_ context.Context, tx *sql.Tx, _ string) (*float64, error) {
+	s.unitPriceLookupTx = tx
+	if s.unitPriceErr != nil {
+		return nil, s.unitPriceErr
+	}
+	return s.electricityUnitPrice, nil
+}
+
+func (s *billingRepositoryStub) UpdateBillMeter(_ context.Context, _ *sql.Tx, params UpdateMeterParams) (*Bill, error) {
+	s.updateMeterParams = &params
+	if s.updateMeterErr != nil {
+		return nil, s.updateMeterErr
+	}
+	return s.updatedMeterBill, nil
+}
+
+func (s *billingRepositoryStub) UpdateBillPayment(_ context.Context, _ *sql.Tx, params UpdatePaymentParams) (*Bill, error) {
+	s.updatePaymentParams = &params
+	if s.updatePaymentErr != nil {
+		return nil, s.updatePaymentErr
+	}
+	return s.updatedPaymentBill, nil
+}
+
+type accountingRepositoryStub struct {
+	entry *AccountingEntryParams
+	err   error
+}
+
+func (s *accountingRepositoryStub) CreateAccountingEntry(_ context.Context, _ *sql.Tx, params AccountingEntryParams) error {
+	s.entry = &params
+	if s.err != nil {
+		return s.err
+	}
+	return nil
+}
+
+type recordingPublisher struct {
+	events []any
+}
+
+func (p *recordingPublisher) Publish(_ context.Context, event any) error {
+	p.events = append(p.events, event)
+	return nil
+}
+
+func billForCommand(billType string, status string, amount *int) *Bill {
+	return &Bill{
+		ID:          testBillID,
+		LeaseID:     testLeaseID,
+		TenantID:    testTenantID,
+		RoomID:      testRoomID,
+		PropertyID:  testPropertyID,
+		Type:        billType,
+		Amount:      amount,
+		PeriodStart: time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:   time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC),
+		DueDate:     time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC),
+		Status:      status,
+		Version:     1,
+	}
+}
+
+func assertAppErrorCode(t *testing.T, err error, expectedCode string) {
+	t.Helper()
+
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected apperr.Error, got %T: %v", err, err)
+	}
+	if appErr.Code != expectedCode {
+		t.Fatalf("error code = %q, want %q", appErr.Code, expectedCode)
+	}
+}
+
+func assertAppErrorDetails(t *testing.T, err error, expected map[string]any) {
+	t.Helper()
+
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected apperr.Error, got %T: %v", err, err)
+	}
+	details, ok := appErr.Details.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected details map, got %#v", appErr.Details)
+	}
+	for key, expectedValue := range expected {
+		if details[key] != expectedValue {
+			t.Fatalf("details[%s] = %#v, want %#v", key, details[key], expectedValue)
+		}
+	}
+}
+
+func floatPtr(value float64) *float64 {
+	return &value
+}
+
+func intPtr(value int) *int {
+	return &value
+}

--- a/internal/application/billing/record_commands_test.go
+++ b/internal/application/billing/record_commands_test.go
@@ -50,15 +50,20 @@ func TestGetBillServicePassesActorScopeToRepository(t *testing.T) {
 	}
 }
 
-func TestListBillsServiceRejectsNegativePagination(t *testing.T) {
+func TestListBillsServiceRejectsInvalidPagination(t *testing.T) {
 	tests := []struct {
 		name  string
 		input ListBillsInput
 		field string
 	}{
 		{
-			name:  "negative limit",
-			input: ListBillsInput{ActorRole: "staff", Limit: -1},
+			name:  "zero limit",
+			input: ListBillsInput{ActorRole: "staff", Limit: 0},
+			field: "limit",
+		},
+		{
+			name:  "limit too large",
+			input: ListBillsInput{ActorRole: "staff", Limit: 101},
 			field: "limit",
 		},
 		{

--- a/internal/application/billing/record_commands_test.go
+++ b/internal/application/billing/record_commands_test.go
@@ -50,6 +50,59 @@ func TestGetBillServicePassesActorScopeToRepository(t *testing.T) {
 	}
 }
 
+func TestListBillsServiceRejectsNegativePagination(t *testing.T) {
+	tests := []struct {
+		name  string
+		input ListBillsInput
+		field string
+	}{
+		{
+			name:  "negative limit",
+			input: ListBillsInput{ActorRole: "staff", Limit: -1},
+			field: "limit",
+		},
+		{
+			name:  "negative offset",
+			input: ListBillsInput{ActorRole: "staff", Limit: 10, Offset: -1},
+			field: "offset",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &billingRepositoryStub{}
+			service := NewListBillsService(repo)
+
+			_, err := service.Execute(context.Background(), tt.input)
+			assertAppErrorCode(t, err, apperr.CodeBadRequest)
+			assertAppErrorDetails(t, err, map[string]any{"field": tt.field})
+			if repo.listBillsQuery != nil {
+				t.Fatalf("unexpected ListBills call: %+v", repo.listBillsQuery)
+			}
+		})
+	}
+}
+
+func TestListBillsServiceForwardsValidatedPagination(t *testing.T) {
+	repo := &billingRepositoryStub{}
+	service := NewListBillsService(repo)
+
+	_, err := service.Execute(context.Background(), ListBillsInput{
+		ActorRole: "staff",
+		Limit:     25,
+		Offset:    50,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if repo.listBillsQuery == nil {
+		t.Fatal("expected ListBills query")
+	}
+	if repo.listBillsQuery.Limit != 25 || repo.listBillsQuery.Offset != 50 {
+		t.Fatalf("pagination = limit %d offset %d, want 25/50", repo.listBillsQuery.Limit, repo.listBillsQuery.Offset)
+	}
+}
+
 func TestRecordMeterServiceRecordsMeterAndPublishesEventAfterCommit(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -188,6 +241,43 @@ func TestRecordMeterServiceRejectsBusinessRulesAndRollsBackWithoutEvent(t *testi
 				t.Fatalf("ExpectationsWereMet: %v", err)
 			}
 		})
+	}
+}
+
+func TestRecordMeterServiceMapsMissingUnitPriceDependency(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	repo := &billingRepositoryStub{
+		billForUpdate:    billForCommand(domainbilling.TypeElectricity, domainbilling.StatusPendingMeter, nil),
+		previousReading:  1250,
+		unitPriceErr:     ErrPropertyElectricityUnitPriceNotFound,
+		updatedMeterBill: billForCommand(domainbilling.TypeElectricity, domainbilling.StatusPendingPayment, intPtr(585)),
+	}
+	publisher := &recordingPublisher{}
+	service := NewRecordMeterService(repo, dbtxrunner.New(db, publisher))
+
+	_, err = service.Execute(context.Background(), RecordMeterInput{
+		ActorRole:      "staff",
+		BillID:         testBillID,
+		CurrentReading: 1380,
+	})
+	assertAppErrorCode(t, err, apperr.CodeInternalServerError)
+	assertAppErrorDetails(t, err, map[string]any{"dependency": "electricity_unit_price"})
+	if repo.updateMeterParams != nil {
+		t.Fatalf("unexpected UpdateBillMeter call: %+v", repo.updateMeterParams)
+	}
+	if len(publisher.events) != 0 {
+		t.Fatalf("expected no events, got %d", len(publisher.events))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
 	}
 }
 
@@ -424,6 +514,7 @@ func TestRecordPaymentServiceRollsBackWhenAccountingEntryFails(t *testing.T) {
 
 type billingRepositoryStub struct {
 	bills                           []Bill
+	listBillsQuery                  *ListBillsQuery
 	bill                            *Bill
 	getBillQuery                    *GetBillQuery
 	billForUpdate                   *Bill
@@ -444,7 +535,8 @@ type billingRepositoryStub struct {
 	updatePaymentErr                error
 }
 
-func (s *billingRepositoryStub) ListBills(_ context.Context, _ ListBillsQuery) ([]Bill, error) {
+func (s *billingRepositoryStub) ListBills(_ context.Context, query ListBillsQuery) ([]Bill, error) {
+	s.listBillsQuery = &query
 	return s.bills, nil
 }
 

--- a/internal/application/billing/record_meter.go
+++ b/internal/application/billing/record_meter.go
@@ -1,0 +1,156 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	domainbilling "stds_backend/internal/domain/billing"
+	domainevents "stds_backend/internal/domain/events"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// RecordMeterInput is the command payload for recording a bill meter reading.
+type RecordMeterInput struct {
+	ActorRole      string
+	BillID         string
+	CurrentReading int
+	RecordedAt     *time.Time
+}
+
+// RecordMeterService records electricity meter readings.
+type RecordMeterService struct {
+	repo     Repository
+	txRunner TransactionRunner
+}
+
+// NewRecordMeterService returns a RecordMeterService.
+func NewRecordMeterService(repo Repository, txRunner TransactionRunner) *RecordMeterService {
+	return &RecordMeterService{repo: repo, txRunner: txRunner}
+}
+
+// Execute records a meter reading, updates the bill, and emits MeterRecorded after commit.
+func (s *RecordMeterService) Execute(ctx context.Context, input RecordMeterInput) (*Bill, error) {
+	if _, err := normalizeWriteRole(input.ActorRole); err != nil {
+		return nil, err
+	}
+	billID, err := normalizeBillID(input.BillID)
+	if err != nil {
+		return nil, err
+	}
+	if s.txRunner == nil {
+		return nil, apperr.ErrInternalServerError
+	}
+
+	recordedAt := time.Now().UTC()
+	if input.RecordedAt != nil {
+		recordedAt = input.RecordedAt.UTC()
+	}
+
+	var updated *Bill
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+		current, err := s.repo.FindBillByIDForUpdate(ctx, tx, billID)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+
+		previousReading, err := s.repo.FindPreviousElectricityReading(ctx, tx, current.RoomID, current.PeriodStart)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+
+		unitPrice, err := s.repo.FindPropertyElectricityUnitPrice(ctx, tx, current.PropertyID)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		if unitPrice == nil {
+			return apperr.ErrInternalServerError.WithDetails(map[string]interface{}{
+				"field": "electricity_unit_price",
+			})
+		}
+
+		aggregate := domainbilling.Rehydrate(toDomainState(*current))
+		if err := aggregate.RecordMeter(previousReading, input.CurrentReading, *unitPrice, recordedAt); err != nil {
+			return mapMeterDomainError(err, previousReading, input.CurrentReading)
+		}
+
+		state := aggregate.State()
+		updatedBill, err := s.repo.UpdateBillMeter(ctx, tx, UpdateMeterParams{
+			BillID:          billID,
+			PreviousReading: *state.MeterPreviousReading,
+			CurrentReading:  *state.MeterCurrentReading,
+			UnitPrice:       *state.MeterUnitPrice,
+			Amount:          *state.Amount,
+			Status:          state.Status,
+			MeterRecordedAt: *state.MeterRecordedAt,
+			ExpectedVersion: current.Version,
+		})
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+
+		recorder.Record(domainevents.MeterRecorded{
+			BillID:          updatedBill.ID,
+			PropertyID:      updatedBill.PropertyID,
+			RoomID:          updatedBill.RoomID,
+			LeaseID:         updatedBill.LeaseID,
+			PreviousReading: *state.MeterPreviousReading,
+			CurrentReading:  *state.MeterCurrentReading,
+			UnitPrice:       *state.MeterUnitPrice,
+			Amount:          *state.Amount,
+			RecordedAt:      *state.MeterRecordedAt,
+		})
+
+		updated = updatedBill
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return updated, nil
+}
+
+func normalizeBillID(value string) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", apperr.ErrBillNotFound
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return "", apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "id"})
+	}
+
+	return trimmed, nil
+}
+
+func toDomainState(bill Bill) domainbilling.State {
+	return domainbilling.State{
+		ID:                   bill.ID,
+		LeaseID:              bill.LeaseID,
+		TenantID:             bill.TenantID,
+		RoomID:               bill.RoomID,
+		PropertyID:           bill.PropertyID,
+		Type:                 bill.Type,
+		Amount:               bill.Amount,
+		PeriodStart:          bill.PeriodStart,
+		PeriodEnd:            bill.PeriodEnd,
+		DueDate:              bill.DueDate,
+		Status:               bill.Status,
+		PaymentMethod:        bill.PaymentMethod,
+		PaidAt:               bill.PaidAt,
+		PaidAmount:           bill.PaidAmount,
+		MeterPreviousReading: bill.MeterPreviousReading,
+		MeterCurrentReading:  bill.MeterCurrentReading,
+		MeterUnitPrice:       bill.MeterUnitPrice,
+		MeterRecordedAt:      bill.MeterRecordedAt,
+		WrittenOffReason:     bill.WrittenOffReason,
+		OverdueNoticeCount:   bill.OverdueNoticeCount,
+		CreatedAt:            bill.CreatedAt,
+		UpdatedAt:            bill.UpdatedAt,
+		Version:              bill.Version,
+	}
+}

--- a/internal/application/billing/record_meter.go
+++ b/internal/application/billing/record_meter.go
@@ -85,7 +85,6 @@ func (s *RecordMeterService) Execute(ctx context.Context, input RecordMeterInput
 			CurrentReading:  *state.MeterCurrentReading,
 			UnitPrice:       *state.MeterUnitPrice,
 			Amount:          *state.Amount,
-			Status:          state.Status,
 			MeterRecordedAt: *state.MeterRecordedAt,
 			ExpectedVersion: current.Version,
 		})

--- a/internal/application/billing/record_payment.go
+++ b/internal/application/billing/record_payment.go
@@ -78,7 +78,6 @@ func (s *RecordPaymentService) Execute(ctx context.Context, input RecordPaymentI
 			PaidAmount:      *state.PaidAmount,
 			PaymentMethod:   *state.PaymentMethod,
 			PaidAt:          *state.PaidAt,
-			Status:          state.Status,
 			ExpectedVersion: current.Version,
 		})
 		if err != nil {

--- a/internal/application/billing/record_payment.go
+++ b/internal/application/billing/record_payment.go
@@ -1,0 +1,127 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+
+	domainbilling "stds_backend/internal/domain/billing"
+	domainevents "stds_backend/internal/domain/events"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// RecordPaymentInput is the command payload for recording bill payment.
+type RecordPaymentInput struct {
+	ActorRole     string
+	BillID        string
+	PaidAmount    int
+	PaymentMethod string
+	PaidAt        *time.Time
+}
+
+// RecordPaymentService records bill payments.
+type RecordPaymentService struct {
+	repo           Repository
+	accountingRepo AccountingRepository
+	txRunner       TransactionRunner
+}
+
+// NewRecordPaymentService returns a RecordPaymentService.
+func NewRecordPaymentService(repo Repository, accountingRepo AccountingRepository, txRunner TransactionRunner) *RecordPaymentService {
+	return &RecordPaymentService{repo: repo, accountingRepo: accountingRepo, txRunner: txRunner}
+}
+
+// Execute records a bill payment and emits BillPaid after commit.
+func (s *RecordPaymentService) Execute(ctx context.Context, input RecordPaymentInput) (*Bill, error) {
+	if _, err := normalizeWriteRole(input.ActorRole); err != nil {
+		return nil, err
+	}
+	billID, err := normalizeBillID(input.BillID)
+	if err != nil {
+		return nil, err
+	}
+	paymentMethod := strings.TrimSpace(input.PaymentMethod)
+	switch paymentMethod {
+	case "cash", "transfer", "other":
+	default:
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "payment_method"})
+	}
+	if s.txRunner == nil {
+		return nil, apperr.ErrInternalServerError
+	}
+	if s.accountingRepo == nil {
+		return nil, apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_accounting"})
+	}
+
+	paidAt := time.Now().UTC()
+	if input.PaidAt != nil {
+		paidAt = input.PaidAt.UTC()
+	}
+
+	var updated *Bill
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+		current, err := s.repo.FindBillByIDForUpdate(ctx, tx, billID)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+
+		aggregate := domainbilling.Rehydrate(toDomainState(*current))
+		if err := aggregate.RecordPayment(input.PaidAmount, paymentMethod, paidAt); err != nil {
+			return mapDomainError(err, current, input.PaidAmount)
+		}
+
+		state := aggregate.State()
+		updatedBill, err := s.repo.UpdateBillPayment(ctx, tx, UpdatePaymentParams{
+			BillID:          billID,
+			PaidAmount:      *state.PaidAmount,
+			PaymentMethod:   *state.PaymentMethod,
+			PaidAt:          *state.PaidAt,
+			Status:          state.Status,
+			ExpectedVersion: current.Version,
+		})
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+
+		category, err := accountingCategoryForBillType(updatedBill.Type)
+		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+		if err := s.accountingRepo.CreateAccountingEntry(ctx, tx, AccountingEntryParams{
+			PropertyID: updatedBill.PropertyID,
+			Category:   category,
+			Amount:     *state.PaidAmount,
+			SourceRef: map[string]interface{}{
+				"type":    "BillPaid",
+				"bill_id": updatedBill.ID,
+			},
+			Year:  state.PaidAt.Year(),
+			Month: int(state.PaidAt.Month()),
+		}); err != nil {
+			return mapAccountingRepositoryError(err)
+		}
+
+		recorder.Record(domainevents.BillPaid{
+			BillID:        updatedBill.ID,
+			PropertyID:    updatedBill.PropertyID,
+			LeaseID:       updatedBill.LeaseID,
+			RoomID:        updatedBill.RoomID,
+			TenantID:      updatedBill.TenantID,
+			BillType:      updatedBill.Type,
+			Amount:        *state.Amount,
+			PaidAmount:    *state.PaidAmount,
+			PaymentMethod: *state.PaymentMethod,
+			PaidAt:        *state.PaidAt,
+		})
+
+		updated = updatedBill
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return updated, nil
+}

--- a/internal/application/billing/repository.go
+++ b/internal/application/billing/repository.go
@@ -10,9 +10,10 @@ import (
 )
 
 var (
-	ErrBillNotFound             = errors.New("bill not found")
-	ErrConcurrentUpdateConflict = errors.New("concurrent update conflict")
-	ErrPropertyAccountNotFound  = errors.New("property account not found")
+	ErrBillNotFound                         = errors.New("bill not found")
+	ErrConcurrentUpdateConflict             = errors.New("concurrent update conflict")
+	ErrPropertyAccountNotFound              = errors.New("property account not found")
+	ErrPropertyElectricityUnitPriceNotFound = errors.New("property electricity unit price not found")
 )
 
 // TransactionRunner is the txrunner.Runner surface required by billing use cases.

--- a/internal/application/billing/repository.go
+++ b/internal/application/billing/repository.go
@@ -77,7 +77,6 @@ type UpdateMeterParams struct {
 	CurrentReading  int
 	UnitPrice       float64
 	Amount          int
-	Status          string
 	MeterRecordedAt time.Time
 	ExpectedVersion int
 }
@@ -88,7 +87,6 @@ type UpdatePaymentParams struct {
 	PaidAmount      int
 	PaymentMethod   string
 	PaidAt          time.Time
-	Status          string
 	ExpectedVersion int
 }
 

--- a/internal/application/billing/repository.go
+++ b/internal/application/billing/repository.go
@@ -1,0 +1,119 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"stds_backend/internal/platform/database/txrunner"
+)
+
+var (
+	ErrBillNotFound             = errors.New("bill not found")
+	ErrConcurrentUpdateConflict = errors.New("concurrent update conflict")
+	ErrPropertyAccountNotFound  = errors.New("property account not found")
+)
+
+// TransactionRunner is the txrunner.Runner surface required by billing use cases.
+type TransactionRunner interface {
+	WithinTransaction(ctx context.Context, fn func(context.Context, *sql.Tx, *txrunner.EventRecorder) error) error
+}
+
+// Bill is the application read model for API bill responses.
+type Bill struct {
+	ID                   string
+	LeaseID              string
+	TenantID             string
+	RoomID               string
+	PropertyID           string
+	Type                 string
+	Amount               *int
+	DueDate              time.Time
+	Status               string
+	PaymentMethod        *string
+	PaidAt               *time.Time
+	PaidAmount           *int
+	MeterPreviousReading *int
+	MeterCurrentReading  *int
+	MeterUnitPrice       *float64
+	MeterRecordedAt      *time.Time
+	WrittenOffReason     *string
+	OverdueNoticeCount   int
+	PeriodStart          time.Time
+	PeriodEnd            time.Time
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	Version              int
+}
+
+// ListBillsQuery defines filtering, pagination, and role scoping for bill lists.
+type ListBillsQuery struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          *string
+	LeaseID             *string
+	TenantID            *string
+	Status              *string
+	Month               *time.Time
+	Limit               int
+	Offset              int
+}
+
+// GetBillQuery defines role scoping for bill detail retrieval.
+type GetBillQuery struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	BillID              string
+}
+
+// UpdateMeterParams contains persisted fields after meter recording.
+type UpdateMeterParams struct {
+	BillID          string
+	PreviousReading int
+	CurrentReading  int
+	UnitPrice       float64
+	Amount          int
+	Status          string
+	MeterRecordedAt time.Time
+	ExpectedVersion int
+}
+
+// UpdatePaymentParams contains persisted fields after payment recording.
+type UpdatePaymentParams struct {
+	BillID          string
+	PaidAmount      int
+	PaymentMethod   string
+	PaidAt          time.Time
+	Status          string
+	ExpectedVersion int
+}
+
+// Repository defines database operations required by billing use cases.
+type Repository interface {
+	ListBills(ctx context.Context, query ListBillsQuery) ([]Bill, error)
+	FindBillByID(ctx context.Context, query GetBillQuery) (*Bill, error)
+	FindBillByIDForUpdate(ctx context.Context, tx *sql.Tx, billID string) (*Bill, error)
+	FindPreviousElectricityReading(ctx context.Context, tx *sql.Tx, roomID string, beforePeriodStart time.Time) (int, error)
+	FindPropertyElectricityUnitPrice(ctx context.Context, tx *sql.Tx, propertyID string) (*float64, error)
+	UpdateBillMeter(ctx context.Context, tx *sql.Tx, params UpdateMeterParams) (*Bill, error)
+	UpdateBillPayment(ctx context.Context, tx *sql.Tx, params UpdatePaymentParams) (*Bill, error)
+}
+
+// AccountingEntryParams contains accounting entry data derived from BillPaid.
+type AccountingEntryParams struct {
+	PropertyID  string
+	Category    string
+	Amount      int
+	Description *string
+	SourceRef   map[string]interface{}
+	Year        int
+	Month       int
+}
+
+// AccountingRepository defines persistence required to complete bill payment.
+type AccountingRepository interface {
+	CreateAccountingEntry(ctx context.Context, tx *sql.Tx, params AccountingEntryParams) error
+}

--- a/internal/application/billing/subscribers.go
+++ b/internal/application/billing/subscribers.go
@@ -1,0 +1,23 @@
+package billing
+
+import (
+	"fmt"
+
+	domainbilling "stds_backend/internal/domain/billing"
+)
+
+const (
+	AccountingCategoryRentPayment        = "rent_payment"
+	AccountingCategoryElectricityPayment = "electricity_payment"
+)
+
+func accountingCategoryForBillType(billType string) (string, error) {
+	switch billType {
+	case domainbilling.TypeRent:
+		return AccountingCategoryRentPayment, nil
+	case domainbilling.TypeElectricity:
+		return AccountingCategoryElectricityPayment, nil
+	default:
+		return "", fmt.Errorf("unsupported bill type for accounting entry: %s", billType)
+	}
+}

--- a/internal/domain/billing/aggregate.go
+++ b/internal/domain/billing/aggregate.go
@@ -1,0 +1,156 @@
+package billing
+
+import (
+	"math"
+	"strings"
+	"time"
+)
+
+const (
+	TypeRent        = "rent"
+	TypeElectricity = "electricity"
+
+	StatusPendingMeter   = "pending_meter"
+	StatusPendingPayment = "pending_payment"
+	StatusPaid           = "paid"
+	StatusOverdue        = "overdue"
+	StatusVoided         = "voided"
+	StatusWrittenOff     = "written_off"
+)
+
+// State captures bill fields used by billing business rules.
+type State struct {
+	ID                   string
+	LeaseID              string
+	TenantID             string
+	RoomID               string
+	PropertyID           string
+	Type                 string
+	Amount               *int
+	PeriodStart          time.Time
+	PeriodEnd            time.Time
+	DueDate              time.Time
+	Status               string
+	PaymentMethod        *string
+	PaidAt               *time.Time
+	PaidAmount           *int
+	MeterPreviousReading *int
+	MeterCurrentReading  *int
+	MeterUnitPrice       *float64
+	MeterRecordedAt      *time.Time
+	WrittenOffReason     *string
+	OverdueNoticeCount   int
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	Version              int
+}
+
+// Aggregate owns bill state transitions.
+type Aggregate struct {
+	state State
+}
+
+// Rehydrate restores a bill aggregate from persisted state.
+func Rehydrate(state State) *Aggregate {
+	state.Type = strings.TrimSpace(state.Type)
+	state.Status = strings.TrimSpace(state.Status)
+
+	return &Aggregate{state: state}
+}
+
+// State returns a defensive snapshot of aggregate state.
+func (a *Aggregate) State() State {
+	state := a.state
+	state.Amount = cloneInt(a.state.Amount)
+	state.PaymentMethod = cloneString(a.state.PaymentMethod)
+	state.PaidAt = cloneTime(a.state.PaidAt)
+	state.PaidAmount = cloneInt(a.state.PaidAmount)
+	state.MeterPreviousReading = cloneInt(a.state.MeterPreviousReading)
+	state.MeterCurrentReading = cloneInt(a.state.MeterCurrentReading)
+	state.MeterUnitPrice = cloneFloat64(a.state.MeterUnitPrice)
+	state.MeterRecordedAt = cloneTime(a.state.MeterRecordedAt)
+	state.WrittenOffReason = cloneString(a.state.WrittenOffReason)
+
+	return state
+}
+
+// RecordMeter stores a completed electricity reading and moves the bill to payment.
+func (a *Aggregate) RecordMeter(previousReading int, currentReading int, unitPrice float64, recordedAt time.Time) error {
+	if a.state.Type != TypeElectricity {
+		return ErrBillNotElectricityType
+	}
+	if a.state.Status != StatusPendingMeter {
+		return ErrBillStatusNotRecordable
+	}
+	if currentReading < previousReading {
+		return ErrMeterReadingLessThanPrevious
+	}
+
+	usage := currentReading - previousReading
+	amount := int(math.Round(float64(usage) * unitPrice))
+
+	a.state.MeterPreviousReading = &previousReading
+	a.state.MeterCurrentReading = &currentReading
+	a.state.MeterUnitPrice = &unitPrice
+	a.state.MeterRecordedAt = &recordedAt
+	a.state.Amount = &amount
+	a.state.Status = StatusPendingPayment
+
+	return nil
+}
+
+// RecordPayment stores a payment and moves the bill to paid.
+func (a *Aggregate) RecordPayment(paidAmount int, paymentMethod string, paidAt time.Time) error {
+	if a.state.Status == StatusPaid {
+		return ErrBillAlreadyPaid
+	}
+	if a.state.Status != StatusPendingPayment && a.state.Status != StatusOverdue {
+		return ErrBillStatusNotPayable
+	}
+	if a.state.Amount == nil {
+		return ErrBillStatusNotPayable
+	}
+	if paidAmount != *a.state.Amount {
+		return ErrBillPaidAmountMismatch
+	}
+
+	method := strings.TrimSpace(paymentMethod)
+	a.state.PaidAmount = &paidAmount
+	a.state.PaymentMethod = &method
+	a.state.PaidAt = &paidAt
+	a.state.Status = StatusPaid
+
+	return nil
+}
+
+func cloneInt(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneFloat64(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}

--- a/internal/domain/billing/aggregate.go
+++ b/internal/domain/billing/aggregate.go
@@ -108,7 +108,7 @@ func (a *Aggregate) RecordPayment(paidAmount int, paymentMethod string, paidAt t
 		return ErrBillStatusNotPayable
 	}
 	if a.state.Amount == nil {
-		return ErrBillStatusNotPayable
+		return ErrBillAmountMissing
 	}
 	if paidAmount != *a.state.Amount {
 		return ErrBillPaidAmountMismatch

--- a/internal/domain/billing/aggregate_test.go
+++ b/internal/domain/billing/aggregate_test.go
@@ -153,7 +153,7 @@ func TestRecordPaymentRejectsInvalidBillsWithoutMutatingState(t *testing.T) {
 			name:        "missing amount",
 			state:       validBillState(TypeRent, StatusPendingPayment, nil),
 			paidAmount:  12000,
-			expectedErr: ErrBillStatusNotPayable,
+			expectedErr: ErrBillAmountMissing,
 		},
 		{
 			name:        "amount mismatch",

--- a/internal/domain/billing/aggregate_test.go
+++ b/internal/domain/billing/aggregate_test.go
@@ -1,0 +1,217 @@
+package billing
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRecordMeterCalculatesAmountAndMovesToPendingPayment(t *testing.T) {
+	recordedAt := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	aggregate := Rehydrate(validBillState(TypeElectricity, StatusPendingMeter, nil))
+
+	if err := aggregate.RecordMeter(1250, 1380, 4.5, recordedAt); err != nil {
+		t.Fatalf("RecordMeter: %v", err)
+	}
+
+	state := aggregate.State()
+	if state.Status != StatusPendingPayment {
+		t.Fatalf("Status = %q, want %q", state.Status, StatusPendingPayment)
+	}
+	if state.Amount == nil || *state.Amount != 585 {
+		t.Fatalf("Amount = %v, want 585", state.Amount)
+	}
+	if state.MeterPreviousReading == nil || *state.MeterPreviousReading != 1250 {
+		t.Fatalf("MeterPreviousReading = %v, want 1250", state.MeterPreviousReading)
+	}
+	if state.MeterCurrentReading == nil || *state.MeterCurrentReading != 1380 {
+		t.Fatalf("MeterCurrentReading = %v, want 1380", state.MeterCurrentReading)
+	}
+	if state.MeterUnitPrice == nil || *state.MeterUnitPrice != 4.5 {
+		t.Fatalf("MeterUnitPrice = %v, want 4.5", state.MeterUnitPrice)
+	}
+	if state.MeterRecordedAt == nil || !state.MeterRecordedAt.Equal(recordedAt) {
+		t.Fatalf("MeterRecordedAt = %v, want %v", state.MeterRecordedAt, recordedAt)
+	}
+}
+
+func TestRecordMeterRejectsInvalidBillsWithoutMutatingState(t *testing.T) {
+	tests := []struct {
+		name           string
+		state          State
+		previous       int
+		current        int
+		expectedErr    error
+		expectedStatus string
+	}{
+		{
+			name:           "current lower than previous",
+			state:          validBillState(TypeElectricity, StatusPendingMeter, nil),
+			previous:       1380,
+			current:        1250,
+			expectedErr:    ErrMeterReadingLessThanPrevious,
+			expectedStatus: StatusPendingMeter,
+		},
+		{
+			name:           "non electricity bill",
+			state:          validBillState(TypeRent, StatusPendingPayment, intPtr(12000)),
+			previous:       1250,
+			current:        1380,
+			expectedErr:    ErrBillNotElectricityType,
+			expectedStatus: StatusPendingPayment,
+		},
+		{
+			name:           "electricity bill not pending meter",
+			state:          validBillState(TypeElectricity, StatusPendingPayment, nil),
+			previous:       1250,
+			current:        1380,
+			expectedErr:    ErrBillStatusNotRecordable,
+			expectedStatus: StatusPendingPayment,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aggregate := Rehydrate(tt.state)
+
+			err := aggregate.RecordMeter(tt.previous, tt.current, 4.5, time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC))
+			if !errors.Is(err, tt.expectedErr) {
+				t.Fatalf("expected %v, got %v", tt.expectedErr, err)
+			}
+
+			state := aggregate.State()
+			if state.Status != tt.expectedStatus {
+				t.Fatalf("Status = %q, want %q", state.Status, tt.expectedStatus)
+			}
+			if state.MeterPreviousReading != nil || state.MeterCurrentReading != nil || state.MeterUnitPrice != nil || state.MeterRecordedAt != nil {
+				t.Fatalf("meter fields mutated on failure: %+v", state)
+			}
+		})
+	}
+}
+
+func TestRecordPaymentMovesPayableBillsToPaid(t *testing.T) {
+	paidAt := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
+
+	for _, status := range []string{StatusPendingPayment, StatusOverdue} {
+		t.Run(status, func(t *testing.T) {
+			aggregate := Rehydrate(validBillState(TypeRent, status, intPtr(12000)))
+
+			if err := aggregate.RecordPayment(12000, " transfer ", paidAt); err != nil {
+				t.Fatalf("RecordPayment: %v", err)
+			}
+
+			state := aggregate.State()
+			if state.Status != StatusPaid {
+				t.Fatalf("Status = %q, want %q", state.Status, StatusPaid)
+			}
+			if state.PaidAmount == nil || *state.PaidAmount != 12000 {
+				t.Fatalf("PaidAmount = %v, want 12000", state.PaidAmount)
+			}
+			if state.PaymentMethod == nil || *state.PaymentMethod != "transfer" {
+				t.Fatalf("PaymentMethod = %v, want transfer", state.PaymentMethod)
+			}
+			if state.PaidAt == nil || !state.PaidAt.Equal(paidAt) {
+				t.Fatalf("PaidAt = %v, want %v", state.PaidAt, paidAt)
+			}
+		})
+	}
+}
+
+func TestRecordPaymentRejectsInvalidBillsWithoutMutatingState(t *testing.T) {
+	tests := []struct {
+		name        string
+		state       State
+		paidAmount  int
+		expectedErr error
+	}{
+		{
+			name:        "already paid",
+			state:       validBillState(TypeRent, StatusPaid, intPtr(12000)),
+			paidAmount:  12000,
+			expectedErr: ErrBillAlreadyPaid,
+		},
+		{
+			name:        "pending meter",
+			state:       validBillState(TypeElectricity, StatusPendingMeter, nil),
+			paidAmount:  12000,
+			expectedErr: ErrBillStatusNotPayable,
+		},
+		{
+			name:        "voided",
+			state:       validBillState(TypeRent, StatusVoided, intPtr(12000)),
+			paidAmount:  12000,
+			expectedErr: ErrBillStatusNotPayable,
+		},
+		{
+			name:        "written off",
+			state:       validBillState(TypeRent, StatusWrittenOff, intPtr(12000)),
+			paidAmount:  12000,
+			expectedErr: ErrBillStatusNotPayable,
+		},
+		{
+			name:        "missing amount",
+			state:       validBillState(TypeRent, StatusPendingPayment, nil),
+			paidAmount:  12000,
+			expectedErr: ErrBillStatusNotPayable,
+		},
+		{
+			name:        "amount mismatch",
+			state:       validBillState(TypeRent, StatusPendingPayment, intPtr(12000)),
+			paidAmount:  11000,
+			expectedErr: ErrBillPaidAmountMismatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aggregate := Rehydrate(tt.state)
+
+			err := aggregate.RecordPayment(tt.paidAmount, "cash", time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC))
+			if !errors.Is(err, tt.expectedErr) {
+				t.Fatalf("expected %v, got %v", tt.expectedErr, err)
+			}
+
+			state := aggregate.State()
+			if state.Status != tt.state.Status {
+				t.Fatalf("Status = %q, want %q", state.Status, tt.state.Status)
+			}
+			if state.PaidAmount != nil || state.PaymentMethod != nil || state.PaidAt != nil {
+				t.Fatalf("payment fields mutated on failure: %+v", state)
+			}
+		})
+	}
+}
+
+func TestStateReturnsDefensivePointerSnapshot(t *testing.T) {
+	amount := 12000
+	aggregate := Rehydrate(validBillState(TypeRent, StatusPendingPayment, &amount))
+
+	snapshot := aggregate.State()
+	*snapshot.Amount = 1
+
+	if *aggregate.State().Amount != 12000 {
+		t.Fatalf("mutating State snapshot changed aggregate amount")
+	}
+}
+
+func validBillState(billType string, status string, amount *int) State {
+	return State{
+		ID:          "bill-1",
+		LeaseID:     "lease-1",
+		TenantID:    "tenant-1",
+		RoomID:      "room-1",
+		PropertyID:  "property-1",
+		Type:        billType,
+		Amount:      amount,
+		PeriodStart: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:   time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
+		DueDate:     time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC),
+		Status:      status,
+		Version:     1,
+	}
+}
+
+func intPtr(value int) *int {
+	return &value
+}

--- a/internal/domain/billing/errors.go
+++ b/internal/domain/billing/errors.go
@@ -1,0 +1,13 @@
+package billing
+
+import "errors"
+
+var (
+	ErrBillAlreadyPaid              = errors.New("bill is already paid")
+	ErrBillStatusNotPayable         = errors.New("bill status is not payable")
+	ErrBillPaidAmountMismatch       = errors.New("bill paid amount does not match amount")
+	ErrMeterReadingLessThanPrevious = errors.New("meter reading is less than previous reading")
+	ErrBillNotElectricityType       = errors.New("bill is not electricity type")
+	ErrBillStatusNotRecordable      = errors.New("bill status is not recordable")
+	ErrBillAmountMissing            = errors.New("bill amount is missing")
+)

--- a/internal/domain/events/bill_paid.go
+++ b/internal/domain/events/bill_paid.go
@@ -1,0 +1,17 @@
+package events
+
+import "time"
+
+// BillPaid is emitted after a bill payment is recorded.
+type BillPaid struct {
+	BillID        string
+	PropertyID    string
+	LeaseID       string
+	RoomID        string
+	TenantID      string
+	BillType      string
+	Amount        int
+	PaidAmount    int
+	PaymentMethod string
+	PaidAt        time.Time
+}

--- a/internal/domain/events/meter_recorded.go
+++ b/internal/domain/events/meter_recorded.go
@@ -1,0 +1,16 @@
+package events
+
+import "time"
+
+// MeterRecorded is emitted after a bill meter reading is recorded.
+type MeterRecorded struct {
+	BillID          string
+	PropertyID      string
+	RoomID          string
+	LeaseID         string
+	PreviousReading int
+	CurrentReading  int
+	UnitPrice       float64
+	Amount          int
+	RecordedAt      time.Time
+}

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -710,6 +710,7 @@ type RecordMeterRequest struct {
 
 // RecordPaymentRequest defines model for RecordPaymentRequest.
 type RecordPaymentRequest struct {
+	// PaidAmount 收款金額，必須等於帳單 amount；不支援部分收款或溢收。
 	PaidAmount int `json:"paid_amount"`
 
 	// PaidAt 付款時間（選填，預設為伺服器時間）

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -710,10 +710,10 @@ type RecordMeterRequest struct {
 
 // RecordPaymentRequest defines model for RecordPaymentRequest.
 type RecordPaymentRequest struct {
-	// PaidAmount 收款金額，必須等於帳單 amount；不支援部分收款或溢收。
+	// PaidAmount Payment amount. Must exactly equal the bill amount; partial or overpayments are not supported.
 	PaidAmount int `json:"paid_amount"`
 
-	// PaidAt 付款時間（選填，預設為伺服器時間）
+	// PaidAt Payment timestamp. Optional; defaults to the server time.
 	PaidAt        *time.Time                        `json:"paid_at,omitempty"`
 	PaymentMethod RecordPaymentRequestPaymentMethod `json:"payment_method"`
 }

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -58,6 +59,7 @@ type APIServer struct {
 	terminateLeaseSvc *applease.TerminateLeaseService
 	forceTerminateSvc *applease.ForceTerminateLeaseService
 	getForceTermSvc   *applease.GetForceTerminationService
+	billing           BillingServices
 }
 
 // LeaseCommandServices groups optional lease command services beyond creation.
@@ -68,6 +70,90 @@ type LeaseCommandServices struct {
 	TerminateLease      *applease.TerminateLeaseService
 	ForceTerminateLease *applease.ForceTerminateLeaseService
 	GetForceTermination *applease.GetForceTerminationService
+	Billing             BillingServices
+}
+
+// BillingServices groups the billing application entry points used by the
+// transport layer.
+type BillingServices struct {
+	Query   BillingQueryService
+	Meter   BillingMeterService
+	Payment BillingPaymentService
+}
+
+type BillingQueryService interface {
+	ListBills(ctx context.Context, input BillingListInput) ([]BillingBill, error)
+	GetBill(ctx context.Context, input BillingGetInput) (*BillingBill, error)
+}
+
+type BillingMeterService interface {
+	SubmitBillMeter(ctx context.Context, input BillingMeterInput) (*BillingBill, error)
+}
+
+type BillingPaymentService interface {
+	RecordBillPayment(ctx context.Context, input BillingPaymentInput) (*BillingBill, error)
+}
+
+type BillingListInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          *string
+	LeaseID             *string
+	TenantID            *string
+	Status              string
+	Month               *string
+	Limit               int
+	Offset              int
+}
+
+type BillingGetInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	BillID              string
+}
+
+type BillingMeterInput struct {
+	ActorRole           string
+	AssignedPropertyIDs []string
+	BillID              string
+	CurrentReading      int
+}
+
+type BillingPaymentInput struct {
+	ActorRole           string
+	AssignedPropertyIDs []string
+	BillID              string
+	PaidAmount          int
+	PaymentMethod       string
+	PaidAt              *time.Time
+}
+
+type BillingBill struct {
+	ID                   string
+	LeaseID              string
+	TenantID             string
+	RoomID               string
+	PropertyID           string
+	Type                 string
+	Amount               *int
+	PeriodStart          time.Time
+	PeriodEnd            time.Time
+	DueDate              time.Time
+	Status               string
+	PaymentMethod        *string
+	PaidAt               *time.Time
+	PaidAmount           *int
+	MeterPreviousReading *int
+	MeterCurrentReading  *int
+	MeterUnitPrice       *float64
+	MeterRecordedAt      *time.Time
+	WrittenOffReason     *string
+	OverdueNoticeCount   int
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	Version              int
 }
 
 // NewAPIServer returns an API server with only the currently implemented
@@ -126,6 +212,7 @@ func NewAPIServer(
 		server.terminateLeaseSvc = leaseCommands[0].TerminateLease
 		server.forceTerminateSvc = leaseCommands[0].ForceTerminateLease
 		server.getForceTermSvc = leaseCommands[0].GetForceTermination
+		server.billing = leaseCommands[0].Billing
 	}
 
 	return server
@@ -156,7 +243,67 @@ func (s *APIServer) SyncAuth(c *gin.Context) {
 }
 
 // ListBills handles the bill listing endpoint.
-func (s *APIServer) ListBills(c *gin.Context, params api.ListBillsParams) { writeNotImplemented(c) }
+func (s *APIServer) ListBills(c *gin.Context, params api.ListBillsParams) {
+	if s.billing.Query == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_query"}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	if params.Month != nil && !isYYYYMM(*params.Month) {
+		c.Error(apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "month",
+			"reason": "must use YYYY-MM format",
+		}))
+		return
+	}
+
+	pagination, err := queryparams.NormalizePagination(params.Page, params.Limit)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	status := ""
+	if params.Status != nil {
+		status = string(*params.Status)
+	}
+
+	var tenantID *string
+	if params.TenantId != nil {
+		value := params.TenantId.String()
+		tenantID = &value
+	}
+
+	bills, err := s.billing.Query.ListBills(c.Request.Context(), BillingListInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		PropertyID:          params.PropertyId,
+		LeaseID:             params.LeaseId,
+		TenantID:            tenantID,
+		Status:              status,
+		Month:               params.Month,
+		Limit:               pagination.Limit,
+		Offset:              pagination.Offset,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	items := make([]api.BillResponse, 0, len(bills))
+	for i := range bills {
+		items = append(items, toBillResponse(&bills[i]))
+	}
+
+	c.JSON(http.StatusOK, api.BillListResponse{Data: &items})
+}
 
 // CreateAttachmentUploadURL handles attachment upload URL creation.
 func (s *APIServer) CreateAttachmentUploadURL(c *gin.Context) { writeNotImplemented(c) }
@@ -175,13 +322,99 @@ func (s *APIServer) CreateBillAttachment(c *gin.Context, id openapi_types.UUID) 
 }
 
 // GetBill handles the bill detail endpoint.
-func (s *APIServer) GetBill(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) GetBill(c *gin.Context, id string) {
+	if s.billing.Query == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_query"}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	bill, err := s.billing.Query.GetBill(c.Request.Context(), BillingGetInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		BillID:              id,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toBillResponse(bill))
+}
 
 // SubmitBillMeter handles meter submission for a bill.
-func (s *APIServer) SubmitBillMeter(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) SubmitBillMeter(c *gin.Context, id string) {
+	if s.billing.Meter == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_meter"}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	var request api.RecordMeterRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	bill, err := s.billing.Meter.SubmitBillMeter(c.Request.Context(), BillingMeterInput{
+		ActorRole:           principal.Role,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		BillID:              id,
+		CurrentReading:      request.CurrentReading,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toBillResponse(bill))
+}
 
 // RecordBillPayment handles payment recording for a bill.
-func (s *APIServer) RecordBillPayment(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) RecordBillPayment(c *gin.Context, id string) {
+	if s.billing.Payment == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_payment"}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	var request api.RecordPaymentRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	bill, err := s.billing.Payment.RecordBillPayment(c.Request.Context(), BillingPaymentInput{
+		ActorRole:           principal.Role,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		BillID:              id,
+		PaidAmount:          request.PaidAmount,
+		PaymentMethod:       string(request.PaymentMethod),
+		PaidAt:              request.PaidAt,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toBillResponse(bill))
+}
 
 // GetForceTermination handles force-termination detail retrieval.
 func (s *APIServer) GetForceTermination(c *gin.Context, id openapi_types.UUID) {
@@ -1407,6 +1640,73 @@ func parseUUID(value string) (openapi_types.UUID, bool) {
 	}
 
 	return parsed, true
+}
+
+func isYYYYMM(value string) bool {
+	if len(value) != len("2006-01") || value[4] != '-' {
+		return false
+	}
+
+	_, err := time.Parse("2006-01", value)
+	return err == nil
+}
+
+func toBillResponse(bill *BillingBill) api.BillResponse {
+	id, idOK := parseUUID(bill.ID)
+	leaseID, leaseOK := parseUUID(bill.LeaseID)
+	tenantID, tenantOK := parseUUID(bill.TenantID)
+	roomID, roomOK := parseUUID(bill.RoomID)
+	propertyID, propertyOK := parseUUID(bill.PropertyID)
+	billType := api.BillResponseType(bill.Type)
+	status := api.BillResponseStatus(bill.Status)
+	periodStart := openapi_types.Date{Time: bill.PeriodStart}
+	periodEnd := openapi_types.Date{Time: bill.PeriodEnd}
+	dueDate := openapi_types.Date{Time: bill.DueDate}
+	createdAt := bill.CreatedAt
+	updatedAt := bill.UpdatedAt
+	overdueNoticeCount := bill.OverdueNoticeCount
+	version := bill.Version
+
+	response := api.BillResponse{
+		Amount:               bill.Amount,
+		CreatedAt:            &createdAt,
+		DueDate:              &dueDate,
+		MeterCurrentReading:  bill.MeterCurrentReading,
+		MeterPreviousReading: bill.MeterPreviousReading,
+		MeterRecordedAt:      bill.MeterRecordedAt,
+		MeterUnitPrice:       bill.MeterUnitPrice,
+		OverdueNoticeCount:   &overdueNoticeCount,
+		PaidAmount:           bill.PaidAmount,
+		PaidAt:               bill.PaidAt,
+		PeriodEnd:            &periodEnd,
+		PeriodStart:          &periodStart,
+		Status:               &status,
+		Type:                 &billType,
+		UpdatedAt:            &updatedAt,
+		Version:              &version,
+		WrittenOffReason:     bill.WrittenOffReason,
+	}
+	if idOK {
+		response.Id = &id
+	}
+	if leaseOK {
+		response.LeaseId = &leaseID
+	}
+	if tenantOK {
+		response.TenantId = &tenantID
+	}
+	if roomOK {
+		response.RoomId = &roomID
+	}
+	if propertyOK {
+		response.PropertyId = &propertyID
+	}
+	if bill.PaymentMethod != nil {
+		paymentMethod := api.BillResponsePaymentMethod(*bill.PaymentMethod)
+		response.PaymentMethod = &paymentMethod
+	}
+
+	return response
 }
 
 func (s *APIServer) runJob(c *gin.Context, jobKey appjobs.JobKey, windowKey string) {

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -255,7 +255,7 @@ func (s *APIServer) ListBills(c *gin.Context, params api.ListBillsParams) {
 		return
 	}
 
-	if params.Month != nil && !isYYYYMM(*params.Month) {
+	if params.Month != nil && !queryparams.IsYYYYMM(*params.Month) {
 		c.Error(apperr.ErrBadRequest.WithDetails(map[string]interface{}{
 			"field":  "month",
 			"reason": "must use YYYY-MM format",
@@ -1640,15 +1640,6 @@ func parseUUID(value string) (openapi_types.UUID, bool) {
 	}
 
 	return parsed, true
-}
-
-func isYYYYMM(value string) bool {
-	if len(value) != len("2006-01") || value[4] != '-' {
-		return false
-	}
-
-	_, err := time.Parse("2006-01", value)
-	return err == nil
 }
 
 func toBillResponse(bill *BillingBill) api.BillResponse {

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -1,10 +1,19 @@
 package handler
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/gin-gonic/gin"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	"stds_backend/internal/http/api"
+	"stds_backend/internal/http/requestctx"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
 )
 
@@ -58,5 +67,180 @@ func TestToRoomResponseAllowsNilOptionalFields(t *testing.T) {
 		if value, ok := payload[field]; !ok || value != nil {
 			t.Fatalf("expected %s null, got %v", field, payload[field])
 		}
+	}
+}
+
+func TestListBillsForwardsFiltersAndPagination(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	query := &recordingBillingQuery{
+		bills: []BillingBill{testBillingBill()},
+	}
+	server := &APIServer{billing: BillingServices{Query: query}}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/bills", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID:              "user-1",
+		Role:                "staff",
+		AssignedPropertyIDs: []string{"property-1"},
+	})
+
+	propertyID := "10000000-0000-0000-0000-000000000001"
+	leaseID := "40000000-0000-0000-0000-000000000001"
+	tenantID := openapi_types.UUID([16]byte{0x50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	status := api.Paid
+	month := "2026-04"
+	page := 2
+	limit := 10
+
+	server.ListBills(c, api.ListBillsParams{
+		PropertyId: &propertyID,
+		LeaseId:    &leaseID,
+		TenantId:   &tenantID,
+		Status:     &status,
+		Month:      &month,
+		Page:       &page,
+		Limit:      &limit,
+	})
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if query.input.ActorRole != "staff" || query.input.ActorUserID != "user-1" {
+		t.Fatalf("unexpected actor input: %+v", query.input)
+	}
+	if query.input.PropertyID == nil || *query.input.PropertyID != propertyID {
+		t.Fatalf("PropertyID = %v, want %s", query.input.PropertyID, propertyID)
+	}
+	if query.input.LeaseID == nil || *query.input.LeaseID != leaseID {
+		t.Fatalf("LeaseID = %v, want %s", query.input.LeaseID, leaseID)
+	}
+	if query.input.TenantID == nil || *query.input.TenantID != tenantID.String() {
+		t.Fatalf("TenantID = %v, want %s", query.input.TenantID, tenantID.String())
+	}
+	if query.input.Status != "paid" || query.input.Month == nil || *query.input.Month != month {
+		t.Fatalf("unexpected filters: %+v", query.input)
+	}
+	if query.input.Limit != 10 || query.input.Offset != 10 {
+		t.Fatalf("pagination = limit %d offset %d, want 10/10", query.input.Limit, query.input.Offset)
+	}
+
+	var response api.BillListResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.Data == nil || len(*response.Data) != 1 {
+		t.Fatalf("expected one bill response, got %+v", response.Data)
+	}
+	if (*response.Data)[0].Amount == nil || *(*response.Data)[0].Amount != 12000 {
+		t.Fatalf("unexpected bill response: %+v", (*response.Data)[0])
+	}
+}
+
+func TestGetBillForwardsActorScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	query := &recordingBillingQuery{
+		getBill: testBillingBill(),
+	}
+	server := &APIServer{billing: BillingServices{Query: query}}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/bills/30000000-0000-0000-0000-000000000001", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID:              "user-1",
+		Role:                "owner",
+		AssignedPropertyIDs: []string{"property-1"},
+	})
+
+	server.GetBill(c, "30000000-0000-0000-0000-000000000001")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if query.getInput.ActorRole != "owner" || query.getInput.ActorUserID != "user-1" {
+		t.Fatalf("unexpected actor input: %+v", query.getInput)
+	}
+	if len(query.getInput.AssignedPropertyIDs) != 1 || query.getInput.AssignedPropertyIDs[0] != "property-1" {
+		t.Fatalf("unexpected assigned properties: %+v", query.getInput.AssignedPropertyIDs)
+	}
+	if query.getInput.BillID != "30000000-0000-0000-0000-000000000001" {
+		t.Fatalf("BillID = %q", query.getInput.BillID)
+	}
+}
+
+func TestRecordBillPaymentBindsRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	payment := &recordingBillingPayment{bill: testBillingBill()}
+	server := &APIServer{billing: BillingServices{Payment: payment}}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	paidAt := "2026-04-24T11:30:00Z"
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/bills/30000000-0000-0000-0000-000000000001/payment", bytes.NewBufferString(`{"payment_method":"transfer","paid_amount":12000,"paid_at":"`+paidAt+`"}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+	requestctx.SetPrincipal(c, requestctx.Principal{Role: "organizer"})
+
+	server.RecordBillPayment(c, "30000000-0000-0000-0000-000000000001")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if payment.input.BillID != "30000000-0000-0000-0000-000000000001" || payment.input.PaymentMethod != "transfer" || payment.input.PaidAmount != 12000 {
+		t.Fatalf("unexpected payment input: %+v", payment.input)
+	}
+	expectedPaidAt := time.Date(2026, 4, 24, 11, 30, 0, 0, time.UTC)
+	if payment.input.PaidAt == nil || !payment.input.PaidAt.Equal(expectedPaidAt) {
+		t.Fatalf("PaidAt = %v, want %v", payment.input.PaidAt, expectedPaidAt)
+	}
+}
+
+type recordingBillingQuery struct {
+	input    BillingListInput
+	getInput BillingGetInput
+	bills    []BillingBill
+	getBill  BillingBill
+}
+
+func (q *recordingBillingQuery) ListBills(_ context.Context, input BillingListInput) ([]BillingBill, error) {
+	q.input = input
+	return q.bills, nil
+}
+
+func (q *recordingBillingQuery) GetBill(_ context.Context, input BillingGetInput) (*BillingBill, error) {
+	q.getInput = input
+	return &q.getBill, nil
+}
+
+type recordingBillingPayment struct {
+	input BillingPaymentInput
+	bill  BillingBill
+}
+
+func (p *recordingBillingPayment) RecordBillPayment(_ context.Context, input BillingPaymentInput) (*BillingBill, error) {
+	p.input = input
+	return &p.bill, nil
+}
+
+func testBillingBill() BillingBill {
+	amount := 12000
+	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	return BillingBill{
+		ID:                 "30000000-0000-0000-0000-000000000001",
+		LeaseID:            "40000000-0000-0000-0000-000000000001",
+		TenantID:           "50000000-0000-0000-0000-000000000001",
+		RoomID:             "20000000-0000-0000-0000-000000000001",
+		PropertyID:         "10000000-0000-0000-0000-000000000001",
+		Type:               "rent",
+		Amount:             &amount,
+		PeriodStart:        time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:          time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
+		DueDate:            time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		Status:             "paid",
+		OverdueNoticeCount: 0,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+		Version:            1,
 	}
 }

--- a/internal/http/queryparams/pagination.go
+++ b/internal/http/queryparams/pagination.go
@@ -1,6 +1,10 @@
 package queryparams
 
-import "stds_backend/internal/shared/apperr"
+import (
+	"time"
+
+	"stds_backend/internal/shared/apperr"
+)
 
 const (
 	// DefaultPage is the default 1-based page number for list endpoints.
@@ -49,4 +53,14 @@ func NormalizePagination(page *int, limit *int) (Pagination, error) {
 	normalized.Offset = (normalized.Page - 1) * normalized.Limit
 
 	return normalized, nil
+}
+
+// IsYYYYMM reports whether value uses the YYYY-MM month format.
+func IsYYYYMM(value string) bool {
+	if len(value) != len("2006-01") || value[4] != '-' {
+		return false
+	}
+
+	_, err := time.Parse("2006-01", value)
+	return err == nil
 }

--- a/internal/http/queryparams/pagination_test.go
+++ b/internal/http/queryparams/pagination_test.go
@@ -91,6 +91,27 @@ func TestNormalizePaginationRejectsInvalidValues(t *testing.T) {
 	}
 }
 
+func TestIsYYYYMM(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "valid month", value: "2026-04", want: true},
+		{name: "missing zero padding", value: "2026-4", want: false},
+		{name: "invalid month", value: "2026-13", want: false},
+		{name: "wrong separator", value: "2026/04", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsYYYYMM(tt.value); got != tt.want {
+				t.Fatalf("IsYYYYMM(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 func intPtr(v int) *int {
 	return &v
 }

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -182,7 +182,7 @@ func routePolicies(authzRepos AuthorizationRepositories) []routePolicy {
 		{method: "POST", path: "/api/v1/attachments/upload-url", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "DELETE", path: "/api/v1/attachments/:id", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByAttachmentID, apperr.ErrAttachmentNotFound)},
 
-		{method: "GET", path: "/api/v1/bills", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}},
+		{method: "GET", path: "/api/v1/bills", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}, propertyResolver: middleware.QueryPropertyID("property_id")},
 		{method: "GET", path: "/api/v1/bills/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByBillID, apperr.ErrBillNotFound)},
 		{method: "POST", path: "/api/v1/bills/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByBillID, apperr.ErrBillNotFound)},
 		{method: "GET", path: "/api/v1/bills/:id", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByBillID, apperr.ErrBillNotFound)},

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -2151,11 +2151,13 @@ func TestDeletePropertyReturnsOccupiedRoomDetails(t *testing.T) {
 
 func TestGetBillResolvesPropertyAccessThroughOwnershipQuery(t *testing.T) {
 	repo := fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}}
-	engine := newTestEngine(repo, fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}}, fakePropertyRepo{}, fakeResourceOwnershipRepo{
+	var capturedBillID string
+	engine := newTestEngineWithBilling(repo, fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}}, fakePropertyRepo{}, fakeResourceOwnershipRepo{
 		propertyByBillID: map[string]string{
 			testBillID1: testPropertyID1,
 		},
-	}, "", fakeJobRunsRepo{})
+		billIDLookup: &capturedBillID,
+	}, "", fakeJobRunsRepo{}, handler.BillingServices{Query: fakeBillingQuery{}})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/bills/"+testBillID1, nil)
 	req.Header.Set("Authorization", "Bearer valid-token")
@@ -2163,8 +2165,11 @@ func TestGetBillResolvesPropertyAccessThroughOwnershipQuery(t *testing.T) {
 
 	engine.ServeHTTP(resp, req)
 
-	if resp.Code != http.StatusInternalServerError {
-		t.Fatalf("expected 500, got %d: %s", resp.Code, resp.Body.String())
+	if capturedBillID != testBillID1 {
+		t.Fatalf("ownership lookup bill id = %q, want %q", capturedBillID, testBillID1)
+	}
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
 	}
 }
 
@@ -2975,6 +2980,7 @@ type fakeResourceOwnershipRepo struct {
 	propertyByTenantID           map[string]string
 	propertyByLeaseID            map[string]string
 	propertyByBillID             map[string]string
+	billIDLookup                 *string
 	propertyByJournalLogID       map[string]string
 	propertyByRepairRequestID    map[string]string
 	propertyByForceTerminationID map[string]string
@@ -2994,6 +3000,16 @@ type customClaimsCall struct {
 	firebaseUID         string
 	role                string
 	assignedPropertyIDs []string
+}
+
+type fakeBillingQuery struct{}
+
+func (fakeBillingQuery) ListBills(_ context.Context, _ handler.BillingListInput) ([]handler.BillingBill, error) {
+	return nil, nil
+}
+
+func (fakeBillingQuery) GetBill(_ context.Context, _ handler.BillingGetInput) (*handler.BillingBill, error) {
+	return nil, apperr.ErrBillNotFound
 }
 
 type testUserAccountRepositoryAdapter struct {
@@ -4131,6 +4147,9 @@ func (f fakeResourceOwnershipRepo) FindPropertyIDByLeaseID(_ context.Context, le
 }
 
 func (f fakeResourceOwnershipRepo) FindPropertyIDByBillID(_ context.Context, billID string) (string, error) {
+	if f.billIDLookup != nil {
+		*f.billIDLookup = billID
+	}
 	return lookupPropertyID(f.propertyByBillID, billID)
 }
 
@@ -4191,6 +4210,24 @@ func newTestEngine(userRepo fakeUserRepo, authenticator fakeAuthenticator, prope
 		fakePropertyQueryRepo{},
 		fakeLeaseQueryRepo{},
 		fakeTenantQueryRepo{},
+	)
+}
+
+func newTestEngineWithBilling(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, billing handler.BillingServices) *gin.Engine {
+	return newTestEngineWithAllServices(
+		userRepo,
+		authenticator,
+		propertyRepo,
+		ownershipRepo,
+		schedulerKey,
+		jobRunsRepo,
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
+		fakeTenantQueryRepo{},
+		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		handler.LeaseCommandServices{Billing: billing},
 	)
 }
 

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -2163,8 +2163,33 @@ func TestGetBillResolvesPropertyAccessThroughOwnershipQuery(t *testing.T) {
 
 	engine.ServeHTTP(resp, req)
 
-	if resp.Code != http.StatusNotImplemented {
-		t.Fatalf("expected 501, got %d: %s", resp.Code, resp.Body.String())
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestListBillsRejectsUnassignedPropertyFilter(t *testing.T) {
+	engine := newTestEngine(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID2}},
+		fakePropertyRepo{
+			ownerByPropertyID: map[string]string{
+				testPropertyID1: "owner-1",
+			},
+		},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/bills?property_id="+testPropertyID1, nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
 	}
 }
 

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -143,7 +143,7 @@ func (r *SQLRepository) ListAccessible(ctx context.Context, scope Scope, filter 
 }
 
 // FindByIDAccessible returns one visible bill. Pending electricity bills with a NULL
-// previous reading receive a display value from the previous completed bill, or 0.
+// previous reading receive the previous completed bill reading when one exists.
 func (r *SQLRepository) FindByIDAccessible(ctx context.Context, billID string, scope Scope) (*Bill, error) {
 	filter := BillFilter{Limit: 1}
 	query, args, ok := buildAccessibleBillQuery(scope, filter, true, &billID)
@@ -165,7 +165,7 @@ func (r *SQLRepository) FindByIDAccessible(ctx context.Context, billID string, s
 			if !errors.Is(err, ErrNotFound) {
 				return nil, err
 			}
-			previous = 0
+			return bill, nil
 		}
 		bill.MeterPreviousReading = &previous
 	}
@@ -219,16 +219,16 @@ FOR UPDATE
 
 // FindPreviousMeterReading returns the prior completed electricity reading for a room.
 func (r *SQLRepository) FindPreviousMeterReading(ctx context.Context, roomID string, periodStart time.Time) (int, error) {
-	return r.findPreviousMeterReading(ctx, r.db, roomID, periodStart)
+	return r.findPreviousMeterReading(ctx, r.db, roomID, periodStart, false)
 }
 
 // FindPreviousMeterReadingForUpdate returns the prior completed electricity reading inside a transaction.
 func (r *SQLRepository) FindPreviousMeterReadingForUpdate(ctx context.Context, tx *sql.Tx, roomID string, periodStart time.Time) (int, error) {
-	return r.findPreviousMeterReading(ctx, tx, roomID, periodStart)
+	return r.findPreviousMeterReading(ctx, tx, roomID, periodStart, true)
 }
 
-func (r *SQLRepository) findPreviousMeterReading(ctx context.Context, queryer rowQueryer, roomID string, periodStart time.Time) (int, error) {
-	const query = `
+func (r *SQLRepository) findPreviousMeterReading(ctx context.Context, queryer rowQueryer, roomID string, periodStart time.Time, forUpdate bool) (int, error) {
+	query := `
 SELECT meter_current_reading
 FROM bills
 WHERE room_id = $1
@@ -239,6 +239,9 @@ WHERE room_id = $1
 ORDER BY period_end DESC, due_date DESC, created_at DESC
 LIMIT 1
 `
+	if forUpdate {
+		query += "FOR UPDATE\n"
+	}
 
 	var reading int
 	if err := queryer.QueryRowContext(ctx, query, roomID, periodStart).Scan(&reading); err != nil {

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -111,7 +111,7 @@ func NewRepository(db *sql.DB) *SQLRepository {
 }
 
 // ListAccessible returns active bills visible to the provided scope.
-func (r *SQLRepository) ListAccessible(ctx context.Context, scope Scope, filter BillFilter) ([]Bill, error) {
+func (r *SQLRepository) ListAccessible(ctx context.Context, scope Scope, filter BillFilter) (bills []Bill, err error) {
 	query, args, ok := buildAccessibleBillQuery(scope, filter, false, nil)
 	if !ok {
 		return []Bill{}, nil
@@ -121,9 +121,13 @@ func (r *SQLRepository) ListAccessible(ctx context.Context, scope Scope, filter 
 	if err != nil {
 		return nil, fmt.Errorf("list accessible bills: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close bill rows: %w", cerr)
+		}
+	}()
 
-	bills := make([]Bill, 0)
+	bills = make([]Bill, 0)
 	for rows.Next() {
 		bill, err := scanBill(rows)
 		if err != nil {

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -1,0 +1,605 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var (
+	// ErrNotFound indicates that no active row matched the requested lookup.
+	ErrNotFound = errors.New("billing repository not found")
+	// ErrConcurrentUpdate indicates that an optimistic-lock update matched no row.
+	ErrConcurrentUpdate = errors.New("billing repository concurrent update")
+)
+
+// Scope contains the persistence-level access information needed by bill queries.
+type Scope struct {
+	Role                string
+	UserID              string
+	AssignedPropertyIDs []string
+}
+
+// BillFilter contains optional list filters.
+type BillFilter struct {
+	PropertyID *string
+	LeaseID    *string
+	TenantID   *string
+	Status     *string
+	Month      *string
+	Limit      int
+	Offset     int
+}
+
+// Bill is the billing read and mutation model persisted in PostgreSQL.
+type Bill struct {
+	ID                   string
+	LeaseID              string
+	TenantID             string
+	RoomID               string
+	PropertyID           string
+	Type                 string
+	Amount               *int
+	PeriodStart          time.Time
+	PeriodEnd            time.Time
+	DueDate              time.Time
+	Status               string
+	PaymentMethod        *string
+	PaidAt               *time.Time
+	PaidAmount           *int
+	MeterPreviousReading *int
+	MeterCurrentReading  *int
+	MeterUnitPrice       *float64
+	MeterRecordedAt      *time.Time
+	WrittenOffReason     *string
+	OverdueNoticeCount   int
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	Version              int
+}
+
+// UpdateMeterParams contains the fields persisted after recording electricity meter usage.
+type UpdateMeterParams struct {
+	BillID               string
+	Version              int
+	MeterPreviousReading int
+	MeterCurrentReading  int
+	MeterUnitPrice       float64
+	MeterRecordedAt      time.Time
+	Amount               int
+}
+
+// UpdatePaymentParams contains the fields persisted after collecting payment.
+type UpdatePaymentParams struct {
+	BillID        string
+	Version       int
+	PaymentMethod string
+	PaidAmount    int
+	PaidAt        time.Time
+}
+
+// PropertyAccount is the accounting account attached to a property.
+type PropertyAccount struct {
+	ID         string
+	PropertyID string
+	Version    int
+}
+
+// CreateAccountingEntryParams contains one accounting entry insert.
+type CreateAccountingEntryParams struct {
+	PropertyAccountID string
+	Category          string
+	Amount            int
+	Description       *string
+	SourceRef         map[string]any
+	Year              int
+	Month             int
+}
+
+// SQLRepository persists and reads billing data from PostgreSQL.
+type SQLRepository struct {
+	db *sql.DB
+}
+
+// NewRepository returns a PostgreSQL-backed billing repository.
+func NewRepository(db *sql.DB) *SQLRepository {
+	return &SQLRepository{db: db}
+}
+
+// ListAccessible returns active bills visible to the provided scope.
+func (r *SQLRepository) ListAccessible(ctx context.Context, scope Scope, filter BillFilter) ([]Bill, error) {
+	query, args, ok := buildAccessibleBillQuery(scope, filter, false, nil)
+	if !ok {
+		return []Bill{}, nil
+	}
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list accessible bills: %w", err)
+	}
+	defer rows.Close()
+
+	bills := make([]Bill, 0)
+	for rows.Next() {
+		bill, err := scanBill(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan bill row: %w", err)
+		}
+		bills = append(bills, *bill)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate bill rows: %w", err)
+	}
+
+	return bills, nil
+}
+
+// FindByIDAccessible returns one visible bill. Pending electricity bills with a NULL
+// previous reading receive a display value from the previous completed bill, or 0.
+func (r *SQLRepository) FindByIDAccessible(ctx context.Context, billID string, scope Scope) (*Bill, error) {
+	filter := BillFilter{Limit: 1}
+	query, args, ok := buildAccessibleBillQuery(scope, filter, true, &billID)
+	if !ok {
+		return nil, ErrNotFound
+	}
+
+	bill, err := scanBill(r.db.QueryRowContext(ctx, query, args...))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find accessible bill by id: %w", err)
+	}
+
+	if bill.Type == "electricity" && bill.MeterPreviousReading == nil {
+		previous, err := r.FindPreviousMeterReading(ctx, bill.RoomID, bill.PeriodStart)
+		if err != nil {
+			if !errors.Is(err, ErrNotFound) {
+				return nil, err
+			}
+			previous = 0
+		}
+		bill.MeterPreviousReading = &previous
+	}
+
+	return bill, nil
+}
+
+// GetBillForUpdate locks an active bill for mutation.
+func (r *SQLRepository) GetBillForUpdate(ctx context.Context, tx *sql.Tx, billID string) (*Bill, error) {
+	const query = `
+SELECT
+	b.id,
+	b.lease_id,
+	b.tenant_id,
+	b.room_id,
+	b.property_id,
+	b.type,
+	b.amount,
+	b.period_start,
+	b.period_end,
+	b.due_date,
+	b.status,
+	b.payment_method,
+	b.paid_at,
+	b.paid_amount,
+	b.meter_previous_reading,
+	b.meter_current_reading,
+	b.meter_unit_price,
+	b.meter_recorded_at,
+	b.written_off_reason,
+	b.overdue_notice_count,
+	b.created_at,
+	b.updated_at,
+	b.version
+FROM bills b
+WHERE b.id = $1
+  AND b.deleted_at IS NULL
+FOR UPDATE
+`
+
+	bill, err := scanBill(tx.QueryRowContext(ctx, query, billID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get bill for update: %w", err)
+	}
+
+	return bill, nil
+}
+
+// FindPreviousMeterReading returns the prior completed electricity reading for a room.
+func (r *SQLRepository) FindPreviousMeterReading(ctx context.Context, roomID string, periodStart time.Time) (int, error) {
+	return r.findPreviousMeterReading(ctx, r.db, roomID, periodStart)
+}
+
+// FindPreviousMeterReadingForUpdate returns the prior completed electricity reading inside a transaction.
+func (r *SQLRepository) FindPreviousMeterReadingForUpdate(ctx context.Context, tx *sql.Tx, roomID string, periodStart time.Time) (int, error) {
+	return r.findPreviousMeterReading(ctx, tx, roomID, periodStart)
+}
+
+func (r *SQLRepository) findPreviousMeterReading(ctx context.Context, queryer rowQueryer, roomID string, periodStart time.Time) (int, error) {
+	const query = `
+SELECT meter_current_reading
+FROM bills
+WHERE room_id = $1
+  AND type = 'electricity'
+  AND meter_current_reading IS NOT NULL
+  AND period_end < $2
+  AND deleted_at IS NULL
+ORDER BY period_end DESC, due_date DESC, created_at DESC
+LIMIT 1
+`
+
+	var reading int
+	if err := queryer.QueryRowContext(ctx, query, roomID, periodStart).Scan(&reading); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, ErrNotFound
+		}
+		return 0, fmt.Errorf("find previous meter reading: %w", err)
+	}
+
+	return reading, nil
+}
+
+// FindPropertyElectricityUnitPrice returns the active property's unit price, preserving NULL as nil.
+func (r *SQLRepository) FindPropertyElectricityUnitPrice(ctx context.Context, propertyID string) (*float64, error) {
+	return r.findPropertyElectricityUnitPrice(ctx, r.db, propertyID)
+}
+
+// FindPropertyElectricityUnitPriceForUpdate returns the active property's unit price inside a transaction.
+func (r *SQLRepository) FindPropertyElectricityUnitPriceForUpdate(ctx context.Context, tx *sql.Tx, propertyID string) (*float64, error) {
+	return r.findPropertyElectricityUnitPrice(ctx, tx, propertyID)
+}
+
+func (r *SQLRepository) findPropertyElectricityUnitPrice(ctx context.Context, queryer rowQueryer, propertyID string) (*float64, error) {
+	const query = `
+SELECT electricity_unit_price
+FROM properties
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+
+	var unitPrice sql.NullFloat64
+	if err := queryer.QueryRowContext(ctx, query, propertyID).Scan(&unitPrice); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find property electricity unit price: %w", err)
+	}
+	if !unitPrice.Valid {
+		return nil, nil
+	}
+
+	return &unitPrice.Float64, nil
+}
+
+// UpdateMeter records meter details and moves the bill to pending payment.
+func (r *SQLRepository) UpdateMeter(ctx context.Context, tx *sql.Tx, params UpdateMeterParams) error {
+	const query = `
+UPDATE bills
+SET meter_previous_reading = $3,
+    meter_current_reading = $4,
+    meter_unit_price = $5,
+    meter_recorded_at = $6,
+    amount = $7,
+    status = 'pending_payment',
+    updated_at = now(),
+    version = version + 1
+WHERE id = $1
+  AND version = $2
+  AND deleted_at IS NULL
+`
+
+	result, err := tx.ExecContext(ctx, query,
+		params.BillID,
+		params.Version,
+		params.MeterPreviousReading,
+		params.MeterCurrentReading,
+		params.MeterUnitPrice,
+		params.MeterRecordedAt,
+		params.Amount,
+	)
+	if err != nil {
+		return fmt.Errorf("update bill meter: %w", err)
+	}
+
+	if err := ensureUpdated(result); err != nil {
+		if errors.Is(err, ErrConcurrentUpdate) {
+			return err
+		}
+		return fmt.Errorf("update bill meter: %w", err)
+	}
+
+	return nil
+}
+
+// UpdatePayment records payment details and moves the bill to paid.
+func (r *SQLRepository) UpdatePayment(ctx context.Context, tx *sql.Tx, params UpdatePaymentParams) error {
+	const query = `
+UPDATE bills
+SET payment_method = $3,
+    paid_amount = $4,
+    paid_at = $5,
+    status = 'paid',
+    updated_at = now(),
+    version = version + 1
+WHERE id = $1
+  AND version = $2
+  AND deleted_at IS NULL
+`
+
+	result, err := tx.ExecContext(ctx, query,
+		params.BillID,
+		params.Version,
+		params.PaymentMethod,
+		params.PaidAmount,
+		params.PaidAt,
+	)
+	if err != nil {
+		return fmt.Errorf("update bill payment: %w", err)
+	}
+
+	if err := ensureUpdated(result); err != nil {
+		if errors.Is(err, ErrConcurrentUpdate) {
+			return err
+		}
+		return fmt.Errorf("update bill payment: %w", err)
+	}
+
+	return nil
+}
+
+// FindPropertyAccountByPropertyID returns the active accounting account for a property.
+func (r *SQLRepository) FindPropertyAccountByPropertyID(ctx context.Context, tx *sql.Tx, propertyID string) (*PropertyAccount, error) {
+	const query = `
+SELECT id, property_id, version
+FROM property_accounts
+WHERE property_id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+
+	var account PropertyAccount
+	if err := tx.QueryRowContext(ctx, query, propertyID).Scan(&account.ID, &account.PropertyID, &account.Version); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find property account by property id: %w", err)
+	}
+
+	return &account, nil
+}
+
+// InsertAccountingEntry inserts one income entry for a bill payment.
+func (r *SQLRepository) InsertAccountingEntry(ctx context.Context, tx *sql.Tx, params CreateAccountingEntryParams) error {
+	sourceRef, err := json.Marshal(params.SourceRef)
+	if err != nil {
+		return fmt.Errorf("marshal accounting source ref: %w", err)
+	}
+
+	const query = `
+INSERT INTO accounting_entries (
+	property_account_id,
+	category,
+	amount,
+	description,
+	source_ref,
+	year,
+	month
+) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)
+`
+
+	if _, err := tx.ExecContext(ctx, query,
+		params.PropertyAccountID,
+		params.Category,
+		params.Amount,
+		nullableString(params.Description),
+		string(sourceRef),
+		params.Year,
+		params.Month,
+	); err != nil {
+		return fmt.Errorf("insert accounting entry: %w", err)
+	}
+
+	return nil
+}
+
+func buildAccessibleBillQuery(scope Scope, filter BillFilter, single bool, billID *string) (string, []any, bool) {
+	base := `
+SELECT
+	b.id,
+	b.lease_id,
+	b.tenant_id,
+	b.room_id,
+	b.property_id,
+	b.type,
+	b.amount,
+	b.period_start,
+	b.period_end,
+	b.due_date,
+	b.status,
+	b.payment_method,
+	b.paid_at,
+	b.paid_amount,
+	b.meter_previous_reading,
+	b.meter_current_reading,
+	b.meter_unit_price,
+	b.meter_recorded_at,
+	b.written_off_reason,
+	b.overdue_notice_count,
+	b.created_at,
+	b.updated_at,
+	b.version
+FROM bills b
+`
+	args := []any{}
+	joins := []string{}
+	conditions := []string{"b.deleted_at IS NULL"}
+	if billID != nil {
+		args = append(args, *billID)
+		conditions = append([]string{fmt.Sprintf("b.id = $%d", len(args))}, conditions...)
+	}
+
+	switch strings.TrimSpace(scope.Role) {
+	case "admin":
+	case "organizer", "staff":
+		if len(scope.AssignedPropertyIDs) == 0 {
+			return "", nil, false
+		}
+		placeholders := make([]string, 0, len(scope.AssignedPropertyIDs))
+		for _, id := range scope.AssignedPropertyIDs {
+			args = append(args, id)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		conditions = append(conditions, "b.property_id IN ("+strings.Join(placeholders, ", ")+")")
+	case "owner":
+		joins = append(joins, "JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL")
+		args = append(args, scope.UserID)
+		conditions = append(conditions, fmt.Sprintf("p.owner_id = $%d", len(args)))
+	default:
+		return "", nil, false
+	}
+
+	if filter.PropertyID != nil && strings.TrimSpace(*filter.PropertyID) != "" {
+		args = append(args, strings.TrimSpace(*filter.PropertyID))
+		conditions = append(conditions, fmt.Sprintf("b.property_id = $%d", len(args)))
+	}
+	if filter.LeaseID != nil && strings.TrimSpace(*filter.LeaseID) != "" {
+		args = append(args, strings.TrimSpace(*filter.LeaseID))
+		conditions = append(conditions, fmt.Sprintf("b.lease_id = $%d", len(args)))
+	}
+	if filter.TenantID != nil && strings.TrimSpace(*filter.TenantID) != "" {
+		args = append(args, strings.TrimSpace(*filter.TenantID))
+		conditions = append(conditions, fmt.Sprintf("b.tenant_id = $%d", len(args)))
+	}
+	if filter.Status != nil && strings.TrimSpace(*filter.Status) != "" {
+		args = append(args, strings.TrimSpace(*filter.Status))
+		conditions = append(conditions, fmt.Sprintf("b.status = $%d", len(args)))
+	}
+	if filter.Month != nil && strings.TrimSpace(*filter.Month) != "" {
+		args = append(args, strings.TrimSpace(*filter.Month))
+		conditions = append(conditions, fmt.Sprintf("b.due_date >= to_date($%d, 'YYYY-MM')", len(args)))
+		conditions = append(conditions, fmt.Sprintf("b.due_date < to_date($%d, 'YYYY-MM') + INTERVAL '1 month'", len(args)))
+	}
+
+	if len(joins) > 0 {
+		base += strings.Join(joins, "\n") + "\n"
+	}
+	base += "WHERE " + strings.Join(conditions, "\n  AND ")
+	if single {
+		base += "\nLIMIT 1"
+		return base, args, true
+	}
+
+	args = append(args, filter.Limit, filter.Offset)
+	base += fmt.Sprintf("\nORDER BY b.due_date DESC, b.created_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
+	return base, args, true
+}
+
+func scanBill(row rowScanner) (*Bill, error) {
+	var bill Bill
+	var amount sql.NullInt64
+	var paymentMethod sql.NullString
+	var paidAt sql.NullTime
+	var paidAmount sql.NullInt64
+	var meterPreviousReading sql.NullInt64
+	var meterCurrentReading sql.NullInt64
+	var meterUnitPrice sql.NullFloat64
+	var meterRecordedAt sql.NullTime
+	var writtenOffReason sql.NullString
+
+	if err := row.Scan(
+		&bill.ID,
+		&bill.LeaseID,
+		&bill.TenantID,
+		&bill.RoomID,
+		&bill.PropertyID,
+		&bill.Type,
+		&amount,
+		&bill.PeriodStart,
+		&bill.PeriodEnd,
+		&bill.DueDate,
+		&bill.Status,
+		&paymentMethod,
+		&paidAt,
+		&paidAmount,
+		&meterPreviousReading,
+		&meterCurrentReading,
+		&meterUnitPrice,
+		&meterRecordedAt,
+		&writtenOffReason,
+		&bill.OverdueNoticeCount,
+		&bill.CreatedAt,
+		&bill.UpdatedAt,
+		&bill.Version,
+	); err != nil {
+		return nil, err
+	}
+
+	if amount.Valid {
+		value := int(amount.Int64)
+		bill.Amount = &value
+	}
+	if paymentMethod.Valid {
+		bill.PaymentMethod = &paymentMethod.String
+	}
+	if paidAt.Valid {
+		bill.PaidAt = &paidAt.Time
+	}
+	if paidAmount.Valid {
+		value := int(paidAmount.Int64)
+		bill.PaidAmount = &value
+	}
+	if meterPreviousReading.Valid {
+		value := int(meterPreviousReading.Int64)
+		bill.MeterPreviousReading = &value
+	}
+	if meterCurrentReading.Valid {
+		value := int(meterCurrentReading.Int64)
+		bill.MeterCurrentReading = &value
+	}
+	if meterUnitPrice.Valid {
+		bill.MeterUnitPrice = &meterUnitPrice.Float64
+	}
+	if meterRecordedAt.Valid {
+		bill.MeterRecordedAt = &meterRecordedAt.Time
+	}
+	if writtenOffReason.Valid {
+		bill.WrittenOffReason = &writtenOffReason.String
+	}
+
+	return &bill, nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+type rowQueryer interface {
+	QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
+}
+
+func ensureUpdated(result sql.Result) error {
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read rows affected: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrConcurrentUpdate
+	}
+	return nil
+}
+
+func nullableString(value *string) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -130,7 +130,7 @@ LIMIT 1
 	}
 }
 
-func TestFindByIDAccessibleDefaultsPreviousReadingToZeroWhenNoHistory(t *testing.T) {
+func TestFindByIDAccessiblePreservesNilPreviousReadingWhenNoHistory(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)
 
@@ -151,8 +151,8 @@ func TestFindByIDAccessibleDefaultsPreviousReadingToZeroWhenNoHistory(t *testing
 	if err != nil {
 		t.Fatalf("FindByIDAccessible: %v", err)
 	}
-	if bill.MeterPreviousReading == nil || *bill.MeterPreviousReading != 0 {
-		t.Fatalf("MeterPreviousReading = %v, want 0", bill.MeterPreviousReading)
+	if bill.MeterPreviousReading != nil {
+		t.Fatalf("MeterPreviousReading = %v, want nil", bill.MeterPreviousReading)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -208,6 +208,7 @@ WHERE room_id = $1
   AND deleted_at IS NULL
 ORDER BY period_end DESC, due_date DESC, created_at DESC
 LIMIT 1
+FOR UPDATE
 `)).
 		WithArgs("room-1", periodStart).
 		WillReturnRows(sqlmock.NewRows([]string{"meter_current_reading"}).AddRow(1250))

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -1,0 +1,406 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestListAccessibleOwnerScopeReturnsOwnedBills(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`(?s)FROM bills b\s+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL\s+WHERE b.deleted_at IS NULL\s+AND p.owner_id = \$1\s+ORDER BY b.due_date DESC, b.created_at DESC LIMIT \$2 OFFSET \$3`).
+		WithArgs("user-1", 10, 0).
+		WillReturnRows(billRows().AddRow(
+			"bill-1", "lease-1", "tenant-1", "room-1", "property-owned", "rent", 12000,
+			now, now, now, "pending_payment", nil, nil, nil, nil, nil, nil, nil, nil, 0, now, now, 1,
+		))
+
+	bills, err := repo.ListAccessible(context.Background(), Scope{Role: "owner", UserID: "user-1"}, BillFilter{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListAccessible: %v", err)
+	}
+	if len(bills) != 1 {
+		t.Fatalf("expected 1 bill, got %d", len(bills))
+	}
+	if bills[0].PropertyID != "property-owned" {
+		t.Fatalf("PropertyID = %q, want property-owned", bills[0].PropertyID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListAccessibleOrganizerWithNoAssignedPropertiesReturnsEmpty(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	bills, err := repo.ListAccessible(context.Background(), Scope{Role: "organizer"}, BillFilter{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListAccessible: %v", err)
+	}
+	if len(bills) != 0 {
+		t.Fatalf("expected no bills, got %d", len(bills))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListAccessibleAppliesFiltersAndPagination(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	propertyID := "property-1"
+	leaseID := "lease-1"
+	tenantID := "tenant-1"
+	status := "pending_payment"
+	month := "2026-04"
+
+	mock.ExpectQuery(`(?s)b.property_id IN \(\$1\).*b.property_id = \$2.*b.lease_id = \$3.*b.tenant_id = \$4.*b.status = \$5.*b.due_date >= to_date\(\$6, 'YYYY-MM'\).*b.due_date < to_date\(\$6, 'YYYY-MM'\) \+ INTERVAL '1 month'.*LIMIT \$7 OFFSET \$8`).
+		WithArgs("property-1", propertyID, leaseID, tenantID, status, month, 25, 50).
+		WillReturnRows(billRows())
+
+	_, err := repo.ListAccessible(context.Background(), Scope{
+		Role:                "staff",
+		AssignedPropertyIDs: []string{"property-1"},
+	}, BillFilter{
+		PropertyID: &propertyID,
+		LeaseID:    &leaseID,
+		TenantID:   &tenantID,
+		Status:     &status,
+		Month:      &month,
+		Limit:      25,
+		Offset:     50,
+	})
+	if err != nil {
+		t.Fatalf("ListAccessible: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindByIDAccessibleComputesPreviousReadingWhenMissing(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`(?s)WHERE b.id = \$1\s+AND b.deleted_at IS NULL\s+LIMIT 1`).
+		WithArgs("bill-1").
+		WillReturnRows(billRows().AddRow(
+			"bill-1", "lease-1", "tenant-1", "room-1", "property-1", "electricity", nil,
+			periodStart, time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC), now, "pending_meter",
+			nil, nil, nil, nil, nil, nil, nil, nil, 0, now, now, 1,
+		))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT meter_current_reading
+FROM bills
+WHERE room_id = $1
+  AND type = 'electricity'
+  AND meter_current_reading IS NOT NULL
+  AND period_end < $2
+  AND deleted_at IS NULL
+ORDER BY period_end DESC, due_date DESC, created_at DESC
+LIMIT 1
+`)).
+		WithArgs("room-1", periodStart).
+		WillReturnRows(sqlmock.NewRows([]string{"meter_current_reading"}).AddRow(1250))
+
+	bill, err := repo.FindByIDAccessible(context.Background(), "bill-1", Scope{Role: "admin"})
+	if err != nil {
+		t.Fatalf("FindByIDAccessible: %v", err)
+	}
+	if bill.MeterPreviousReading == nil || *bill.MeterPreviousReading != 1250 {
+		t.Fatalf("MeterPreviousReading = %v, want 1250", bill.MeterPreviousReading)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindByIDAccessibleDefaultsPreviousReadingToZeroWhenNoHistory(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`(?s)WHERE b.id = \$1\s+AND b.deleted_at IS NULL\s+LIMIT 1`).
+		WithArgs("bill-1").
+		WillReturnRows(billRows().AddRow(
+			"bill-1", "lease-1", "tenant-1", "room-1", "property-1", "electricity", nil,
+			periodStart, time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC), now, "pending_meter",
+			nil, nil, nil, nil, nil, nil, nil, nil, 0, now, now, 1,
+		))
+	mock.ExpectQuery(`(?s)SELECT meter_current_reading\s+FROM bills.*period_end < \$2.*LIMIT 1`).
+		WithArgs("room-1", periodStart).
+		WillReturnError(sql.ErrNoRows)
+
+	bill, err := repo.FindByIDAccessible(context.Background(), "bill-1", Scope{Role: "admin"})
+	if err != nil {
+		t.Fatalf("FindByIDAccessible: %v", err)
+	}
+	if bill.MeterPreviousReading == nil || *bill.MeterPreviousReading != 0 {
+		t.Fatalf("MeterPreviousReading = %v, want 0", bill.MeterPreviousReading)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPreviousMeterReadingChoosesLatestSameRoomCompletedElectricityBill(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT meter_current_reading
+FROM bills
+WHERE room_id = $1
+  AND type = 'electricity'
+  AND meter_current_reading IS NOT NULL
+  AND period_end < $2
+  AND deleted_at IS NULL
+ORDER BY period_end DESC, due_date DESC, created_at DESC
+LIMIT 1
+`)).
+		WithArgs("room-1", periodStart).
+		WillReturnRows(sqlmock.NewRows([]string{"meter_current_reading"}).AddRow(1250))
+
+	reading, err := repo.FindPreviousMeterReading(context.Background(), "room-1", periodStart)
+	if err != nil {
+		t.Fatalf("FindPreviousMeterReading: %v", err)
+	}
+	if reading != 1250 {
+		t.Fatalf("reading = %d, want 1250", reading)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPreviousMeterReadingForUpdateUsesTransaction(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	tx := beginBillingTx(t, db, mock)
+	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT meter_current_reading
+FROM bills
+WHERE room_id = $1
+  AND type = 'electricity'
+  AND meter_current_reading IS NOT NULL
+  AND period_end < $2
+  AND deleted_at IS NULL
+ORDER BY period_end DESC, due_date DESC, created_at DESC
+LIMIT 1
+`)).
+		WithArgs("room-1", periodStart).
+		WillReturnRows(sqlmock.NewRows([]string{"meter_current_reading"}).AddRow(1250))
+	mock.ExpectCommit()
+
+	reading, err := repo.FindPreviousMeterReadingForUpdate(context.Background(), tx, "room-1", periodStart)
+	if err != nil {
+		t.Fatalf("FindPreviousMeterReadingForUpdate: %v", err)
+	}
+	if reading != 1250 {
+		t.Fatalf("reading = %d, want 1250", reading)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPropertyElectricityUnitPriceForUpdateUsesTransaction(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	tx := beginBillingTx(t, db, mock)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT electricity_unit_price
+FROM properties
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("property-1").
+		WillReturnRows(sqlmock.NewRows([]string{"electricity_unit_price"}).AddRow(4.5))
+	mock.ExpectCommit()
+
+	unitPrice, err := repo.FindPropertyElectricityUnitPriceForUpdate(context.Background(), tx, "property-1")
+	if err != nil {
+		t.Fatalf("FindPropertyElectricityUnitPriceForUpdate: %v", err)
+	}
+	if unitPrice == nil || *unitPrice != 4.5 {
+		t.Fatalf("unitPrice = %v, want 4.5", unitPrice)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdateMeterRowsAffectedZeroMapsToConcurrentSentinel(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	tx := beginBillingTx(t, db, mock)
+	recordedAt := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	mock.ExpectExec(`(?s)UPDATE bills\s+SET meter_previous_reading = \$3,.*status = 'pending_payment'.*WHERE id = \$1\s+AND version = \$2`).
+		WithArgs("bill-1", 1, 1250, 1380, 4.5, recordedAt, 585).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	err := repo.UpdateMeter(context.Background(), tx, UpdateMeterParams{
+		BillID:               "bill-1",
+		Version:              1,
+		MeterPreviousReading: 1250,
+		MeterCurrentReading:  1380,
+		MeterUnitPrice:       4.5,
+		MeterRecordedAt:      recordedAt,
+		Amount:               585,
+	})
+	if !errors.Is(err, ErrConcurrentUpdate) {
+		t.Fatalf("expected ErrConcurrentUpdate, got %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdatePaymentRowsAffectedZeroMapsToConcurrentSentinel(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	tx := beginBillingTx(t, db, mock)
+	paidAt := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
+	mock.ExpectExec(`(?s)UPDATE bills\s+SET payment_method = \$3,.*status = 'paid'.*WHERE id = \$1\s+AND version = \$2`).
+		WithArgs("bill-1", 1, "transfer", 585, paidAt).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	err := repo.UpdatePayment(context.Background(), tx, UpdatePaymentParams{
+		BillID:        "bill-1",
+		Version:       1,
+		PaymentMethod: "transfer",
+		PaidAmount:    585,
+		PaidAt:        paidAt,
+	})
+	if !errors.Is(err, ErrConcurrentUpdate) {
+		t.Fatalf("expected ErrConcurrentUpdate, got %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestInsertAccountingEntryWritesCategoryAmountSourceRefYearAndMonth(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer db.Close()
+
+	tx := beginBillingTx(t, db, mock)
+	description := "bill payment"
+	mock.ExpectExec(`(?s)INSERT INTO accounting_entries \(\s+property_account_id,\s+category,\s+amount,\s+description,\s+source_ref,\s+year,\s+month\s+\) VALUES \(\$1, \$2, \$3, \$4, \$5::jsonb, \$6, \$7\)`).
+		WithArgs("account-1", "rent_income", 12000, description, `{"bill_id":"bill-1"}`, 2026, 4).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := repo.InsertAccountingEntry(context.Background(), tx, CreateAccountingEntryParams{
+		PropertyAccountID: "account-1",
+		Category:          "rent_income",
+		Amount:            12000,
+		Description:       &description,
+		SourceRef:         map[string]any{"bill_id": "bill-1"},
+		Year:              2026,
+		Month:             4,
+	})
+	if err != nil {
+		t.Fatalf("InsertAccountingEntry: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func newBillingRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+
+	return db, mock, NewRepository(db)
+}
+
+func beginBillingTx(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.Tx {
+	t.Helper()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	return tx
+}
+
+func billRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"lease_id",
+		"tenant_id",
+		"room_id",
+		"property_id",
+		"type",
+		"amount",
+		"period_start",
+		"period_end",
+		"due_date",
+		"status",
+		"payment_method",
+		"paid_at",
+		"paid_amount",
+		"meter_previous_reading",
+		"meter_current_reading",
+		"meter_unit_price",
+		"meter_recorded_at",
+		"written_off_reason",
+		"overdue_notice_count",
+		"created_at",
+		"updated_at",
+		"version",
+	})
+}

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestListAccessibleOwnerScopeReturnsOwnedBills(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
 	mock.ExpectQuery(`(?s)FROM bills b\s+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL\s+WHERE b.deleted_at IS NULL\s+AND p.owner_id = \$1\s+ORDER BY b.due_date DESC, b.created_at DESC LIMIT \$2 OFFSET \$3`).
@@ -41,7 +41,7 @@ func TestListAccessibleOwnerScopeReturnsOwnedBills(t *testing.T) {
 
 func TestListAccessibleOrganizerWithNoAssignedPropertiesReturnsEmpty(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	bills, err := repo.ListAccessible(context.Background(), Scope{Role: "organizer"}, BillFilter{Limit: 10})
 	if err != nil {
@@ -57,7 +57,7 @@ func TestListAccessibleOrganizerWithNoAssignedPropertiesReturnsEmpty(t *testing.
 
 func TestListAccessibleAppliesFiltersAndPagination(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	propertyID := "property-1"
 	leaseID := "lease-1"
@@ -92,7 +92,7 @@ func TestListAccessibleAppliesFiltersAndPagination(t *testing.T) {
 
 func TestFindByIDAccessibleComputesPreviousReadingWhenMissing(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
@@ -132,7 +132,7 @@ LIMIT 1
 
 func TestFindByIDAccessibleDefaultsPreviousReadingToZeroWhenNoHistory(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
@@ -162,7 +162,7 @@ func TestFindByIDAccessibleDefaultsPreviousReadingToZeroWhenNoHistory(t *testing
 
 func TestFindPreviousMeterReadingChoosesLatestSameRoomCompletedElectricityBill(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	mock.ExpectQuery(regexp.QuoteMeta(`
@@ -194,7 +194,7 @@ LIMIT 1
 
 func TestFindPreviousMeterReadingForUpdateUsesTransaction(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	tx := beginBillingTx(t, db, mock)
 	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
@@ -231,7 +231,7 @@ LIMIT 1
 
 func TestFindPropertyElectricityUnitPriceForUpdateUsesTransaction(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	tx := beginBillingTx(t, db, mock)
 	mock.ExpectQuery(regexp.QuoteMeta(`
@@ -263,7 +263,7 @@ LIMIT 1
 
 func TestUpdateMeterRowsAffectedZeroMapsToConcurrentSentinel(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	tx := beginBillingTx(t, db, mock)
 	recordedAt := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
@@ -295,7 +295,7 @@ func TestUpdateMeterRowsAffectedZeroMapsToConcurrentSentinel(t *testing.T) {
 
 func TestUpdatePaymentRowsAffectedZeroMapsToConcurrentSentinel(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	tx := beginBillingTx(t, db, mock)
 	paidAt := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
@@ -325,7 +325,7 @@ func TestUpdatePaymentRowsAffectedZeroMapsToConcurrentSentinel(t *testing.T) {
 
 func TestInsertAccountingEntryWritesCategoryAmountSourceRefYearAndMonth(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
-	defer db.Close()
+	defer closeBillingDB(t, db)
 
 	tx := beginBillingTx(t, db, mock)
 	description := "bill payment"
@@ -366,11 +366,19 @@ func newBillingRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository)
 	return db, mock, NewRepository(db)
 }
 
+func closeBillingDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	if err := db.Close(); err != nil {
+		t.Logf("db.Close: %v", err)
+	}
+}
+
 func beginBillingTx(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.Tx {
 	t.Helper()
 
 	mock.ExpectBegin()
-	tx, err := db.Begin()
+	tx, err := db.BeginTx(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Begin: %v", err)
 	}

--- a/internal/server/billing_adapters.go
+++ b/internal/server/billing_adapters.go
@@ -175,6 +175,9 @@ func (a billingRepositoryAdapter) FindPreviousElectricityReading(ctx context.Con
 func (a billingRepositoryAdapter) FindPropertyElectricityUnitPrice(ctx context.Context, tx *sql.Tx, propertyID string) (*float64, error) {
 	unitPrice, err := a.repo.FindPropertyElectricityUnitPriceForUpdate(ctx, tx, propertyID)
 	if err != nil {
+		if errors.Is(err, dbbilling.ErrNotFound) {
+			return nil, appbilling.ErrPropertyElectricityUnitPriceNotFound
+		}
 		return nil, mapBillingRepositoryError(err)
 	}
 

--- a/internal/server/billing_adapters.go
+++ b/internal/server/billing_adapters.go
@@ -1,0 +1,324 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	appbilling "stds_backend/internal/application/billing"
+	"stds_backend/internal/http/handler"
+	dbbilling "stds_backend/internal/platform/database/billing"
+	dbtxrunner "stds_backend/internal/platform/database/txrunner"
+)
+
+func newBillingServices(db *sql.DB, txRunner *dbtxrunner.Runner) handler.BillingServices {
+	repo := dbbilling.NewRepository(db)
+	billingRepo := billingRepositoryAdapter{repo: repo}
+	accountingRepo := billingAccountingRepositoryAdapter{repo: repo}
+
+	return handler.BillingServices{
+		Query: billingQueryServiceAdapter{
+			listBills: appbilling.NewListBillsService(billingRepo),
+			getBill:   appbilling.NewGetBillService(billingRepo),
+		},
+		Meter:   billingMeterServiceAdapter{service: appbilling.NewRecordMeterService(billingRepo, txRunner)},
+		Payment: billingPaymentServiceAdapter{service: appbilling.NewRecordPaymentService(billingRepo, accountingRepo, txRunner)},
+	}
+}
+
+type billingQueryServiceAdapter struct {
+	listBills *appbilling.ListBillsService
+	getBill   *appbilling.GetBillService
+}
+
+func (a billingQueryServiceAdapter) ListBills(ctx context.Context, input handler.BillingListInput) ([]handler.BillingBill, error) {
+	var status *string
+	if input.Status != "" {
+		status = &input.Status
+	}
+
+	bills, err := a.listBills.Execute(ctx, appbilling.ListBillsInput{
+		ActorRole:           input.ActorRole,
+		ActorUserID:         input.ActorUserID,
+		AssignedPropertyIDs: input.AssignedPropertyIDs,
+		PropertyID:          input.PropertyID,
+		LeaseID:             input.LeaseID,
+		TenantID:            input.TenantID,
+		Status:              status,
+		Month:               input.Month,
+		Limit:               input.Limit,
+		Offset:              input.Offset,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toHandlerBills(bills), nil
+}
+
+func (a billingQueryServiceAdapter) GetBill(ctx context.Context, input handler.BillingGetInput) (*handler.BillingBill, error) {
+	bill, err := a.getBill.Execute(ctx, appbilling.GetBillInput{
+		ActorRole:           input.ActorRole,
+		ActorUserID:         input.ActorUserID,
+		AssignedPropertyIDs: input.AssignedPropertyIDs,
+		BillID:              input.BillID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toHandlerBill(*bill), nil
+}
+
+type billingMeterServiceAdapter struct {
+	service *appbilling.RecordMeterService
+}
+
+func (a billingMeterServiceAdapter) SubmitBillMeter(ctx context.Context, input handler.BillingMeterInput) (*handler.BillingBill, error) {
+	bill, err := a.service.Execute(ctx, appbilling.RecordMeterInput{
+		ActorRole:      input.ActorRole,
+		BillID:         input.BillID,
+		CurrentReading: input.CurrentReading,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toHandlerBill(*bill), nil
+}
+
+type billingPaymentServiceAdapter struct {
+	service *appbilling.RecordPaymentService
+}
+
+func (a billingPaymentServiceAdapter) RecordBillPayment(ctx context.Context, input handler.BillingPaymentInput) (*handler.BillingBill, error) {
+	bill, err := a.service.Execute(ctx, appbilling.RecordPaymentInput{
+		ActorRole:     input.ActorRole,
+		BillID:        input.BillID,
+		PaidAmount:    input.PaidAmount,
+		PaymentMethod: input.PaymentMethod,
+		PaidAt:        input.PaidAt,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toHandlerBill(*bill), nil
+}
+
+type billingRepositoryAdapter struct {
+	repo *dbbilling.SQLRepository
+}
+
+func (a billingRepositoryAdapter) ListBills(ctx context.Context, query appbilling.ListBillsQuery) ([]appbilling.Bill, error) {
+	var month *string
+	if query.Month != nil {
+		value := query.Month.Format("2006-01")
+		month = &value
+	}
+
+	bills, err := a.repo.ListAccessible(ctx, dbbilling.Scope{
+		Role:                query.ActorRole,
+		UserID:              query.ActorUserID,
+		AssignedPropertyIDs: query.AssignedPropertyIDs,
+	}, dbbilling.BillFilter{
+		PropertyID: query.PropertyID,
+		LeaseID:    query.LeaseID,
+		TenantID:   query.TenantID,
+		Status:     query.Status,
+		Month:      month,
+		Limit:      query.Limit,
+		Offset:     query.Offset,
+	})
+	if err != nil {
+		return nil, mapBillingRepositoryError(err)
+	}
+
+	return toAppBills(bills), nil
+}
+
+func (a billingRepositoryAdapter) FindBillByID(ctx context.Context, query appbilling.GetBillQuery) (*appbilling.Bill, error) {
+	bill, err := a.repo.FindByIDAccessible(ctx, query.BillID, dbbilling.Scope{
+		Role:                query.ActorRole,
+		UserID:              query.ActorUserID,
+		AssignedPropertyIDs: query.AssignedPropertyIDs,
+	})
+	if err != nil {
+		return nil, mapBillingRepositoryError(err)
+	}
+
+	return toAppBill(*bill), nil
+}
+
+func (a billingRepositoryAdapter) FindBillByIDForUpdate(ctx context.Context, tx *sql.Tx, billID string) (*appbilling.Bill, error) {
+	bill, err := a.repo.GetBillForUpdate(ctx, tx, billID)
+	if err != nil {
+		return nil, mapBillingRepositoryError(err)
+	}
+
+	return toAppBill(*bill), nil
+}
+
+func (a billingRepositoryAdapter) FindPreviousElectricityReading(ctx context.Context, tx *sql.Tx, roomID string, beforePeriodStart time.Time) (int, error) {
+	reading, err := a.repo.FindPreviousMeterReadingForUpdate(ctx, tx, roomID, beforePeriodStart)
+	if err != nil {
+		if errors.Is(err, dbbilling.ErrNotFound) {
+			return 0, nil
+		}
+		return 0, mapBillingRepositoryError(err)
+	}
+
+	return reading, nil
+}
+
+func (a billingRepositoryAdapter) FindPropertyElectricityUnitPrice(ctx context.Context, tx *sql.Tx, propertyID string) (*float64, error) {
+	unitPrice, err := a.repo.FindPropertyElectricityUnitPriceForUpdate(ctx, tx, propertyID)
+	if err != nil {
+		return nil, mapBillingRepositoryError(err)
+	}
+
+	return unitPrice, nil
+}
+
+func (a billingRepositoryAdapter) UpdateBillMeter(ctx context.Context, tx *sql.Tx, params appbilling.UpdateMeterParams) (*appbilling.Bill, error) {
+	if err := a.repo.UpdateMeter(ctx, tx, dbbilling.UpdateMeterParams{
+		BillID:               params.BillID,
+		Version:              params.ExpectedVersion,
+		MeterPreviousReading: params.PreviousReading,
+		MeterCurrentReading:  params.CurrentReading,
+		MeterUnitPrice:       params.UnitPrice,
+		MeterRecordedAt:      params.MeterRecordedAt,
+		Amount:               params.Amount,
+	}); err != nil {
+		return nil, mapBillingRepositoryError(err)
+	}
+
+	return a.FindBillByIDForUpdate(ctx, tx, params.BillID)
+}
+
+func (a billingRepositoryAdapter) UpdateBillPayment(ctx context.Context, tx *sql.Tx, params appbilling.UpdatePaymentParams) (*appbilling.Bill, error) {
+	if err := a.repo.UpdatePayment(ctx, tx, dbbilling.UpdatePaymentParams{
+		BillID:        params.BillID,
+		Version:       params.ExpectedVersion,
+		PaymentMethod: params.PaymentMethod,
+		PaidAmount:    params.PaidAmount,
+		PaidAt:        params.PaidAt,
+	}); err != nil {
+		return nil, mapBillingRepositoryError(err)
+	}
+
+	return a.FindBillByIDForUpdate(ctx, tx, params.BillID)
+}
+
+type billingAccountingRepositoryAdapter struct {
+	repo *dbbilling.SQLRepository
+}
+
+func (a billingAccountingRepositoryAdapter) CreateAccountingEntry(ctx context.Context, tx *sql.Tx, params appbilling.AccountingEntryParams) error {
+	account, err := a.repo.FindPropertyAccountByPropertyID(ctx, tx, params.PropertyID)
+	if err != nil {
+		if errors.Is(err, dbbilling.ErrNotFound) {
+			return appbilling.ErrPropertyAccountNotFound
+		}
+
+		return err
+	}
+
+	return a.repo.InsertAccountingEntry(ctx, tx, dbbilling.CreateAccountingEntryParams{
+		PropertyAccountID: account.ID,
+		Category:          params.Category,
+		Amount:            params.Amount,
+		Description:       params.Description,
+		SourceRef:         params.SourceRef,
+		Year:              params.Year,
+		Month:             params.Month,
+	})
+}
+
+func mapBillingRepositoryError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, dbbilling.ErrNotFound):
+		return appbilling.ErrBillNotFound
+	case errors.Is(err, dbbilling.ErrConcurrentUpdate):
+		return appbilling.ErrConcurrentUpdateConflict
+	default:
+		return err
+	}
+}
+
+func toAppBills(bills []dbbilling.Bill) []appbilling.Bill {
+	result := make([]appbilling.Bill, 0, len(bills))
+	for i := range bills {
+		result = append(result, *toAppBill(bills[i]))
+	}
+
+	return result
+}
+
+func toAppBill(bill dbbilling.Bill) *appbilling.Bill {
+	return &appbilling.Bill{
+		ID:                   bill.ID,
+		LeaseID:              bill.LeaseID,
+		TenantID:             bill.TenantID,
+		RoomID:               bill.RoomID,
+		PropertyID:           bill.PropertyID,
+		Type:                 bill.Type,
+		Amount:               bill.Amount,
+		PeriodStart:          bill.PeriodStart,
+		PeriodEnd:            bill.PeriodEnd,
+		DueDate:              bill.DueDate,
+		Status:               bill.Status,
+		PaymentMethod:        bill.PaymentMethod,
+		PaidAt:               bill.PaidAt,
+		PaidAmount:           bill.PaidAmount,
+		MeterPreviousReading: bill.MeterPreviousReading,
+		MeterCurrentReading:  bill.MeterCurrentReading,
+		MeterUnitPrice:       bill.MeterUnitPrice,
+		MeterRecordedAt:      bill.MeterRecordedAt,
+		WrittenOffReason:     bill.WrittenOffReason,
+		OverdueNoticeCount:   bill.OverdueNoticeCount,
+		CreatedAt:            bill.CreatedAt,
+		UpdatedAt:            bill.UpdatedAt,
+		Version:              bill.Version,
+	}
+}
+
+func toHandlerBills(bills []appbilling.Bill) []handler.BillingBill {
+	result := make([]handler.BillingBill, 0, len(bills))
+	for i := range bills {
+		result = append(result, *toHandlerBill(bills[i]))
+	}
+
+	return result
+}
+
+func toHandlerBill(bill appbilling.Bill) *handler.BillingBill {
+	return &handler.BillingBill{
+		ID:                   bill.ID,
+		LeaseID:              bill.LeaseID,
+		TenantID:             bill.TenantID,
+		RoomID:               bill.RoomID,
+		PropertyID:           bill.PropertyID,
+		Type:                 bill.Type,
+		Amount:               bill.Amount,
+		PeriodStart:          bill.PeriodStart,
+		PeriodEnd:            bill.PeriodEnd,
+		DueDate:              bill.DueDate,
+		Status:               bill.Status,
+		PaymentMethod:        bill.PaymentMethod,
+		PaidAt:               bill.PaidAt,
+		PaidAmount:           bill.PaidAmount,
+		MeterPreviousReading: bill.MeterPreviousReading,
+		MeterCurrentReading:  bill.MeterCurrentReading,
+		MeterUnitPrice:       bill.MeterUnitPrice,
+		MeterRecordedAt:      bill.MeterRecordedAt,
+		WrittenOffReason:     bill.WrittenOffReason,
+		OverdueNoticeCount:   bill.OverdueNoticeCount,
+		CreatedAt:            bill.CreatedAt,
+		UpdatedAt:            bill.UpdatedAt,
+		Version:              bill.Version,
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -125,6 +125,7 @@ func New(cfg *config.Config) (*Server, error) {
 		TerminateLease:      terminateLeaseService,
 		ForceTerminateLease: forceTerminateLeaseService,
 		GetForceTermination: getForceTerminationService,
+		Billing:             newBillingServices(db, txRunner),
 	})
 
 	return &Server{


### PR DESCRIPTION
Closes #18

## Summary
- Implement billing bill list/detail, meter recording, and payment confirmation APIs.
- Add Billing aggregate, application services, repository adapters, and database queries for the issue #18 vertical slice.
- Enforce meter and payment business rules, including previous-reading validation, electricity amount calculation, duplicate payment rejection, paid amount matching, and overdue-to-paid transition.
- Make payment confirmation atomically write both the bill payment state and accounting entry in the same transaction; `BillPaid` remains a post-commit event for non-core side effects.
- Thread bill detail actor scope through the application/repository path and keep meter decision reads inside the mutation transaction.

## Validation
- `go test ./internal/http/handler ./internal/application/billing ./internal/platform/database/billing ./internal/http/router ./internal/server`
- `go test ./...`

## Notes
- `gh` is not installed in this environment, so the PR was created through the GitHub connector after pushing the branch with git.