### PR TITLE
[016][P5][Billing] Implement pending meter, meter history, and financial reports

### DIFF
--- a/internal/application/billing/errors.go
+++ b/internal/application/billing/errors.go
@@ -15,6 +15,7 @@ const (
 	CodeBillStatusNotRecordable      = "BILL_STATUS_NOT_RECORDABLE"
 	CodeBillStatusNotPayable         = "BILL_STATUS_NOT_PAYABLE"
 	CodeBillPaidAmountMismatch       = "BILL_PAID_AMOUNT_MISMATCH"
+	CodeFinancialReportNotFound      = "FINANCIAL_REPORT_NOT_FOUND"
 )
 
 var (
@@ -47,6 +48,11 @@ var (
 		CodeBillPaidAmountMismatch,
 		http.StatusUnprocessableEntity,
 		"Paid amount must equal bill amount.",
+	)
+	ErrFinancialReportNotFound = apperr.New(
+		CodeFinancialReportNotFound,
+		http.StatusNotFound,
+		"Financial report not found.",
 	)
 )
 

--- a/internal/application/billing/reports.go
+++ b/internal/application/billing/reports.go
@@ -1,0 +1,564 @@
+package billing
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	domainevents "stds_backend/internal/domain/events"
+	"stds_backend/internal/shared/apperr"
+)
+
+var ErrFinancialReportNotFoundRepository = errors.New("financial report not found")
+
+// Clock provides current time for current-month report routing.
+type Clock interface {
+	Now() time.Time
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time {
+	return time.Now()
+}
+
+// PendingMeterQuery defines role scoping for pending meter reads.
+type PendingMeterQuery struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+}
+
+// MeterHistoryQuery defines role scoping and period filters for meter history reads.
+type MeterHistoryQuery struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	RoomID              string
+	Year                *int
+	Month               *int
+}
+
+// FinancialReportSummaryQuery defines role scoping for financial report summary reads.
+type FinancialReportSummaryQuery struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	Year                *int
+	CurrentYear         int
+	CurrentMonth        int
+}
+
+// FinancialReportQuery defines role scoping for financial report detail reads.
+type FinancialReportQuery struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	Year                int
+	Month               int
+}
+
+// FinancialReportSummary is the application read model for report summary rows.
+type FinancialReportSummary struct {
+	Year         int
+	Month        int
+	TotalIncome  int
+	TotalExpense int
+	Net          int
+}
+
+// FinancialReportEntry is the application read model for one report entry.
+type FinancialReportEntry struct {
+	Category    string
+	Description *string
+	Amount      int
+}
+
+// FinancialReport is the application read model for a property monthly report.
+type FinancialReport struct {
+	PropertyID   string
+	Year         int
+	Month        int
+	TotalIncome  int
+	TotalExpense int
+	Net          int
+	IsFinalized  bool
+	Entries      []FinancialReportEntry
+}
+
+// ReportRepository defines read operations required by billing report use cases.
+type ReportRepository interface {
+	ListPendingMeterBills(ctx context.Context, query PendingMeterQuery) ([]Bill, error)
+	ListPropertyMeterHistory(ctx context.Context, query MeterHistoryQuery) ([]Bill, error)
+	ListRoomMeterHistory(ctx context.Context, query MeterHistoryQuery) ([]Bill, error)
+	ListFinancialReportSummaries(ctx context.Context, query FinancialReportSummaryQuery) ([]FinancialReportSummary, error)
+	FindLiveFinancialReport(ctx context.Context, query FinancialReportQuery) (*FinancialReport, error)
+	FindSnapshotFinancialReport(ctx context.Context, query FinancialReportQuery) (*FinancialReport, error)
+}
+
+// ListPendingMeterInput is the use-case input for property pending meter reads.
+type ListPendingMeterInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+}
+
+// ListPendingMeterService lists bills waiting for meter readings.
+type ListPendingMeterService struct {
+	repo ReportRepository
+}
+
+// NewListPendingMeterService returns a ListPendingMeterService.
+func NewListPendingMeterService(repo ReportRepository) *ListPendingMeterService {
+	return &ListPendingMeterService{repo: repo}
+}
+
+// Execute validates report read scope and returns pending meter bills.
+func (s *ListPendingMeterService) Execute(ctx context.Context, input ListPendingMeterInput) ([]Bill, error) {
+	actorRole, err := normalizeMeterReportRole(input.ActorRole)
+	if err != nil {
+		return nil, err
+	}
+	propertyID, err := normalizeRequiredUUID(input.PropertyID, "property_id", apperr.ErrPropertyNotFound)
+	if err != nil {
+		return nil, err
+	}
+
+	bills, err := s.repo.ListPendingMeterBills(ctx, PendingMeterQuery{
+		ActorRole:           actorRole,
+		ActorUserID:         strings.TrimSpace(input.ActorUserID),
+		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
+		PropertyID:          propertyID,
+	})
+	if err != nil {
+		return nil, mapReportRepositoryError(err)
+	}
+	return bills, nil
+}
+
+// ListPropertyMeterHistoryInput is the use-case input for property meter history reads.
+type ListPropertyMeterHistoryInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	Year                *int
+}
+
+// ListPropertyMeterHistoryService lists property-level meter history.
+type ListPropertyMeterHistoryService struct {
+	repo ReportRepository
+}
+
+// NewListPropertyMeterHistoryService returns a ListPropertyMeterHistoryService.
+func NewListPropertyMeterHistoryService(repo ReportRepository) *ListPropertyMeterHistoryService {
+	return &ListPropertyMeterHistoryService{repo: repo}
+}
+
+// Execute validates report read scope and returns property meter history.
+func (s *ListPropertyMeterHistoryService) Execute(ctx context.Context, input ListPropertyMeterHistoryInput) ([]Bill, error) {
+	actorRole, err := normalizeMeterReportRole(input.ActorRole)
+	if err != nil {
+		return nil, err
+	}
+	propertyID, err := normalizeRequiredUUID(input.PropertyID, "property_id", apperr.ErrPropertyNotFound)
+	if err != nil {
+		return nil, err
+	}
+	year, err := normalizeOptionalYear(input.Year)
+	if err != nil {
+		return nil, err
+	}
+
+	bills, err := s.repo.ListPropertyMeterHistory(ctx, MeterHistoryQuery{
+		ActorRole:           actorRole,
+		ActorUserID:         strings.TrimSpace(input.ActorUserID),
+		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
+		PropertyID:          propertyID,
+		Year:                year,
+	})
+	if err != nil {
+		return nil, mapReportRepositoryError(err)
+	}
+	return bills, nil
+}
+
+// ListRoomMeterHistoryInput is the use-case input for room meter history reads.
+type ListRoomMeterHistoryInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	RoomID              string
+	Year                *int
+	Month               *int
+}
+
+// ListRoomMeterHistoryService lists room-level meter history.
+type ListRoomMeterHistoryService struct {
+	repo ReportRepository
+}
+
+// NewListRoomMeterHistoryService returns a ListRoomMeterHistoryService.
+func NewListRoomMeterHistoryService(repo ReportRepository) *ListRoomMeterHistoryService {
+	return &ListRoomMeterHistoryService{repo: repo}
+}
+
+// Execute validates report read scope and returns room meter history.
+func (s *ListRoomMeterHistoryService) Execute(ctx context.Context, input ListRoomMeterHistoryInput) ([]Bill, error) {
+	actorRole, err := normalizeMeterReportRole(input.ActorRole)
+	if err != nil {
+		return nil, err
+	}
+	roomID, err := normalizeRequiredUUID(input.RoomID, "room_id", apperr.ErrRoomNotFound)
+	if err != nil {
+		return nil, err
+	}
+	year, err := normalizeOptionalYear(input.Year)
+	if err != nil {
+		return nil, err
+	}
+	month, err := normalizeOptionalMonthInt(input.Month)
+	if err != nil {
+		return nil, err
+	}
+	if month != nil && year == nil {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "year",
+			"reason": "is required when month is provided",
+		})
+	}
+
+	bills, err := s.repo.ListRoomMeterHistory(ctx, MeterHistoryQuery{
+		ActorRole:           actorRole,
+		ActorUserID:         strings.TrimSpace(input.ActorUserID),
+		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
+		RoomID:              roomID,
+		Year:                year,
+		Month:               month,
+	})
+	if err != nil {
+		return nil, mapReportRepositoryError(err)
+	}
+	return bills, nil
+}
+
+// ListFinancialReportSummariesInput is the use-case input for report summary reads.
+type ListFinancialReportSummariesInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	Year                *int
+}
+
+// ListFinancialReportSummariesService lists report summaries.
+type ListFinancialReportSummariesService struct {
+	repo  ReportRepository
+	clock Clock
+}
+
+// NewListFinancialReportSummariesService returns a ListFinancialReportSummariesService.
+func NewListFinancialReportSummariesService(repo ReportRepository, clocks ...Clock) *ListFinancialReportSummariesService {
+	var clock Clock = systemClock{}
+	if len(clocks) > 0 && clocks[0] != nil {
+		clock = clocks[0]
+	}
+	return &ListFinancialReportSummariesService{repo: repo, clock: clock}
+}
+
+// Execute validates financial report read scope and returns summaries.
+func (s *ListFinancialReportSummariesService) Execute(ctx context.Context, input ListFinancialReportSummariesInput) ([]FinancialReportSummary, error) {
+	actorRole, err := normalizeFinancialReportReadRole(input.ActorRole)
+	if err != nil {
+		return nil, err
+	}
+	propertyID, err := normalizeRequiredUUID(input.PropertyID, "property_id", apperr.ErrPropertyNotFound)
+	if err != nil {
+		return nil, err
+	}
+	year, err := normalizeOptionalYear(input.Year)
+	if err != nil {
+		return nil, err
+	}
+	now := s.clock.Now()
+
+	summaries, err := s.repo.ListFinancialReportSummaries(ctx, FinancialReportSummaryQuery{
+		ActorRole:           actorRole,
+		ActorUserID:         strings.TrimSpace(input.ActorUserID),
+		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
+		PropertyID:          propertyID,
+		Year:                year,
+		CurrentYear:         now.Year(),
+		CurrentMonth:        int(now.Month()),
+	})
+	if err != nil {
+		return nil, mapReportRepositoryError(err)
+	}
+	return summaries, nil
+}
+
+// GetFinancialReportInput is the use-case input for report detail reads.
+type GetFinancialReportInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	Year                int
+	Month               int
+}
+
+// GetFinancialReportService retrieves one financial report.
+type GetFinancialReportService struct {
+	repo  ReportRepository
+	clock Clock
+}
+
+// NewGetFinancialReportService returns a GetFinancialReportService.
+func NewGetFinancialReportService(repo ReportRepository, clock Clock) *GetFinancialReportService {
+	if clock == nil {
+		clock = systemClock{}
+	}
+	return &GetFinancialReportService{repo: repo, clock: clock}
+}
+
+// Execute validates financial report read scope and chooses live or snapshot data.
+func (s *GetFinancialReportService) Execute(ctx context.Context, input GetFinancialReportInput) (*FinancialReport, error) {
+	query, err := s.normalizeFinancialReportQuery(input)
+	if err != nil {
+		return nil, err
+	}
+	return s.findFinancialReport(ctx, query)
+}
+
+func (s *GetFinancialReportService) normalizeFinancialReportQuery(input GetFinancialReportInput) (FinancialReportQuery, error) {
+	actorRole, err := normalizeFinancialReportReadRole(input.ActorRole)
+	if err != nil {
+		return FinancialReportQuery{}, err
+	}
+	propertyID, err := normalizeRequiredUUID(input.PropertyID, "property_id", apperr.ErrPropertyNotFound)
+	if err != nil {
+		return FinancialReportQuery{}, err
+	}
+	if err := validateYear(input.Year); err != nil {
+		return FinancialReportQuery{}, err
+	}
+	if err := validateMonth(input.Month); err != nil {
+		return FinancialReportQuery{}, err
+	}
+	return FinancialReportQuery{
+		ActorRole:           actorRole,
+		ActorUserID:         strings.TrimSpace(input.ActorUserID),
+		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
+		PropertyID:          propertyID,
+		Year:                input.Year,
+		Month:               input.Month,
+	}, nil
+}
+
+func (s *GetFinancialReportService) findFinancialReport(ctx context.Context, query FinancialReportQuery) (*FinancialReport, error) {
+	now := s.clock.Now()
+	var report *FinancialReport
+	var err error
+	if query.Year == now.Year() && query.Month == int(now.Month()) {
+		report, err = s.repo.FindLiveFinancialReport(ctx, query)
+	} else {
+		report, err = s.repo.FindSnapshotFinancialReport(ctx, query)
+	}
+	if err != nil {
+		return nil, mapReportRepositoryError(err)
+	}
+	if report == nil {
+		return nil, ErrFinancialReportNotFound
+	}
+	return report, nil
+}
+
+// SendFinancialReportInput is the use-case input for report send requests.
+type SendFinancialReportInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	Year                int
+	Month               int
+}
+
+// SendFinancialReportService validates a report and emits FinancialReportSendRequested.
+type SendFinancialReportService struct {
+	repo      ReportRepository
+	publisher domainevents.Publisher
+	clock     Clock
+}
+
+// NewSendFinancialReportService returns a SendFinancialReportService.
+func NewSendFinancialReportService(repo ReportRepository, publisher domainevents.Publisher, clock Clock) *SendFinancialReportService {
+	if publisher == nil {
+		publisher = domainevents.NoopPublisher{}
+	}
+	if clock == nil {
+		clock = systemClock{}
+	}
+	return &SendFinancialReportService{repo: repo, publisher: publisher, clock: clock}
+}
+
+// Execute validates the report exists, then publishes FinancialReportSendRequested.
+func (s *SendFinancialReportService) Execute(ctx context.Context, input SendFinancialReportInput) (*FinancialReport, error) {
+	query, err := s.normalizeFinancialReportSendQuery(input)
+	if err != nil {
+		return nil, err
+	}
+
+	report, err := s.findFinancialReport(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.publisher.Publish(ctx, domainevents.FinancialReportSendRequested{
+		PropertyID: query.PropertyID,
+		Year:       query.Year,
+		Month:      query.Month,
+		OccurredAt: s.clock.Now().UTC(),
+	}); err != nil {
+		return nil, apperr.ErrInternalServerError.WithCause(err)
+	}
+	return report, nil
+}
+
+func (s *SendFinancialReportService) normalizeFinancialReportSendQuery(input SendFinancialReportInput) (FinancialReportQuery, error) {
+	actorRole, err := normalizeFinancialReportSendRole(input.ActorRole)
+	if err != nil {
+		return FinancialReportQuery{}, err
+	}
+	propertyID, err := normalizeRequiredUUID(input.PropertyID, "property_id", apperr.ErrPropertyNotFound)
+	if err != nil {
+		return FinancialReportQuery{}, err
+	}
+	if err := validateYear(input.Year); err != nil {
+		return FinancialReportQuery{}, err
+	}
+	if err := validateMonth(input.Month); err != nil {
+		return FinancialReportQuery{}, err
+	}
+	return FinancialReportQuery{
+		ActorRole:           actorRole,
+		ActorUserID:         strings.TrimSpace(input.ActorUserID),
+		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
+		PropertyID:          propertyID,
+		Year:                input.Year,
+		Month:               input.Month,
+	}, nil
+}
+
+func (s *SendFinancialReportService) findFinancialReport(ctx context.Context, query FinancialReportQuery) (*FinancialReport, error) {
+	now := s.clock.Now()
+	var report *FinancialReport
+	var err error
+	if query.Year == now.Year() && query.Month == int(now.Month()) {
+		report, err = s.repo.FindLiveFinancialReport(ctx, query)
+	} else {
+		report, err = s.repo.FindSnapshotFinancialReport(ctx, query)
+	}
+	if err != nil {
+		return nil, mapReportRepositoryError(err)
+	}
+	if report == nil {
+		return nil, ErrFinancialReportNotFound
+	}
+	return report, nil
+}
+
+func normalizeMeterReportRole(role string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(role))
+	switch normalized {
+	case "admin", "organizer", "staff":
+		return normalized, nil
+	default:
+		return "", apperr.ErrForbidden
+	}
+}
+
+func normalizeFinancialReportReadRole(role string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(role))
+	switch normalized {
+	case "admin", "organizer", "staff", "owner":
+		return normalized, nil
+	default:
+		return "", apperr.ErrForbidden
+	}
+}
+
+func normalizeFinancialReportSendRole(role string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(role))
+	switch normalized {
+	case "admin", "organizer":
+		return normalized, nil
+	default:
+		return "", apperr.ErrForbidden
+	}
+}
+
+func normalizeRequiredUUID(value string, field string, emptyErr error) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "", emptyErr
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return "", apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+	}
+	return trimmed, nil
+}
+
+func normalizeOptionalYear(value *int) (*int, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if err := validateYear(*value); err != nil {
+		return nil, err
+	}
+	year := *value
+	return &year, nil
+}
+
+func normalizeOptionalMonthInt(value *int) (*int, error) {
+	if value == nil {
+		return nil, nil
+	}
+	if err := validateMonth(*value); err != nil {
+		return nil, err
+	}
+	month := *value
+	return &month, nil
+}
+
+func validateYear(value int) error {
+	if value < 1 {
+		return apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "year"})
+	}
+	return nil
+}
+
+func validateMonth(value int) error {
+	if value < 1 || value > 12 {
+		return apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "month"})
+	}
+	return nil
+}
+
+func mapReportRepositoryError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, ErrFinancialReportNotFoundRepository):
+		return ErrFinancialReportNotFound
+	default:
+		return apperr.ErrInternalServerError.WithCause(err)
+	}
+}

--- a/internal/application/billing/reports.go
+++ b/internal/application/billing/reports.go
@@ -25,6 +25,13 @@ func (systemClock) Now() time.Time {
 	return time.Now()
 }
 
+var taiwanReportLocation = time.FixedZone("Asia/Taipei", 8*60*60)
+
+func currentReportPeriod(clock Clock) (int, int) {
+	now := clock.Now().In(taiwanReportLocation)
+	return now.Year(), int(now.Month())
+}
+
 // PendingMeterQuery defines role scoping for pending meter reads.
 type PendingMeterQuery struct {
 	ActorRole           string
@@ -288,7 +295,7 @@ func (s *ListFinancialReportSummariesService) Execute(ctx context.Context, input
 	if err != nil {
 		return nil, err
 	}
-	now := s.clock.Now()
+	currentYear, currentMonth := currentReportPeriod(s.clock)
 
 	summaries, err := s.repo.ListFinancialReportSummaries(ctx, FinancialReportSummaryQuery{
 		ActorRole:           actorRole,
@@ -296,8 +303,8 @@ func (s *ListFinancialReportSummariesService) Execute(ctx context.Context, input
 		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
 		PropertyID:          propertyID,
 		Year:                year,
-		CurrentYear:         now.Year(),
-		CurrentMonth:        int(now.Month()),
+		CurrentYear:         currentYear,
+		CurrentMonth:        currentMonth,
 	})
 	if err != nil {
 		return nil, mapReportRepositoryError(err)
@@ -364,10 +371,10 @@ func (s *GetFinancialReportService) normalizeFinancialReportQuery(input GetFinan
 }
 
 func (s *GetFinancialReportService) findFinancialReport(ctx context.Context, query FinancialReportQuery) (*FinancialReport, error) {
-	now := s.clock.Now()
+	currentYear, currentMonth := currentReportPeriod(s.clock)
 	var report *FinancialReport
 	var err error
-	if query.Year == now.Year() && query.Month == int(now.Month()) {
+	if query.Year == currentYear && query.Month == currentMonth {
 		report, err = s.repo.FindLiveFinancialReport(ctx, query)
 	} else {
 		report, err = s.repo.FindSnapshotFinancialReport(ctx, query)
@@ -457,10 +464,10 @@ func (s *SendFinancialReportService) normalizeFinancialReportSendQuery(input Sen
 }
 
 func (s *SendFinancialReportService) findFinancialReport(ctx context.Context, query FinancialReportQuery) (*FinancialReport, error) {
-	now := s.clock.Now()
+	currentYear, currentMonth := currentReportPeriod(s.clock)
 	var report *FinancialReport
 	var err error
-	if query.Year == now.Year() && query.Month == int(now.Month()) {
+	if query.Year == currentYear && query.Month == currentMonth {
 		report, err = s.repo.FindLiveFinancialReport(ctx, query)
 	} else {
 		report, err = s.repo.FindSnapshotFinancialReport(ctx, query)

--- a/internal/application/billing/reports.go
+++ b/internal/application/billing/reports.go
@@ -400,9 +400,6 @@ type SendFinancialReportService struct {
 
 // NewSendFinancialReportService returns a SendFinancialReportService.
 func NewSendFinancialReportService(repo ReportRepository, publisher domainevents.Publisher, clock Clock) *SendFinancialReportService {
-	if publisher == nil {
-		publisher = domainevents.NoopPublisher{}
-	}
 	if clock == nil {
 		clock = systemClock{}
 	}
@@ -419,6 +416,9 @@ func (s *SendFinancialReportService) Execute(ctx context.Context, input SendFina
 	report, err := s.findFinancialReport(ctx, query)
 	if err != nil {
 		return nil, err
+	}
+	if s.publisher == nil {
+		return nil, apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "financial_report_publisher"})
 	}
 	if err := s.publisher.Publish(ctx, domainevents.FinancialReportSendRequested{
 		PropertyID: query.PropertyID,

--- a/internal/application/billing/reports_test.go
+++ b/internal/application/billing/reports_test.go
@@ -241,6 +241,58 @@ func TestSendFinancialReportEmitsEventWhenReportExists(t *testing.T) {
 	}
 }
 
+func TestSendFinancialReportUsesCurrentMonthLivePath(t *testing.T) {
+	occurredAt := time.Date(2026, 4, 24, 10, 30, 0, 0, time.UTC)
+	repo := &reportRepositoryStub{
+		liveReport:     reportForTest(2026, 4, false),
+		snapshotReport: reportForTest(2026, 4, true),
+	}
+	publisher := &recordingPublisher{}
+	service := NewSendFinancialReportService(repo, publisher, fixedClock{now: occurredAt})
+
+	report, err := service.Execute(context.Background(), SendFinancialReportInput{
+		ActorRole:  "organizer",
+		PropertyID: testPropertyID,
+		Year:       2026,
+		Month:      4,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if report == nil || report.IsFinalized {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if repo.liveReportQuery == nil || repo.liveReportQuery.Year != 2026 || repo.liveReportQuery.Month != 4 {
+		t.Fatalf("expected live query for current month, got %+v", repo.liveReportQuery)
+	}
+	if repo.snapshotReportQuery != nil {
+		t.Fatalf("unexpected snapshot query: %+v", repo.snapshotReportQuery)
+	}
+	if len(publisher.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(publisher.events))
+	}
+	event, ok := publisher.events[0].(domainevents.FinancialReportSendRequested)
+	if !ok {
+		t.Fatalf("expected FinancialReportSendRequested, got %T", publisher.events[0])
+	}
+	if event.PropertyID != testPropertyID || event.Year != 2026 || event.Month != 4 || !event.OccurredAt.Equal(occurredAt) {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+}
+
+func TestSendFinancialReportRequiresPublisher(t *testing.T) {
+	repo := &reportRepositoryStub{snapshotReport: reportForTest(2026, 3, true)}
+	service := NewSendFinancialReportService(repo, nil, fixedClock{now: time.Date(2026, 4, 24, 10, 30, 0, 0, time.UTC)})
+
+	_, err := service.Execute(context.Background(), SendFinancialReportInput{
+		ActorRole:  "organizer",
+		PropertyID: testPropertyID,
+		Year:       2026,
+		Month:      3,
+	})
+	assertAppErrorCode(t, err, apperr.CodeInternalServerError)
+}
+
 type reportRepositoryStub struct {
 	pendingMeterBills         []Bill
 	pendingMeterQuery         *PendingMeterQuery

--- a/internal/application/billing/reports_test.go
+++ b/internal/application/billing/reports_test.go
@@ -166,6 +166,78 @@ func TestFinancialReportDetailUsesCurrentMonthLivePath(t *testing.T) {
 	}
 }
 
+func TestFinancialReportCurrentPeriodUsesTaiwanTimezone(t *testing.T) {
+	now := time.Date(2026, 3, 31, 16, 30, 0, 0, time.UTC)
+
+	t.Run("summary current period", func(t *testing.T) {
+		repo := &reportRepositoryStub{summaries: []FinancialReportSummary{}}
+		service := NewListFinancialReportSummariesService(repo, fixedClock{now: now})
+
+		_, err := service.Execute(context.Background(), ListFinancialReportSummariesInput{
+			ActorRole:  "staff",
+			PropertyID: testPropertyID,
+		})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if repo.summaryQuery == nil {
+			t.Fatal("expected summary query")
+		}
+		if repo.summaryQuery.CurrentYear != 2026 || repo.summaryQuery.CurrentMonth != 4 {
+			t.Fatalf("unexpected current period: %+v", repo.summaryQuery)
+		}
+	})
+
+	t.Run("detail current period", func(t *testing.T) {
+		repo := &reportRepositoryStub{
+			liveReport:     reportForTest(2026, 4, false),
+			snapshotReport: reportForTest(2026, 4, true),
+		}
+		service := NewGetFinancialReportService(repo, fixedClock{now: now})
+
+		report, err := service.Execute(context.Background(), GetFinancialReportInput{
+			ActorRole:  "staff",
+			PropertyID: testPropertyID,
+			Year:       2026,
+			Month:      4,
+		})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if report == nil || report.IsFinalized {
+			t.Fatalf("unexpected report: %+v", report)
+		}
+		if repo.liveReportQuery == nil || repo.snapshotReportQuery != nil {
+			t.Fatalf("expected live query only, live=%+v snapshot=%+v", repo.liveReportQuery, repo.snapshotReportQuery)
+		}
+	})
+
+	t.Run("send current period", func(t *testing.T) {
+		repo := &reportRepositoryStub{
+			liveReport:     reportForTest(2026, 4, false),
+			snapshotReport: reportForTest(2026, 4, true),
+		}
+		publisher := &recordingPublisher{}
+		service := NewSendFinancialReportService(repo, publisher, fixedClock{now: now})
+
+		report, err := service.Execute(context.Background(), SendFinancialReportInput{
+			ActorRole:  "organizer",
+			PropertyID: testPropertyID,
+			Year:       2026,
+			Month:      4,
+		})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if report == nil || report.IsFinalized {
+			t.Fatalf("unexpected report: %+v", report)
+		}
+		if repo.liveReportQuery == nil || repo.snapshotReportQuery != nil {
+			t.Fatalf("expected live query only, live=%+v snapshot=%+v", repo.liveReportQuery, repo.snapshotReportQuery)
+		}
+	})
+}
+
 func TestFinancialReportSummaryReturnsEmptySlice(t *testing.T) {
 	repo := &reportRepositoryStub{summaries: []FinancialReportSummary{}}
 	service := NewListFinancialReportSummariesService(repo)

--- a/internal/application/billing/reports_test.go
+++ b/internal/application/billing/reports_test.go
@@ -1,0 +1,349 @@
+package billing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	domainevents "stds_backend/internal/domain/events"
+	"stds_backend/internal/shared/apperr"
+)
+
+func TestReportServicesValidateRoles(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("owner cannot read pending meters", func(t *testing.T) {
+		repo := &reportRepositoryStub{}
+		service := NewListPendingMeterService(repo)
+
+		_, err := service.Execute(ctx, ListPendingMeterInput{
+			ActorRole:  "owner",
+			PropertyID: testPropertyID,
+		})
+		assertAppErrorCode(t, err, apperr.CodeForbidden)
+		if repo.pendingMeterQuery != nil {
+			t.Fatalf("unexpected pending meter query: %+v", repo.pendingMeterQuery)
+		}
+	})
+
+	t.Run("owner cannot read property meter history", func(t *testing.T) {
+		repo := &reportRepositoryStub{}
+		service := NewListPropertyMeterHistoryService(repo)
+
+		_, err := service.Execute(ctx, ListPropertyMeterHistoryInput{
+			ActorRole:  "owner",
+			PropertyID: testPropertyID,
+		})
+		assertAppErrorCode(t, err, apperr.CodeForbidden)
+		if repo.propertyMeterHistoryQuery != nil {
+			t.Fatalf("unexpected property meter history query: %+v", repo.propertyMeterHistoryQuery)
+		}
+	})
+
+	t.Run("owner cannot read room meter history", func(t *testing.T) {
+		repo := &reportRepositoryStub{}
+		service := NewListRoomMeterHistoryService(repo)
+
+		_, err := service.Execute(ctx, ListRoomMeterHistoryInput{
+			ActorRole: "owner",
+			RoomID:    testRoomID,
+		})
+		assertAppErrorCode(t, err, apperr.CodeForbidden)
+		if repo.roomMeterHistoryQuery != nil {
+			t.Fatalf("unexpected room meter history query: %+v", repo.roomMeterHistoryQuery)
+		}
+	})
+
+	t.Run("owner can read financial report", func(t *testing.T) {
+		repo := &reportRepositoryStub{
+			snapshotReport: reportForTest(2026, 3, true),
+		}
+		service := NewGetFinancialReportService(repo, fixedClock{now: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)})
+
+		report, err := service.Execute(ctx, GetFinancialReportInput{
+			ActorRole:  "owner",
+			PropertyID: testPropertyID,
+			Year:       2026,
+			Month:      3,
+		})
+		if err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+		if report == nil || report.PropertyID != testPropertyID {
+			t.Fatalf("unexpected report: %+v", report)
+		}
+		if repo.snapshotReportQuery == nil || repo.snapshotReportQuery.ActorRole != "owner" {
+			t.Fatalf("unexpected snapshot query: %+v", repo.snapshotReportQuery)
+		}
+	})
+
+	t.Run("owner cannot send financial report", func(t *testing.T) {
+		repo := &reportRepositoryStub{}
+		publisher := &recordingPublisher{}
+		service := NewSendFinancialReportService(repo, publisher, fixedClock{now: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)})
+
+		_, err := service.Execute(ctx, SendFinancialReportInput{
+			ActorRole:  "owner",
+			PropertyID: testPropertyID,
+			Year:       2026,
+			Month:      3,
+		})
+		assertAppErrorCode(t, err, apperr.CodeForbidden)
+		if len(publisher.events) != 0 {
+			t.Fatalf("expected no events, got %d", len(publisher.events))
+		}
+		if repo.snapshotReportQuery != nil || repo.liveReportQuery != nil {
+			t.Fatalf("unexpected report query: live=%+v snapshot=%+v", repo.liveReportQuery, repo.snapshotReportQuery)
+		}
+	})
+}
+
+func TestFinancialReportDetailMissingMapsToNotFound(t *testing.T) {
+	t.Run("snapshot missing", func(t *testing.T) {
+		repo := &reportRepositoryStub{snapshotReportErr: ErrFinancialReportNotFoundRepository}
+		service := NewGetFinancialReportService(repo, fixedClock{now: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)})
+
+		_, err := service.Execute(context.Background(), GetFinancialReportInput{
+			ActorRole:  "staff",
+			PropertyID: testPropertyID,
+			Year:       2026,
+			Month:      3,
+		})
+		assertAppErrorCode(t, err, CodeFinancialReportNotFound)
+	})
+
+	t.Run("live missing", func(t *testing.T) {
+		repo := &reportRepositoryStub{liveReportErr: ErrFinancialReportNotFoundRepository}
+		service := NewGetFinancialReportService(repo, fixedClock{now: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)})
+
+		_, err := service.Execute(context.Background(), GetFinancialReportInput{
+			ActorRole:  "staff",
+			PropertyID: testPropertyID,
+			Year:       2026,
+			Month:      4,
+		})
+		assertAppErrorCode(t, err, CodeFinancialReportNotFound)
+	})
+}
+
+func TestFinancialReportDetailUsesCurrentMonthLivePath(t *testing.T) {
+	repo := &reportRepositoryStub{
+		liveReport:     reportForTest(2026, 4, false),
+		snapshotReport: reportForTest(2026, 3, true),
+	}
+	service := NewGetFinancialReportService(repo, fixedClock{now: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)})
+
+	current, err := service.Execute(context.Background(), GetFinancialReportInput{
+		ActorRole:  "staff",
+		PropertyID: testPropertyID,
+		Year:       2026,
+		Month:      4,
+	})
+	if err != nil {
+		t.Fatalf("current Execute: %v", err)
+	}
+	if current == nil || current.IsFinalized {
+		t.Fatalf("unexpected current report: %+v", current)
+	}
+	if repo.liveReportQuery == nil || repo.liveReportQuery.Year != 2026 || repo.liveReportQuery.Month != 4 {
+		t.Fatalf("expected live query for current month, got %+v", repo.liveReportQuery)
+	}
+
+	historical, err := service.Execute(context.Background(), GetFinancialReportInput{
+		ActorRole:  "staff",
+		PropertyID: testPropertyID,
+		Year:       2026,
+		Month:      3,
+	})
+	if err != nil {
+		t.Fatalf("historical Execute: %v", err)
+	}
+	if historical == nil || !historical.IsFinalized {
+		t.Fatalf("unexpected historical report: %+v", historical)
+	}
+	if repo.snapshotReportQuery == nil || repo.snapshotReportQuery.Year != 2026 || repo.snapshotReportQuery.Month != 3 {
+		t.Fatalf("expected snapshot query for historical month, got %+v", repo.snapshotReportQuery)
+	}
+}
+
+func TestFinancialReportSummaryReturnsEmptySlice(t *testing.T) {
+	repo := &reportRepositoryStub{summaries: []FinancialReportSummary{}}
+	service := NewListFinancialReportSummariesService(repo)
+
+	summaries, err := service.Execute(context.Background(), ListFinancialReportSummariesInput{
+		ActorRole:  "owner",
+		PropertyID: testPropertyID,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if summaries == nil || len(summaries) != 0 {
+		t.Fatalf("expected empty summary slice, got %+v", summaries)
+	}
+}
+
+func TestFinancialReportSummaryPreservesActorScope(t *testing.T) {
+	repo := &reportRepositoryStub{summaries: []FinancialReportSummary{}}
+	service := NewListFinancialReportSummariesService(repo, fixedClock{now: time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)})
+	year := 2026
+
+	_, err := service.Execute(context.Background(), ListFinancialReportSummariesInput{
+		ActorRole:           "staff",
+		ActorUserID:         "user-1",
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          testPropertyID,
+		Year:                &year,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if repo.summaryQuery == nil {
+		t.Fatal("expected summary query")
+	}
+	if repo.summaryQuery.ActorRole != "staff" || repo.summaryQuery.ActorUserID != "user-1" {
+		t.Fatalf("unexpected actor scope: %+v", repo.summaryQuery)
+	}
+	if len(repo.summaryQuery.AssignedPropertyIDs) != 1 || repo.summaryQuery.AssignedPropertyIDs[0] != testPropertyID {
+		t.Fatalf("unexpected assigned property scope: %+v", repo.summaryQuery.AssignedPropertyIDs)
+	}
+	if repo.summaryQuery.Year == nil || *repo.summaryQuery.Year != 2026 {
+		t.Fatalf("unexpected year: %+v", repo.summaryQuery.Year)
+	}
+}
+
+func TestSendFinancialReportEmitsEventWhenReportExists(t *testing.T) {
+	occurredAt := time.Date(2026, 4, 24, 10, 30, 0, 0, time.UTC)
+	repo := &reportRepositoryStub{snapshotReport: reportForTest(2026, 3, true)}
+	publisher := &recordingPublisher{}
+	service := NewSendFinancialReportService(repo, publisher, fixedClock{now: occurredAt})
+
+	report, err := service.Execute(context.Background(), SendFinancialReportInput{
+		ActorRole:  "organizer",
+		PropertyID: testPropertyID,
+		Year:       2026,
+		Month:      3,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if report == nil || report.Year != 2026 || report.Month != 3 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if len(publisher.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(publisher.events))
+	}
+	event, ok := publisher.events[0].(domainevents.FinancialReportSendRequested)
+	if !ok {
+		t.Fatalf("expected FinancialReportSendRequested, got %T", publisher.events[0])
+	}
+	if event.PropertyID != testPropertyID || event.Year != 2026 || event.Month != 3 || !event.OccurredAt.Equal(occurredAt) {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+}
+
+type reportRepositoryStub struct {
+	pendingMeterBills         []Bill
+	pendingMeterQuery         *PendingMeterQuery
+	propertyMeterHistoryBills []Bill
+	propertyMeterHistoryQuery *MeterHistoryQuery
+	roomMeterHistoryBills     []Bill
+	roomMeterHistoryQuery     *MeterHistoryQuery
+	summaries                 []FinancialReportSummary
+	summaryQuery              *FinancialReportSummaryQuery
+	liveReport                *FinancialReport
+	liveReportQuery           *FinancialReportQuery
+	liveReportErr             error
+	snapshotReport            *FinancialReport
+	snapshotReportQuery       *FinancialReportQuery
+	snapshotReportErr         error
+	err                       error
+}
+
+func (s *reportRepositoryStub) ListPendingMeterBills(_ context.Context, query PendingMeterQuery) ([]Bill, error) {
+	s.pendingMeterQuery = &query
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.pendingMeterBills, nil
+}
+
+func (s *reportRepositoryStub) ListPropertyMeterHistory(_ context.Context, query MeterHistoryQuery) ([]Bill, error) {
+	s.propertyMeterHistoryQuery = &query
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.propertyMeterHistoryBills, nil
+}
+
+func (s *reportRepositoryStub) ListRoomMeterHistory(_ context.Context, query MeterHistoryQuery) ([]Bill, error) {
+	s.roomMeterHistoryQuery = &query
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.roomMeterHistoryBills, nil
+}
+
+func (s *reportRepositoryStub) ListFinancialReportSummaries(_ context.Context, query FinancialReportSummaryQuery) ([]FinancialReportSummary, error) {
+	s.summaryQuery = &query
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.summaries, nil
+}
+
+func (s *reportRepositoryStub) FindLiveFinancialReport(_ context.Context, query FinancialReportQuery) (*FinancialReport, error) {
+	s.liveReportQuery = &query
+	if s.liveReportErr != nil {
+		return nil, s.liveReportErr
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.liveReport, nil
+}
+
+func (s *reportRepositoryStub) FindSnapshotFinancialReport(_ context.Context, query FinancialReportQuery) (*FinancialReport, error) {
+	s.snapshotReportQuery = &query
+	if s.snapshotReportErr != nil {
+		return nil, s.snapshotReportErr
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.snapshotReport, nil
+}
+
+type fixedClock struct {
+	now time.Time
+}
+
+func (c fixedClock) Now() time.Time {
+	return c.now
+}
+
+func reportForTest(year int, month int, finalized bool) *FinancialReport {
+	return &FinancialReport{
+		PropertyID:   testPropertyID,
+		Year:         year,
+		Month:        month,
+		TotalIncome:  12000,
+		TotalExpense: 500,
+		Net:          11500,
+		IsFinalized:  finalized,
+		Entries: []FinancialReportEntry{
+			{
+				Category:    AccountingCategoryRentPayment,
+				Description: stringPtr("rent"),
+				Amount:      12000,
+			},
+		},
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+var _ ReportRepository = (*reportRepositoryStub)(nil)
+var _ Clock = fixedClock{}
+var _ domainevents.Publisher = (*recordingPublisher)(nil)

--- a/internal/domain/events/financial_report_send_requested.go
+++ b/internal/domain/events/financial_report_send_requested.go
@@ -1,0 +1,11 @@
+package events
+
+import "time"
+
+// FinancialReportSendRequested is emitted after a report is validated for delivery.
+type FinancialReportSendRequested struct {
+	PropertyID string
+	Year       int
+	Month      int
+	OccurredAt time.Time
+}

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -76,9 +76,12 @@ type LeaseCommandServices struct {
 // BillingServices groups the billing application entry points used by the
 // transport layer.
 type BillingServices struct {
-	Query   BillingQueryService
-	Meter   BillingMeterService
-	Payment BillingPaymentService
+	Query            BillingQueryService
+	Meter            BillingMeterService
+	Payment          BillingPaymentService
+	PropertyMeters   BillingPropertyMeterService
+	RoomMeters       BillingRoomMeterService
+	FinancialReports BillingFinancialReportService
 }
 
 type BillingQueryService interface {
@@ -92,6 +95,21 @@ type BillingMeterService interface {
 
 type BillingPaymentService interface {
 	RecordBillPayment(ctx context.Context, input BillingPaymentInput) (*BillingBill, error)
+}
+
+type BillingPropertyMeterService interface {
+	ListPropertyPendingMeters(ctx context.Context, input BillingPropertyMetersInput) ([]BillingBill, error)
+	ListPropertyMeterHistory(ctx context.Context, input BillingPropertyMeterHistoryInput) ([]BillingBill, error)
+}
+
+type BillingRoomMeterService interface {
+	ListRoomMeterHistory(ctx context.Context, input BillingRoomMeterHistoryInput) ([]BillingBill, error)
+}
+
+type BillingFinancialReportService interface {
+	ListFinancialReportSummaries(ctx context.Context, input BillingFinancialReportSummaryInput) ([]BillingFinancialReportSummary, error)
+	GetFinancialReport(ctx context.Context, input BillingFinancialReportInput) (*BillingFinancialReport, error)
+	SendFinancialReport(ctx context.Context, input BillingFinancialReportInput) (*BillingFinancialReport, error)
 }
 
 type BillingListInput struct {
@@ -130,6 +148,47 @@ type BillingPaymentInput struct {
 	PaidAt              *time.Time
 }
 
+type BillingPropertyMetersInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+}
+
+type BillingPropertyMeterHistoryInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	Year                *int
+}
+
+type BillingRoomMeterHistoryInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	RoomID              string
+	Year                *int
+	Month               *int
+}
+
+type BillingFinancialReportSummaryInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	Year                *int
+}
+
+type BillingFinancialReportInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	Year                int
+	Month               int
+}
+
 type BillingBill struct {
 	ID                   string
 	LeaseID              string
@@ -154,6 +213,31 @@ type BillingBill struct {
 	CreatedAt            time.Time
 	UpdatedAt            time.Time
 	Version              int
+}
+
+type BillingFinancialReportSummary struct {
+	Year         int
+	Month        int
+	TotalIncome  int
+	TotalExpense int
+	Net          int
+}
+
+type BillingFinancialReport struct {
+	PropertyID   string
+	Year         int
+	Month        int
+	TotalIncome  int
+	TotalExpense int
+	Net          int
+	IsFinalized  bool
+	Entries      []BillingFinancialReportEntry
+}
+
+type BillingFinancialReportEntry struct {
+	Category    string
+	Description *string
+	Amount      int
 }
 
 // NewAPIServer returns an API server with only the currently implemented
@@ -929,27 +1013,164 @@ func (s *APIServer) GetPropertyDashboard(c *gin.Context, id string) { writeNotIm
 // GetPropertyFinancialReportSummary handles financial report summary retrieval
 // for a property.
 func (s *APIServer) GetPropertyFinancialReportSummary(c *gin.Context, id string, params api.GetPropertyFinancialReportSummaryParams) {
-	writeNotImplemented(c)
+	if s.billing.FinancialReports == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_financial_reports"}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	summaries, err := s.billing.FinancialReports.ListFinancialReportSummaries(c.Request.Context(), BillingFinancialReportSummaryInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		PropertyID:          id,
+		Year:                params.Year,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	items := make([]api.FinancialReportSummaryItem, 0, len(summaries))
+	for i := range summaries {
+		items = append(items, toFinancialReportSummaryItem(summaries[i]))
+	}
+
+	c.JSON(http.StatusOK, api.FinancialReportListResponse{Data: &items})
 }
 
 // GetPropertyFinancialReport handles financial report retrieval for a property
 // month.
 func (s *APIServer) GetPropertyFinancialReport(c *gin.Context, id string, year int, month int) {
-	writeNotImplemented(c)
+	if s.billing.FinancialReports == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_financial_reports"}))
+		return
+	}
+	if !isValidMonth(month) {
+		c.Error(apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "month",
+			"reason": "must be between 1 and 12",
+		}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	report, err := s.billing.FinancialReports.GetFinancialReport(c.Request.Context(), BillingFinancialReportInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		PropertyID:          id,
+		Year:                year,
+		Month:               month,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toFinancialReportResponse(report))
 }
 
 // SendPropertyFinancialReport handles sending a property's financial report.
 func (s *APIServer) SendPropertyFinancialReport(c *gin.Context, id string, year int, month int) {
-	writeNotImplemented(c)
+	if s.billing.FinancialReports == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_financial_reports"}))
+		return
+	}
+	if !isValidMonth(month) {
+		c.Error(apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "month",
+			"reason": "must be between 1 and 12",
+		}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	report, err := s.billing.FinancialReports.SendFinancialReport(c.Request.Context(), BillingFinancialReportInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		PropertyID:          id,
+		Year:                year,
+		Month:               month,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toFinancialReportResponse(report))
 }
 
 // ListPropertyMeterHistory handles property meter history retrieval.
 func (s *APIServer) ListPropertyMeterHistory(c *gin.Context, id string, params api.ListPropertyMeterHistoryParams) {
-	writeNotImplemented(c)
+	if s.billing.PropertyMeters == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_property_meters"}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	bills, err := s.billing.PropertyMeters.ListPropertyMeterHistory(c.Request.Context(), BillingPropertyMeterHistoryInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		PropertyID:          id,
+		Year:                params.Year,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toBillListResponse(bills))
 }
 
 // ListPropertyPendingMeters handles pending meter retrieval for a property.
-func (s *APIServer) ListPropertyPendingMeters(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) ListPropertyPendingMeters(c *gin.Context, id string) {
+	if s.billing.PropertyMeters == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_property_meters"}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	bills, err := s.billing.PropertyMeters.ListPropertyPendingMeters(c.Request.Context(), BillingPropertyMetersInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		PropertyID:          id,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toBillListResponse(bills))
+}
 
 // ListPropertyRooms handles room listing for a property.
 func (s *APIServer) ListPropertyRooms(c *gin.Context, id string, params api.ListPropertyRoomsParams) {
@@ -1146,7 +1367,47 @@ func (s *APIServer) CreateRoomMaintenance(c *gin.Context, id string) {
 
 // ListRoomMeterHistory handles room meter history retrieval.
 func (s *APIServer) ListRoomMeterHistory(c *gin.Context, id string, params api.ListRoomMeterHistoryParams) {
-	writeNotImplemented(c)
+	if params.Month != nil && params.Year == nil {
+		c.Error(apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "year",
+			"reason": "is required when month is provided",
+		}))
+		c.Status(http.StatusBadRequest)
+		return
+	}
+	if params.Month != nil && !isValidMonth(*params.Month) {
+		c.Error(apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "month",
+			"reason": "must be between 1 and 12",
+		}))
+		c.Status(http.StatusBadRequest)
+		return
+	}
+	if s.billing.RoomMeters == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "billing_room_meters"}))
+		return
+	}
+
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	bills, err := s.billing.RoomMeters.ListRoomMeterHistory(c.Request.Context(), BillingRoomMeterHistoryInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		RoomID:              id,
+		Year:                params.Year,
+		Month:               params.Month,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toBillListResponse(bills))
 }
 
 // ListTenants handles the tenant listing endpoint.
@@ -1642,6 +1903,19 @@ func parseUUID(value string) (openapi_types.UUID, bool) {
 	return parsed, true
 }
 
+func isValidMonth(month int) bool {
+	return month >= 1 && month <= 12
+}
+
+func toBillListResponse(bills []BillingBill) api.BillListResponse {
+	items := make([]api.BillResponse, 0, len(bills))
+	for i := range bills {
+		items = append(items, toBillResponse(&bills[i]))
+	}
+
+	return api.BillListResponse{Data: &items}
+}
+
 func toBillResponse(bill *BillingBill) api.BillResponse {
 	id, idOK := parseUUID(bill.ID)
 	leaseID, leaseOK := parseUUID(bill.LeaseID)
@@ -1698,6 +1972,62 @@ func toBillResponse(bill *BillingBill) api.BillResponse {
 	}
 
 	return response
+}
+
+func toFinancialReportSummaryItem(summary BillingFinancialReportSummary) api.FinancialReportSummaryItem {
+	year := summary.Year
+	month := summary.Month
+	totalIncome := summary.TotalIncome
+	totalExpense := summary.TotalExpense
+	net := summary.Net
+
+	return api.FinancialReportSummaryItem{
+		Year:         &year,
+		Month:        &month,
+		TotalIncome:  &totalIncome,
+		TotalExpense: &totalExpense,
+		Net:          &net,
+	}
+}
+
+func toFinancialReportResponse(report *BillingFinancialReport) api.FinancialReportResponse {
+	propertyID, propertyOK := parseUUID(report.PropertyID)
+	year := report.Year
+	month := report.Month
+	totalIncome := report.TotalIncome
+	totalExpense := report.TotalExpense
+	net := report.Net
+	isFinalized := report.IsFinalized
+	entries := make([]api.FinancialReportEntryItem, 0, len(report.Entries))
+	for i := range report.Entries {
+		entries = append(entries, toFinancialReportEntryItem(report.Entries[i]))
+	}
+
+	response := api.FinancialReportResponse{
+		Year:         &year,
+		Month:        &month,
+		TotalIncome:  &totalIncome,
+		TotalExpense: &totalExpense,
+		Net:          &net,
+		IsFinalized:  &isFinalized,
+		Entries:      &entries,
+	}
+	if propertyOK {
+		response.PropertyId = &propertyID
+	}
+
+	return response
+}
+
+func toFinancialReportEntryItem(entry BillingFinancialReportEntry) api.FinancialReportEntryItem {
+	amount := entry.Amount
+	category := api.FinancialReportEntryItemCategory(entry.Category)
+
+	return api.FinancialReportEntryItem{
+		Amount:      &amount,
+		Category:    &category,
+		Description: entry.Description,
+	}
 }
 
 func (s *APIServer) runJob(c *gin.Context, jobKey appjobs.JobKey, windowKey string) {

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"stds_backend/internal/http/api"
 	"stds_backend/internal/http/requestctx"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
+	"stds_backend/internal/shared/apperr"
 )
 
 func TestToPropertyResponseAllowsNilElectricityUnitPrice(t *testing.T) {
@@ -196,6 +198,280 @@ func TestRecordBillPaymentBindsRequest(t *testing.T) {
 	}
 }
 
+func TestListPropertyPendingMetersReturnsBillListResponseAndForwardsActorScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	meters := &recordingPropertyMeters{
+		pendingBills: []BillingBill{testPendingMeterBill()},
+	}
+	server := &APIServer{billing: BillingServices{PropertyMeters: meters}}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/properties/10000000-0000-0000-0000-000000000001/pending-meter", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID:              "user-1",
+		Role:                "staff",
+		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000001"},
+	})
+
+	server.ListPropertyPendingMeters(c, "10000000-0000-0000-0000-000000000001")
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if meters.pendingInput.ActorRole != "staff" || meters.pendingInput.ActorUserID != "user-1" {
+		t.Fatalf("unexpected actor input: %+v", meters.pendingInput)
+	}
+	if len(meters.pendingInput.AssignedPropertyIDs) != 1 || meters.pendingInput.AssignedPropertyIDs[0] != "10000000-0000-0000-0000-000000000001" {
+		t.Fatalf("unexpected assigned properties: %+v", meters.pendingInput.AssignedPropertyIDs)
+	}
+	if meters.pendingInput.PropertyID != "10000000-0000-0000-0000-000000000001" {
+		t.Fatalf("PropertyID = %q", meters.pendingInput.PropertyID)
+	}
+
+	var response api.BillListResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.Data == nil || len(*response.Data) != 1 {
+		t.Fatalf("expected one pending meter bill, got %+v", response.Data)
+	}
+	if (*response.Data)[0].MeterPreviousReading == nil || *(*response.Data)[0].MeterPreviousReading != 1250 {
+		t.Fatalf("unexpected pending meter bill response: %+v", (*response.Data)[0])
+	}
+}
+
+func TestListPropertyMeterHistoryReturnsBillPeriodsForYear(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	meters := &recordingPropertyMeters{
+		historyBills: []BillingBill{testBillingBill()},
+	}
+	server := &APIServer{billing: BillingServices{PropertyMeters: meters}}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/properties/10000000-0000-0000-0000-000000000001/meter-history?year=2026", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID:              "user-1",
+		Role:                "organizer",
+		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000001"},
+	})
+	year := 2026
+
+	server.ListPropertyMeterHistory(c, "10000000-0000-0000-0000-000000000001", api.ListPropertyMeterHistoryParams{Year: &year})
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if meters.historyInput.PropertyID != "10000000-0000-0000-0000-000000000001" {
+		t.Fatalf("PropertyID = %q", meters.historyInput.PropertyID)
+	}
+	if meters.historyInput.Year == nil || *meters.historyInput.Year != 2026 {
+		t.Fatalf("Year = %v, want 2026", meters.historyInput.Year)
+	}
+
+	var response api.BillListResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.Data == nil || len(*response.Data) != 1 {
+		t.Fatalf("expected one meter history bill, got %+v", response.Data)
+	}
+	bill := (*response.Data)[0]
+	if bill.PeriodStart == nil || bill.PeriodEnd == nil {
+		t.Fatalf("expected bill period in response: %+v", bill)
+	}
+	if bill.Amount == nil || *bill.Amount != 12000 {
+		t.Fatalf("unexpected meter history bill response: %+v", bill)
+	}
+}
+
+func TestListRoomMeterHistoryRejectsMonthWithoutYear(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := &APIServer{billing: BillingServices{RoomMeters: &recordingRoomMeters{}}}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/rooms/20000000-0000-0000-0000-000000000001/meter-history?month=4", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID:              "user-1",
+		Role:                "staff",
+		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000001"},
+	})
+	month := 4
+
+	server.ListRoomMeterHistory(c, "20000000-0000-0000-0000-000000000001", api.ListRoomMeterHistoryParams{Month: &month})
+
+	if len(c.Errors) != 1 {
+		t.Fatalf("expected one error, got %d", len(c.Errors))
+	}
+	var appErr *apperr.Error
+	if !errors.As(c.Errors[0].Err, &appErr) || appErr.Code != apperr.CodeBadRequest {
+		t.Fatalf("expected BAD_REQUEST, got %v", c.Errors[0].Err)
+	}
+}
+
+func TestListRoomMeterHistoryForwardsYearMonthAndReturnsBillListResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	meters := &recordingRoomMeters{
+		bills: []BillingBill{testBillingBill()},
+	}
+	server := &APIServer{billing: BillingServices{RoomMeters: meters}}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/rooms/20000000-0000-0000-0000-000000000001/meter-history?year=2026&month=4", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID:              "user-1",
+		Role:                "staff",
+		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000001"},
+	})
+	year := 2026
+	month := 4
+
+	server.ListRoomMeterHistory(c, "20000000-0000-0000-0000-000000000001", api.ListRoomMeterHistoryParams{Year: &year, Month: &month})
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if meters.input.RoomID != "20000000-0000-0000-0000-000000000001" {
+		t.Fatalf("RoomID = %q", meters.input.RoomID)
+	}
+	if meters.input.Year == nil || *meters.input.Year != 2026 || meters.input.Month == nil || *meters.input.Month != 4 {
+		t.Fatalf("unexpected period filters: %+v", meters.input)
+	}
+
+	var response api.BillListResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.Data == nil || len(*response.Data) != 1 {
+		t.Fatalf("expected one room meter history bill, got %+v", response.Data)
+	}
+}
+
+func TestGetPropertyFinancialReportSummaryReturnsSummaryListAndEmptyList(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name      string
+		summaries []BillingFinancialReportSummary
+		wantLen   int
+	}{
+		{
+			name: "summary list",
+			summaries: []BillingFinancialReportSummary{
+				{Year: 2026, Month: 3, TotalIncome: 185000, TotalExpense: 12000, Net: 173000},
+			},
+			wantLen: 1,
+		},
+		{name: "empty list", summaries: []BillingFinancialReportSummary{}, wantLen: 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reports := &recordingFinancialReports{summaries: tc.summaries}
+			server := &APIServer{billing: BillingServices{FinancialReports: reports}}
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/properties/10000000-0000-0000-0000-000000000001/financial-report?year=2026", nil)
+			requestctx.SetPrincipal(c, requestctx.Principal{
+				UserID:              "user-1",
+				Role:                "owner",
+				AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000001"},
+			})
+			year := 2026
+
+			server.GetPropertyFinancialReportSummary(c, "10000000-0000-0000-0000-000000000001", api.GetPropertyFinancialReportSummaryParams{Year: &year})
+
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+			}
+			if reports.summaryInput.PropertyID != "10000000-0000-0000-0000-000000000001" || reports.summaryInput.ActorRole != "owner" {
+				t.Fatalf("unexpected summary input: %+v", reports.summaryInput)
+			}
+			if reports.summaryInput.Year == nil || *reports.summaryInput.Year != 2026 {
+				t.Fatalf("Year = %v, want 2026", reports.summaryInput.Year)
+			}
+
+			var response api.FinancialReportListResponse
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Fatalf("json.Unmarshal: %v", err)
+			}
+			if response.Data == nil || len(*response.Data) != tc.wantLen {
+				t.Fatalf("expected %d summaries, got %+v", tc.wantLen, response.Data)
+			}
+		})
+	}
+}
+
+func TestGetPropertyFinancialReportReturnsDetailResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	reports := &recordingFinancialReports{report: testFinancialReport()}
+	server := &APIServer{billing: BillingServices{FinancialReports: reports}}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/properties/10000000-0000-0000-0000-000000000001/financial-report/2026/4", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID:              "user-1",
+		Role:                "staff",
+		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000001"},
+	})
+
+	server.GetPropertyFinancialReport(c, "10000000-0000-0000-0000-000000000001", 2026, 4)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if reports.getInput.PropertyID != "10000000-0000-0000-0000-000000000001" || reports.getInput.Year != 2026 || reports.getInput.Month != 4 {
+		t.Fatalf("unexpected report input: %+v", reports.getInput)
+	}
+
+	var response api.FinancialReportResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.IsFinalized == nil || !*response.IsFinalized || response.TotalIncome == nil || *response.TotalIncome != 185000 {
+		t.Fatalf("unexpected financial report response: %+v", response)
+	}
+	if response.Entries == nil || len(*response.Entries) != 1 || (*response.Entries)[0].Category == nil || *(*response.Entries)[0].Category != api.RentPayment {
+		t.Fatalf("unexpected financial report entries: %+v", response.Entries)
+	}
+}
+
+func TestSendPropertyFinancialReportReturnsReportResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	reports := &recordingFinancialReports{sentReport: testFinancialReport()}
+	server := &APIServer{billing: BillingServices{FinancialReports: reports}}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/properties/10000000-0000-0000-0000-000000000001/financial-report/2026/4/send", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID:              "user-1",
+		Role:                "organizer",
+		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000001"},
+	})
+
+	server.SendPropertyFinancialReport(c, "10000000-0000-0000-0000-000000000001", 2026, 4)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if reports.sendInput.PropertyID != "10000000-0000-0000-0000-000000000001" || reports.sendInput.ActorRole != "organizer" {
+		t.Fatalf("unexpected send input: %+v", reports.sendInput)
+	}
+
+	var response api.FinancialReportResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.PropertyId == nil || response.PropertyId.String() != "10000000-0000-0000-0000-000000000001" {
+		t.Fatalf("unexpected sent report response: %+v", response)
+	}
+}
+
 type recordingBillingQuery struct {
 	input    BillingListInput
 	getInput BillingGetInput
@@ -223,6 +499,57 @@ func (p *recordingBillingPayment) RecordBillPayment(_ context.Context, input Bil
 	return &p.bill, nil
 }
 
+type recordingPropertyMeters struct {
+	pendingInput BillingPropertyMetersInput
+	historyInput BillingPropertyMeterHistoryInput
+	pendingBills []BillingBill
+	historyBills []BillingBill
+}
+
+func (m *recordingPropertyMeters) ListPropertyPendingMeters(_ context.Context, input BillingPropertyMetersInput) ([]BillingBill, error) {
+	m.pendingInput = input
+	return m.pendingBills, nil
+}
+
+func (m *recordingPropertyMeters) ListPropertyMeterHistory(_ context.Context, input BillingPropertyMeterHistoryInput) ([]BillingBill, error) {
+	m.historyInput = input
+	return m.historyBills, nil
+}
+
+type recordingRoomMeters struct {
+	input BillingRoomMeterHistoryInput
+	bills []BillingBill
+}
+
+func (m *recordingRoomMeters) ListRoomMeterHistory(_ context.Context, input BillingRoomMeterHistoryInput) ([]BillingBill, error) {
+	m.input = input
+	return m.bills, nil
+}
+
+type recordingFinancialReports struct {
+	summaryInput BillingFinancialReportSummaryInput
+	getInput     BillingFinancialReportInput
+	sendInput    BillingFinancialReportInput
+	summaries    []BillingFinancialReportSummary
+	report       BillingFinancialReport
+	sentReport   BillingFinancialReport
+}
+
+func (r *recordingFinancialReports) ListFinancialReportSummaries(_ context.Context, input BillingFinancialReportSummaryInput) ([]BillingFinancialReportSummary, error) {
+	r.summaryInput = input
+	return r.summaries, nil
+}
+
+func (r *recordingFinancialReports) GetFinancialReport(_ context.Context, input BillingFinancialReportInput) (*BillingFinancialReport, error) {
+	r.getInput = input
+	return &r.report, nil
+}
+
+func (r *recordingFinancialReports) SendFinancialReport(_ context.Context, input BillingFinancialReportInput) (*BillingFinancialReport, error) {
+	r.sendInput = input
+	return &r.sentReport, nil
+}
+
 func testBillingBill() BillingBill {
 	amount := 12000
 	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
@@ -242,5 +569,31 @@ func testBillingBill() BillingBill {
 		CreatedAt:          now,
 		UpdatedAt:          now,
 		Version:            1,
+	}
+}
+
+func testPendingMeterBill() BillingBill {
+	previousReading := 1250
+	bill := testBillingBill()
+	bill.ID = "30000000-0000-0000-0000-000000000002"
+	bill.Status = "pending_meter"
+	bill.Amount = nil
+	bill.MeterPreviousReading = &previousReading
+	return bill
+}
+
+func testFinancialReport() BillingFinancialReport {
+	description := "101 room April rent"
+	return BillingFinancialReport{
+		PropertyID:   "10000000-0000-0000-0000-000000000001",
+		Year:         2026,
+		Month:        4,
+		TotalIncome:  185000,
+		TotalExpense: 12000,
+		Net:          173000,
+		IsFinalized:  true,
+		Entries: []BillingFinancialReportEntry{
+			{Category: "rent_payment", Description: &description, Amount: 18000},
+		},
 	}
 }

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -462,6 +462,9 @@ func TestSendPropertyFinancialReportReturnsReportResponse(t *testing.T) {
 	if reports.sendInput.PropertyID != "10000000-0000-0000-0000-000000000001" || reports.sendInput.ActorRole != "organizer" {
 		t.Fatalf("unexpected send input: %+v", reports.sendInput)
 	}
+	if reports.sendInput.Year != 2026 || reports.sendInput.Month != 4 {
+		t.Fatalf("unexpected send period: %+v", reports.sendInput)
+	}
 
 	var response api.FinancialReportResponse
 	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -2173,6 +2173,148 @@ func TestGetBillResolvesPropertyAccessThroughOwnershipQuery(t *testing.T) {
 	}
 }
 
+func TestFinancialReportReadAllowsOwnerOwningProperty(t *testing.T) {
+	engine := newTestEngine(
+		fakeUserRepo{role: "owner", userID: "owner-1"},
+		fakeAuthenticator{role: "owner"},
+		fakePropertyRepo{
+			ownerByPropertyID: map[string]string{
+				testPropertyID1: "owner-1",
+			},
+		},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/properties/"+testPropertyID1+"/financial-report/2026/4", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code == http.StatusUnauthorized || resp.Code == http.StatusForbidden {
+		t.Fatalf("expected owner read to pass policy, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestMeterRoutesRejectOwnerRole(t *testing.T) {
+	paths := []struct {
+		name string
+		path string
+	}{
+		{name: "property pending meters", path: "/api/v1/properties/" + testPropertyID1 + "/pending-meter"},
+		{name: "property meter history", path: "/api/v1/properties/" + testPropertyID1 + "/meter-history"},
+	}
+
+	for _, tc := range paths {
+		t.Run(tc.name, func(t *testing.T) {
+			engine := newTestEngine(
+				fakeUserRepo{role: "owner", userID: "owner-1"},
+				fakeAuthenticator{role: "owner"},
+				fakePropertyRepo{
+					ownerByPropertyID: map[string]string{
+						testPropertyID1: "owner-1",
+					},
+				},
+				fakeResourceOwnershipRepo{},
+				"",
+				fakeJobRunsRepo{},
+			)
+
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer valid-token")
+			resp := httptest.NewRecorder()
+
+			engine.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusForbidden {
+				t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestSendFinancialReportPolicyAllowsAdminAndOrganizerOnly(t *testing.T) {
+	tests := []struct {
+		name          string
+		role          string
+		assigned      []string
+		wantForbidden bool
+	}{
+		{name: "admin", role: "admin"},
+		{name: "organizer", role: "organizer", assigned: []string{testPropertyID1}},
+		{name: "staff", role: "staff", assigned: []string{testPropertyID1}, wantForbidden: true},
+		{name: "owner", role: "owner", wantForbidden: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			engine := newTestEngine(
+				fakeUserRepo{role: tt.role, assignedPropertyIDs: tt.assigned},
+				fakeAuthenticator{role: tt.role, assignedPropertyIDs: tt.assigned},
+				fakePropertyRepo{
+					ownerByPropertyID: map[string]string{
+						testPropertyID1: "user-1",
+					},
+				},
+				fakeResourceOwnershipRepo{},
+				"",
+				fakeJobRunsRepo{},
+			)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/properties/"+testPropertyID1+"/financial-report/2026/4/send", nil)
+			req.Header.Set("Authorization", "Bearer valid-token")
+			resp := httptest.NewRecorder()
+
+			engine.ServeHTTP(resp, req)
+
+			if tt.wantForbidden {
+				if resp.Code != http.StatusForbidden {
+					t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
+				}
+				return
+			}
+			if resp.Code == http.StatusUnauthorized || resp.Code == http.StatusForbidden {
+				t.Fatalf("expected send to pass policy, got %d: %s", resp.Code, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestRoomMeterHistoryUsesRoomPropertyResolverAndReturnsRoomNotFound(t *testing.T) {
+	var capturedRoomID string
+	engine := newTestEngine(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{roomIDLookup: &capturedRoomID},
+		"",
+		fakeJobRunsRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/rooms/"+testMissingRoomID+"/meter-history", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if capturedRoomID != testMissingRoomID {
+		t.Fatalf("room resolver id = %q, want %q", capturedRoomID, testMissingRoomID)
+	}
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["error_code"] != apperr.CodeRoomNotFound {
+		t.Fatalf("expected %s, got %v", apperr.CodeRoomNotFound, payload["error_code"])
+	}
+}
+
 func TestListBillsRejectsUnassignedPropertyFilter(t *testing.T) {
 	engine := newTestEngine(
 		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}},
@@ -2977,6 +3119,7 @@ type findLeaseCall struct {
 
 type fakeResourceOwnershipRepo struct {
 	propertyByRoomID             map[string]string
+	roomIDLookup                 *string
 	propertyByTenantID           map[string]string
 	propertyByLeaseID            map[string]string
 	propertyByBillID             map[string]string
@@ -4135,6 +4278,9 @@ func (f fakeLeaseQueryRepo) FindByIDAccessible(_ context.Context, id string, rol
 }
 
 func (f fakeResourceOwnershipRepo) FindPropertyIDByRoomID(_ context.Context, roomID string) (string, error) {
+	if f.roomIDLookup != nil {
+		*f.roomIDLookup = roomID
+	}
 	return lookupPropertyID(f.propertyByRoomID, roomID)
 }
 

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -317,6 +317,7 @@ SELECT
 FROM bills b
 JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL
 WHERE b.property_id = $1
+  AND b.type = 'electricity'
   AND b.status = 'pending_meter'
   AND b.deleted_at IS NULL
 `

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -634,22 +635,35 @@ INSERT INTO accounting_entries (
 
 // ListFinancialReportSummaries returns finalized summaries and the requested current live summary.
 func (r *SQLRepository) ListFinancialReportSummaries(ctx context.Context, scope Scope, propertyID string, year *int, currentYear int, currentMonth int) ([]FinancialReportSummary, error) {
-	summaries := make([]FinancialReportSummary, 0)
-
 	finalized, err := r.listFinalizedFinancialReportSummaries(ctx, scope, propertyID, year)
 	if err != nil {
 		return nil, err
 	}
-	summaries = append(summaries, finalized...)
+	byMonth := make(map[string]FinancialReportSummary, len(finalized)+1)
+	for _, summary := range finalized {
+		byMonth[financialReportSummaryKey(summary.Year, summary.Month)] = summary
+	}
 
 	if year == nil || *year == currentYear {
 		live, err := r.listLiveFinancialReportSummaries(ctx, scope, propertyID, currentYear, currentMonth)
 		if err != nil {
 			return nil, err
 		}
-		summaries = append(summaries, live...)
+		for _, summary := range live {
+			byMonth[financialReportSummaryKey(summary.Year, summary.Month)] = summary
+		}
 	}
 
+	summaries := make([]FinancialReportSummary, 0, len(byMonth))
+	for _, summary := range byMonth {
+		summaries = append(summaries, summary)
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].Year != summaries[j].Year {
+			return summaries[i].Year > summaries[j].Year
+		}
+		return summaries[i].Month > summaries[j].Month
+	})
 	return summaries, nil
 }
 
@@ -706,17 +720,19 @@ WHERE ms.property_id = $1
 func (r *SQLRepository) listLiveFinancialReportSummaries(ctx context.Context, scope Scope, propertyID string, year int, month int) (summaries []FinancialReportSummary, err error) {
 	query := `
 SELECT
-	ae.year,
-	ae.month,
+	$2::int AS year,
+	$3::int AS month,
 	COALESCE(SUM(CASE WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_income,
-	COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_expense
+	COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_expense,
+	COALESCE(SUM(CASE WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount) ELSE 0 END), 0)
+		- COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS net
 FROM property_accounts pa
 JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL
-JOIN accounting_entries ae ON ae.property_account_id = pa.id
-WHERE pa.property_id = $1
-  AND pa.deleted_at IS NULL
+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id
   AND ae.year = $2
   AND ae.month = $3
+WHERE pa.property_id = $1
+  AND pa.deleted_at IS NULL
 `
 	args := []any{propertyID, year, month}
 	var ok bool
@@ -724,7 +740,7 @@ WHERE pa.property_id = $1
 	if !ok {
 		return []FinancialReportSummary{}, nil
 	}
-	query += "GROUP BY ae.year, ae.month\nORDER BY ae.year DESC, ae.month DESC\n"
+	query += "GROUP BY pa.property_id\n"
 
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -739,10 +755,9 @@ WHERE pa.property_id = $1
 	summaries = make([]FinancialReportSummary, 0)
 	for rows.Next() {
 		var summary FinancialReportSummary
-		if err := rows.Scan(&summary.Year, &summary.Month, &summary.TotalIncome, &summary.TotalExpense); err != nil {
+		if err := rows.Scan(&summary.Year, &summary.Month, &summary.TotalIncome, &summary.TotalExpense, &summary.Net); err != nil {
 			return nil, fmt.Errorf("scan live financial report summary row: %w", err)
 		}
-		summary.Net = summary.TotalIncome - summary.TotalExpense
 		summaries = append(summaries, summary)
 	}
 	if err := rows.Err(); err != nil {
@@ -760,7 +775,7 @@ func (r *SQLRepository) GetFinancialReport(ctx context.Context, scope Scope, pro
 	return r.getFinalizedFinancialReport(ctx, scope, propertyID, year, month)
 }
 
-func (r *SQLRepository) getFinalizedFinancialReport(ctx context.Context, scope Scope, propertyID string, year int, month int) (*FinancialReport, error) {
+func (r *SQLRepository) getFinalizedFinancialReport(ctx context.Context, scope Scope, propertyID string, year int, month int) (report *FinancialReport, err error) {
 	query := `
 SELECT
 	ms.property_id,
@@ -794,9 +809,12 @@ WHERE ms.property_id = $1
 	if err != nil {
 		return nil, fmt.Errorf("get finalized financial report: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close finalized financial report rows: %w", cerr)
+		}
+	}()
 
-	var report *FinancialReport
 	for rows.Next() {
 		entry, hasEntry, rowReport, err := scanFinalizedFinancialReportRow(rows)
 		if err != nil {
@@ -819,7 +837,7 @@ WHERE ms.property_id = $1
 	return report, nil
 }
 
-func (r *SQLRepository) getLiveFinancialReport(ctx context.Context, scope Scope, propertyID string, year int, month int) (*FinancialReport, error) {
+func (r *SQLRepository) getLiveFinancialReport(ctx context.Context, scope Scope, propertyID string, year int, month int) (report *FinancialReport, err error) {
 	query := `
 SELECT
 	pa.property_id,
@@ -851,9 +869,12 @@ WHERE pa.property_id = $1
 	if err != nil {
 		return nil, fmt.Errorf("get live financial report: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close live financial report rows: %w", cerr)
+		}
+	}()
 
-	var report *FinancialReport
 	for rows.Next() {
 		if report == nil {
 			report = &FinancialReport{
@@ -994,6 +1015,10 @@ func appendPropertyScope(query string, args []any, scope Scope, propertyAlias st
 	default:
 		return "", nil, false
 	}
+}
+
+func financialReportSummaryKey(year int, month int) string {
+	return fmt.Sprintf("%04d-%02d", year, month)
 }
 
 func scanBill(row rowScanner) (*Bill, error) {

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -100,6 +100,38 @@ type CreateAccountingEntryParams struct {
 	Month             int
 }
 
+// FinancialReportSummary is one monthly financial report summary row.
+type FinancialReportSummary struct {
+	Year         int
+	Month        int
+	TotalIncome  int
+	TotalExpense int
+	Net          int
+	IsFinalized  bool
+}
+
+// FinancialReport is one monthly financial report with detail entries.
+type FinancialReport struct {
+	PropertyID   string
+	Year         int
+	Month        int
+	TotalIncome  int
+	TotalExpense int
+	Net          int
+	IsFinalized  bool
+	Entries      []FinancialReportEntry
+}
+
+// FinancialReportEntry is one financial report detail entry.
+type FinancialReportEntry struct {
+	ID          string
+	Category    string
+	Description *string
+	Amount      int
+	SourceRef   json.RawMessage
+	CreatedAt   time.Time
+}
+
 // SQLRepository persists and reads billing data from PostgreSQL.
 type SQLRepository struct {
 	db *sql.DB
@@ -252,6 +284,188 @@ LIMIT 1
 	}
 
 	return reading, nil
+}
+
+// ListPropertyPendingMeters returns active pending electricity meter bills for one property.
+func (r *SQLRepository) ListPropertyPendingMeters(ctx context.Context, scope Scope, propertyID string) (bills []Bill, err error) {
+	query := `
+SELECT
+	b.id,
+	b.lease_id,
+	b.tenant_id,
+	b.room_id,
+	b.property_id,
+	b.type,
+	b.amount,
+	b.period_start,
+	b.period_end,
+	b.due_date,
+	b.status,
+	b.payment_method,
+	b.paid_at,
+	b.paid_amount,
+	b.meter_previous_reading,
+	b.meter_current_reading,
+	b.meter_unit_price,
+	b.meter_recorded_at,
+	b.written_off_reason,
+	b.overdue_notice_count,
+	b.created_at,
+	b.updated_at,
+	b.version
+FROM bills b
+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL
+WHERE b.property_id = $1
+  AND b.status = 'pending_meter'
+  AND b.deleted_at IS NULL
+`
+	args := []any{propertyID}
+	var ok bool
+	query, args, ok = appendPropertyScope(query, args, scope, "p")
+	if !ok {
+		return []Bill{}, nil
+	}
+	query += "ORDER BY b.period_start ASC, b.period_end ASC, b.created_at ASC\n"
+
+	return r.listBills(ctx, query, "list property pending meters", args...)
+}
+
+// ListPropertyMeterHistory returns recorded electricity bills for a property.
+func (r *SQLRepository) ListPropertyMeterHistory(ctx context.Context, scope Scope, propertyID string, year *int) ([]Bill, error) {
+	query := `
+SELECT
+	b.id,
+	b.lease_id,
+	b.tenant_id,
+	b.room_id,
+	b.property_id,
+	b.type,
+	b.amount,
+	b.period_start,
+	b.period_end,
+	b.due_date,
+	b.status,
+	b.payment_method,
+	b.paid_at,
+	b.paid_amount,
+	b.meter_previous_reading,
+	b.meter_current_reading,
+	b.meter_unit_price,
+	b.meter_recorded_at,
+	b.written_off_reason,
+	b.overdue_notice_count,
+	b.created_at,
+	b.updated_at,
+	b.version
+FROM bills b
+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL
+WHERE b.property_id = $1
+  AND b.type = 'electricity'
+  AND b.meter_current_reading IS NOT NULL
+  AND b.status NOT IN ('voided', 'written_off')
+  AND b.deleted_at IS NULL
+`
+	args := []any{propertyID}
+	var ok bool
+	query, args, ok = appendPropertyScope(query, args, scope, "p")
+	if !ok {
+		return []Bill{}, nil
+	}
+	if year != nil {
+		periodStart := time.Date(*year, 1, 1, 0, 0, 0, 0, time.UTC)
+		periodEnd := periodStart.AddDate(1, 0, 0)
+		args = append(args, periodEnd, periodStart)
+		query += fmt.Sprintf("  AND b.period_start < $%d\n  AND b.period_end >= $%d\n", len(args)-1, len(args))
+	}
+	query += "ORDER BY b.period_start DESC, b.period_end DESC, b.created_at DESC\n"
+
+	return r.listBills(ctx, query, "list property meter history", args...)
+}
+
+// ListRoomMeterHistory returns recorded electricity bills for a room.
+func (r *SQLRepository) ListRoomMeterHistory(ctx context.Context, scope Scope, roomID string, year *int, month *int) ([]Bill, error) {
+	query := `
+SELECT
+	b.id,
+	b.lease_id,
+	b.tenant_id,
+	b.room_id,
+	b.property_id,
+	b.type,
+	b.amount,
+	b.period_start,
+	b.period_end,
+	b.due_date,
+	b.status,
+	b.payment_method,
+	b.paid_at,
+	b.paid_amount,
+	b.meter_previous_reading,
+	b.meter_current_reading,
+	b.meter_unit_price,
+	b.meter_recorded_at,
+	b.written_off_reason,
+	b.overdue_notice_count,
+	b.created_at,
+	b.updated_at,
+	b.version
+FROM bills b
+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL
+WHERE b.room_id = $1
+  AND b.type = 'electricity'
+  AND b.meter_current_reading IS NOT NULL
+  AND b.status NOT IN ('voided', 'written_off')
+  AND b.deleted_at IS NULL
+`
+	args := []any{roomID}
+	var ok bool
+	query, args, ok = appendPropertyScope(query, args, scope, "p")
+	if !ok {
+		return []Bill{}, nil
+	}
+	if year != nil || month != nil {
+		filterYear := time.Now().UTC().Year()
+		if year != nil {
+			filterYear = *year
+		}
+		periodStart := time.Date(filterYear, 1, 1, 0, 0, 0, 0, time.UTC)
+		periodEnd := periodStart.AddDate(1, 0, 0)
+		if month != nil {
+			periodStart = time.Date(filterYear, time.Month(*month), 1, 0, 0, 0, 0, time.UTC)
+			periodEnd = periodStart.AddDate(0, 1, 0)
+		}
+		args = append(args, periodEnd, periodStart)
+		query += fmt.Sprintf("  AND b.period_start < $%d\n  AND b.period_end >= $%d\n", len(args)-1, len(args))
+	}
+	query += "ORDER BY b.period_start DESC, b.period_end DESC, b.created_at DESC\n"
+
+	return r.listBills(ctx, query, "list room meter history", args...)
+}
+
+func (r *SQLRepository) listBills(ctx context.Context, query string, operation string, args ...any) (bills []Bill, err error) {
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", operation, err)
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close bill rows: %w", cerr)
+		}
+	}()
+
+	bills = make([]Bill, 0)
+	for rows.Next() {
+		bill, err := scanBill(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan bill row: %w", err)
+		}
+		bills = append(bills, *bill)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate bill rows: %w", err)
+	}
+
+	return bills, nil
 }
 
 // FindPropertyElectricityUnitPrice returns the active property's unit price, preserving NULL as nil.
@@ -418,6 +632,254 @@ INSERT INTO accounting_entries (
 	return nil
 }
 
+// ListFinancialReportSummaries returns finalized summaries and the requested current live summary.
+func (r *SQLRepository) ListFinancialReportSummaries(ctx context.Context, scope Scope, propertyID string, year *int, currentYear int, currentMonth int) ([]FinancialReportSummary, error) {
+	summaries := make([]FinancialReportSummary, 0)
+
+	finalized, err := r.listFinalizedFinancialReportSummaries(ctx, scope, propertyID, year)
+	if err != nil {
+		return nil, err
+	}
+	summaries = append(summaries, finalized...)
+
+	if year == nil || *year == currentYear {
+		live, err := r.listLiveFinancialReportSummaries(ctx, scope, propertyID, currentYear, currentMonth)
+		if err != nil {
+			return nil, err
+		}
+		summaries = append(summaries, live...)
+	}
+
+	return summaries, nil
+}
+
+func (r *SQLRepository) listFinalizedFinancialReportSummaries(ctx context.Context, scope Scope, propertyID string, year *int) (summaries []FinancialReportSummary, err error) {
+	query := `
+SELECT
+	ms.year,
+	ms.month,
+	ms.total_income,
+	ms.total_expense,
+	ms.net
+FROM monthly_snapshots ms
+JOIN properties p ON p.id = ms.property_id AND p.deleted_at IS NULL
+WHERE ms.property_id = $1
+`
+	args := []any{propertyID}
+	var ok bool
+	query, args, ok = appendPropertyScope(query, args, scope, "p")
+	if !ok {
+		return []FinancialReportSummary{}, nil
+	}
+	if year != nil {
+		args = append(args, *year)
+		query += fmt.Sprintf("  AND ms.year = $%d\n", len(args))
+	}
+	query += "ORDER BY ms.year DESC, ms.month DESC\n"
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list finalized financial report summaries: %w", err)
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close finalized financial report summary rows: %w", cerr)
+		}
+	}()
+
+	summaries = make([]FinancialReportSummary, 0)
+	for rows.Next() {
+		var summary FinancialReportSummary
+		if err := rows.Scan(&summary.Year, &summary.Month, &summary.TotalIncome, &summary.TotalExpense, &summary.Net); err != nil {
+			return nil, fmt.Errorf("scan finalized financial report summary row: %w", err)
+		}
+		summary.IsFinalized = true
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate finalized financial report summary rows: %w", err)
+	}
+
+	return summaries, nil
+}
+
+func (r *SQLRepository) listLiveFinancialReportSummaries(ctx context.Context, scope Scope, propertyID string, year int, month int) (summaries []FinancialReportSummary, err error) {
+	query := `
+SELECT
+	ae.year,
+	ae.month,
+	COALESCE(SUM(CASE WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_income,
+	COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_expense
+FROM property_accounts pa
+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL
+JOIN accounting_entries ae ON ae.property_account_id = pa.id
+WHERE pa.property_id = $1
+  AND pa.deleted_at IS NULL
+  AND ae.year = $2
+  AND ae.month = $3
+`
+	args := []any{propertyID, year, month}
+	var ok bool
+	query, args, ok = appendPropertyScope(query, args, scope, "p")
+	if !ok {
+		return []FinancialReportSummary{}, nil
+	}
+	query += "GROUP BY ae.year, ae.month\nORDER BY ae.year DESC, ae.month DESC\n"
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list live financial report summaries: %w", err)
+	}
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close live financial report summary rows: %w", cerr)
+		}
+	}()
+
+	summaries = make([]FinancialReportSummary, 0)
+	for rows.Next() {
+		var summary FinancialReportSummary
+		if err := rows.Scan(&summary.Year, &summary.Month, &summary.TotalIncome, &summary.TotalExpense); err != nil {
+			return nil, fmt.Errorf("scan live financial report summary row: %w", err)
+		}
+		summary.Net = summary.TotalIncome - summary.TotalExpense
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate live financial report summary rows: %w", err)
+	}
+
+	return summaries, nil
+}
+
+// GetFinancialReport returns one finalized or live monthly report with entries.
+func (r *SQLRepository) GetFinancialReport(ctx context.Context, scope Scope, propertyID string, year int, month int, live bool) (*FinancialReport, error) {
+	if live {
+		return r.getLiveFinancialReport(ctx, scope, propertyID, year, month)
+	}
+	return r.getFinalizedFinancialReport(ctx, scope, propertyID, year, month)
+}
+
+func (r *SQLRepository) getFinalizedFinancialReport(ctx context.Context, scope Scope, propertyID string, year int, month int) (*FinancialReport, error) {
+	query := `
+SELECT
+	ms.property_id,
+	ms.year,
+	ms.month,
+	ms.total_income,
+	ms.total_expense,
+	ms.net,
+	mse.id,
+	mse.category,
+	mse.description,
+	mse.amount,
+	mse.source_ref,
+	mse.created_at
+FROM monthly_snapshots ms
+JOIN properties p ON p.id = ms.property_id AND p.deleted_at IS NULL
+LEFT JOIN monthly_snapshot_entries mse ON mse.snapshot_id = ms.id
+WHERE ms.property_id = $1
+  AND ms.year = $2
+  AND ms.month = $3
+`
+	args := []any{propertyID, year, month}
+	var ok bool
+	query, args, ok = appendPropertyScope(query, args, scope, "p")
+	if !ok {
+		return nil, ErrNotFound
+	}
+	query += "ORDER BY mse.created_at ASC, mse.id ASC\n"
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get finalized financial report: %w", err)
+	}
+	defer rows.Close()
+
+	var report *FinancialReport
+	for rows.Next() {
+		entry, hasEntry, rowReport, err := scanFinalizedFinancialReportRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan finalized financial report row: %w", err)
+		}
+		if report == nil {
+			report = rowReport
+		}
+		if hasEntry {
+			report.Entries = append(report.Entries, entry)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate finalized financial report rows: %w", err)
+	}
+	if report == nil {
+		return nil, ErrNotFound
+	}
+
+	return report, nil
+}
+
+func (r *SQLRepository) getLiveFinancialReport(ctx context.Context, scope Scope, propertyID string, year int, month int) (*FinancialReport, error) {
+	query := `
+SELECT
+	pa.property_id,
+	$2::int AS year,
+	$3::int AS month,
+	ae.id,
+	ae.category,
+	ae.description,
+	ae.amount,
+	ae.source_ref,
+	ae.created_at
+FROM property_accounts pa
+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL
+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id
+  AND ae.year = $2
+  AND ae.month = $3
+WHERE pa.property_id = $1
+  AND pa.deleted_at IS NULL
+`
+	args := []any{propertyID, year, month}
+	var ok bool
+	query, args, ok = appendPropertyScope(query, args, scope, "p")
+	if !ok {
+		return nil, ErrNotFound
+	}
+	query += "ORDER BY ae.created_at ASC, ae.id ASC\n"
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get live financial report: %w", err)
+	}
+	defer rows.Close()
+
+	var report *FinancialReport
+	for rows.Next() {
+		if report == nil {
+			report = &FinancialReport{
+				Entries: make([]FinancialReportEntry, 0),
+			}
+		}
+		entry, hasEntry, err := scanLiveFinancialReportRow(rows, report)
+		if err != nil {
+			return nil, fmt.Errorf("scan live financial report row: %w", err)
+		}
+		if hasEntry {
+			report.Entries = append(report.Entries, entry)
+			addFinancialReportAmount(report, entry.Category, entry.Amount)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate live financial report rows: %w", err)
+	}
+	if report == nil {
+		return nil, ErrNotFound
+	}
+	report.Net = report.TotalIncome - report.TotalExpense
+
+	return report, nil
+}
+
 func buildAccessibleBillQuery(scope Scope, filter BillFilter, single bool, billID *string) (string, []any, bool) {
 	base := `
 SELECT
@@ -510,6 +972,30 @@ FROM bills b
 	return base, args, true
 }
 
+func appendPropertyScope(query string, args []any, scope Scope, propertyAlias string) (string, []any, bool) {
+	switch strings.TrimSpace(scope.Role) {
+	case "admin":
+		return query, args, true
+	case "organizer", "staff":
+		if len(scope.AssignedPropertyIDs) == 0 {
+			return "", nil, false
+		}
+		placeholders := make([]string, 0, len(scope.AssignedPropertyIDs))
+		for _, id := range scope.AssignedPropertyIDs {
+			args = append(args, id)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		query += "  AND " + propertyAlias + ".id IN (" + strings.Join(placeholders, ", ") + ")\n"
+		return query, args, true
+	case "owner":
+		args = append(args, strings.TrimSpace(scope.UserID))
+		query += fmt.Sprintf("  AND %s.owner_id = $%d\n", propertyAlias, len(args))
+		return query, args, true
+	default:
+		return "", nil, false
+	}
+}
+
 func scanBill(row rowScanner) (*Bill, error) {
 	var bill Bill
 	var amount sql.NullInt64
@@ -583,6 +1069,118 @@ func scanBill(row rowScanner) (*Bill, error) {
 	}
 
 	return &bill, nil
+}
+
+func scanFinalizedFinancialReportRow(row rowScanner) (FinancialReportEntry, bool, *FinancialReport, error) {
+	var report FinancialReport
+	var entry FinancialReportEntry
+	var entryID sql.NullString
+	var category sql.NullString
+	var description sql.NullString
+	var amount sql.NullInt64
+	var sourceRef sql.NullString
+	var createdAt sql.NullTime
+
+	if err := row.Scan(
+		&report.PropertyID,
+		&report.Year,
+		&report.Month,
+		&report.TotalIncome,
+		&report.TotalExpense,
+		&report.Net,
+		&entryID,
+		&category,
+		&description,
+		&amount,
+		&sourceRef,
+		&createdAt,
+	); err != nil {
+		return FinancialReportEntry{}, false, nil, err
+	}
+	hasEntry := entryID.Valid
+	if entryID.Valid {
+		entry.ID = entryID.String
+	}
+	if category.Valid {
+		entry.Category = category.String
+	}
+	if description.Valid {
+		entry.Description = &description.String
+	}
+	if amount.Valid {
+		entry.Amount = int(amount.Int64)
+	}
+	if sourceRef.Valid {
+		entry.SourceRef = json.RawMessage(sourceRef.String)
+	}
+	if createdAt.Valid {
+		entry.CreatedAt = createdAt.Time
+	}
+	report.IsFinalized = true
+	report.Entries = make([]FinancialReportEntry, 0)
+
+	return entry, hasEntry, &report, nil
+}
+
+func scanLiveFinancialReportRow(row rowScanner, report *FinancialReport) (FinancialReportEntry, bool, error) {
+	var entry FinancialReportEntry
+	var entryID sql.NullString
+	var category sql.NullString
+	var description sql.NullString
+	var amount sql.NullInt64
+	var sourceRef sql.NullString
+	var createdAt sql.NullTime
+
+	if err := row.Scan(
+		&report.PropertyID,
+		&report.Year,
+		&report.Month,
+		&entryID,
+		&category,
+		&description,
+		&amount,
+		&sourceRef,
+		&createdAt,
+	); err != nil {
+		return FinancialReportEntry{}, false, err
+	}
+	hasEntry := entryID.Valid
+	if entryID.Valid {
+		entry.ID = entryID.String
+	}
+	if category.Valid {
+		entry.Category = category.String
+	}
+	if description.Valid {
+		entry.Description = &description.String
+	}
+	if amount.Valid {
+		entry.Amount = int(amount.Int64)
+	}
+	if sourceRef.Valid {
+		entry.SourceRef = json.RawMessage(sourceRef.String)
+	}
+	if createdAt.Valid {
+		entry.CreatedAt = createdAt.Time
+	}
+
+	return entry, hasEntry, nil
+}
+
+func addFinancialReportAmount(report *FinancialReport, category string, amount int) {
+	switch category {
+	case "rent_payment", "electricity_payment", "deposit_deduction":
+		report.TotalIncome += absInt(amount)
+	case "deposit_refund", "journal_expense":
+		report.TotalExpense += absInt(amount)
+	}
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
 }
 
 type rowScanner interface {

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -230,6 +230,79 @@ FOR UPDATE
 	}
 }
 
+func TestListPropertyPendingMetersFiltersPendingMeterAndReturnsPeriodBounds(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`(?s)FROM bills b\s+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL\s+WHERE b.property_id = \$1\s+AND b.status = 'pending_meter'\s+AND b.deleted_at IS NULL`).
+		WithArgs("property-1").
+		WillReturnRows(billRows().AddRow(
+			"bill-1", "lease-1", "tenant-1", "room-1", "property-1", "electricity", nil,
+			periodStart, periodEnd, now, "pending_meter", nil, nil, nil, nil, nil, nil, nil, nil, 0, now, now, 1,
+		))
+
+	bills, err := repo.ListPropertyPendingMeters(context.Background(), Scope{Role: "admin"}, "property-1")
+	if err != nil {
+		t.Fatalf("ListPropertyPendingMeters: %v", err)
+	}
+	if len(bills) != 1 {
+		t.Fatalf("expected 1 bill, got %d", len(bills))
+	}
+	if !bills[0].PeriodStart.Equal(periodStart) || !bills[0].PeriodEnd.Equal(periodEnd) {
+		t.Fatalf("period = %s..%s, want %s..%s", bills[0].PeriodStart, bills[0].PeriodEnd, periodStart, periodEnd)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListPropertyMeterHistoryYearFilterUsesPeriodOverlap(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	year := 2026
+	rangeStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	rangeEnd := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`(?s)b.property_id = \$1\s+AND b.type = 'electricity'\s+AND b.meter_current_reading IS NOT NULL\s+AND b.status NOT IN \('voided', 'written_off'\)\s+AND b.deleted_at IS NULL\s+AND b.period_start < \$2\s+AND b.period_end >= \$3`).
+		WithArgs("property-1", rangeEnd, rangeStart).
+		WillReturnRows(billRows())
+
+	_, err := repo.ListPropertyMeterHistory(context.Background(), Scope{Role: "admin"}, "property-1", &year)
+	if err != nil {
+		t.Fatalf("ListPropertyMeterHistory: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListRoomMeterHistoryMonthFilterUsesPeriodOverlap(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	year := 2026
+	month := 4
+	rangeStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	rangeEnd := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`(?s)b.room_id = \$1\s+AND b.type = 'electricity'\s+AND b.meter_current_reading IS NOT NULL\s+AND b.status NOT IN \('voided', 'written_off'\)\s+AND b.deleted_at IS NULL\s+AND b.period_start < \$2\s+AND b.period_end >= \$3`).
+		WithArgs("room-1", rangeEnd, rangeStart).
+		WillReturnRows(billRows())
+
+	_, err := repo.ListRoomMeterHistory(context.Background(), Scope{Role: "admin"}, "room-1", &year, &month)
+	if err != nil {
+		t.Fatalf("ListRoomMeterHistory: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func TestFindPropertyElectricityUnitPriceForUpdateUsesTransaction(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)
@@ -356,6 +429,142 @@ func TestInsertAccountingEntryWritesCategoryAmountSourceRefYearAndMonth(t *testi
 	}
 }
 
+func TestGetFinancialReportFinalizedMapsSnapshotEntries(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	createdAt := time.Date(2026, 4, 30, 23, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`(?s)FROM monthly_snapshots ms\s+JOIN properties p ON p.id = ms.property_id AND p.deleted_at IS NULL\s+LEFT JOIN monthly_snapshot_entries mse ON mse.snapshot_id = ms.id\s+WHERE ms.property_id = \$1\s+AND ms.year = \$2\s+AND ms.month = \$3`).
+		WithArgs("property-1", 2026, 4).
+		WillReturnRows(financialReportFinalizedRows().
+			AddRow("property-1", 2026, 4, 13000, 1500, 11500, "entry-1", "rent_payment", "rent", 12000, []byte(`{"bill_id":"bill-1"}`), createdAt).
+			AddRow("property-1", 2026, 4, 13000, 1500, 11500, "entry-2", "journal_expense", nil, 1500, []byte(`{"journal_log_id":"journal-1"}`), createdAt))
+
+	report, err := repo.GetFinancialReport(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 4, false)
+	if err != nil {
+		t.Fatalf("GetFinancialReport finalized: %v", err)
+	}
+	if !report.IsFinalized {
+		t.Fatalf("IsFinalized = false, want true")
+	}
+	if report.TotalIncome != 13000 || report.TotalExpense != 1500 || report.Net != 11500 {
+		t.Fatalf("totals = income %d expense %d net %d, want 13000 1500 11500", report.TotalIncome, report.TotalExpense, report.Net)
+	}
+	if len(report.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(report.Entries))
+	}
+	if report.Entries[0].Category != "rent_payment" || report.Entries[0].Description == nil || *report.Entries[0].Description != "rent" {
+		t.Fatalf("first entry = %+v, want rent_payment with description", report.Entries[0])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestGetFinancialReportLiveMapsAccountingEntriesAndAggregatesTotals(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	createdAt := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`(?s)FROM property_accounts pa\s+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL\s+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id\s+AND ae.year = \$2\s+AND ae.month = \$3\s+WHERE pa.property_id = \$1\s+AND pa.deleted_at IS NULL`).
+		WithArgs("property-1", 2026, 4).
+		WillReturnRows(financialReportLiveRows().
+			AddRow("property-1", 2026, 4, "entry-1", "rent_payment", "rent", 12000, []byte(`{"bill_id":"bill-1"}`), createdAt).
+			AddRow("property-1", 2026, 4, "entry-2", "electricity_payment", nil, 1000, []byte(`{"bill_id":"bill-2"}`), createdAt).
+			AddRow("property-1", 2026, 4, "entry-3", "deposit_refund", "refund", -3000, []byte(`{"lease_id":"lease-1"}`), createdAt).
+			AddRow("property-1", 2026, 4, "entry-4", "journal_expense", nil, 500, []byte(`{"journal_log_id":"journal-1"}`), createdAt))
+
+	report, err := repo.GetFinancialReport(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 4, true)
+	if err != nil {
+		t.Fatalf("GetFinancialReport live: %v", err)
+	}
+	if report.IsFinalized {
+		t.Fatalf("IsFinalized = true, want false")
+	}
+	if report.TotalIncome != 13000 || report.TotalExpense != 3500 || report.Net != 9500 {
+		t.Fatalf("totals = income %d expense %d net %d, want 13000 3500 9500", report.TotalIncome, report.TotalExpense, report.Net)
+	}
+	if len(report.Entries) != 4 {
+		t.Fatalf("entries = %d, want 4", len(report.Entries))
+	}
+	if report.Entries[2].Amount != -3000 {
+		t.Fatalf("deposit refund amount = %d, want stored -3000", report.Entries[2].Amount)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestGetFinancialReportFinalizedAllowsEmptyEntries(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	mock.ExpectQuery(`(?s)FROM monthly_snapshots ms\s+JOIN properties p ON p.id = ms.property_id AND p.deleted_at IS NULL\s+LEFT JOIN monthly_snapshot_entries mse ON mse.snapshot_id = ms.id\s+WHERE ms.property_id = \$1\s+AND ms.year = \$2\s+AND ms.month = \$3`).
+		WithArgs("property-1", 2026, 4).
+		WillReturnRows(financialReportFinalizedRows().
+			AddRow("property-1", 2026, 4, 0, 0, 0, nil, nil, nil, nil, nil, nil))
+
+	report, err := repo.GetFinancialReport(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 4, false)
+	if err != nil {
+		t.Fatalf("GetFinancialReport finalized: %v", err)
+	}
+	if len(report.Entries) != 0 {
+		t.Fatalf("entries = %d, want 0", len(report.Entries))
+	}
+	if !report.IsFinalized || report.TotalIncome != 0 || report.TotalExpense != 0 || report.Net != 0 {
+		t.Fatalf("unexpected empty finalized report: %+v", report)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestGetFinancialReportLiveAllowsEmptyEntries(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	mock.ExpectQuery(`(?s)FROM property_accounts pa\s+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL\s+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id\s+AND ae.year = \$2\s+AND ae.month = \$3\s+WHERE pa.property_id = \$1\s+AND pa.deleted_at IS NULL`).
+		WithArgs("property-1", 2026, 4).
+		WillReturnRows(financialReportLiveRows().
+			AddRow("property-1", 2026, 4, nil, nil, nil, nil, nil, nil))
+
+	report, err := repo.GetFinancialReport(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 4, true)
+	if err != nil {
+		t.Fatalf("GetFinancialReport live: %v", err)
+	}
+	if len(report.Entries) != 0 {
+		t.Fatalf("entries = %d, want 0", len(report.Entries))
+	}
+	if report.IsFinalized || report.TotalIncome != 0 || report.TotalExpense != 0 || report.Net != 0 {
+		t.Fatalf("unexpected empty live report: %+v", report)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestGetFinancialReportLiveNoPropertyAccountReturnsNotFound(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	mock.ExpectQuery(`(?s)FROM property_accounts pa\s+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL\s+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id\s+AND ae.year = \$2\s+AND ae.month = \$3\s+WHERE pa.property_id = \$1\s+AND pa.deleted_at IS NULL`).
+		WithArgs("property-1", 2026, 4).
+		WillReturnRows(financialReportLiveRows())
+
+	_, err := repo.GetFinancialReport(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 4, true)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func newBillingRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
 	t.Helper()
 
@@ -411,5 +620,36 @@ func billRows() *sqlmock.Rows {
 		"created_at",
 		"updated_at",
 		"version",
+	})
+}
+
+func financialReportFinalizedRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"property_id",
+		"year",
+		"month",
+		"total_income",
+		"total_expense",
+		"net",
+		"id",
+		"category",
+		"description",
+		"amount",
+		"source_ref",
+		"created_at",
+	})
+}
+
+func financialReportLiveRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"property_id",
+		"year",
+		"month",
+		"id",
+		"category",
+		"description",
+		"amount",
+		"source_ref",
+		"created_at",
 	})
 }

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -237,7 +237,7 @@ func TestListPropertyPendingMetersFiltersPendingMeterAndReturnsPeriodBounds(t *t
 	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	periodEnd := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
 	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
-	mock.ExpectQuery(`(?s)FROM bills b\s+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL\s+WHERE b.property_id = \$1\s+AND b.status = 'pending_meter'\s+AND b.deleted_at IS NULL`).
+	mock.ExpectQuery(`(?s)FROM bills b\s+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL\s+WHERE b.property_id = \$1\s+AND b.type = 'electricity'\s+AND b.status = 'pending_meter'\s+AND b.deleted_at IS NULL`).
 		WithArgs("property-1").
 		WillReturnRows(billRows().AddRow(
 			"bill-1", "lease-1", "tenant-1", "room-1", "property-1", "electricity", nil,

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -565,6 +565,68 @@ func TestGetFinancialReportLiveNoPropertyAccountReturnsNotFound(t *testing.T) {
 	}
 }
 
+func TestListFinancialReportSummariesDeduplicatesAndSortsLiveOverSnapshot(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	mock.ExpectQuery(`(?s)FROM monthly_snapshots ms\s+JOIN properties p ON p.id = ms.property_id AND p.deleted_at IS NULL\s+WHERE ms.property_id = \$1\s+ORDER BY ms.year DESC, ms.month DESC`).
+		WithArgs("property-1").
+		WillReturnRows(financialReportSummaryRows().
+			AddRow(2026, 4, 1000, 100, 900).
+			AddRow(2026, 3, 3000, 300, 2700))
+	mock.ExpectQuery(`(?s)FROM property_accounts pa\s+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL\s+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id\s+AND ae.year = \$2\s+AND ae.month = \$3\s+WHERE pa.property_id = \$1\s+AND pa.deleted_at IS NULL\s+GROUP BY pa.property_id`).
+		WithArgs("property-1", 2026, 4).
+		WillReturnRows(financialReportSummaryRows().
+			AddRow(2026, 4, 5000, 200, 4800))
+
+	summaries, err := repo.ListFinancialReportSummaries(context.Background(), Scope{Role: "admin"}, "property-1", nil, 2026, 4)
+	if err != nil {
+		t.Fatalf("ListFinancialReportSummaries: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("summaries = %d, want 2", len(summaries))
+	}
+	if summaries[0].Year != 2026 || summaries[0].Month != 4 || summaries[0].TotalIncome != 5000 || summaries[0].Net != 4800 {
+		t.Fatalf("unexpected current summary: %+v", summaries[0])
+	}
+	if summaries[1].Year != 2026 || summaries[1].Month != 3 {
+		t.Fatalf("unexpected second summary: %+v", summaries[1])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListFinancialReportSummariesIncludesEmptyLiveMonthWhenAccountExists(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	year := 2026
+	mock.ExpectQuery(`(?s)FROM monthly_snapshots ms\s+JOIN properties p ON p.id = ms.property_id AND p.deleted_at IS NULL\s+WHERE ms.property_id = \$1\s+AND ms.year = \$2\s+ORDER BY ms.year DESC, ms.month DESC`).
+		WithArgs("property-1", 2026).
+		WillReturnRows(financialReportSummaryRows())
+	mock.ExpectQuery(`(?s)FROM property_accounts pa\s+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL\s+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id\s+AND ae.year = \$2\s+AND ae.month = \$3\s+WHERE pa.property_id = \$1\s+AND pa.deleted_at IS NULL\s+GROUP BY pa.property_id`).
+		WithArgs("property-1", 2026, 4).
+		WillReturnRows(financialReportSummaryRows().
+			AddRow(2026, 4, 0, 0, 0))
+
+	summaries, err := repo.ListFinancialReportSummaries(context.Background(), Scope{Role: "admin"}, "property-1", &year, 2026, 4)
+	if err != nil {
+		t.Fatalf("ListFinancialReportSummaries: %v", err)
+	}
+	if len(summaries) != 1 {
+		t.Fatalf("summaries = %d, want 1", len(summaries))
+	}
+	if summaries[0].Year != 2026 || summaries[0].Month != 4 || summaries[0].TotalIncome != 0 || summaries[0].TotalExpense != 0 || summaries[0].Net != 0 {
+		t.Fatalf("unexpected empty live summary: %+v", summaries[0])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func newBillingRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
 	t.Helper()
 
@@ -651,5 +713,15 @@ func financialReportLiveRows() *sqlmock.Rows {
 		"amount",
 		"source_ref",
 		"created_at",
+	})
+}
+
+func financialReportSummaryRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"year",
+		"month",
+		"total_income",
+		"total_expense",
+		"net",
 	})
 }

--- a/internal/server/billing_adapters.go
+++ b/internal/server/billing_adapters.go
@@ -7,14 +7,16 @@ import (
 	"time"
 
 	appbilling "stds_backend/internal/application/billing"
+	domainevents "stds_backend/internal/domain/events"
 	"stds_backend/internal/http/handler"
 	dbbilling "stds_backend/internal/platform/database/billing"
 	dbtxrunner "stds_backend/internal/platform/database/txrunner"
 )
 
-func newBillingServices(db *sql.DB, txRunner *dbtxrunner.Runner) handler.BillingServices {
+func newBillingServices(db *sql.DB, txRunner *dbtxrunner.Runner, publisher domainevents.Publisher) handler.BillingServices {
 	repo := dbbilling.NewRepository(db)
 	billingRepo := billingRepositoryAdapter{repo: repo}
+	reportRepo := billingReportRepositoryAdapter{repo: repo}
 	accountingRepo := billingAccountingRepositoryAdapter{repo: repo}
 
 	return handler.BillingServices{
@@ -22,8 +24,11 @@ func newBillingServices(db *sql.DB, txRunner *dbtxrunner.Runner) handler.Billing
 			listBills: appbilling.NewListBillsService(billingRepo),
 			getBill:   appbilling.NewGetBillService(billingRepo),
 		},
-		Meter:   billingMeterServiceAdapter{service: appbilling.NewRecordMeterService(billingRepo, txRunner)},
-		Payment: billingPaymentServiceAdapter{service: appbilling.NewRecordPaymentService(billingRepo, accountingRepo, txRunner)},
+		Meter:            billingMeterServiceAdapter{service: appbilling.NewRecordMeterService(billingRepo, txRunner)},
+		Payment:          billingPaymentServiceAdapter{service: appbilling.NewRecordPaymentService(billingRepo, accountingRepo, txRunner)},
+		PropertyMeters:   billingPropertyMeterServiceAdapter{pendingMeters: appbilling.NewListPendingMeterService(reportRepo), meterHistory: appbilling.NewListPropertyMeterHistoryService(reportRepo)},
+		RoomMeters:       billingRoomMeterServiceAdapter{meterHistory: appbilling.NewListRoomMeterHistoryService(reportRepo)},
+		FinancialReports: billingFinancialReportServiceAdapter{summaries: appbilling.NewListFinancialReportSummariesService(reportRepo), get: appbilling.NewGetFinancialReportService(reportRepo, nil), send: appbilling.NewSendFinancialReportService(reportRepo, publisher, nil)},
 	}
 }
 
@@ -105,6 +110,113 @@ func (a billingPaymentServiceAdapter) RecordBillPayment(ctx context.Context, inp
 	}
 
 	return toHandlerBill(*bill), nil
+}
+
+type billingPropertyMeterServiceAdapter struct {
+	pendingMeters *appbilling.ListPendingMeterService
+	meterHistory  *appbilling.ListPropertyMeterHistoryService
+}
+
+func (a billingPropertyMeterServiceAdapter) ListPropertyPendingMeters(ctx context.Context, input handler.BillingPropertyMetersInput) ([]handler.BillingBill, error) {
+	bills, err := a.pendingMeters.Execute(ctx, appbilling.ListPendingMeterInput{
+		ActorRole:           input.ActorRole,
+		ActorUserID:         input.ActorUserID,
+		AssignedPropertyIDs: input.AssignedPropertyIDs,
+		PropertyID:          input.PropertyID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toHandlerBills(bills), nil
+}
+
+func (a billingPropertyMeterServiceAdapter) ListPropertyMeterHistory(ctx context.Context, input handler.BillingPropertyMeterHistoryInput) ([]handler.BillingBill, error) {
+	bills, err := a.meterHistory.Execute(ctx, appbilling.ListPropertyMeterHistoryInput{
+		ActorRole:           input.ActorRole,
+		ActorUserID:         input.ActorUserID,
+		AssignedPropertyIDs: input.AssignedPropertyIDs,
+		PropertyID:          input.PropertyID,
+		Year:                input.Year,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toHandlerBills(bills), nil
+}
+
+type billingRoomMeterServiceAdapter struct {
+	meterHistory *appbilling.ListRoomMeterHistoryService
+}
+
+func (a billingRoomMeterServiceAdapter) ListRoomMeterHistory(ctx context.Context, input handler.BillingRoomMeterHistoryInput) ([]handler.BillingBill, error) {
+	bills, err := a.meterHistory.Execute(ctx, appbilling.ListRoomMeterHistoryInput{
+		ActorRole:           input.ActorRole,
+		ActorUserID:         input.ActorUserID,
+		AssignedPropertyIDs: input.AssignedPropertyIDs,
+		RoomID:              input.RoomID,
+		Year:                input.Year,
+		Month:               input.Month,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toHandlerBills(bills), nil
+}
+
+type billingFinancialReportServiceAdapter struct {
+	summaries *appbilling.ListFinancialReportSummariesService
+	get       *appbilling.GetFinancialReportService
+	send      *appbilling.SendFinancialReportService
+}
+
+func (a billingFinancialReportServiceAdapter) ListFinancialReportSummaries(ctx context.Context, input handler.BillingFinancialReportSummaryInput) ([]handler.BillingFinancialReportSummary, error) {
+	summaries, err := a.summaries.Execute(ctx, appbilling.ListFinancialReportSummariesInput{
+		ActorRole:           input.ActorRole,
+		ActorUserID:         input.ActorUserID,
+		AssignedPropertyIDs: input.AssignedPropertyIDs,
+		PropertyID:          input.PropertyID,
+		Year:                input.Year,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toHandlerFinancialReportSummaries(summaries), nil
+}
+
+func (a billingFinancialReportServiceAdapter) GetFinancialReport(ctx context.Context, input handler.BillingFinancialReportInput) (*handler.BillingFinancialReport, error) {
+	report, err := a.get.Execute(ctx, appbilling.GetFinancialReportInput{
+		ActorRole:           input.ActorRole,
+		ActorUserID:         input.ActorUserID,
+		AssignedPropertyIDs: input.AssignedPropertyIDs,
+		PropertyID:          input.PropertyID,
+		Year:                input.Year,
+		Month:               input.Month,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toHandlerFinancialReport(*report), nil
+}
+
+func (a billingFinancialReportServiceAdapter) SendFinancialReport(ctx context.Context, input handler.BillingFinancialReportInput) (*handler.BillingFinancialReport, error) {
+	report, err := a.send.Execute(ctx, appbilling.SendFinancialReportInput{
+		ActorRole:           input.ActorRole,
+		ActorUserID:         input.ActorUserID,
+		AssignedPropertyIDs: input.AssignedPropertyIDs,
+		PropertyID:          input.PropertyID,
+		Year:                input.Year,
+		Month:               input.Month,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toHandlerFinancialReport(*report), nil
 }
 
 type billingRepositoryAdapter struct {
@@ -214,6 +326,88 @@ func (a billingRepositoryAdapter) UpdateBillPayment(ctx context.Context, tx *sql
 	return a.FindBillByIDForUpdate(ctx, tx, params.BillID)
 }
 
+type billingReportRepositoryAdapter struct {
+	repo *dbbilling.SQLRepository
+}
+
+func (a billingReportRepositoryAdapter) ListPendingMeterBills(ctx context.Context, query appbilling.PendingMeterQuery) ([]appbilling.Bill, error) {
+	bills, err := a.repo.ListPropertyPendingMeters(ctx, dbbilling.Scope{
+		Role:                query.ActorRole,
+		UserID:              query.ActorUserID,
+		AssignedPropertyIDs: query.AssignedPropertyIDs,
+	}, query.PropertyID)
+	if err != nil {
+		return nil, mapBillingReportRepositoryError(err)
+	}
+
+	return toAppBills(bills), nil
+}
+
+func (a billingReportRepositoryAdapter) ListPropertyMeterHistory(ctx context.Context, query appbilling.MeterHistoryQuery) ([]appbilling.Bill, error) {
+	bills, err := a.repo.ListPropertyMeterHistory(ctx, dbbilling.Scope{
+		Role:                query.ActorRole,
+		UserID:              query.ActorUserID,
+		AssignedPropertyIDs: query.AssignedPropertyIDs,
+	}, query.PropertyID, query.Year)
+	if err != nil {
+		return nil, mapBillingReportRepositoryError(err)
+	}
+
+	return toAppBills(bills), nil
+}
+
+func (a billingReportRepositoryAdapter) ListRoomMeterHistory(ctx context.Context, query appbilling.MeterHistoryQuery) ([]appbilling.Bill, error) {
+	bills, err := a.repo.ListRoomMeterHistory(ctx, dbbilling.Scope{
+		Role:                query.ActorRole,
+		UserID:              query.ActorUserID,
+		AssignedPropertyIDs: query.AssignedPropertyIDs,
+	}, query.RoomID, query.Year, query.Month)
+	if err != nil {
+		return nil, mapBillingReportRepositoryError(err)
+	}
+
+	return toAppBills(bills), nil
+}
+
+func (a billingReportRepositoryAdapter) ListFinancialReportSummaries(ctx context.Context, query appbilling.FinancialReportSummaryQuery) ([]appbilling.FinancialReportSummary, error) {
+	summaries, err := a.repo.ListFinancialReportSummaries(ctx, dbbilling.Scope{
+		Role:                query.ActorRole,
+		UserID:              query.ActorUserID,
+		AssignedPropertyIDs: query.AssignedPropertyIDs,
+	}, query.PropertyID, query.Year, query.CurrentYear, query.CurrentMonth)
+	if err != nil {
+		return nil, mapBillingReportRepositoryError(err)
+	}
+
+	return toAppFinancialReportSummaries(summaries), nil
+}
+
+func (a billingReportRepositoryAdapter) FindLiveFinancialReport(ctx context.Context, query appbilling.FinancialReportQuery) (*appbilling.FinancialReport, error) {
+	report, err := a.repo.GetFinancialReport(ctx, dbbilling.Scope{
+		Role:                query.ActorRole,
+		UserID:              query.ActorUserID,
+		AssignedPropertyIDs: query.AssignedPropertyIDs,
+	}, query.PropertyID, query.Year, query.Month, true)
+	if err != nil {
+		return nil, mapBillingReportRepositoryError(err)
+	}
+
+	return toAppFinancialReport(*report), nil
+}
+
+func (a billingReportRepositoryAdapter) FindSnapshotFinancialReport(ctx context.Context, query appbilling.FinancialReportQuery) (*appbilling.FinancialReport, error) {
+	report, err := a.repo.GetFinancialReport(ctx, dbbilling.Scope{
+		Role:                query.ActorRole,
+		UserID:              query.ActorUserID,
+		AssignedPropertyIDs: query.AssignedPropertyIDs,
+	}, query.PropertyID, query.Year, query.Month, false)
+	if err != nil {
+		return nil, mapBillingReportRepositoryError(err)
+	}
+
+	return toAppFinancialReport(*report), nil
+}
+
 type billingAccountingRepositoryAdapter struct {
 	repo *dbbilling.SQLRepository
 }
@@ -247,6 +441,17 @@ func mapBillingRepositoryError(err error) error {
 		return appbilling.ErrBillNotFound
 	case errors.Is(err, dbbilling.ErrConcurrentUpdate):
 		return appbilling.ErrConcurrentUpdateConflict
+	default:
+		return err
+	}
+}
+
+func mapBillingReportRepositoryError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, dbbilling.ErrNotFound):
+		return appbilling.ErrFinancialReportNotFoundRepository
 	default:
 		return err
 	}
@@ -289,6 +494,43 @@ func toAppBill(bill dbbilling.Bill) *appbilling.Bill {
 	}
 }
 
+func toAppFinancialReportSummaries(summaries []dbbilling.FinancialReportSummary) []appbilling.FinancialReportSummary {
+	result := make([]appbilling.FinancialReportSummary, 0, len(summaries))
+	for i := range summaries {
+		result = append(result, appbilling.FinancialReportSummary{
+			Year:         summaries[i].Year,
+			Month:        summaries[i].Month,
+			TotalIncome:  summaries[i].TotalIncome,
+			TotalExpense: summaries[i].TotalExpense,
+			Net:          summaries[i].Net,
+		})
+	}
+
+	return result
+}
+
+func toAppFinancialReport(report dbbilling.FinancialReport) *appbilling.FinancialReport {
+	entries := make([]appbilling.FinancialReportEntry, 0, len(report.Entries))
+	for i := range report.Entries {
+		entries = append(entries, appbilling.FinancialReportEntry{
+			Category:    report.Entries[i].Category,
+			Description: report.Entries[i].Description,
+			Amount:      report.Entries[i].Amount,
+		})
+	}
+
+	return &appbilling.FinancialReport{
+		PropertyID:   report.PropertyID,
+		Year:         report.Year,
+		Month:        report.Month,
+		TotalIncome:  report.TotalIncome,
+		TotalExpense: report.TotalExpense,
+		Net:          report.Net,
+		IsFinalized:  report.IsFinalized,
+		Entries:      entries,
+	}
+}
+
 func toHandlerBills(bills []appbilling.Bill) []handler.BillingBill {
 	result := make([]handler.BillingBill, 0, len(bills))
 	for i := range bills {
@@ -323,5 +565,42 @@ func toHandlerBill(bill appbilling.Bill) *handler.BillingBill {
 		CreatedAt:            bill.CreatedAt,
 		UpdatedAt:            bill.UpdatedAt,
 		Version:              bill.Version,
+	}
+}
+
+func toHandlerFinancialReportSummaries(summaries []appbilling.FinancialReportSummary) []handler.BillingFinancialReportSummary {
+	result := make([]handler.BillingFinancialReportSummary, 0, len(summaries))
+	for i := range summaries {
+		result = append(result, handler.BillingFinancialReportSummary{
+			Year:         summaries[i].Year,
+			Month:        summaries[i].Month,
+			TotalIncome:  summaries[i].TotalIncome,
+			TotalExpense: summaries[i].TotalExpense,
+			Net:          summaries[i].Net,
+		})
+	}
+
+	return result
+}
+
+func toHandlerFinancialReport(report appbilling.FinancialReport) *handler.BillingFinancialReport {
+	entries := make([]handler.BillingFinancialReportEntry, 0, len(report.Entries))
+	for i := range report.Entries {
+		entries = append(entries, handler.BillingFinancialReportEntry{
+			Category:    report.Entries[i].Category,
+			Description: report.Entries[i].Description,
+			Amount:      report.Entries[i].Amount,
+		})
+	}
+
+	return &handler.BillingFinancialReport{
+		PropertyID:   report.PropertyID,
+		Year:         report.Year,
+		Month:        report.Month,
+		TotalIncome:  report.TotalIncome,
+		TotalExpense: report.TotalExpense,
+		Net:          report.Net,
+		IsFinalized:  report.IsFinalized,
+		Entries:      entries,
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -125,7 +125,7 @@ func New(cfg *config.Config) (*Server, error) {
 		TerminateLease:      terminateLeaseService,
 		ForceTerminateLease: forceTerminateLeaseService,
 		GetForceTermination: getForceTerminationService,
-		Billing:             newBillingServices(db, txRunner),
+		Billing:             newBillingServices(db, txRunner, bus),
 	})
 
 	return &Server{


### PR DESCRIPTION
## Summary

- Implement billing pending-meter and meter-history read APIs with cadence-aware bill period semantics.
- Implement financial report summary/detail reads across live current-month accounting entries and historical monthly snapshots.
- Implement financial report send as a Billing action that validates the report and emits `FinancialReportSendRequested` for downstream notification handling.
- Add focused application, repository, handler, and router tests for response shapes, authorization policy, period overlap filtering, empty report handling, and event publication.

## Notes

- Notification subscriber implementation is intentionally deferred and tracked in #37.
- `PropertyCreated -> PropertyAccount` subscriber remains tracked in #37 and is not folded into this issue.

Closes #19

## Validation

- `env GOCACHE=/tmp/go-cache go test ./...`
- `git diff --check`