### PR TITLE
Implement repair request APIs and workflow actions

### DIFF
--- a/docs/spec/schema.sql
+++ b/docs/spec/schema.sql
@@ -402,6 +402,7 @@ CREATE TABLE repair_requests (
     assigned_to     UUID        REFERENCES users(id),  -- nullable
     title           VARCHAR(200) NOT NULL,
     description     TEXT         NOT NULL,
+    cancel_reason   TEXT,
     -- status：submitted | assigned | in_progress | completed | cancelled
     status          VARCHAR(20)  NOT NULL CHECK (status IN (
                         'submitted', 'assigned', 'in_progress', 'completed', 'cancelled'

--- a/internal/application/repair/create.go
+++ b/internal/application/repair/create.go
@@ -1,0 +1,100 @@
+package repair
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	domainrepair "stds_backend/internal/domain/repair"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// CreateInput is the command payload for repair request creation.
+type CreateInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	RoomID              string
+	Title               string
+	Description         string
+}
+
+// CreateService creates repair requests.
+type CreateService struct {
+	repo     Repository
+	txRunner TransactionRunner
+}
+
+// NewCreateService returns a CreateService.
+func NewCreateService(repo Repository, txRunner TransactionRunner) *CreateService {
+	return &CreateService{repo: repo, txRunner: txRunner}
+}
+
+// Execute creates a submitted repair request.
+func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*RepairRequest, error) {
+	actorRole, err := normalizeWriteRole(input.ActorRole)
+	if err != nil {
+		return nil, err
+	}
+	actorUserID, err := normalizeRequiredUUID(input.ActorUserID, "actor_user_id", apperr.ErrUnauthorized)
+	if err != nil {
+		return nil, err
+	}
+	propertyID, err := normalizeRequiredUUID(input.PropertyID, "property_id", apperr.ErrPropertyNotFound)
+	if err != nil {
+		return nil, err
+	}
+	roomID, err := normalizeRequiredUUID(input.RoomID, "room_id", apperr.ErrRoomNotFound)
+	if err != nil {
+		return nil, err
+	}
+	title := strings.TrimSpace(input.Title)
+	description := strings.TrimSpace(input.Description)
+	if _, err := domainrepair.New(domainrepair.State{
+		PropertyID:  propertyID,
+		RoomID:      roomID,
+		SubmittedBy: actorUserID,
+		Title:       title,
+		Description: description,
+	}); err != nil {
+		return nil, mapDomainError(err)
+	}
+	if s.txRunner == nil {
+		return nil, apperr.ErrInternalServerError
+	}
+
+	var created *RepairRequest
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		room, err := s.repo.FindRoomByID(ctx, tx, roomID)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		if room.PropertyID != propertyID {
+			return apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "room_id"})
+		}
+		if err := requirePropertyAccess(actorRole, input.AssignedPropertyIDs, propertyID); err != nil {
+			return err
+		}
+
+		repairRequest, err := s.repo.Create(ctx, tx, CreateParams{
+			PropertyID:  propertyID,
+			RoomID:      roomID,
+			SubmittedBy: actorUserID,
+			Title:       title,
+			Description: description,
+		})
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+
+		created = repairRequest
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return created, nil
+}

--- a/internal/application/repair/create.go
+++ b/internal/application/repair/create.go
@@ -52,6 +52,9 @@ func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*Repair
 	}
 	title := strings.TrimSpace(input.Title)
 	description := strings.TrimSpace(input.Description)
+	if err := requirePropertyAccess(actorRole, input.AssignedPropertyIDs, propertyID); err != nil {
+		return nil, err
+	}
 	if _, err := domainrepair.New(domainrepair.State{
 		PropertyID:  propertyID,
 		RoomID:      roomID,
@@ -73,9 +76,6 @@ func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*Repair
 		}
 		if room.PropertyID != propertyID {
 			return apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "room_id"})
-		}
-		if err := requirePropertyAccess(actorRole, input.AssignedPropertyIDs, propertyID); err != nil {
-			return err
 		}
 
 		repairRequest, err := s.repo.Create(ctx, tx, CreateParams{

--- a/internal/application/repair/delete.go
+++ b/internal/application/repair/delete.go
@@ -1,0 +1,49 @@
+package repair
+
+import (
+	"context"
+	"database/sql"
+
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// DeleteInput is the command payload for soft deletion.
+type DeleteInput struct {
+	ID string
+}
+
+// DeleteService soft-deletes repair requests.
+type DeleteService struct {
+	repo     Repository
+	txRunner TransactionRunner
+}
+
+// NewDeleteService returns a DeleteService.
+func NewDeleteService(repo Repository, txRunner TransactionRunner) *DeleteService {
+	return &DeleteService{repo: repo, txRunner: txRunner}
+}
+
+// Execute performs a soft delete.
+func (s *DeleteService) Execute(ctx context.Context, input DeleteInput) error {
+	id, err := normalizeRequiredUUID(input.ID, "id", ErrRepairRequestNotFound)
+	if err != nil {
+		return err
+	}
+	if s.txRunner == nil {
+		return apperr.ErrInternalServerError
+	}
+
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		if err := s.repo.SoftDelete(ctx, tx, id); err != nil {
+			return mapRepositoryError(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/application/repair/errors.go
+++ b/internal/application/repair/errors.go
@@ -1,0 +1,91 @@
+package repair
+
+import (
+	"errors"
+	"net/http"
+
+	domainrepair "stds_backend/internal/domain/repair"
+	"stds_backend/internal/shared/apperr"
+)
+
+const (
+	CodeValidationRepairTitleRequired = "VALIDATION_REPAIR_TITLE_REQUIRED"
+	CodeInvalidStatusForAssign        = "REPAIR_INVALID_STATUS_FOR_ASSIGN"
+	CodeInvalidStatusForProgress      = "REPAIR_INVALID_STATUS_FOR_PROGRESS"
+	CodeInvalidStatusForComplete      = "REPAIR_INVALID_STATUS_FOR_COMPLETE"
+	CodeInvalidStatusForCancel        = "REPAIR_INVALID_STATUS_FOR_CANCEL"
+	CodeRepairAlreadyCompleted        = "REPAIR_ALREADY_COMPLETED"
+)
+
+var (
+	ErrValidationRepairTitleRequired = apperr.New(
+		CodeValidationRepairTitleRequired,
+		http.StatusBadRequest,
+		"Repair title is required.",
+	)
+	ErrInvalidStatusForAssign = apperr.New(
+		CodeInvalidStatusForAssign,
+		http.StatusUnprocessableEntity,
+		"Only submitted repair requests can be assigned.",
+	)
+	ErrInvalidStatusForProgress = apperr.New(
+		CodeInvalidStatusForProgress,
+		http.StatusUnprocessableEntity,
+		"Only assigned repair requests can be progressed.",
+	)
+	ErrInvalidStatusForComplete = apperr.New(
+		CodeInvalidStatusForComplete,
+		http.StatusUnprocessableEntity,
+		"Only in-progress repair requests can be completed.",
+	)
+	ErrInvalidStatusForCancel = apperr.New(
+		CodeInvalidStatusForCancel,
+		http.StatusUnprocessableEntity,
+		"Only active repair requests can be cancelled.",
+	)
+	ErrRepairAlreadyCompleted = apperr.New(
+		CodeRepairAlreadyCompleted,
+		http.StatusUnprocessableEntity,
+		"Completed repair requests cannot be cancelled.",
+	)
+)
+
+func mapRepositoryError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, ErrRepairRequestNotFound):
+		return apperr.ErrRepairRequestNotFound
+	case errors.Is(err, ErrRoomNotFound):
+		return apperr.ErrRoomNotFound
+	case errors.Is(err, ErrUserNotFound):
+		return apperr.ErrUserNotFound
+	default:
+		return apperr.ErrInternalServerError.WithCause(err)
+	}
+}
+
+func mapDomainError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, domainrepair.ErrTitleRequired):
+		return ErrValidationRepairTitleRequired
+	case errors.Is(err, domainrepair.ErrInvalidStatusForAssign):
+		return ErrInvalidStatusForAssign
+	case errors.Is(err, domainrepair.ErrInvalidStatusForProgress):
+		return ErrInvalidStatusForProgress
+	case errors.Is(err, domainrepair.ErrInvalidStatusForComplete):
+		return ErrInvalidStatusForComplete
+	case errors.Is(err, domainrepair.ErrInvalidStatusForCancel):
+		return ErrInvalidStatusForCancel
+	case errors.Is(err, domainrepair.ErrRepairAlreadyCompleted):
+		return ErrRepairAlreadyCompleted
+	default:
+		return apperr.ErrInternalServerError.WithCause(err)
+	}
+}

--- a/internal/application/repair/helpers.go
+++ b/internal/application/repair/helpers.go
@@ -1,0 +1,55 @@
+package repair
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+func normalizeWriteRole(role string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(role))
+	switch normalized {
+	case "admin", "organizer", "staff":
+		return normalized, nil
+	default:
+		return "", apperr.ErrForbidden
+	}
+}
+
+func normalizeRequiredUUID(value string, field string, notFound error) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || trimmed == "00000000-0000-0000-0000-000000000000" {
+		return "", notFound
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return "", apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+	}
+
+	return trimmed, nil
+}
+
+func containsAssignedProperty(assignedPropertyIDs []string, propertyID string) bool {
+	for _, assignedPropertyID := range assignedPropertyIDs {
+		if strings.TrimSpace(assignedPropertyID) == propertyID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func requirePropertyAccess(role string, assignedPropertyIDs []string, propertyID string) error {
+	switch role {
+	case "admin":
+		return nil
+	case "organizer", "staff":
+		if containsAssignedProperty(assignedPropertyIDs, propertyID) {
+			return nil
+		}
+		return apperr.ErrForbidden.WithDetails(map[string]interface{}{"property_id": propertyID})
+	default:
+		return apperr.ErrForbidden
+	}
+}

--- a/internal/application/repair/repository.go
+++ b/internal/application/repair/repository.go
@@ -1,0 +1,115 @@
+package repair
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"stds_backend/internal/platform/database/txrunner"
+)
+
+var (
+	ErrRepairRequestNotFound = errors.New("repair request not found")
+	ErrRoomNotFound          = errors.New("repair room not found")
+	ErrUserNotFound          = errors.New("repair user not found")
+)
+
+// TransactionRunner is the txrunner.Runner surface required by repair use cases.
+type TransactionRunner interface {
+	WithinTransaction(ctx context.Context, fn func(context.Context, *sql.Tx, *txrunner.EventRecorder) error) error
+}
+
+// RepairRequest is the application-facing repair request shape.
+type RepairRequest struct {
+	ID           string
+	PropertyID   string
+	RoomID       string
+	SubmittedBy  string
+	AssignedTo   *string
+	Title        string
+	Description  string
+	Status       string
+	SubmittedAt  time.Time
+	AssignedAt   *time.Time
+	CompletedAt  *time.Time
+	CancelReason *string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// Room captures room ownership needed by repair creation.
+type Room struct {
+	ID         string
+	PropertyID string
+}
+
+// User captures assignee role semantics.
+type User struct {
+	ID                  string
+	Role                string
+	AssignedPropertyIDs []string
+}
+
+// ListQuery defines filtering, pagination, and role scoping for repair lists.
+type ListQuery struct {
+	ActorRole           string
+	AssignedPropertyIDs []string
+	PropertyID          *string
+	RoomID              *string
+	Status              *string
+	AssignedTo          *string
+	Limit               int
+	Offset              int
+}
+
+// CreateParams contains fields for repair request creation.
+type CreateParams struct {
+	PropertyID  string
+	RoomID      string
+	SubmittedBy string
+	Title       string
+	Description string
+}
+
+// UpdateParams contains descriptive repair updates.
+type UpdateParams struct {
+	ID          string
+	Title       string
+	Description string
+}
+
+// AssignParams contains persisted assignment fields.
+type AssignParams struct {
+	ID         string
+	AssignedTo string
+	AssignedAt time.Time
+}
+
+// CompleteParams contains completion fields.
+type CompleteParams struct {
+	ID          string
+	CompletedAt time.Time
+}
+
+// CancelParams contains cancellation fields.
+type CancelParams struct {
+	ID           string
+	CancelReason *string
+}
+
+// Repository defines persistence required by repair use cases.
+type Repository interface {
+	List(ctx context.Context, query ListQuery) ([]RepairRequest, error)
+	FindByID(ctx context.Context, id string) (*RepairRequest, error)
+	FindByIDForUpdate(ctx context.Context, tx *sql.Tx, id string) (*RepairRequest, error)
+	FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*Room, error)
+	FindUserByID(ctx context.Context, tx *sql.Tx, id string) (*User, error)
+	Create(ctx context.Context, tx *sql.Tx, params CreateParams) (*RepairRequest, error)
+	Update(ctx context.Context, tx *sql.Tx, params UpdateParams) (*RepairRequest, error)
+	SoftDelete(ctx context.Context, tx *sql.Tx, id string) error
+	Assign(ctx context.Context, tx *sql.Tx, params AssignParams) (*RepairRequest, error)
+	Progress(ctx context.Context, tx *sql.Tx, id string) (*RepairRequest, error)
+	Complete(ctx context.Context, tx *sql.Tx, params CompleteParams) (*RepairRequest, error)
+	Cancel(ctx context.Context, tx *sql.Tx, params CancelParams) (*RepairRequest, error)
+}

--- a/internal/application/repair/update.go
+++ b/internal/application/repair/update.go
@@ -1,0 +1,78 @@
+package repair
+
+import (
+	"context"
+	"database/sql"
+
+	domainrepair "stds_backend/internal/domain/repair"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// UpdateInput is the command payload for repair request updates.
+type UpdateInput struct {
+	ID          string
+	Title       *string
+	Description *string
+}
+
+// UpdateService updates repair request descriptive fields.
+type UpdateService struct {
+	repo     Repository
+	txRunner TransactionRunner
+}
+
+// NewUpdateService returns an UpdateService.
+func NewUpdateService(repo Repository, txRunner TransactionRunner) *UpdateService {
+	return &UpdateService{repo: repo, txRunner: txRunner}
+}
+
+// Execute updates allowed descriptive fields.
+func (s *UpdateService) Execute(ctx context.Context, input UpdateInput) (*RepairRequest, error) {
+	id, err := normalizeRequiredUUID(input.ID, "id", ErrRepairRequestNotFound)
+	if err != nil {
+		return nil, err
+	}
+	if input.Title == nil && input.Description == nil {
+		return nil, apperr.ErrBadRequest
+	}
+	if s.txRunner == nil {
+		return nil, apperr.ErrInternalServerError
+	}
+
+	var updated *RepairRequest
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		current, err := s.repo.FindByIDForUpdate(ctx, tx, id)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		aggregate, err := domainrepair.Rehydrate(toDomainState(current))
+		if err != nil {
+			return mapDomainError(err)
+		}
+		if err := aggregate.Update(domainrepair.UpdateInput{
+			Title:       input.Title,
+			Description: input.Description,
+		}); err != nil {
+			return mapDomainError(err)
+		}
+
+		state := aggregate.State()
+		repairRequest, err := s.repo.Update(ctx, tx, UpdateParams{
+			ID:          id,
+			Title:       state.Title,
+			Description: state.Description,
+		})
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+
+		updated = repairRequest
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return updated, nil
+}

--- a/internal/application/repair/workflow.go
+++ b/internal/application/repair/workflow.go
@@ -1,0 +1,236 @@
+package repair
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"time"
+
+	domainevents "stds_backend/internal/domain/events"
+	domainrepair "stds_backend/internal/domain/repair"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// AssignInput is the command payload for repair assignment.
+type AssignInput struct {
+	ActorRole   string
+	ActorUserID string
+	ID          string
+	AssignedTo  string
+}
+
+// CancelInput is the command payload for repair cancellation.
+type CancelInput struct {
+	ID     string
+	Reason *string
+}
+
+// WorkflowService applies repair status transitions.
+type WorkflowService struct {
+	repo     Repository
+	txRunner TransactionRunner
+	now      func() time.Time
+}
+
+// NewWorkflowService returns a WorkflowService.
+func NewWorkflowService(repo Repository, txRunner TransactionRunner) *WorkflowService {
+	return &WorkflowService{repo: repo, txRunner: txRunner, now: time.Now}
+}
+
+// Assign assigns a submitted repair request.
+func (s *WorkflowService) Assign(ctx context.Context, input AssignInput) (*RepairRequest, error) {
+	actorRole, err := normalizeWriteRole(input.ActorRole)
+	if err != nil {
+		return nil, err
+	}
+	actorUserID, err := normalizeRequiredUUID(input.ActorUserID, "actor_user_id", apperr.ErrUnauthorized)
+	if err != nil {
+		return nil, err
+	}
+	id, err := normalizeRequiredUUID(input.ID, "id", ErrRepairRequestNotFound)
+	if err != nil {
+		return nil, err
+	}
+	assignedTo, err := normalizeRequiredUUID(input.AssignedTo, "assigned_to", apperr.ErrUserNotFound)
+	if err != nil {
+		return nil, err
+	}
+	if actorRole == "staff" && assignedTo != actorUserID {
+		return nil, apperr.ErrForbidden
+	}
+	if s.txRunner == nil {
+		return nil, apperr.ErrInternalServerError
+	}
+
+	var updated *RepairRequest
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		assignee, err := s.repo.FindUserByID(ctx, tx, assignedTo)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		if assignee.Role != "organizer" && assignee.Role != "staff" {
+			return apperr.ErrForbidden
+		}
+
+		current, err := s.repo.FindByIDForUpdate(ctx, tx, id)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		if !containsAssignedProperty(assignee.AssignedPropertyIDs, current.PropertyID) {
+			return apperr.ErrForbidden.WithDetails(map[string]interface{}{"property_id": current.PropertyID})
+		}
+		aggregate, err := domainrepair.Rehydrate(toDomainState(current))
+		if err != nil {
+			return mapDomainError(err)
+		}
+		assignedAt := s.now().UTC()
+		if err := aggregate.Assign(assignedTo, assignedAt); err != nil {
+			return mapDomainError(err)
+		}
+		state := aggregate.State()
+
+		repairRequest, err := s.repo.Assign(ctx, tx, AssignParams{
+			ID:         id,
+			AssignedTo: *state.AssignedTo,
+			AssignedAt: *state.AssignedAt,
+		})
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+
+		updated = repairRequest
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return updated, nil
+}
+
+// Progress moves an assigned repair request to in_progress.
+func (s *WorkflowService) Progress(ctx context.Context, id string) (*RepairRequest, error) {
+	return s.transition(ctx, id, func(aggregate *domainrepair.Aggregate, recorder *txrunner.EventRecorder) error {
+		return aggregate.Progress()
+	}, func(ctx context.Context, tx *sql.Tx, state domainrepair.State) (*RepairRequest, error) {
+		return s.repo.Progress(ctx, tx, state.ID)
+	})
+}
+
+// Complete marks an in-progress repair request completed and emits RepairCompleted.
+func (s *WorkflowService) Complete(ctx context.Context, id string) (*RepairRequest, error) {
+	completedAt := s.now().UTC()
+	return s.transition(ctx, id, func(aggregate *domainrepair.Aggregate, recorder *txrunner.EventRecorder) error {
+		return aggregate.Complete(completedAt)
+	}, func(ctx context.Context, tx *sql.Tx, state domainrepair.State) (*RepairRequest, error) {
+		return s.repo.Complete(ctx, tx, CompleteParams{ID: state.ID, CompletedAt: completedAt})
+	}, func(updated *RepairRequest, recorder *txrunner.EventRecorder) {
+		recorder.Record(domainevents.RepairCompleted{
+			RepairRequestID: updated.ID,
+			RoomID:          updated.RoomID,
+			PropertyID:      updated.PropertyID,
+			OccurredAt:      completedAt,
+		})
+	})
+}
+
+// Cancel marks an active repair request cancelled and emits RepairCancelled.
+func (s *WorkflowService) Cancel(ctx context.Context, input CancelInput) (*RepairRequest, error) {
+	reason := trimmedString(input.Reason)
+	cancelledAt := s.now().UTC()
+	return s.transition(ctx, input.ID, func(aggregate *domainrepair.Aggregate, recorder *txrunner.EventRecorder) error {
+		return aggregate.Cancel(reason)
+	}, func(ctx context.Context, tx *sql.Tx, state domainrepair.State) (*RepairRequest, error) {
+		return s.repo.Cancel(ctx, tx, CancelParams{ID: state.ID, CancelReason: state.CancelReason})
+	}, func(updated *RepairRequest, recorder *txrunner.EventRecorder) {
+		recorder.Record(domainevents.RepairCancelled{
+			RepairRequestID: updated.ID,
+			RoomID:          updated.RoomID,
+			PropertyID:      updated.PropertyID,
+			OccurredAt:      cancelledAt,
+		})
+	})
+}
+
+func (s *WorkflowService) transition(
+	ctx context.Context,
+	rawID string,
+	mutate func(*domainrepair.Aggregate, *txrunner.EventRecorder) error,
+	persist func(context.Context, *sql.Tx, domainrepair.State) (*RepairRequest, error),
+	afterPersist ...func(*RepairRequest, *txrunner.EventRecorder),
+) (*RepairRequest, error) {
+	id, err := normalizeRequiredUUID(rawID, "id", ErrRepairRequestNotFound)
+	if err != nil {
+		return nil, err
+	}
+	if s.txRunner == nil {
+		return nil, apperr.ErrInternalServerError
+	}
+
+	var updated *RepairRequest
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+		current, err := s.repo.FindByIDForUpdate(ctx, tx, id)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		aggregate, err := domainrepair.Rehydrate(toDomainState(current))
+		if err != nil {
+			return mapDomainError(err)
+		}
+		if err := mutate(aggregate, recorder); err != nil {
+			return mapDomainError(err)
+		}
+		state := aggregate.State()
+		state.ID = id
+
+		repairRequest, err := persist(ctx, tx, state)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		for _, fn := range afterPersist {
+			fn(repairRequest, recorder)
+		}
+
+		updated = repairRequest
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return updated, nil
+}
+
+func toDomainState(repairRequest *RepairRequest) domainrepair.State {
+	if repairRequest == nil {
+		return domainrepair.State{}
+	}
+
+	return domainrepair.State{
+		ID:           repairRequest.ID,
+		PropertyID:   repairRequest.PropertyID,
+		RoomID:       repairRequest.RoomID,
+		SubmittedBy:  repairRequest.SubmittedBy,
+		AssignedTo:   repairRequest.AssignedTo,
+		Title:        repairRequest.Title,
+		Description:  repairRequest.Description,
+		Status:       repairRequest.Status,
+		SubmittedAt:  repairRequest.SubmittedAt,
+		AssignedAt:   repairRequest.AssignedAt,
+		CompletedAt:  repairRequest.CompletedAt,
+		CancelReason: repairRequest.CancelReason,
+	}
+}
+
+func trimmedString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}

--- a/internal/application/repair/workflow_test.go
+++ b/internal/application/repair/workflow_test.go
@@ -1,0 +1,338 @@
+package repair
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	domainevents "stds_backend/internal/domain/events"
+	"stds_backend/internal/platform/database/txrunner"
+)
+
+func TestAssignRejectsStaffAssigningAnotherUser(t *testing.T) {
+	service := NewWorkflowService(&workflowRepoStub{}, fakeTxRunner{})
+
+	_, err := service.Assign(context.Background(), AssignInput{
+		ActorRole:   "staff",
+		ActorUserID: testStaffID,
+		ID:          testRepairID,
+		AssignedTo:  testOrganizerID,
+	})
+
+	if err == nil || err.Error() != "Forbidden." {
+		t.Fatalf("expected forbidden, got %v", err)
+	}
+}
+
+func TestAssignAllowsOrganizerAssigneeAndPersistsTransition(t *testing.T) {
+	repo := &workflowRepoStub{
+		user:          &User{ID: testOrganizerID, Role: "organizer", AssignedPropertyIDs: []string{testPropertyID}},
+		repairRequest: submittedRepairRequest(),
+	}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+	service.now = func() time.Time { return testNow }
+
+	repairRequest, err := service.Assign(context.Background(), AssignInput{
+		ActorRole:   "organizer",
+		ActorUserID: testOrganizerID,
+		ID:          testRepairID,
+		AssignedTo:  testOrganizerID,
+	})
+	if err != nil {
+		t.Fatalf("Assign: %v", err)
+	}
+
+	if repo.assignParams.AssignedTo != testOrganizerID {
+		t.Fatalf("expected assigned_to %s, got %s", testOrganizerID, repo.assignParams.AssignedTo)
+	}
+	if !repo.assignParams.AssignedAt.Equal(testNow) {
+		t.Fatalf("expected assigned_at %s, got %s", testNow, repo.assignParams.AssignedAt)
+	}
+	if repairRequest.Status != "assigned" {
+		t.Fatalf("expected assigned status, got %s", repairRequest.Status)
+	}
+}
+
+func TestAssignRejectsAssigneeOutsideRepairProperty(t *testing.T) {
+	repo := &workflowRepoStub{
+		user:          &User{ID: testOrganizerID, Role: "organizer", AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000099"}},
+		repairRequest: submittedRepairRequest(),
+	}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Assign(context.Background(), AssignInput{
+		ActorRole:   "organizer",
+		ActorUserID: testOrganizerID,
+		ID:          testRepairID,
+		AssignedTo:  testOrganizerID,
+	})
+
+	if err == nil || err.Error() != "Forbidden." {
+		t.Fatalf("expected forbidden, got %v", err)
+	}
+}
+
+func TestAssignRejectsOwnerAssignee(t *testing.T) {
+	repo := &workflowRepoStub{
+		user:          &User{ID: testOwnerID, Role: "owner"},
+		repairRequest: submittedRepairRequest(),
+	}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Assign(context.Background(), AssignInput{
+		ActorRole:   "organizer",
+		ActorUserID: testOrganizerID,
+		ID:          testRepairID,
+		AssignedTo:  testOwnerID,
+	})
+
+	if err == nil || err.Error() != "Forbidden." {
+		t.Fatalf("expected forbidden, got %v", err)
+	}
+}
+
+func TestProgressRejectsNonAssignedRepair(t *testing.T) {
+	repo := &workflowRepoStub{repairRequest: submittedRepairRequest()}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Progress(context.Background(), testRepairID)
+
+	if !errors.Is(err, ErrInvalidStatusForProgress) {
+		t.Fatalf("expected invalid progress status, got %v", err)
+	}
+}
+
+func TestCancelPersistsReason(t *testing.T) {
+	reason := "owner deferred"
+	repo := &workflowRepoStub{repairRequest: submittedRepairRequest()}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	repairRequest, err := service.Cancel(context.Background(), CancelInput{
+		ID:     testRepairID,
+		Reason: &reason,
+	})
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	if repo.cancelParams.CancelReason == nil || *repo.cancelParams.CancelReason != reason {
+		t.Fatalf("expected cancel reason %q, got %#v", reason, repo.cancelParams.CancelReason)
+	}
+	if repairRequest.Status != "cancelled" {
+		t.Fatalf("expected cancelled status, got %s", repairRequest.Status)
+	}
+}
+
+func TestCancelCompletedRepairReturnsAlreadyCompleted(t *testing.T) {
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "completed"
+	repo := &workflowRepoStub{repairRequest: repairRequest}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Cancel(context.Background(), CancelInput{ID: testRepairID})
+
+	if !errors.Is(err, ErrRepairAlreadyCompleted) {
+		t.Fatalf("expected already completed, got %v", err)
+	}
+}
+
+func TestCancelCancelledRepairReturnsInvalidStatus(t *testing.T) {
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "cancelled"
+	repo := &workflowRepoStub{repairRequest: repairRequest}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Cancel(context.Background(), CancelInput{ID: testRepairID})
+
+	if !errors.Is(err, ErrInvalidStatusForCancel) {
+		t.Fatalf("expected invalid cancel status, got %v", err)
+	}
+}
+
+func TestCompletePublishesRepairCompletedAfterCommit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "in_progress"
+	repo := &workflowRepoStub{repairRequest: repairRequest}
+	publisher := &repairRecordingPublisher{}
+	service := NewWorkflowService(repo, txrunner.New(db, publisher))
+	service.now = func() time.Time { return testNow }
+
+	_, err = service.Complete(context.Background(), testRepairID)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if len(publisher.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(publisher.events))
+	}
+	event, ok := publisher.events[0].(domainevents.RepairCompleted)
+	if !ok {
+		t.Fatalf("expected RepairCompleted, got %T", publisher.events[0])
+	}
+	if event.RepairRequestID != testRepairID || event.RoomID != testRoomID || event.PropertyID != testPropertyID {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCancelPublishesRepairCancelledAfterCommit(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := &workflowRepoStub{repairRequest: submittedRepairRequest()}
+	publisher := &repairRecordingPublisher{}
+	service := NewWorkflowService(repo, txrunner.New(db, publisher))
+	service.now = func() time.Time { return testNow }
+
+	_, err = service.Cancel(context.Background(), CancelInput{ID: testRepairID})
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if len(publisher.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(publisher.events))
+	}
+	event, ok := publisher.events[0].(domainevents.RepairCancelled)
+	if !ok {
+		t.Fatalf("expected RepairCancelled, got %T", publisher.events[0])
+	}
+	if event.RepairRequestID != testRepairID || event.RoomID != testRoomID || event.PropertyID != testPropertyID {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+const (
+	testRepairID    = "70000000-0000-0000-0000-000000000001"
+	testPropertyID  = "10000000-0000-0000-0000-000000000001"
+	testRoomID      = "20000000-0000-0000-0000-000000000001"
+	testStaffID     = "00000000-0000-0000-0000-000000000002"
+	testOrganizerID = "00000000-0000-0000-0000-000000000003"
+	testOwnerID     = "00000000-0000-0000-0000-000000000004"
+)
+
+var testNow = time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+
+type fakeTxRunner struct{}
+
+func (fakeTxRunner) WithinTransaction(ctx context.Context, fn func(context.Context, *sql.Tx, *txrunner.EventRecorder) error) error {
+	return fn(ctx, nil, &txrunner.EventRecorder{})
+}
+
+type repairRecordingPublisher struct {
+	events []any
+}
+
+func (p *repairRecordingPublisher) Publish(_ context.Context, event any) error {
+	p.events = append(p.events, event)
+	return nil
+}
+
+type workflowRepoStub struct {
+	user          *User
+	repairRequest *RepairRequest
+	assignParams  AssignParams
+	cancelParams  CancelParams
+}
+
+func (r *workflowRepoStub) List(context.Context, ListQuery) ([]RepairRequest, error) {
+	return nil, nil
+}
+
+func (r *workflowRepoStub) FindByID(context.Context, string) (*RepairRequest, error) {
+	return r.repairRequest, nil
+}
+
+func (r *workflowRepoStub) FindByIDForUpdate(context.Context, *sql.Tx, string) (*RepairRequest, error) {
+	if r.repairRequest == nil {
+		return nil, ErrRepairRequestNotFound
+	}
+	cloned := *r.repairRequest
+	return &cloned, nil
+}
+
+func (r *workflowRepoStub) FindRoomByID(context.Context, *sql.Tx, string) (*Room, error) {
+	return &Room{ID: testRoomID, PropertyID: testPropertyID}, nil
+}
+
+func (r *workflowRepoStub) FindUserByID(context.Context, *sql.Tx, string) (*User, error) {
+	if r.user == nil {
+		return nil, ErrUserNotFound
+	}
+	return r.user, nil
+}
+
+func (r *workflowRepoStub) Create(context.Context, *sql.Tx, CreateParams) (*RepairRequest, error) {
+	return nil, nil
+}
+
+func (r *workflowRepoStub) Update(context.Context, *sql.Tx, UpdateParams) (*RepairRequest, error) {
+	return nil, nil
+}
+
+func (r *workflowRepoStub) SoftDelete(context.Context, *sql.Tx, string) error {
+	return nil
+}
+
+func (r *workflowRepoStub) Assign(_ context.Context, _ *sql.Tx, params AssignParams) (*RepairRequest, error) {
+	r.assignParams = params
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "assigned"
+	repairRequest.AssignedTo = &params.AssignedTo
+	repairRequest.AssignedAt = &params.AssignedAt
+	return repairRequest, nil
+}
+
+func (r *workflowRepoStub) Progress(context.Context, *sql.Tx, string) (*RepairRequest, error) {
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "in_progress"
+	return repairRequest, nil
+}
+
+func (r *workflowRepoStub) Complete(context.Context, *sql.Tx, CompleteParams) (*RepairRequest, error) {
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "completed"
+	return repairRequest, nil
+}
+
+func (r *workflowRepoStub) Cancel(_ context.Context, _ *sql.Tx, params CancelParams) (*RepairRequest, error) {
+	r.cancelParams = params
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "cancelled"
+	repairRequest.CancelReason = params.CancelReason
+	return repairRequest, nil
+}
+
+func submittedRepairRequest() *RepairRequest {
+	return &RepairRequest{
+		ID:          testRepairID,
+		PropertyID:  testPropertyID,
+		RoomID:      testRoomID,
+		SubmittedBy: testStaffID,
+		Title:       "Leak",
+		Description: "Bathroom leak",
+		Status:      "submitted",
+		SubmittedAt: testNow,
+		CreatedAt:   testNow,
+		UpdatedAt:   testNow,
+	}
+}

--- a/internal/application/repair/workflow_test.go
+++ b/internal/application/repair/workflow_test.go
@@ -11,6 +11,7 @@ import (
 
 	domainevents "stds_backend/internal/domain/events"
 	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
 )
 
 func TestAssignRejectsStaffAssigningAnotherUser(t *testing.T) {
@@ -23,7 +24,7 @@ func TestAssignRejectsStaffAssigningAnotherUser(t *testing.T) {
 		AssignedTo:  testOrganizerID,
 	})
 
-	if err == nil || err.Error() != "Forbidden." {
+	if !errors.Is(err, apperr.ErrForbidden) {
 		t.Fatalf("expected forbidden, got %v", err)
 	}
 }
@@ -71,7 +72,7 @@ func TestAssignRejectsAssigneeOutsideRepairProperty(t *testing.T) {
 		AssignedTo:  testOrganizerID,
 	})
 
-	if err == nil || err.Error() != "Forbidden." {
+	if !errors.Is(err, apperr.ErrForbidden) {
 		t.Fatalf("expected forbidden, got %v", err)
 	}
 }
@@ -90,7 +91,7 @@ func TestAssignRejectsOwnerAssignee(t *testing.T) {
 		AssignedTo:  testOwnerID,
 	})
 
-	if err == nil || err.Error() != "Forbidden." {
+	if !errors.Is(err, apperr.ErrForbidden) {
 		t.Fatalf("expected forbidden, got %v", err)
 	}
 }

--- a/internal/domain/events/repair_cancelled.go
+++ b/internal/domain/events/repair_cancelled.go
@@ -1,0 +1,11 @@
+package events
+
+import "time"
+
+// RepairCancelled is emitted after a repair request is cancelled.
+type RepairCancelled struct {
+	RepairRequestID string
+	RoomID          string
+	PropertyID      string
+	OccurredAt      time.Time
+}

--- a/internal/domain/events/repair_completed.go
+++ b/internal/domain/events/repair_completed.go
@@ -1,0 +1,11 @@
+package events
+
+import "time"
+
+// RepairCompleted is emitted after a repair request is completed.
+type RepairCompleted struct {
+	RepairRequestID string
+	RoomID          string
+	PropertyID      string
+	OccurredAt      time.Time
+}

--- a/internal/domain/repair/aggregate.go
+++ b/internal/domain/repair/aggregate.go
@@ -1,0 +1,209 @@
+package repair
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	StatusSubmitted  = "submitted"
+	StatusAssigned   = "assigned"
+	StatusInProgress = "in_progress"
+	StatusCompleted  = "completed"
+	StatusCancelled  = "cancelled"
+)
+
+// State is the persisted repair request aggregate state.
+type State struct {
+	ID           string
+	PropertyID   string
+	RoomID       string
+	SubmittedBy  string
+	AssignedTo   *string
+	Title        string
+	Description  string
+	Status       string
+	SubmittedAt  time.Time
+	AssignedAt   *time.Time
+	CompletedAt  *time.Time
+	CancelReason *string
+}
+
+// UpdateInput contains descriptive repair request updates.
+type UpdateInput struct {
+	Title       *string
+	Description *string
+}
+
+// Aggregate owns repair request command rules.
+type Aggregate struct {
+	state State
+}
+
+// New creates a repair request aggregate for create commands.
+func New(state State) (*Aggregate, error) {
+	normalized, err := normalizeState(state, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Aggregate{state: normalized}, nil
+}
+
+// Rehydrate reconstructs an existing repair request aggregate.
+func Rehydrate(state State) (*Aggregate, error) {
+	normalized, err := normalizeState(state, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Aggregate{state: normalized}, nil
+}
+
+// Update applies descriptive updates.
+func (a *Aggregate) Update(input UpdateInput) error {
+	if a == nil {
+		return nil
+	}
+
+	if input.Title != nil {
+		title := strings.TrimSpace(*input.Title)
+		if title == "" {
+			return ErrTitleRequired
+		}
+		a.state.Title = title
+	}
+	if input.Description != nil {
+		a.state.Description = strings.TrimSpace(*input.Description)
+	}
+
+	return nil
+}
+
+// Assign transitions submitted repairs to assigned.
+func (a *Aggregate) Assign(assignedTo string, assignedAt time.Time) error {
+	if a.state.Status != StatusSubmitted {
+		return ErrInvalidStatusForAssign
+	}
+
+	value := strings.TrimSpace(assignedTo)
+	a.state.AssignedTo = &value
+	a.state.AssignedAt = timePtr(assignedAt)
+	a.state.Status = StatusAssigned
+	return nil
+}
+
+// Progress transitions assigned repairs to in progress.
+func (a *Aggregate) Progress() error {
+	if a.state.Status != StatusAssigned {
+		return ErrInvalidStatusForProgress
+	}
+
+	a.state.Status = StatusInProgress
+	return nil
+}
+
+// Complete transitions in-progress repairs to completed.
+func (a *Aggregate) Complete(completedAt time.Time) error {
+	if a.state.Status != StatusInProgress {
+		return ErrInvalidStatusForComplete
+	}
+
+	a.state.CompletedAt = timePtr(completedAt)
+	a.state.Status = StatusCompleted
+	return nil
+}
+
+// Cancel transitions active repairs to cancelled.
+func (a *Aggregate) Cancel(reason *string) error {
+	switch a.state.Status {
+	case StatusCompleted:
+		return ErrRepairAlreadyCompleted
+	case StatusSubmitted, StatusAssigned, StatusInProgress:
+		a.state.CancelReason = trimOptional(reason)
+		a.state.Status = StatusCancelled
+		return nil
+	default:
+		return ErrInvalidStatusForCancel
+	}
+}
+
+// State returns an immutable snapshot.
+func (a *Aggregate) State() State {
+	if a == nil {
+		return State{}
+	}
+
+	state := a.state
+	state.AssignedTo = cloneStringPtr(a.state.AssignedTo)
+	state.AssignedAt = cloneTimePtr(a.state.AssignedAt)
+	state.CompletedAt = cloneTimePtr(a.state.CompletedAt)
+	state.CancelReason = cloneStringPtr(a.state.CancelReason)
+	return state
+}
+
+func normalizeState(state State, create bool) (State, error) {
+	state.ID = strings.TrimSpace(state.ID)
+	state.PropertyID = strings.TrimSpace(state.PropertyID)
+	state.RoomID = strings.TrimSpace(state.RoomID)
+	state.SubmittedBy = strings.TrimSpace(state.SubmittedBy)
+	state.Title = strings.TrimSpace(state.Title)
+	state.Description = strings.TrimSpace(state.Description)
+	state.Status = strings.TrimSpace(state.Status)
+
+	if state.Title == "" {
+		return State{}, ErrTitleRequired
+	}
+	if state.Status == "" && create {
+		state.Status = StatusSubmitted
+	}
+	if !isValidStatus(state.Status) {
+		return State{}, ErrInvalidStatus
+	}
+	state.AssignedTo = trimOptional(state.AssignedTo)
+	state.CancelReason = trimOptional(state.CancelReason)
+	return state, nil
+}
+
+func isValidStatus(status string) bool {
+	switch status {
+	case StatusSubmitted, StatusAssigned, StatusInProgress, StatusCompleted, StatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func trimOptional(value *string) *string {
+	if value == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func cloneStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+
+	cloned := *value
+	return &cloned
+}
+
+func cloneTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+
+	cloned := *value
+	return &cloned
+}
+
+func timePtr(value time.Time) *time.Time {
+	return &value
+}

--- a/internal/domain/repair/errors.go
+++ b/internal/domain/repair/errors.go
@@ -1,0 +1,13 @@
+package repair
+
+import "errors"
+
+var (
+	ErrTitleRequired            = errors.New("repair title required")
+	ErrInvalidStatus            = errors.New("repair invalid status")
+	ErrInvalidStatusForAssign   = errors.New("repair invalid status for assign")
+	ErrInvalidStatusForProgress = errors.New("repair invalid status for progress")
+	ErrInvalidStatusForComplete = errors.New("repair invalid status for complete")
+	ErrRepairAlreadyCompleted   = errors.New("repair already completed")
+	ErrInvalidStatusForCancel   = errors.New("repair invalid status for cancel")
+)

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -15,6 +15,7 @@ import (
 	appjobs "stds_backend/internal/application/jobs"
 	applease "stds_backend/internal/application/lease"
 	appproperty "stds_backend/internal/application/property"
+	apprepair "stds_backend/internal/application/repair"
 	apptenant "stds_backend/internal/application/tenant"
 	domainusers "stds_backend/internal/domain/users"
 	"stds_backend/internal/http/api"
@@ -42,6 +43,7 @@ type APIServer struct {
 	jobTriggerService *appjobs.TriggerService
 	propertyQueryRepo dbpropertyquery.Repository
 	leaseQueryRepo    dbleasequery.Repository
+	repairQueryRepo   RepairQueryRepository
 	tenantQueryRepo   dbtenantquery.Repository
 	createPropertySvc *appproperty.CreatePropertyService
 	updatePropertySvc *appproperty.UpdatePropertyService
@@ -60,6 +62,7 @@ type APIServer struct {
 	forceTerminateSvc *applease.ForceTerminateLeaseService
 	getForceTermSvc   *applease.GetForceTerminationService
 	billing           BillingServices
+	repair            RepairServices
 }
 
 // LeaseCommandServices groups optional lease command services beyond creation.
@@ -82,6 +85,20 @@ type BillingServices struct {
 	PropertyMeters   BillingPropertyMeterService
 	RoomMeters       BillingRoomMeterService
 	FinancialReports BillingFinancialReportService
+}
+
+// RepairServices groups repair request application services used by the transport layer.
+type RepairServices struct {
+	Create   *apprepair.CreateService
+	Update   *apprepair.UpdateService
+	Delete   *apprepair.DeleteService
+	Workflow *apprepair.WorkflowService
+}
+
+// RepairQueryRepository serves repair request read endpoints.
+type RepairQueryRepository interface {
+	List(ctx context.Context, query apprepair.ListQuery) ([]apprepair.RepairRequest, error)
+	FindByID(ctx context.Context, id string) (*apprepair.RepairRequest, error)
 }
 
 type BillingQueryService interface {
@@ -253,6 +270,7 @@ func NewAPIServer(
 	jobTriggerService *appjobs.TriggerService,
 	propertyQueryRepo dbpropertyquery.Repository,
 	leaseQueryRepo dbleasequery.Repository,
+	repairQueryRepo RepairQueryRepository,
 	tenantQueryRepo dbtenantquery.Repository,
 	createPropertySvc *appproperty.CreatePropertyService,
 	updatePropertySvc *appproperty.UpdatePropertyService,
@@ -264,6 +282,7 @@ func NewAPIServer(
 	createTenantSvc *apptenant.CreateTenantService,
 	updateTenantSvc *apptenant.UpdateTenantService,
 	createLeaseSvc *applease.CreateLeaseService,
+	repairServices RepairServices,
 	leaseCommands ...LeaseCommandServices,
 ) *APIServer {
 	server := &APIServer{
@@ -277,6 +296,7 @@ func NewAPIServer(
 		jobTriggerService: jobTriggerService,
 		propertyQueryRepo: propertyQueryRepo,
 		leaseQueryRepo:    leaseQueryRepo,
+		repairQueryRepo:   repairQueryRepo,
 		tenantQueryRepo:   tenantQueryRepo,
 		createPropertySvc: createPropertySvc,
 		updatePropertySvc: updatePropertySvc,
@@ -288,6 +308,7 @@ func NewAPIServer(
 		createTenantSvc:   createTenantSvc,
 		updateTenantSvc:   updateTenantSvc,
 		createLeaseSvc:    createLeaseSvc,
+		repair:            repairServices,
 	}
 	if len(leaseCommands) > 0 {
 		server.updateLeaseSvc = leaseCommands[0].UpdateLease
@@ -307,6 +328,17 @@ func writeNotImplemented(c *gin.Context) {
 	c.AbortWithStatusJSON(http.StatusNotImplemented, api.ErrorResponse{
 		Message: &message,
 	})
+}
+
+func mapRepairQueryError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, apprepair.ErrRepairRequestNotFound) {
+		return apperr.ErrRepairRequestNotFound
+	}
+
+	return apperr.ErrInternalServerError.WithCause(err)
 }
 
 // SyncAuth handles the auth sync endpoint.
@@ -1241,11 +1273,99 @@ func (s *APIServer) CreatePropertyRoom(c *gin.Context, id string) {
 
 // ListRepairRequests handles the repair request listing endpoint.
 func (s *APIServer) ListRepairRequests(c *gin.Context, params api.ListRepairRequestsParams) {
-	writeNotImplemented(c)
+	if s.repairQueryRepo == nil {
+		writeNotImplemented(c)
+		return
+	}
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	pagination, err := queryparams.NormalizePagination(params.Page, params.Limit)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	status := ""
+	if params.Status != nil {
+		status = string(*params.Status)
+	}
+	var statusPtr *string
+	if status != "" {
+		statusPtr = &status
+	}
+	var propertyID *string
+	if authorizedPropertyID := requestctx.GetPropertyID(c); authorizedPropertyID != "" {
+		propertyID = &authorizedPropertyID
+	}
+	roomID, err := queryparams.NormalizeOptionalUUID(params.RoomId, "room_id")
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	assignedTo, err := queryparams.NormalizeOptionalUUID(params.AssignedTo, "assigned_to")
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	items, err := s.repairQueryRepo.List(c.Request.Context(), apprepair.ListQuery{
+		ActorRole:           principal.Role,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		PropertyID:          propertyID,
+		RoomID:              roomID,
+		Status:              statusPtr,
+		AssignedTo:          assignedTo,
+		Limit:               pagination.Limit,
+		Offset:              pagination.Offset,
+	})
+	if err != nil {
+		c.Error(mapRepairQueryError(err))
+		return
+	}
+
+	responses := make([]api.RepairRequestResponse, 0, len(items))
+	for _, item := range items {
+		responses = append(responses, toApplicationRepairRequestResponse(&item))
+	}
+	c.JSON(http.StatusOK, api.RepairRequestListResponse{Data: &responses})
 }
 
 // CreateRepairRequest handles repair request creation.
-func (s *APIServer) CreateRepairRequest(c *gin.Context) { writeNotImplemented(c) }
+func (s *APIServer) CreateRepairRequest(c *gin.Context) {
+	if s.repair.Create == nil {
+		writeNotImplemented(c)
+		return
+	}
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+	var request api.CreateRepairRequestRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	repairRequest, err := s.repair.Create.Execute(c.Request.Context(), apprepair.CreateInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		PropertyID:          request.PropertyId.String(),
+		RoomID:              request.RoomId.String(),
+		Title:               request.Title,
+		Description:         request.Description,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, toApplicationRepairRequestResponse(repairRequest))
+}
 
 // ListRepairRequestAttachments handles repair request attachment listing.
 func (s *APIServer) ListRepairRequestAttachments(c *gin.Context, id openapi_types.UUID) {
@@ -1258,25 +1378,145 @@ func (s *APIServer) CreateRepairRequestAttachment(c *gin.Context, id openapi_typ
 }
 
 // DeleteRepairRequest handles repair request deletion.
-func (s *APIServer) DeleteRepairRequest(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) DeleteRepairRequest(c *gin.Context, id string) {
+	if s.repair.Delete == nil {
+		writeNotImplemented(c)
+		return
+	}
+	if err := s.repair.Delete.Execute(c.Request.Context(), apprepair.DeleteInput{ID: id}); err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
 
 // GetRepairRequest handles repair request detail retrieval.
-func (s *APIServer) GetRepairRequest(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) GetRepairRequest(c *gin.Context, id string) {
+	if s.repairQueryRepo == nil {
+		writeNotImplemented(c)
+		return
+	}
+	repairRequest, err := s.repairQueryRepo.FindByID(c.Request.Context(), id)
+	if err != nil {
+		c.Error(mapRepairQueryError(err))
+		return
+	}
+
+	c.JSON(http.StatusOK, toApplicationRepairRequestResponse(repairRequest))
+}
 
 // UpdateRepairRequest handles repair request updates.
-func (s *APIServer) UpdateRepairRequest(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) UpdateRepairRequest(c *gin.Context, id string) {
+	if s.repair.Update == nil {
+		writeNotImplemented(c)
+		return
+	}
+	var request api.UpdateRepairRequestRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	repairRequest, err := s.repair.Update.Execute(c.Request.Context(), apprepair.UpdateInput{
+		ID:          id,
+		Title:       request.Title,
+		Description: request.Description,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toApplicationRepairRequestResponse(repairRequest))
+}
 
 // AssignRepairRequest handles repair request assignment.
-func (s *APIServer) AssignRepairRequest(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) AssignRepairRequest(c *gin.Context, id string) {
+	if s.repair.Workflow == nil {
+		writeNotImplemented(c)
+		return
+	}
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+	var request api.AssignRepairRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	repairRequest, err := s.repair.Workflow.Assign(c.Request.Context(), apprepair.AssignInput{
+		ActorRole:   principal.Role,
+		ActorUserID: principal.UserID,
+		ID:          id,
+		AssignedTo:  request.AssignedTo.String(),
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toApplicationRepairRequestResponse(repairRequest))
+}
 
 // CancelRepairRequest handles repair request cancellation.
-func (s *APIServer) CancelRepairRequest(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) CancelRepairRequest(c *gin.Context, id string) {
+	if s.repair.Workflow == nil {
+		writeNotImplemented(c)
+		return
+	}
+	var request api.CancelRepairRequest
+	if c.Request.Body != nil && c.Request.ContentLength != 0 {
+		if err := c.ShouldBindJSON(&request); err != nil {
+			c.Error(apperr.ErrBadRequest.WithCause(err))
+			return
+		}
+	}
+
+	repairRequest, err := s.repair.Workflow.Cancel(c.Request.Context(), apprepair.CancelInput{
+		ID:     id,
+		Reason: request.Reason,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toApplicationRepairRequestResponse(repairRequest))
+}
 
 // CompleteRepairRequest handles repair request completion.
-func (s *APIServer) CompleteRepairRequest(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) CompleteRepairRequest(c *gin.Context, id string) {
+	if s.repair.Workflow == nil {
+		writeNotImplemented(c)
+		return
+	}
+	repairRequest, err := s.repair.Workflow.Complete(c.Request.Context(), id)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toApplicationRepairRequestResponse(repairRequest))
+}
 
 // ProgressRepairRequest handles repair request progress updates.
-func (s *APIServer) ProgressRepairRequest(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) ProgressRepairRequest(c *gin.Context, id string) {
+	if s.repair.Workflow == nil {
+		writeNotImplemented(c)
+		return
+	}
+	repairRequest, err := s.repair.Workflow.Progress(c.Request.Context(), id)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toApplicationRepairRequestResponse(repairRequest))
+}
 
 // DeleteRoom handles room deletion.
 func (s *APIServer) DeleteRoom(c *gin.Context, id string) {
@@ -1361,7 +1601,7 @@ func (s *APIServer) CreateRoomMaintenance(c *gin.Context, id string) {
 
 	c.JSON(http.StatusOK, api.SetMaintenanceResponse{
 		Room:          toCreatedRoomResponse(result.Room),
-		RepairRequest: toRepairRequestResponse(result.RepairRequest),
+		RepairRequest: toPropertyRepairRequestResponse(result.RepairRequest),
 	})
 }
 
@@ -2405,21 +2645,79 @@ func toLeaseReplaceResponse(result *applease.ReplaceLeaseResult) api.LeaseReplac
 	}
 }
 
-func toRepairRequestResponse(repairRequest *appproperty.RepairRequest) api.RepairRequestResponse {
-	id, ok := parseUUID(repairRequest.ID)
-	propertyID, propertyOK := parseUUID(repairRequest.PropertyID)
-	roomID, roomOK := parseUUID(repairRequest.RoomID)
-	submittedBy, submittedByOK := parseUUID(repairRequest.SubmittedBy)
-	title := repairRequest.Title
-	description := repairRequest.Description
-	status := api.RepairRequestResponseStatus(repairRequest.Status)
-	submittedAt := repairRequest.SubmittedAt
-	createdAt := repairRequest.CreatedAt
-	updatedAt := repairRequest.UpdatedAt
+func toPropertyRepairRequestResponse(repairRequest *appproperty.RepairRequest) api.RepairRequestResponse {
+	if repairRequest == nil {
+		return api.RepairRequestResponse{}
+	}
+
+	return toRepairRequestResponseFields(
+		repairRequest.ID,
+		repairRequest.PropertyID,
+		repairRequest.RoomID,
+		repairRequest.SubmittedBy,
+		repairRequest.AssignedTo,
+		repairRequest.Title,
+		repairRequest.Description,
+		repairRequest.Status,
+		repairRequest.SubmittedAt,
+		repairRequest.AssignedAt,
+		repairRequest.CompletedAt,
+		repairRequest.CreatedAt,
+		repairRequest.UpdatedAt,
+	)
+}
+
+func toApplicationRepairRequestResponse(repairRequest *apprepair.RepairRequest) api.RepairRequestResponse {
+	if repairRequest == nil {
+		return api.RepairRequestResponse{}
+	}
+
+	return toRepairRequestResponseFields(
+		repairRequest.ID,
+		repairRequest.PropertyID,
+		repairRequest.RoomID,
+		repairRequest.SubmittedBy,
+		repairRequest.AssignedTo,
+		repairRequest.Title,
+		repairRequest.Description,
+		repairRequest.Status,
+		repairRequest.SubmittedAt,
+		repairRequest.AssignedAt,
+		repairRequest.CompletedAt,
+		repairRequest.CreatedAt,
+		repairRequest.UpdatedAt,
+	)
+}
+
+func toRepairRequestResponseFields(
+	idValue string,
+	propertyIDValue string,
+	roomIDValue string,
+	submittedByValue string,
+	assignedToValue *string,
+	titleValue string,
+	descriptionValue string,
+	statusValue string,
+	submittedAtValue time.Time,
+	assignedAtValue *time.Time,
+	completedAtValue *time.Time,
+	createdAtValue time.Time,
+	updatedAtValue time.Time,
+) api.RepairRequestResponse {
+	id, ok := parseUUID(idValue)
+	propertyID, propertyOK := parseUUID(propertyIDValue)
+	roomID, roomOK := parseUUID(roomIDValue)
+	submittedBy, submittedByOK := parseUUID(submittedByValue)
+	title := titleValue
+	description := descriptionValue
+	status := api.RepairRequestResponseStatus(statusValue)
+	submittedAt := submittedAtValue
+	createdAt := createdAtValue
+	updatedAt := updatedAtValue
 
 	response := api.RepairRequestResponse{
-		AssignedAt:  repairRequest.AssignedAt,
-		CompletedAt: repairRequest.CompletedAt,
+		AssignedAt:  assignedAtValue,
+		CompletedAt: completedAtValue,
 		CreatedAt:   &createdAt,
 		Description: &description,
 		Status:      &status,
@@ -2439,8 +2737,8 @@ func toRepairRequestResponse(repairRequest *appproperty.RepairRequest) api.Repai
 	if submittedByOK {
 		response.SubmittedBy = &submittedBy
 	}
-	if repairRequest.AssignedTo != nil {
-		assignedTo, assignedToOK := parseUUID(*repairRequest.AssignedTo)
+	if assignedToValue != nil {
+		assignedTo, assignedToOK := parseUUID(*assignedToValue)
 		if assignedToOK {
 			response.AssignedTo = &assignedTo
 		}

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -13,9 +14,12 @@ import (
 	"github.com/gin-gonic/gin"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
+	apprepair "stds_backend/internal/application/repair"
 	"stds_backend/internal/http/api"
+	"stds_backend/internal/http/middleware"
 	"stds_backend/internal/http/requestctx"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
+	"stds_backend/internal/platform/database/txrunner"
 	"stds_backend/internal/shared/apperr"
 )
 
@@ -311,6 +315,124 @@ func TestListRoomMeterHistoryRejectsMonthWithoutYear(t *testing.T) {
 	}
 }
 
+func TestListRepairRequestsForwardsOwnershipFiltersAndReturnsResponseShape(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	propertyID := "10000000-0000-0000-0000-000000000001"
+	roomID := "20000000-0000-0000-0000-000000000001"
+	assignedTo := "00000000-0000-0000-0000-000000000002"
+	status := api.Submitted
+	page := 2
+	limit := 10
+	now := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+	queryRepo := &recordingRepairQueryRepo{
+		items: []apprepair.RepairRequest{{
+			ID:          "70000000-0000-0000-0000-000000000001",
+			PropertyID:  propertyID,
+			RoomID:      roomID,
+			SubmittedBy: assignedTo,
+			Title:       "Leak",
+			Description: "Bathroom leak",
+			Status:      "submitted",
+			SubmittedAt: now,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}},
+	}
+	server := &APIServer{repairQueryRepo: queryRepo}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/repair-requests", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID:              assignedTo,
+		Role:                "staff",
+		AssignedPropertyIDs: []string{propertyID},
+	})
+	requestctx.SetPropertyID(c, propertyID)
+
+	server.ListRepairRequests(c, api.ListRepairRequestsParams{
+		RoomId:     &roomID,
+		Status:     &status,
+		AssignedTo: &assignedTo,
+		Page:       &page,
+		Limit:      &limit,
+	})
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if queryRepo.query.ActorRole != "staff" || len(queryRepo.query.AssignedPropertyIDs) != 1 || queryRepo.query.AssignedPropertyIDs[0] != propertyID {
+		t.Fatalf("unexpected actor scope: %+v", queryRepo.query)
+	}
+	if queryRepo.query.PropertyID == nil || *queryRepo.query.PropertyID != propertyID {
+		t.Fatalf("expected property filter %s, got %#v", propertyID, queryRepo.query.PropertyID)
+	}
+	if queryRepo.query.RoomID == nil || *queryRepo.query.RoomID != roomID {
+		t.Fatalf("expected room filter %s, got %#v", roomID, queryRepo.query.RoomID)
+	}
+	if queryRepo.query.Status == nil || *queryRepo.query.Status != "submitted" {
+		t.Fatalf("expected submitted status filter, got %#v", queryRepo.query.Status)
+	}
+	if queryRepo.query.AssignedTo == nil || *queryRepo.query.AssignedTo != assignedTo {
+		t.Fatalf("expected assigned_to filter %s, got %#v", assignedTo, queryRepo.query.AssignedTo)
+	}
+	if queryRepo.query.Limit != 10 || queryRepo.query.Offset != 10 {
+		t.Fatalf("unexpected pagination: limit=%d offset=%d", queryRepo.query.Limit, queryRepo.query.Offset)
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	data, ok := payload["data"].([]any)
+	if !ok || len(data) != 1 {
+		t.Fatalf("expected one repair response, got %#v", payload["data"])
+	}
+	item, ok := data[0].(map[string]any)
+	if !ok {
+		t.Fatalf("expected object repair response, got %#v", data[0])
+	}
+	if item["id"] != "70000000-0000-0000-0000-000000000001" || item["status"] != "submitted" {
+		t.Fatalf("unexpected repair response: %#v", item)
+	}
+}
+
+func TestCancelRepairRequestInvalidTransitionUsesSharedErrorShape(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repairRequest := testApplicationRepairRequest()
+	repairRequest.Status = "cancelled"
+	repo := &handlerRepairRepositoryStub{repairRequest: repairRequest}
+	server := &APIServer{
+		repair: RepairServices{
+			Workflow: apprepair.NewWorkflowService(repo, handlerRepairTxRunner{}),
+		},
+	}
+	engine := gin.New()
+	engine.Use(middleware.ErrorHandler(nil))
+	engine.POST("/repair-requests/:id/cancel", func(c *gin.Context) {
+		server.CancelRepairRequest(c, c.Param("id"))
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/repair-requests/70000000-0000-0000-0000-000000000001/cancel", nil)
+	resp := httptest.NewRecorder()
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", resp.Code, resp.Body.String())
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if payload["error_code"] != apprepair.CodeInvalidStatusForCancel {
+		t.Fatalf("expected %s, got %v", apprepair.CodeInvalidStatusForCancel, payload["error_code"])
+	}
+	if _, ok := payload["details"].(map[string]any); !ok {
+		t.Fatalf("expected shared error details object, got %#v", payload["details"])
+	}
+}
+
 func TestListRoomMeterHistoryForwardsYearMonthAndReturnsBillListResponse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -553,6 +675,86 @@ func (r *recordingFinancialReports) SendFinancialReport(_ context.Context, input
 	return &r.sentReport, nil
 }
 
+type recordingRepairQueryRepo struct {
+	query apprepair.ListQuery
+	items []apprepair.RepairRequest
+	err   error
+}
+
+func (r *recordingRepairQueryRepo) List(_ context.Context, query apprepair.ListQuery) ([]apprepair.RepairRequest, error) {
+	r.query = query
+	return r.items, r.err
+}
+
+func (r *recordingRepairQueryRepo) FindByID(context.Context, string) (*apprepair.RepairRequest, error) {
+	if len(r.items) == 0 {
+		return nil, apprepair.ErrRepairRequestNotFound
+	}
+	return &r.items[0], r.err
+}
+
+type handlerRepairTxRunner struct{}
+
+func (handlerRepairTxRunner) WithinTransaction(ctx context.Context, fn func(context.Context, *sql.Tx, *txrunner.EventRecorder) error) error {
+	return fn(ctx, nil, &txrunner.EventRecorder{})
+}
+
+type handlerRepairRepositoryStub struct {
+	repairRequest *apprepair.RepairRequest
+}
+
+func (r *handlerRepairRepositoryStub) List(context.Context, apprepair.ListQuery) ([]apprepair.RepairRequest, error) {
+	return nil, nil
+}
+
+func (r *handlerRepairRepositoryStub) FindByID(context.Context, string) (*apprepair.RepairRequest, error) {
+	return r.repairRequest, nil
+}
+
+func (r *handlerRepairRepositoryStub) FindByIDForUpdate(context.Context, *sql.Tx, string) (*apprepair.RepairRequest, error) {
+	if r.repairRequest == nil {
+		return nil, apprepair.ErrRepairRequestNotFound
+	}
+	cloned := *r.repairRequest
+	return &cloned, nil
+}
+
+func (r *handlerRepairRepositoryStub) FindRoomByID(context.Context, *sql.Tx, string) (*apprepair.Room, error) {
+	return nil, nil
+}
+
+func (r *handlerRepairRepositoryStub) FindUserByID(context.Context, *sql.Tx, string) (*apprepair.User, error) {
+	return nil, nil
+}
+
+func (r *handlerRepairRepositoryStub) Create(context.Context, *sql.Tx, apprepair.CreateParams) (*apprepair.RepairRequest, error) {
+	return nil, nil
+}
+
+func (r *handlerRepairRepositoryStub) Update(context.Context, *sql.Tx, apprepair.UpdateParams) (*apprepair.RepairRequest, error) {
+	return nil, nil
+}
+
+func (r *handlerRepairRepositoryStub) SoftDelete(context.Context, *sql.Tx, string) error {
+	return nil
+}
+
+func (r *handlerRepairRepositoryStub) Assign(context.Context, *sql.Tx, apprepair.AssignParams) (*apprepair.RepairRequest, error) {
+	return nil, nil
+}
+
+func (r *handlerRepairRepositoryStub) Progress(context.Context, *sql.Tx, string) (*apprepair.RepairRequest, error) {
+	return nil, nil
+}
+
+func (r *handlerRepairRepositoryStub) Complete(context.Context, *sql.Tx, apprepair.CompleteParams) (*apprepair.RepairRequest, error) {
+	return nil, nil
+}
+
+func (r *handlerRepairRepositoryStub) Cancel(context.Context, *sql.Tx, apprepair.CancelParams) (*apprepair.RepairRequest, error) {
+	return nil, nil
+}
+
 func testBillingBill() BillingBill {
 	amount := 12000
 	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
@@ -598,5 +800,21 @@ func testFinancialReport() BillingFinancialReport {
 		Entries: []BillingFinancialReportEntry{
 			{Category: "rent_payment", Description: &description, Amount: 18000},
 		},
+	}
+}
+
+func testApplicationRepairRequest() *apprepair.RepairRequest {
+	now := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+	return &apprepair.RepairRequest{
+		ID:          "70000000-0000-0000-0000-000000000001",
+		PropertyID:  "10000000-0000-0000-0000-000000000001",
+		RoomID:      "20000000-0000-0000-0000-000000000001",
+		SubmittedBy: "00000000-0000-0000-0000-000000000002",
+		Title:       "Leak",
+		Description: "Bathroom leak",
+		Status:      "submitted",
+		SubmittedAt: now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
 	}
 }

--- a/internal/http/queryparams/pagination_test.go
+++ b/internal/http/queryparams/pagination_test.go
@@ -112,6 +112,27 @@ func TestIsYYYYMM(t *testing.T) {
 	}
 }
 
+func TestNormalizeOptionalUUIDTrimsAndValidates(t *testing.T) {
+	value := " 10000000-0000-0000-0000-000000000001 "
+
+	normalized, err := NormalizeOptionalUUID(&value, "property_id")
+	if err != nil {
+		t.Fatalf("NormalizeOptionalUUID: %v", err)
+	}
+	if normalized == nil || *normalized != "10000000-0000-0000-0000-000000000001" {
+		t.Fatalf("unexpected normalized uuid: %#v", normalized)
+	}
+}
+
+func TestNormalizeOptionalUUIDRejectsInvalidUUID(t *testing.T) {
+	value := "not-a-uuid"
+
+	_, err := NormalizeOptionalUUID(&value, "property_id")
+	if err == nil {
+		t.Fatalf("expected invalid uuid error")
+	}
+}
+
 func intPtr(v int) *int {
 	return &v
 }

--- a/internal/http/queryparams/pagination_test.go
+++ b/internal/http/queryparams/pagination_test.go
@@ -128,8 +128,29 @@ func TestNormalizeOptionalUUIDRejectsInvalidUUID(t *testing.T) {
 	value := "not-a-uuid"
 
 	_, err := NormalizeOptionalUUID(&value, "property_id")
-	if err == nil {
-		t.Fatalf("expected invalid uuid error")
+	assertBadRequestFieldError(t, err, "property_id")
+}
+
+func TestNormalizeOptionalUUIDRejectsBlankValue(t *testing.T) {
+	value := "   "
+
+	_, err := NormalizeOptionalUUID(&value, "property_id")
+	assertBadRequestFieldError(t, err, "property_id")
+}
+
+func assertBadRequestFieldError(t *testing.T, err error, field string) {
+	t.Helper()
+
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected apperr.Error, got %T", err)
+	}
+	if appErr.Code != apperr.CodeBadRequest {
+		t.Fatalf("expected BAD_REQUEST, got %s", appErr.Code)
+	}
+	details, ok := appErr.Details.(map[string]interface{})
+	if !ok || details["field"] != field {
+		t.Fatalf("unexpected details: %#v", appErr.Details)
 	}
 }
 

--- a/internal/http/queryparams/uuid.go
+++ b/internal/http/queryparams/uuid.go
@@ -1,0 +1,26 @@
+package queryparams
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+// NormalizeOptionalUUID trims and validates an optional UUID query parameter.
+func NormalizeOptionalUUID(value *string, field string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+	}
+
+	return &trimmed, nil
+}

--- a/internal/http/queryparams/uuid.go
+++ b/internal/http/queryparams/uuid.go
@@ -19,7 +19,9 @@ func NormalizeOptionalUUID(value *string, field string) (*string, error) {
 		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
 	}
 	if _, err := uuid.Parse(trimmed); err != nil {
-		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+		return nil, apperr.ErrBadRequest.
+			WithCause(err).
+			WithDetails(map[string]interface{}{"field": field})
 	}
 
 	return &trimmed, nil

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -58,6 +58,7 @@ func New(
 	jobTriggerService *appjobs.TriggerService,
 	propertyQueryRepo dbpropertyquery.Repository,
 	leaseQueryRepo dbleasequery.Repository,
+	repairQueryRepo handler.RepairQueryRepository,
 	tenantQueryRepo dbtenantquery.Repository,
 	createPropertyService *appproperty.CreatePropertyService,
 	updatePropertyService *appproperty.UpdatePropertyService,
@@ -69,6 +70,7 @@ func New(
 	createTenantService *apptenant.CreateTenantService,
 	updateTenantService *apptenant.UpdateTenantService,
 	createLeaseService *applease.CreateLeaseService,
+	repairServices handler.RepairServices,
 	leaseCommands ...handler.LeaseCommandServices,
 ) *gin.Engine {
 	engine := gin.New()
@@ -86,7 +88,7 @@ func New(
 	engine.GET("/openapi.yaml", docsHandler.OpenAPI)
 	engine.GET("/scalar", docsHandler.Scalar)
 
-	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, leaseCommands...), api.GinServerOptions{
+	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, repairQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, repairServices, leaseCommands...), api.GinServerOptions{
 		BaseURL: "/api/v1",
 		Middlewares: []api.MiddlewareFunc{
 			protectedAPIMiddleware(appCfg, authenticator, userRepo, authzRepos),
@@ -233,7 +235,7 @@ func routePolicies(authzRepos AuthorizationRepositories) []routePolicy {
 		{method: "GET", path: "/api/v1/properties/:id/rooms", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}, propertyResolver: middleware.ParamPropertyID("id")},
 		{method: "POST", path: "/api/v1/properties/:id/rooms", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ParamPropertyID("id")},
 
-		{method: "GET", path: "/api/v1/repair-requests", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
+		{method: "GET", path: "/api/v1/repair-requests", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.QueryPropertyID("property_id")},
 		{method: "POST", path: "/api/v1/repair-requests", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "GET", path: "/api/v1/repair-requests/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByRepairRequestID, apperr.ErrRepairRequestNotFound)},
 		{method: "POST", path: "/api/v1/repair-requests/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByRepairRequestID, apperr.ErrRepairRequestNotFound)},

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -21,6 +21,7 @@ import (
 	applease "stds_backend/internal/application/lease"
 	appnotification "stds_backend/internal/application/notification"
 	appproperty "stds_backend/internal/application/property"
+	apprepair "stds_backend/internal/application/repair"
 	apptenant "stds_backend/internal/application/tenant"
 	"stds_backend/internal/config"
 	domainusers "stds_backend/internal/domain/users"
@@ -3082,6 +3083,8 @@ type fakeLeaseQueryRepo struct {
 	findCall *findLeaseCall
 }
 
+type fakeRepairQueryRepo struct{}
+
 type listRoomsCall struct {
 	propertyID string
 	status     string
@@ -4277,6 +4280,14 @@ func (f fakeLeaseQueryRepo) FindByIDAccessible(_ context.Context, id string, rol
 	}, nil
 }
 
+func (fakeRepairQueryRepo) List(context.Context, apprepair.ListQuery) ([]apprepair.RepairRequest, error) {
+	return []apprepair.RepairRequest{}, nil
+}
+
+func (fakeRepairQueryRepo) FindByID(context.Context, string) (*apprepair.RepairRequest, error) {
+	return nil, apprepair.ErrRepairRequestNotFound
+}
+
 func (f fakeResourceOwnershipRepo) FindPropertyIDByRoomID(_ context.Context, roomID string) (string, error) {
 	if f.roomIDLookup != nil {
 		*f.roomIDLookup = roomID
@@ -4455,6 +4466,7 @@ func newTestEngineWithAllServices(userRepo fakeUserRepo, authenticator fakeAuthe
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		propertyQueryRepo,
 		leaseQueryRepo,
+		fakeRepairQueryRepo{},
 		tenantQueryRepo,
 		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
 		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
@@ -4466,6 +4478,7 @@ func newTestEngineWithAllServices(userRepo fakeUserRepo, authenticator fakeAuthe
 		createTenantService,
 		updateTenantService,
 		createLeaseService,
+		handler.RepairServices{},
 		leaseCommands...,
 	)
 }
@@ -4515,6 +4528,7 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		propertyQueryRepo,
 		fakeLeaseQueryRepo{},
+		fakeRepairQueryRepo{},
 		fakeTenantQueryRepo{},
 		createPropertyService,
 		updatePropertyService,
@@ -4526,6 +4540,7 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		handler.RepairServices{},
 	)
 }
 
@@ -4555,6 +4570,7 @@ func newTestEngineWithRoomServices(userRepo fakeUserRepo, authenticator fakeAuth
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		propertyQueryRepo,
 		fakeLeaseQueryRepo{},
+		fakeRepairQueryRepo{},
 		fakeTenantQueryRepo{},
 		createPropertyService,
 		updatePropertyService,
@@ -4566,6 +4582,7 @@ func newTestEngineWithRoomServices(userRepo fakeUserRepo, authenticator fakeAuth
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		handler.RepairServices{},
 	)
 }
 
@@ -4583,6 +4600,21 @@ func firstAssignedPropertyIDs(assigned []string) []string {
 	}
 
 	return []string{testPropertyID1}
+}
+
+func TestRepairRequestListRouteUsesQueryPropertyResolver(t *testing.T) {
+	policies := routePolicies(AuthorizationRepositories{ResourceOwnership: fakeResourceOwnershipRepo{}})
+
+	for _, policy := range policies {
+		if policy.method == http.MethodGet && policy.path == "/api/v1/repair-requests" {
+			if policy.propertyResolver == nil {
+				t.Fatalf("expected repair request list route to use query property resolver")
+			}
+			return
+		}
+	}
+
+	t.Fatalf("repair request list route policy not found")
 }
 
 func firstRole(role string) string {

--- a/internal/platform/database/migrate/migrations/000014_add_repair_cancel_reason.down.sql
+++ b/internal/platform/database/migrate/migrations/000014_add_repair_cancel_reason.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE repair_requests
+    DROP COLUMN IF EXISTS cancel_reason;

--- a/internal/platform/database/migrate/migrations/000014_add_repair_cancel_reason.up.sql
+++ b/internal/platform/database/migrate/migrations/000014_add_repair_cancel_reason.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE repair_requests
+    ADD COLUMN IF NOT EXISTS cancel_reason TEXT;

--- a/internal/platform/database/repair/repository.go
+++ b/internal/platform/database/repair/repository.go
@@ -1,0 +1,388 @@
+package repair
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	apprepair "stds_backend/internal/application/repair"
+)
+
+// SQLRepository persists and reads repair request state.
+type SQLRepository struct {
+	db *sql.DB
+}
+
+// NewRepository returns a repair repository backed by db.
+func NewRepository(db *sql.DB) *SQLRepository {
+	return &SQLRepository{db: db}
+}
+
+// List returns active repair requests visible to the actor scope.
+func (r *SQLRepository) List(ctx context.Context, query apprepair.ListQuery) ([]apprepair.RepairRequest, error) {
+	base := selectRepairRequestColumns + `
+FROM repair_requests rr
+WHERE rr.deleted_at IS NULL
+`
+	args := make([]any, 0)
+
+	switch strings.TrimSpace(query.ActorRole) {
+	case "organizer", "staff":
+		if len(query.AssignedPropertyIDs) == 0 {
+			return []apprepair.RepairRequest{}, nil
+		}
+		placeholders := make([]string, 0, len(query.AssignedPropertyIDs))
+		for _, id := range query.AssignedPropertyIDs {
+			args = append(args, id)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		base += "\n  AND rr.property_id IN (" + strings.Join(placeholders, ", ") + ")"
+	case "admin":
+	default:
+		return []apprepair.RepairRequest{}, nil
+	}
+
+	if query.PropertyID != nil {
+		args = append(args, *query.PropertyID)
+		base += fmt.Sprintf("\n  AND rr.property_id = $%d", len(args))
+	}
+	if query.RoomID != nil {
+		args = append(args, *query.RoomID)
+		base += fmt.Sprintf("\n  AND rr.room_id = $%d", len(args))
+	}
+	if query.Status != nil {
+		args = append(args, *query.Status)
+		base += fmt.Sprintf("\n  AND rr.status = $%d", len(args))
+	}
+	if query.AssignedTo != nil {
+		args = append(args, *query.AssignedTo)
+		base += fmt.Sprintf("\n  AND rr.assigned_to = $%d", len(args))
+	}
+
+	args = append(args, query.Limit, query.Offset)
+	base += fmt.Sprintf("\nORDER BY rr.created_at DESC, rr.id DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
+
+	rows, err := r.db.QueryContext(ctx, base, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list repair requests: %w", err)
+	}
+	defer rows.Close()
+
+	items := []apprepair.RepairRequest{}
+	for rows.Next() {
+		item, err := scanRepairRequest(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan repair request: %w", err)
+		}
+		items = append(items, *item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate repair requests: %w", err)
+	}
+
+	return items, nil
+}
+
+// FindByID returns one active repair request.
+func (r *SQLRepository) FindByID(ctx context.Context, id string) (*apprepair.RepairRequest, error) {
+	query := selectRepairRequestColumns + `
+FROM repair_requests rr
+WHERE rr.id = $1
+  AND rr.deleted_at IS NULL
+LIMIT 1
+`
+	repairRequest, err := scanRepairRequest(r.db.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, apprepair.ErrRepairRequestNotFound
+		}
+		return nil, fmt.Errorf("query repair request by id: %w", err)
+	}
+
+	return repairRequest, nil
+}
+
+// FindByIDForUpdate locks one active repair request for command use.
+func (r *SQLRepository) FindByIDForUpdate(ctx context.Context, tx *sql.Tx, id string) (*apprepair.RepairRequest, error) {
+	query := selectRepairRequestColumns + `
+FROM repair_requests rr
+WHERE rr.id = $1
+  AND rr.deleted_at IS NULL
+FOR UPDATE
+`
+	repairRequest, err := scanRepairRequest(tx.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, apprepair.ErrRepairRequestNotFound
+		}
+		return nil, fmt.Errorf("query repair request by id for update: %w", err)
+	}
+
+	return repairRequest, nil
+}
+
+// FindRoomByID returns an active room's owning property.
+func (r *SQLRepository) FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*apprepair.Room, error) {
+	const query = `
+SELECT id, property_id
+FROM rooms
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+	var room apprepair.Room
+	if err := tx.QueryRowContext(ctx, query, id).Scan(&room.ID, &room.PropertyID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, apprepair.ErrRoomNotFound
+		}
+		return nil, fmt.Errorf("query repair room by id: %w", err)
+	}
+
+	return &room, nil
+}
+
+// FindUserByID returns an active user's role.
+func (r *SQLRepository) FindUserByID(ctx context.Context, tx *sql.Tx, id string) (*apprepair.User, error) {
+	const query = `
+SELECT
+	id,
+	role,
+	COALESCE(assigned_property_ids, '[]'::jsonb)::text AS assigned_property_ids
+FROM users
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+	var user apprepair.User
+	var assignedPropertyIDs string
+	if err := tx.QueryRowContext(ctx, query, id).Scan(&user.ID, &user.Role, &assignedPropertyIDs); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, apprepair.ErrUserNotFound
+		}
+		return nil, fmt.Errorf("query repair assignee by id: %w", err)
+	}
+	if err := json.Unmarshal([]byte(assignedPropertyIDs), &user.AssignedPropertyIDs); err != nil {
+		return nil, fmt.Errorf("decode repair assignee assigned_property_ids: %w", err)
+	}
+
+	return &user, nil
+}
+
+// Create inserts a submitted repair request.
+func (r *SQLRepository) Create(ctx context.Context, tx *sql.Tx, params apprepair.CreateParams) (*apprepair.RepairRequest, error) {
+	query := `
+INSERT INTO repair_requests (
+	property_id,
+	room_id,
+	submitted_by,
+	title,
+	description
+) VALUES ($1, $2, $3, $4, $5)
+` + returningRepairRequestColumns
+
+	repairRequest, err := scanRepairRequest(tx.QueryRowContext(ctx, query, params.PropertyID, params.RoomID, params.SubmittedBy, params.Title, params.Description))
+	if err != nil {
+		return nil, fmt.Errorf("create repair request: %w", err)
+	}
+
+	return repairRequest, nil
+}
+
+// Update persists descriptive repair request fields.
+func (r *SQLRepository) Update(ctx context.Context, tx *sql.Tx, params apprepair.UpdateParams) (*apprepair.RepairRequest, error) {
+	query := `
+UPDATE repair_requests
+SET title = $2,
+    description = $3,
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+` + returningRepairRequestColumns
+
+	repairRequest, err := scanRepairRequest(tx.QueryRowContext(ctx, query, params.ID, params.Title, params.Description))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, apprepair.ErrRepairRequestNotFound
+		}
+		return nil, fmt.Errorf("update repair request: %w", err)
+	}
+
+	return repairRequest, nil
+}
+
+// SoftDelete marks a repair request deleted.
+func (r *SQLRepository) SoftDelete(ctx context.Context, tx *sql.Tx, id string) error {
+	const query = `
+UPDATE repair_requests
+SET deleted_at = now(),
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+`
+	result, err := tx.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("soft delete repair request: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("soft delete repair request rows affected: %w", err)
+	}
+	if affected == 0 {
+		return apprepair.ErrRepairRequestNotFound
+	}
+
+	return nil
+}
+
+// Assign persists assignment transition fields.
+func (r *SQLRepository) Assign(ctx context.Context, tx *sql.Tx, params apprepair.AssignParams) (*apprepair.RepairRequest, error) {
+	query := `
+UPDATE repair_requests
+SET status = 'assigned',
+    assigned_to = $2,
+    assigned_at = $3,
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+` + returningRepairRequestColumns
+
+	return r.scanUpdated(tx.QueryRowContext(ctx, query, params.ID, params.AssignedTo, params.AssignedAt), "assign repair request")
+}
+
+// Progress persists assigned -> in_progress.
+func (r *SQLRepository) Progress(ctx context.Context, tx *sql.Tx, id string) (*apprepair.RepairRequest, error) {
+	query := `
+UPDATE repair_requests
+SET status = 'in_progress',
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+` + returningRepairRequestColumns
+
+	return r.scanUpdated(tx.QueryRowContext(ctx, query, id), "progress repair request")
+}
+
+// Complete persists in_progress -> completed.
+func (r *SQLRepository) Complete(ctx context.Context, tx *sql.Tx, params apprepair.CompleteParams) (*apprepair.RepairRequest, error) {
+	query := `
+UPDATE repair_requests
+SET status = 'completed',
+    completed_at = $2,
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+` + returningRepairRequestColumns
+
+	return r.scanUpdated(tx.QueryRowContext(ctx, query, params.ID, params.CompletedAt), "complete repair request")
+}
+
+// Cancel persists active -> cancelled.
+func (r *SQLRepository) Cancel(ctx context.Context, tx *sql.Tx, params apprepair.CancelParams) (*apprepair.RepairRequest, error) {
+	query := `
+UPDATE repair_requests
+SET status = 'cancelled',
+    cancel_reason = $2,
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+` + returningRepairRequestColumns
+
+	return r.scanUpdated(tx.QueryRowContext(ctx, query, params.ID, params.CancelReason), "cancel repair request")
+}
+
+func (r *SQLRepository) scanUpdated(row rowScanner, operation string) (*apprepair.RepairRequest, error) {
+	repairRequest, err := scanRepairRequest(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, apprepair.ErrRepairRequestNotFound
+		}
+		return nil, fmt.Errorf("%s: %w", operation, err)
+	}
+
+	return repairRequest, nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+const selectRepairRequestColumns = `
+SELECT
+	rr.id,
+	rr.property_id,
+	rr.room_id,
+	rr.submitted_by,
+	rr.assigned_to,
+	rr.title,
+	rr.description,
+	rr.status,
+	rr.submitted_at,
+	rr.assigned_at,
+	rr.completed_at,
+	rr.cancel_reason,
+	rr.created_at,
+	rr.updated_at
+`
+
+const returningRepairRequestColumns = `
+RETURNING
+	id,
+	property_id,
+	room_id,
+	submitted_by,
+	assigned_to,
+	title,
+	description,
+	status,
+	submitted_at,
+	assigned_at,
+	completed_at,
+	cancel_reason,
+	created_at,
+	updated_at
+`
+
+func scanRepairRequest(row rowScanner) (*apprepair.RepairRequest, error) {
+	var repairRequest apprepair.RepairRequest
+	var assignedTo sql.NullString
+	var assignedAt sql.NullTime
+	var completedAt sql.NullTime
+	var cancelReason sql.NullString
+
+	if err := row.Scan(
+		&repairRequest.ID,
+		&repairRequest.PropertyID,
+		&repairRequest.RoomID,
+		&repairRequest.SubmittedBy,
+		&assignedTo,
+		&repairRequest.Title,
+		&repairRequest.Description,
+		&repairRequest.Status,
+		&repairRequest.SubmittedAt,
+		&assignedAt,
+		&completedAt,
+		&cancelReason,
+		&repairRequest.CreatedAt,
+		&repairRequest.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	if assignedTo.Valid {
+		repairRequest.AssignedTo = &assignedTo.String
+	}
+	if assignedAt.Valid {
+		repairRequest.AssignedAt = &assignedAt.Time
+	}
+	if completedAt.Valid {
+		repairRequest.CompletedAt = &completedAt.Time
+	}
+	if cancelReason.Valid {
+		repairRequest.CancelReason = &cancelReason.String
+	}
+
+	return &repairRequest, nil
+}

--- a/internal/platform/database/repair/repository_test.go
+++ b/internal/platform/database/repair/repository_test.go
@@ -94,7 +94,7 @@ func TestCancelPersistsCancelReason(t *testing.T) {
 		))
 	mock.ExpectCommit()
 
-	tx, err := db.Begin()
+	tx, err := db.BeginTx(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Begin: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestFindUserByIDLoadsAssignedPropertyIDs(t *testing.T) {
 		))
 	mock.ExpectCommit()
 
-	tx, err := db.Begin()
+	tx, err := db.BeginTx(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Begin: %v", err)
 	}

--- a/internal/platform/database/repair/repository_test.go
+++ b/internal/platform/database/repair/repository_test.go
@@ -1,0 +1,185 @@
+package repair
+
+import (
+	"context"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	apprepair "stds_backend/internal/application/repair"
+)
+
+func TestListScopesOrganizerToAssignedPropertiesAndFilters(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta("FROM repair_requests rr")).
+		WithArgs(testPropertyID, testPropertyID, testRoomID, "submitted", testStaffID, 20, 0).
+		WillReturnRows(repairRows().AddRow(
+			testRepairID,
+			testPropertyID,
+			testRoomID,
+			testStaffID,
+			nil,
+			"Leak",
+			"Bathroom leak",
+			"submitted",
+			now,
+			nil,
+			nil,
+			nil,
+			now,
+			now,
+		))
+
+	repo := NewRepository(db)
+	status := "submitted"
+	roomID := testRoomID
+	assignedTo := testStaffID
+	propertyID := testPropertyID
+	items, err := repo.List(context.Background(), apprepair.ListQuery{
+		ActorRole:           "organizer",
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          &propertyID,
+		RoomID:              &roomID,
+		Status:              &status,
+		AssignedTo:          &assignedTo,
+		Limit:               20,
+		Offset:              0,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != testRepairID {
+		t.Fatalf("unexpected items: %+v", items)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCancelPersistsCancelReason(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	now := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+	cancelReason := "owner deferred"
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("UPDATE repair_requests")).
+		WithArgs(testRepairID, cancelReason).
+		WillReturnRows(repairRows().AddRow(
+			testRepairID,
+			testPropertyID,
+			testRoomID,
+			testStaffID,
+			nil,
+			"Leak",
+			"Bathroom leak",
+			"cancelled",
+			now,
+			nil,
+			nil,
+			cancelReason,
+			now,
+			now,
+		))
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	repo := NewRepository(db)
+	repairRequest, err := repo.Cancel(context.Background(), tx, apprepair.CancelParams{
+		ID:           testRepairID,
+		CancelReason: &cancelReason,
+	})
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if repairRequest.CancelReason == nil || *repairRequest.CancelReason != cancelReason {
+		t.Fatalf("expected cancel reason %q, got %#v", cancelReason, repairRequest.CancelReason)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestFindUserByIDLoadsAssignedPropertyIDs(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT")).
+		WithArgs(testStaffID).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id",
+			"role",
+			"assigned_property_ids",
+		}).AddRow(
+			testStaffID,
+			"staff",
+			`["`+testPropertyID+`"]`,
+		))
+	mock.ExpectCommit()
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	repo := NewRepository(db)
+	user, err := repo.FindUserByID(context.Background(), tx, testStaffID)
+	if err != nil {
+		t.Fatalf("FindUserByID: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if len(user.AssignedPropertyIDs) != 1 || user.AssignedPropertyIDs[0] != testPropertyID {
+		t.Fatalf("unexpected assigned property ids: %#v", user.AssignedPropertyIDs)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func repairRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"property_id",
+		"room_id",
+		"submitted_by",
+		"assigned_to",
+		"title",
+		"description",
+		"status",
+		"submitted_at",
+		"assigned_at",
+		"completed_at",
+		"cancel_reason",
+		"created_at",
+		"updated_at",
+	})
+}
+
+const (
+	testRepairID   = "70000000-0000-0000-0000-000000000001"
+	testPropertyID = "10000000-0000-0000-0000-000000000001"
+	testRoomID     = "20000000-0000-0000-0000-000000000001"
+	testStaffID    = "00000000-0000-0000-0000-000000000002"
+)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	applease "stds_backend/internal/application/lease"
 	appnotification "stds_backend/internal/application/notification"
 	appproperty "stds_backend/internal/application/property"
+	apprepair "stds_backend/internal/application/repair"
 	apptenant "stds_backend/internal/application/tenant"
 	"stds_backend/internal/config"
 	"stds_backend/internal/http/handler"
@@ -22,6 +23,7 @@ import (
 	dbleases "stds_backend/internal/platform/database/leases"
 	dbproperties "stds_backend/internal/platform/database/properties"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
+	dbrepair "stds_backend/internal/platform/database/repair"
 	dbresourceownership "stds_backend/internal/platform/database/resourceownership"
 	dbtenantquery "stds_backend/internal/platform/database/tenantquery"
 	dbtenants "stds_backend/internal/platform/database/tenants"
@@ -61,6 +63,7 @@ func New(cfg *config.Config) (*Server, error) {
 	leaseRepo := dbleases.NewRepository(db)
 	propertyQueryRepo := dbpropertyquery.NewRepository(db)
 	leaseQueryRepo := dbleasequery.NewRepository(db)
+	repairRepo := dbrepair.NewRepository(db)
 	tenantRepo := dbtenants.NewRepository(db)
 	tenantQueryRepo := dbtenantquery.NewRepository(db)
 	resourceOwnershipRepo := dbresourceownership.NewRepository(db)
@@ -105,6 +108,12 @@ func New(cfg *config.Config) (*Server, error) {
 	terminateLeaseService := applease.NewTerminateLeaseService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	forceTerminateLeaseService := applease.NewForceTerminateLeaseService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	getForceTerminationService := applease.NewGetForceTerminationService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
+	repairServices := handler.RepairServices{
+		Create:   apprepair.NewCreateService(repairRepo, txRunner),
+		Update:   apprepair.NewUpdateService(repairRepo, txRunner),
+		Delete:   apprepair.NewDeleteService(repairRepo, txRunner),
+		Workflow: apprepair.NewWorkflowService(repairRepo, txRunner),
+	}
 	occupyRoomOnLeaseCreated := applease.NewOccupyRoomOnLeaseCreatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	activateTenantOnLeaseCreated := applease.NewActivateTenantOnLeaseCreatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	releaseRoomOnLeaseTerminated := applease.NewReleaseRoomOnLeaseTerminatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
@@ -118,7 +127,7 @@ func New(cfg *config.Config) (*Server, error) {
 	engine := router.New(cfg.App, logger, db, authenticator, userRepo, router.AuthorizationRepositories{
 		Properties:        propertyRepo,
 		ResourceOwnership: resourceOwnershipRepo,
-	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, handler.LeaseCommandServices{
+	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, repairRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, repairServices, handler.LeaseCommandServices{
 		UpdateLease:         updateLeaseService,
 		UpdateDeposit:       updateDepositService,
 		ReplaceLease:        replaceLeaseService,

--- a/internal/shared/apperr/error.go
+++ b/internal/shared/apperr/error.go
@@ -34,6 +34,21 @@ func (e *Error) Unwrap() error {
 	return e.Cause
 }
 
+// Is matches application errors by code so cloned errors with details or cause
+// still behave like their sentinel error.
+func (e *Error) Is(target error) bool {
+	if e == nil {
+		return target == nil
+	}
+
+	targetErr, ok := target.(*Error)
+	if !ok || targetErr == nil {
+		return false
+	}
+
+	return e.Code == targetErr.Code
+}
+
 // New creates a shared error without details or wrapped cause.
 func New(code string, httpStatus int, message string) *Error {
 	return &Error{

--- a/internal/shared/apperr/error_test.go
+++ b/internal/shared/apperr/error_test.go
@@ -1,0 +1,19 @@
+package apperr
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestErrorIsMatchesByCode(t *testing.T) {
+	err := ErrBadRequest.
+		WithCause(errors.New("parse uuid")).
+		WithDetails(map[string]interface{}{"field": "property_id"})
+
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("expected errors.Is to match errors with the same code")
+	}
+	if errors.Is(err, ErrForbidden) {
+		t.Fatalf("expected errors.Is not to match a different code")
+	}
+}


### PR DESCRIPTION
## Summary
- Implement repair request list/detail/create/update/delete APIs with ownership-aware access checks and soft-delete behavior.
- Add repair workflow commands for assign, progress, complete, and cancel with status transition validation.
- Persist repair state changes, add cancel reason migration/schema updates, and publish repair lifecycle events for completion and cancellation.
- Cover application, repository, handler, router, and query parameter behavior with focused tests.

Closes #21

## Validation
- `go test ./internal/application/repair ./internal/platform/database/repair ./internal/http/handler ./internal/http/router ./internal/http/queryparams`