### PR TITLE
[codex] implement journal log APIs

### DIFF
--- a/internal/application/billing/subscribers.go
+++ b/internal/application/billing/subscribers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
 
 	domainbilling "stds_backend/internal/domain/billing"
 	domainevents "stds_backend/internal/domain/events"
@@ -50,7 +49,7 @@ func (h *JournalExpenseRecordedHandler) HandleJournalExpenseRecorded(ctx context
 
 	occurredAt := event.OccurredAt.UTC()
 	if occurredAt.IsZero() {
-		occurredAt = time.Now().UTC()
+		return fmt.Errorf("journal expense event missing occurred_at: journal_log_id=%s", event.JournalLogID)
 	}
 
 	return h.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {

--- a/internal/application/billing/subscribers.go
+++ b/internal/application/billing/subscribers.go
@@ -1,14 +1,20 @@
 package billing
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
+	"time"
 
 	domainbilling "stds_backend/internal/domain/billing"
+	domainevents "stds_backend/internal/domain/events"
+	"stds_backend/internal/platform/database/txrunner"
 )
 
 const (
 	AccountingCategoryRentPayment        = "rent_payment"
 	AccountingCategoryElectricityPayment = "electricity_payment"
+	AccountingCategoryJournalExpense     = "journal_expense"
 )
 
 func accountingCategoryForBillType(billType string) (string, error) {
@@ -20,4 +26,46 @@ func accountingCategoryForBillType(billType string) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported bill type for accounting entry: %s", billType)
 	}
+}
+
+// JournalExpenseRecordedHandler records accounting entries for journal expenses.
+type JournalExpenseRecordedHandler struct {
+	accountingRepo AccountingRepository
+	txRunner       TransactionRunner
+}
+
+// NewJournalExpenseRecordedHandler returns a journal expense event handler.
+func NewJournalExpenseRecordedHandler(accountingRepo AccountingRepository, txRunner TransactionRunner) *JournalExpenseRecordedHandler {
+	return &JournalExpenseRecordedHandler{accountingRepo: accountingRepo, txRunner: txRunner}
+}
+
+// HandleJournalExpenseRecorded writes the expense into property accounting.
+func (h *JournalExpenseRecordedHandler) HandleJournalExpenseRecorded(ctx context.Context, event domainevents.JournalExpenseRecorded) error {
+	if h.txRunner == nil {
+		return fmt.Errorf("journal expense handler missing transaction runner")
+	}
+	if h.accountingRepo == nil {
+		return fmt.Errorf("journal expense handler missing accounting repository")
+	}
+
+	occurredAt := event.OccurredAt.UTC()
+	if occurredAt.IsZero() {
+		occurredAt = time.Now().UTC()
+	}
+
+	return h.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		if err := h.accountingRepo.CreateAccountingEntry(ctx, tx, AccountingEntryParams{
+			PropertyID:  event.PropertyID,
+			Category:    AccountingCategoryJournalExpense,
+			Amount:      event.Amount,
+			Description: event.Description,
+			SourceRef:   map[string]interface{}{"type": "JournalExpenseRecorded", "journal_log_id": event.JournalLogID},
+			Year:        occurredAt.Year(),
+			Month:       int(occurredAt.Month()),
+		}); err != nil {
+			return mapAccountingRepositoryError(err)
+		}
+
+		return nil
+	})
 }

--- a/internal/application/billing/subscribers_test.go
+++ b/internal/application/billing/subscribers_test.go
@@ -1,0 +1,63 @@
+package billing
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	domainevents "stds_backend/internal/domain/events"
+	"stds_backend/internal/platform/database/txrunner"
+)
+
+func TestJournalExpenseRecordedHandlerCreatesAccountingEntry(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	accountingRepo := &journalExpenseAccountingRepoStub{}
+	handler := NewJournalExpenseRecordedHandler(accountingRepo, txrunner.New(db, nil))
+	occurredAt := time.Date(2026, 4, 15, 11, 0, 0, 0, time.UTC)
+	description := "Pipe repair"
+
+	err = handler.HandleJournalExpenseRecorded(context.Background(), domainevents.JournalExpenseRecorded{
+		JournalLogID: "60000000-0000-0000-0000-000000000001",
+		PropertyID:   "10000000-0000-0000-0000-000000000001",
+		Amount:       3500,
+		Description:  &description,
+		OccurredAt:   occurredAt,
+	})
+	if err != nil {
+		t.Fatalf("HandleJournalExpenseRecorded() error = %v", err)
+	}
+	if accountingRepo.entry.Category != AccountingCategoryJournalExpense {
+		t.Fatalf("Category = %s, want %s", accountingRepo.entry.Category, AccountingCategoryJournalExpense)
+	}
+	if accountingRepo.entry.Amount != 3500 {
+		t.Fatalf("Amount = %d, want 3500", accountingRepo.entry.Amount)
+	}
+	if accountingRepo.entry.Year != 2026 || accountingRepo.entry.Month != 4 {
+		t.Fatalf("Year/Month = %d/%d, want 2026/4", accountingRepo.entry.Year, accountingRepo.entry.Month)
+	}
+	if accountingRepo.entry.SourceRef["type"] != "JournalExpenseRecorded" || accountingRepo.entry.SourceRef["journal_log_id"] != "60000000-0000-0000-0000-000000000001" {
+		t.Fatalf("SourceRef = %#v", accountingRepo.entry.SourceRef)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+type journalExpenseAccountingRepoStub struct {
+	entry AccountingEntryParams
+}
+
+func (s *journalExpenseAccountingRepoStub) CreateAccountingEntry(_ context.Context, _ *sql.Tx, params AccountingEntryParams) error {
+	s.entry = params
+	return nil
+}

--- a/internal/application/billing/subscribers_test.go
+++ b/internal/application/billing/subscribers_test.go
@@ -48,16 +48,47 @@ func TestJournalExpenseRecordedHandlerCreatesAccountingEntry(t *testing.T) {
 	if accountingRepo.entry.SourceRef["type"] != "JournalExpenseRecorded" || accountingRepo.entry.SourceRef["journal_log_id"] != "60000000-0000-0000-0000-000000000001" {
 		t.Fatalf("SourceRef = %#v", accountingRepo.entry.SourceRef)
 	}
+	if accountingRepo.createCalls != 1 {
+		t.Fatalf("CreateAccountingEntry calls = %d, want 1", accountingRepo.createCalls)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestJournalExpenseRecordedHandlerRejectsMissingOccurredAt(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	accountingRepo := &journalExpenseAccountingRepoStub{}
+	handler := NewJournalExpenseRecordedHandler(accountingRepo, txrunner.New(db, nil))
+
+	err = handler.HandleJournalExpenseRecorded(context.Background(), domainevents.JournalExpenseRecorded{
+		JournalLogID: "60000000-0000-0000-0000-000000000001",
+		PropertyID:   "10000000-0000-0000-0000-000000000001",
+		Amount:       3500,
+	})
+	if err == nil {
+		t.Fatal("HandleJournalExpenseRecorded() error = nil, want error")
+	}
+	if accountingRepo.createCalls != 0 {
+		t.Fatalf("CreateAccountingEntry calls = %d, want 0", accountingRepo.createCalls)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
 	}
 }
 
 type journalExpenseAccountingRepoStub struct {
-	entry AccountingEntryParams
+	entry       AccountingEntryParams
+	createCalls int
 }
 
 func (s *journalExpenseAccountingRepoStub) CreateAccountingEntry(_ context.Context, _ *sql.Tx, params AccountingEntryParams) error {
+	s.createCalls++
 	s.entry = params
 	return nil
 }

--- a/internal/application/journal/create.go
+++ b/internal/application/journal/create.go
@@ -1,0 +1,126 @@
+package journal
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	domainevents "stds_backend/internal/domain/events"
+	domainjournal "stds_backend/internal/domain/journal"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// CreateInput is the command payload for journal log creation.
+type CreateInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+	PropertyID          string
+	RoomID              *string
+	Content             string
+	ExpenseAmount       *int
+	ExpenseDescription  *string
+}
+
+// CreateService creates journal logs.
+type CreateService struct {
+	repo     Repository
+	txRunner TransactionRunner
+}
+
+// NewCreateService returns a CreateService.
+func NewCreateService(repo Repository, txRunner TransactionRunner) *CreateService {
+	return &CreateService{repo: repo, txRunner: txRunner}
+}
+
+// Execute creates a journal log.
+func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*JournalLog, error) {
+	actorRole, err := normalizeWriteRole(input.ActorRole)
+	if err != nil {
+		return nil, err
+	}
+	actorUserID, err := normalizeRequiredUUID(input.ActorUserID, "actor_user_id", apperr.ErrUnauthorized)
+	if err != nil {
+		return nil, err
+	}
+	propertyID, err := normalizeRequiredUUID(input.PropertyID, "property_id", apperr.ErrPropertyNotFound)
+	if err != nil {
+		return nil, err
+	}
+	roomID, err := normalizeOptionalUUID(input.RoomID, "room_id")
+	if err != nil {
+		return nil, err
+	}
+	if err := requirePropertyAccess(actorRole, input.AssignedPropertyIDs, propertyID); err != nil {
+		return nil, err
+	}
+	if _, err := domainjournal.New(domainjournal.State{
+		PropertyID:         propertyID,
+		RoomID:             roomID,
+		AuthorID:           actorUserID,
+		Content:            input.Content,
+		ExpenseAmount:      input.ExpenseAmount,
+		ExpenseDescription: input.ExpenseDescription,
+	}); err != nil {
+		return nil, mapDomainError(err)
+	}
+	if s.txRunner == nil {
+		return nil, apperr.ErrInternalServerError
+	}
+
+	var created *JournalLog
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
+		if err := s.repo.EnsurePropertyExists(ctx, tx, propertyID); err != nil {
+			return mapRepositoryError(err)
+		}
+		if roomID != nil {
+			room, err := s.repo.FindRoomByID(ctx, tx, *roomID)
+			if err != nil {
+				return mapRepositoryError(err)
+			}
+			if room.PropertyID != propertyID {
+				return apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "room_id"})
+			}
+		}
+
+		journalLog, err := s.repo.Create(ctx, tx, CreateParams{
+			PropertyID:         propertyID,
+			RoomID:             roomID,
+			AuthorID:           actorUserID,
+			Content:            strings.TrimSpace(input.Content),
+			ExpenseAmount:      input.ExpenseAmount,
+			ExpenseDescription: trimOptionalString(input.ExpenseDescription),
+		})
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+
+		if journalLog.ExpenseAmount != nil {
+			recorder.Record(domainevents.JournalExpenseRecorded{
+				JournalLogID: journalLog.ID,
+				PropertyID:   journalLog.PropertyID,
+				Amount:       *journalLog.ExpenseAmount,
+				Description:  journalLog.ExpenseDescription,
+				OccurredAt:   journalLog.CreatedAt.UTC(),
+			})
+		}
+
+		created = journalLog
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return created, nil
+}
+
+func trimOptionalString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	return &trimmed
+}

--- a/internal/application/journal/create.go
+++ b/internal/application/journal/create.go
@@ -3,7 +3,6 @@ package journal
 import (
 	"context"
 	"database/sql"
-	"strings"
 
 	domainevents "stds_backend/internal/domain/events"
 	domainjournal "stds_backend/internal/domain/journal"
@@ -55,16 +54,18 @@ func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*Journa
 	if err := requirePropertyAccess(actorRole, input.AssignedPropertyIDs, propertyID); err != nil {
 		return nil, err
 	}
-	if _, err := domainjournal.New(domainjournal.State{
+	aggregate, err := domainjournal.New(domainjournal.State{
 		PropertyID:         propertyID,
 		RoomID:             roomID,
 		AuthorID:           actorUserID,
 		Content:            input.Content,
 		ExpenseAmount:      input.ExpenseAmount,
 		ExpenseDescription: input.ExpenseDescription,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, mapDomainError(err)
 	}
+	state := aggregate.State()
 	if s.txRunner == nil {
 		return nil, apperr.ErrInternalServerError
 	}
@@ -85,12 +86,12 @@ func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*Journa
 		}
 
 		journalLog, err := s.repo.Create(ctx, tx, CreateParams{
-			PropertyID:         propertyID,
-			RoomID:             roomID,
-			AuthorID:           actorUserID,
-			Content:            strings.TrimSpace(input.Content),
-			ExpenseAmount:      input.ExpenseAmount,
-			ExpenseDescription: trimOptionalString(input.ExpenseDescription),
+			PropertyID:         state.PropertyID,
+			RoomID:             state.RoomID,
+			AuthorID:           state.AuthorID,
+			Content:            state.Content,
+			ExpenseAmount:      state.ExpenseAmount,
+			ExpenseDescription: state.ExpenseDescription,
 		})
 		if err != nil {
 			return mapRepositoryError(err)
@@ -114,13 +115,4 @@ func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*Journa
 	}
 
 	return created, nil
-}
-
-func trimOptionalString(value *string) *string {
-	if value == nil {
-		return nil
-	}
-
-	trimmed := strings.TrimSpace(*value)
-	return &trimmed
 }

--- a/internal/application/journal/create_test.go
+++ b/internal/application/journal/create_test.go
@@ -1,0 +1,416 @@
+package journal
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	domainevents "stds_backend/internal/domain/events"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+const (
+	testJournalID  = "60000000-0000-0000-0000-000000000001"
+	testPropertyID = "10000000-0000-0000-0000-000000000001"
+	testRoomID     = "20000000-0000-0000-0000-000000000001"
+	testActorID    = "00000000-0000-0000-0000-000000000002"
+)
+
+func TestCreateServicePublishesJournalExpenseRecordedWhenExpensePresent(t *testing.T) {
+	amount := 3500
+	description := "Pipe repair"
+	repo := &journalRepositoryStub{
+		propertyExists: true,
+		room:           &Room{ID: testRoomID, PropertyID: testPropertyID},
+		created: &JournalLog{
+			ID:                 testJournalID,
+			PropertyID:         testPropertyID,
+			RoomID:             stringPtr(testRoomID),
+			AuthorID:           testActorID,
+			Content:            "Bathroom repair",
+			ExpenseAmount:      &amount,
+			ExpenseDescription: &description,
+			CreatedAt:          time.Now(),
+			UpdatedAt:          time.Now(),
+		},
+	}
+	runner, publisher, cleanup := newJournalTxRunner(t)
+	defer cleanup()
+	service := NewCreateService(repo, runner)
+
+	created, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:           "organizer",
+		ActorUserID:         testActorID,
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          testPropertyID,
+		RoomID:              stringPtr(testRoomID),
+		Content:             " Bathroom repair ",
+		ExpenseAmount:       &amount,
+		ExpenseDescription:  &description,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if created.ID != testJournalID {
+		t.Fatalf("created.ID = %s, want %s", created.ID, testJournalID)
+	}
+	if len(publisher.events) != 1 {
+		t.Fatalf("published events = %d, want 1", len(publisher.events))
+	}
+	event, ok := publisher.events[0].(domainevents.JournalExpenseRecorded)
+	if !ok {
+		t.Fatalf("event type = %T, want JournalExpenseRecorded", publisher.events[0])
+	}
+	if event.JournalLogID != testJournalID || event.PropertyID != testPropertyID || event.Amount != amount {
+		t.Fatalf("event = %+v", event)
+	}
+}
+
+func TestCreateServiceDoesNotPublishExpenseEventWithoutExpense(t *testing.T) {
+	repo := &journalRepositoryStub{
+		propertyExists: true,
+		created: &JournalLog{
+			ID:         testJournalID,
+			PropertyID: testPropertyID,
+			AuthorID:   testActorID,
+			Content:    "Inspection",
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+	}
+	runner, publisher, cleanup := newJournalTxRunner(t)
+	defer cleanup()
+	service := NewCreateService(repo, runner)
+
+	if _, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:           "staff",
+		ActorUserID:         testActorID,
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          testPropertyID,
+		Content:             "Inspection",
+	}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if len(publisher.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(publisher.events))
+	}
+}
+
+func TestCreateServiceRejectsEmptyContent(t *testing.T) {
+	service := NewCreateService(&journalRepositoryStub{}, nil)
+
+	_, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:           "admin",
+		ActorUserID:         testActorID,
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          testPropertyID,
+		Content:             " ",
+	})
+	if !errors.Is(err, ErrValidationJournalContentRequired) {
+		t.Fatalf("Execute() error = %v, want ErrValidationJournalContentRequired", err)
+	}
+}
+
+func TestCreateServiceRejectsUnassignedProperty(t *testing.T) {
+	service := NewCreateService(&journalRepositoryStub{}, nil)
+
+	_, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:           "staff",
+		ActorUserID:         testActorID,
+		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000099"},
+		PropertyID:          testPropertyID,
+		Content:             "Inspection",
+	})
+	if !errors.Is(err, apperr.ErrForbidden) {
+		t.Fatalf("Execute() error = %v, want forbidden", err)
+	}
+}
+
+func TestCreateServiceRejectsRoomFromDifferentProperty(t *testing.T) {
+	repo := &journalRepositoryStub{
+		propertyExists: true,
+		room:           &Room{ID: testRoomID, PropertyID: "10000000-0000-0000-0000-000000000099"},
+	}
+	runner, _, cleanup := newJournalTxRunnerExpectRollback(t)
+	defer cleanup()
+	service := NewCreateService(repo, runner)
+
+	_, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:           "admin",
+		ActorUserID:         testActorID,
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          testPropertyID,
+		RoomID:              stringPtr(testRoomID),
+		Content:             "Inspection",
+	})
+	if !errors.Is(err, apperr.ErrBadRequest) {
+		t.Fatalf("Execute() error = %v, want bad request", err)
+	}
+}
+
+func TestCreateServiceMapsMissingPropertyToNotFound(t *testing.T) {
+	runner, _, cleanup := newJournalTxRunnerExpectRollback(t)
+	defer cleanup()
+	service := NewCreateService(&journalRepositoryStub{}, runner)
+
+	_, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:           "admin",
+		ActorUserID:         testActorID,
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          testPropertyID,
+		Content:             "Inspection",
+	})
+	if !errors.Is(err, apperr.ErrPropertyNotFound) {
+		t.Fatalf("Execute() error = %v, want property not found", err)
+	}
+}
+
+func TestListServiceRejectsInvalidInputBeforeRepository(t *testing.T) {
+	service := NewListService(&journalRepositoryStub{})
+
+	t.Run("invalid property id", func(t *testing.T) {
+		value := "not-a-uuid"
+		_, err := service.Execute(context.Background(), ListInput{
+			ActorRole:  "admin",
+			PropertyID: &value,
+			Limit:      20,
+		})
+		if !errors.Is(err, apperr.ErrBadRequest) {
+			t.Fatalf("Execute() error = %v, want bad request", err)
+		}
+	})
+
+	t.Run("invalid limit", func(t *testing.T) {
+		_, err := service.Execute(context.Background(), ListInput{
+			ActorRole: "admin",
+			Limit:     0,
+		})
+		if !errors.Is(err, apperr.ErrBadRequest) {
+			t.Fatalf("Execute() error = %v, want bad request", err)
+		}
+	})
+
+	t.Run("invalid offset", func(t *testing.T) {
+		_, err := service.Execute(context.Background(), ListInput{
+			ActorRole: "admin",
+			Limit:     20,
+			Offset:    -1,
+		})
+		if !errors.Is(err, apperr.ErrBadRequest) {
+			t.Fatalf("Execute() error = %v, want bad request", err)
+		}
+	})
+}
+
+func TestUpdateServiceUpdatesMutableFields(t *testing.T) {
+	amount := 4200
+	description := "Fixture replacement"
+	repo := &journalRepositoryStub{
+		current: &JournalLog{
+			ID:                 testJournalID,
+			PropertyID:         testPropertyID,
+			AuthorID:           testActorID,
+			Content:            "Original",
+			ExpenseDescription: stringPtr("Old"),
+			CreatedAt:          time.Now(),
+			UpdatedAt:          time.Now(),
+		},
+	}
+	runner, _, cleanup := newJournalTxRunner(t)
+	defer cleanup()
+	service := NewUpdateService(repo, runner)
+	content := " Updated journal "
+
+	updated, err := service.Execute(context.Background(), UpdateInput{
+		ID:                 testJournalID,
+		Content:            &content,
+		ExpenseAmount:      &amount,
+		ExpenseDescription: &description,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if updated.Content != "Updated journal" {
+		t.Fatalf("Content = %q, want trimmed content", updated.Content)
+	}
+	if updated.ExpenseAmount == nil || *updated.ExpenseAmount != amount {
+		t.Fatalf("ExpenseAmount = %v, want %d", updated.ExpenseAmount, amount)
+	}
+	if updated.ExpenseDescription == nil || *updated.ExpenseDescription != description {
+		t.Fatalf("ExpenseDescription = %v, want %s", updated.ExpenseDescription, description)
+	}
+}
+
+func TestUpdateServiceRejectsEmptyContent(t *testing.T) {
+	repo := &journalRepositoryStub{
+		current: &JournalLog{
+			ID:         testJournalID,
+			PropertyID: testPropertyID,
+			AuthorID:   testActorID,
+			Content:    "Original",
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+	}
+	runner, _, cleanup := newJournalTxRunnerExpectRollback(t)
+	defer cleanup()
+	service := NewUpdateService(repo, runner)
+	content := " "
+
+	_, err := service.Execute(context.Background(), UpdateInput{
+		ID:      testJournalID,
+		Content: &content,
+	})
+	if !errors.Is(err, ErrValidationJournalContentRequired) {
+		t.Fatalf("Execute() error = %v, want ErrValidationJournalContentRequired", err)
+	}
+}
+
+func TestDeleteServiceSoftDeletesJournalLog(t *testing.T) {
+	repo := &journalRepositoryStub{}
+	runner, _, cleanup := newJournalTxRunner(t)
+	defer cleanup()
+	service := NewDeleteService(repo, runner)
+
+	if err := service.Execute(context.Background(), DeleteInput{ID: testJournalID}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if repo.deletedID != testJournalID {
+		t.Fatalf("deletedID = %s, want %s", repo.deletedID, testJournalID)
+	}
+}
+
+type journalPublisherStub struct {
+	events []any
+}
+
+func (s *journalPublisherStub) Publish(_ context.Context, event any) error {
+	s.events = append(s.events, event)
+	return nil
+}
+
+func newJournalTxRunner(t *testing.T) (*txrunner.Runner, *journalPublisherStub, func()) {
+	t.Helper()
+
+	return newJournalTxRunnerWithExpectation(t, true)
+}
+
+func newJournalTxRunnerExpectRollback(t *testing.T) (*txrunner.Runner, *journalPublisherStub, func()) {
+	t.Helper()
+
+	return newJournalTxRunnerWithExpectation(t, false)
+}
+
+func newJournalTxRunnerWithExpectation(t *testing.T, commit bool) (*txrunner.Runner, *journalPublisherStub, func()) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	mock.ExpectBegin()
+	if commit {
+		mock.ExpectCommit()
+	} else {
+		mock.ExpectRollback()
+	}
+	publisher := &journalPublisherStub{}
+	cleanup := func() {
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sql expectations: %v", err)
+		}
+		_ = db.Close()
+	}
+
+	return txrunner.New(db, publisher), publisher, cleanup
+}
+
+type journalRepositoryStub struct {
+	propertyExists bool
+	room           *Room
+	created        *JournalLog
+	current        *JournalLog
+	deletedID      string
+}
+
+func (s *journalRepositoryStub) List(context.Context, ListQuery) ([]JournalLog, error) {
+	return nil, nil
+}
+
+func (s *journalRepositoryStub) FindByID(context.Context, string) (*JournalLog, error) {
+	return nil, nil
+}
+
+func (s *journalRepositoryStub) FindByIDForUpdate(context.Context, *sql.Tx, string) (*JournalLog, error) {
+	if s.current == nil {
+		return nil, ErrJournalLogNotFound
+	}
+
+	return s.current, nil
+}
+
+func (s *journalRepositoryStub) EnsurePropertyExists(context.Context, *sql.Tx, string) error {
+	if !s.propertyExists {
+		return ErrPropertyNotFound
+	}
+
+	return nil
+}
+
+func (s *journalRepositoryStub) FindRoomByID(context.Context, *sql.Tx, string) (*Room, error) {
+	if s.room == nil {
+		return nil, ErrRoomNotFound
+	}
+
+	return s.room, nil
+}
+
+func (s *journalRepositoryStub) Create(_ context.Context, _ *sql.Tx, params CreateParams) (*JournalLog, error) {
+	if s.created != nil {
+		return s.created, nil
+	}
+
+	return &JournalLog{
+		ID:                 testJournalID,
+		PropertyID:         params.PropertyID,
+		RoomID:             params.RoomID,
+		AuthorID:           params.AuthorID,
+		Content:            params.Content,
+		ExpenseAmount:      params.ExpenseAmount,
+		ExpenseDescription: params.ExpenseDescription,
+		CreatedAt:          time.Now(),
+		UpdatedAt:          time.Now(),
+	}, nil
+}
+
+func (s *journalRepositoryStub) Update(_ context.Context, _ *sql.Tx, params UpdateParams) (*JournalLog, error) {
+	if s.current == nil {
+		return nil, ErrJournalLogNotFound
+	}
+
+	return &JournalLog{
+		ID:                 params.ID,
+		PropertyID:         s.current.PropertyID,
+		RoomID:             s.current.RoomID,
+		AuthorID:           s.current.AuthorID,
+		Content:            params.Content,
+		ExpenseAmount:      params.ExpenseAmount,
+		ExpenseDescription: params.ExpenseDescription,
+		CreatedAt:          s.current.CreatedAt,
+		UpdatedAt:          time.Now(),
+	}, nil
+}
+
+func (s *journalRepositoryStub) SoftDelete(_ context.Context, _ *sql.Tx, id string) error {
+	s.deletedID = id
+	return nil
+}
+
+func stringPtr(value string) *string {
+	return &value
+}

--- a/internal/application/journal/create_test.go
+++ b/internal/application/journal/create_test.go
@@ -171,9 +171,9 @@ func TestCreateServiceMapsMissingPropertyToNotFound(t *testing.T) {
 }
 
 func TestListServiceRejectsInvalidInputBeforeRepository(t *testing.T) {
-	service := NewListService(&journalRepositoryStub{})
-
 	t.Run("invalid property id", func(t *testing.T) {
+		repo := &journalRepositoryStub{}
+		service := NewListService(repo)
 		value := "not-a-uuid"
 		_, err := service.Execute(context.Background(), ListInput{
 			ActorRole:  "admin",
@@ -183,9 +183,14 @@ func TestListServiceRejectsInvalidInputBeforeRepository(t *testing.T) {
 		if !errors.Is(err, apperr.ErrBadRequest) {
 			t.Fatalf("Execute() error = %v, want bad request", err)
 		}
+		if repo.listCalls != 0 {
+			t.Fatalf("List calls = %d, want 0", repo.listCalls)
+		}
 	})
 
 	t.Run("invalid limit", func(t *testing.T) {
+		repo := &journalRepositoryStub{}
+		service := NewListService(repo)
 		_, err := service.Execute(context.Background(), ListInput{
 			ActorRole: "admin",
 			Limit:     0,
@@ -193,9 +198,14 @@ func TestListServiceRejectsInvalidInputBeforeRepository(t *testing.T) {
 		if !errors.Is(err, apperr.ErrBadRequest) {
 			t.Fatalf("Execute() error = %v, want bad request", err)
 		}
+		if repo.listCalls != 0 {
+			t.Fatalf("List calls = %d, want 0", repo.listCalls)
+		}
 	})
 
 	t.Run("invalid offset", func(t *testing.T) {
+		repo := &journalRepositoryStub{}
+		service := NewListService(repo)
 		_, err := service.Execute(context.Background(), ListInput{
 			ActorRole: "admin",
 			Limit:     20,
@@ -203,6 +213,9 @@ func TestListServiceRejectsInvalidInputBeforeRepository(t *testing.T) {
 		})
 		if !errors.Is(err, apperr.ErrBadRequest) {
 			t.Fatalf("Execute() error = %v, want bad request", err)
+		}
+		if repo.listCalls != 0 {
+			t.Fatalf("List calls = %d, want 0", repo.listCalls)
 		}
 	})
 }
@@ -336,9 +349,11 @@ type journalRepositoryStub struct {
 	created        *JournalLog
 	current        *JournalLog
 	deletedID      string
+	listCalls      int
 }
 
 func (s *journalRepositoryStub) List(context.Context, ListQuery) ([]JournalLog, error) {
+	s.listCalls++
 	return nil, nil
 }
 

--- a/internal/application/journal/delete.go
+++ b/internal/application/journal/delete.go
@@ -1,0 +1,49 @@
+package journal
+
+import (
+	"context"
+	"database/sql"
+
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// DeleteInput is the command payload for soft deletion.
+type DeleteInput struct {
+	ID string
+}
+
+// DeleteService soft-deletes journal logs.
+type DeleteService struct {
+	repo     Repository
+	txRunner TransactionRunner
+}
+
+// NewDeleteService returns a DeleteService.
+func NewDeleteService(repo Repository, txRunner TransactionRunner) *DeleteService {
+	return &DeleteService{repo: repo, txRunner: txRunner}
+}
+
+// Execute performs a soft delete.
+func (s *DeleteService) Execute(ctx context.Context, input DeleteInput) error {
+	id, err := normalizeRequiredUUID(input.ID, "id", ErrJournalLogNotFound)
+	if err != nil {
+		return err
+	}
+	if s.txRunner == nil {
+		return apperr.ErrInternalServerError
+	}
+
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		if err := s.repo.SoftDelete(ctx, tx, id); err != nil {
+			return mapRepositoryError(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/application/journal/errors.go
+++ b/internal/application/journal/errors.go
@@ -1,0 +1,51 @@
+package journal
+
+import (
+	"errors"
+	"net/http"
+
+	domainjournal "stds_backend/internal/domain/journal"
+	"stds_backend/internal/shared/apperr"
+)
+
+const (
+	CodeValidationJournalContentRequired = "VALIDATION_JOURNAL_CONTENT_REQUIRED"
+)
+
+var (
+	ErrValidationJournalContentRequired = apperr.New(
+		CodeValidationJournalContentRequired,
+		http.StatusBadRequest,
+		"Journal content is required.",
+	)
+)
+
+func mapRepositoryError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, ErrJournalLogNotFound):
+		return apperr.ErrJournalLogNotFound
+	case errors.Is(err, ErrPropertyNotFound):
+		return apperr.ErrPropertyNotFound
+	case errors.Is(err, ErrRoomNotFound):
+		return apperr.ErrRoomNotFound
+	default:
+		return apperr.ErrInternalServerError.WithCause(err)
+	}
+}
+
+func mapDomainError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch {
+	case errors.Is(err, domainjournal.ErrContentRequired):
+		return ErrValidationJournalContentRequired
+	default:
+		return apperr.ErrInternalServerError.WithCause(err)
+	}
+}

--- a/internal/application/journal/get.go
+++ b/internal/application/journal/get.go
@@ -1,0 +1,33 @@
+package journal
+
+import "context"
+
+// GetInput is the query payload for journal log detail retrieval.
+type GetInput struct {
+	ID string
+}
+
+// GetService returns one journal log.
+type GetService struct {
+	repo Repository
+}
+
+// NewGetService returns a GetService.
+func NewGetService(repo Repository) *GetService {
+	return &GetService{repo: repo}
+}
+
+// Execute returns one active journal log.
+func (s *GetService) Execute(ctx context.Context, input GetInput) (*JournalLog, error) {
+	id, err := normalizeRequiredUUID(input.ID, "id", ErrJournalLogNotFound)
+	if err != nil {
+		return nil, err
+	}
+
+	item, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return nil, mapRepositoryError(err)
+	}
+
+	return item, nil
+}

--- a/internal/application/journal/helpers.go
+++ b/internal/application/journal/helpers.go
@@ -24,7 +24,7 @@ func normalizeRequiredUUID(value string, field string, notFound error) (string, 
 		return "", notFound
 	}
 	if _, err := uuid.Parse(trimmed); err != nil {
-		return "", apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+		return "", apperr.ErrBadRequest.WithCause(err).WithDetails(map[string]interface{}{"field": field})
 	}
 
 	return trimmed, nil
@@ -40,7 +40,7 @@ func normalizeOptionalUUID(value *string, field string) (*string, error) {
 		return nil, nil
 	}
 	if _, err := uuid.Parse(trimmed); err != nil {
-		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+		return nil, apperr.ErrBadRequest.WithCause(err).WithDetails(map[string]interface{}{"field": field})
 	}
 
 	return &trimmed, nil

--- a/internal/application/journal/helpers.go
+++ b/internal/application/journal/helpers.go
@@ -1,0 +1,71 @@
+package journal
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+func normalizeWriteRole(role string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(role))
+	switch normalized {
+	case "admin", "organizer", "staff":
+		return normalized, nil
+	default:
+		return "", apperr.ErrForbidden
+	}
+}
+
+func normalizeRequiredUUID(value string, field string, notFound error) (string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || trimmed == "00000000-0000-0000-0000-000000000000" {
+		return "", notFound
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return "", apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+	}
+
+	return trimmed, nil
+}
+
+func normalizeOptionalUUID(value *string, field string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil, nil
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+	}
+
+	return &trimmed, nil
+}
+
+func containsAssignedProperty(assignedPropertyIDs []string, propertyID string) bool {
+	for _, assignedPropertyID := range assignedPropertyIDs {
+		if strings.TrimSpace(assignedPropertyID) == propertyID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func requirePropertyAccess(role string, assignedPropertyIDs []string, propertyID string) error {
+	switch role {
+	case "admin":
+		return nil
+	case "organizer", "staff":
+		if containsAssignedProperty(assignedPropertyIDs, propertyID) {
+			return nil
+		}
+		return apperr.ErrForbidden.WithDetails(map[string]interface{}{"property_id": propertyID})
+	default:
+		return apperr.ErrForbidden
+	}
+}

--- a/internal/application/journal/helpers.go
+++ b/internal/application/journal/helpers.go
@@ -47,8 +47,9 @@ func normalizeOptionalUUID(value *string, field string) (*string, error) {
 }
 
 func containsAssignedProperty(assignedPropertyIDs []string, propertyID string) bool {
+	normalizedPropertyID := strings.TrimSpace(propertyID)
 	for _, assignedPropertyID := range assignedPropertyIDs {
-		if strings.TrimSpace(assignedPropertyID) == propertyID {
+		if strings.TrimSpace(assignedPropertyID) == normalizedPropertyID {
 			return true
 		}
 	}

--- a/internal/application/journal/list.go
+++ b/internal/application/journal/list.go
@@ -1,0 +1,107 @@
+package journal
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+const maxListJournalLogsLimit = 100
+
+// ListInput is the query payload for journal log listing.
+type ListInput struct {
+	ActorRole           string
+	AssignedPropertyIDs []string
+	PropertyID          *string
+	RoomID              *string
+	DateFrom            *time.Time
+	DateTo              *time.Time
+	Limit               int
+	Offset              int
+}
+
+// ListService lists journal logs.
+type ListService struct {
+	repo Repository
+}
+
+// NewListService returns a ListService.
+func NewListService(repo Repository) *ListService {
+	return &ListService{repo: repo}
+}
+
+// Execute returns active journal logs visible to the actor.
+func (s *ListService) Execute(ctx context.Context, input ListInput) ([]JournalLog, error) {
+	role := strings.ToLower(strings.TrimSpace(input.ActorRole))
+	switch role {
+	case "admin", "organizer", "staff":
+	default:
+		return nil, apperr.ErrForbidden
+	}
+	propertyID, err := normalizeOptionalFilterUUID(input.PropertyID, "property_id")
+	if err != nil {
+		return nil, err
+	}
+	roomID, err := normalizeOptionalFilterUUID(input.RoomID, "room_id")
+	if err != nil {
+		return nil, err
+	}
+	if input.Limit < 1 || input.Limit > maxListJournalLogsLimit {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "limit",
+			"reason": "must be between 1 and 100",
+		})
+	}
+	if input.Offset < 0 {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field":  "offset",
+			"reason": "must be greater than or equal to 0",
+		})
+	}
+
+	items, err := s.repo.List(ctx, ListQuery{
+		ActorRole:           role,
+		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
+		PropertyID:          propertyID,
+		RoomID:              roomID,
+		DateFrom:            input.DateFrom,
+		DateTo:              input.DateTo,
+		Limit:               input.Limit,
+		Offset:              input.Offset,
+	})
+	if err != nil {
+		return nil, mapRepositoryError(err)
+	}
+
+	return items, nil
+}
+
+func normalizeOptionalFilterUUID(value *string, field string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+	}
+	if _, err := uuid.Parse(trimmed); err != nil {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": field})
+	}
+
+	return &trimmed, nil
+}
+
+func cloneStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+
+	cloned := make([]string, len(values))
+	copy(cloned, values)
+	return cloned
+}

--- a/internal/application/journal/repository.go
+++ b/internal/application/journal/repository.go
@@ -1,0 +1,82 @@
+package journal
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"stds_backend/internal/platform/database/txrunner"
+)
+
+var (
+	ErrJournalLogNotFound = errors.New("journal log not found")
+	ErrPropertyNotFound   = errors.New("journal property not found")
+	ErrRoomNotFound       = errors.New("journal room not found")
+)
+
+// TransactionRunner is the txrunner.Runner surface required by journal use cases.
+type TransactionRunner interface {
+	WithinTransaction(ctx context.Context, fn func(context.Context, *sql.Tx, *txrunner.EventRecorder) error) error
+}
+
+// JournalLog is the application-facing journal log shape.
+type JournalLog struct {
+	ID                 string
+	PropertyID         string
+	RoomID             *string
+	AuthorID           string
+	Content            string
+	ExpenseAmount      *int
+	ExpenseDescription *string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+}
+
+// Room captures room ownership needed by journal creation.
+type Room struct {
+	ID         string
+	PropertyID string
+}
+
+// ListQuery defines filtering, pagination, and role scoping for journal lists.
+type ListQuery struct {
+	ActorRole           string
+	AssignedPropertyIDs []string
+	PropertyID          *string
+	RoomID              *string
+	DateFrom            *time.Time
+	DateTo              *time.Time
+	Limit               int
+	Offset              int
+}
+
+// CreateParams contains fields for journal log creation.
+type CreateParams struct {
+	PropertyID         string
+	RoomID             *string
+	AuthorID           string
+	Content            string
+	ExpenseAmount      *int
+	ExpenseDescription *string
+}
+
+// UpdateParams contains mutable journal log fields.
+type UpdateParams struct {
+	ID                 string
+	Content            string
+	ExpenseAmount      *int
+	ExpenseDescription *string
+}
+
+// Repository defines persistence required by journal use cases.
+type Repository interface {
+	List(ctx context.Context, query ListQuery) ([]JournalLog, error)
+	FindByID(ctx context.Context, id string) (*JournalLog, error)
+	FindByIDForUpdate(ctx context.Context, tx *sql.Tx, id string) (*JournalLog, error)
+	EnsurePropertyExists(ctx context.Context, tx *sql.Tx, id string) error
+	FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*Room, error)
+	Create(ctx context.Context, tx *sql.Tx, params CreateParams) (*JournalLog, error)
+	Update(ctx context.Context, tx *sql.Tx, params UpdateParams) (*JournalLog, error)
+	SoftDelete(ctx context.Context, tx *sql.Tx, id string) error
+}

--- a/internal/application/journal/update.go
+++ b/internal/application/journal/update.go
@@ -1,0 +1,97 @@
+package journal
+
+import (
+	"context"
+	"database/sql"
+
+	domainjournal "stds_backend/internal/domain/journal"
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// UpdateInput is the command payload for journal log updates.
+type UpdateInput struct {
+	ID                 string
+	Content            *string
+	ExpenseAmount      *int
+	ExpenseDescription *string
+}
+
+// UpdateService updates journal logs.
+type UpdateService struct {
+	repo     Repository
+	txRunner TransactionRunner
+}
+
+// NewUpdateService returns an UpdateService.
+func NewUpdateService(repo Repository, txRunner TransactionRunner) *UpdateService {
+	return &UpdateService{repo: repo, txRunner: txRunner}
+}
+
+// Execute updates mutable journal log fields.
+func (s *UpdateService) Execute(ctx context.Context, input UpdateInput) (*JournalLog, error) {
+	id, err := normalizeRequiredUUID(input.ID, "id", ErrJournalLogNotFound)
+	if err != nil {
+		return nil, err
+	}
+	if input.Content == nil && input.ExpenseAmount == nil && input.ExpenseDescription == nil {
+		return nil, apperr.ErrBadRequest
+	}
+	if s.txRunner == nil {
+		return nil, apperr.ErrInternalServerError
+	}
+
+	var updated *JournalLog
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		current, err := s.repo.FindByIDForUpdate(ctx, tx, id)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		aggregate, err := domainjournal.Rehydrate(toDomainState(current))
+		if err != nil {
+			return mapDomainError(err)
+		}
+		if err := aggregate.Update(domainjournal.UpdateInput{
+			Content:            input.Content,
+			ExpenseAmount:      input.ExpenseAmount,
+			ExpenseDescription: input.ExpenseDescription,
+		}); err != nil {
+			return mapDomainError(err)
+		}
+
+		state := aggregate.State()
+		journalLog, err := s.repo.Update(ctx, tx, UpdateParams{
+			ID:                 id,
+			Content:            state.Content,
+			ExpenseAmount:      state.ExpenseAmount,
+			ExpenseDescription: state.ExpenseDescription,
+		})
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+
+		updated = journalLog
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return updated, nil
+}
+
+func toDomainState(journalLog *JournalLog) domainjournal.State {
+	if journalLog == nil {
+		return domainjournal.State{}
+	}
+
+	return domainjournal.State{
+		ID:                 journalLog.ID,
+		PropertyID:         journalLog.PropertyID,
+		RoomID:             journalLog.RoomID,
+		AuthorID:           journalLog.AuthorID,
+		Content:            journalLog.Content,
+		ExpenseAmount:      journalLog.ExpenseAmount,
+		ExpenseDescription: journalLog.ExpenseDescription,
+	}
+}

--- a/internal/domain/events/journal_expense_recorded.go
+++ b/internal/domain/events/journal_expense_recorded.go
@@ -1,0 +1,12 @@
+package events
+
+import "time"
+
+// JournalExpenseRecorded is emitted after a journal log expense is recorded.
+type JournalExpenseRecorded struct {
+	JournalLogID string
+	PropertyID   string
+	Amount       int
+	Description  *string
+	OccurredAt   time.Time
+}

--- a/internal/domain/journal/aggregate.go
+++ b/internal/domain/journal/aggregate.go
@@ -1,0 +1,127 @@
+package journal
+
+import "strings"
+
+// State is the persisted journal log aggregate state.
+type State struct {
+	ID                 string
+	PropertyID         string
+	RoomID             *string
+	AuthorID           string
+	Content            string
+	ExpenseAmount      *int
+	ExpenseDescription *string
+}
+
+// UpdateInput contains mutable journal log fields.
+type UpdateInput struct {
+	Content            *string
+	ExpenseAmount      *int
+	ExpenseDescription *string
+}
+
+// Aggregate owns journal log command rules.
+type Aggregate struct {
+	state State
+}
+
+// New creates a journal log aggregate for create commands.
+func New(state State) (*Aggregate, error) {
+	normalized, err := normalizeState(state)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Aggregate{state: normalized}, nil
+}
+
+// Rehydrate reconstructs an existing journal log aggregate.
+func Rehydrate(state State) (*Aggregate, error) {
+	normalized, err := normalizeState(state)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Aggregate{state: normalized}, nil
+}
+
+// Update applies mutable field changes.
+func (a *Aggregate) Update(input UpdateInput) error {
+	if a == nil {
+		return nil
+	}
+
+	if input.Content != nil {
+		content := strings.TrimSpace(*input.Content)
+		if content == "" {
+			return ErrContentRequired
+		}
+		a.state.Content = content
+	}
+	if input.ExpenseAmount != nil {
+		value := *input.ExpenseAmount
+		a.state.ExpenseAmount = &value
+	}
+	if input.ExpenseDescription != nil {
+		value := strings.TrimSpace(*input.ExpenseDescription)
+		a.state.ExpenseDescription = &value
+	}
+
+	return nil
+}
+
+// State returns an immutable snapshot.
+func (a *Aggregate) State() State {
+	if a == nil {
+		return State{}
+	}
+
+	state := a.state
+	state.RoomID = cloneStringPtr(a.state.RoomID)
+	state.ExpenseAmount = cloneIntPtr(a.state.ExpenseAmount)
+	state.ExpenseDescription = cloneStringPtr(a.state.ExpenseDescription)
+	return state
+}
+
+func normalizeState(state State) (State, error) {
+	state.ID = strings.TrimSpace(state.ID)
+	state.PropertyID = strings.TrimSpace(state.PropertyID)
+	state.AuthorID = strings.TrimSpace(state.AuthorID)
+	state.Content = strings.TrimSpace(state.Content)
+	state.RoomID = trimOptionalString(state.RoomID)
+	state.ExpenseAmount = cloneIntPtr(state.ExpenseAmount)
+	state.ExpenseDescription = trimOptionalString(state.ExpenseDescription)
+
+	if state.Content == "" {
+		return State{}, ErrContentRequired
+	}
+
+	return state, nil
+}
+
+func trimOptionalString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+
+	trimmed := strings.TrimSpace(*value)
+	return &trimmed
+}
+
+func cloneStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+
+	clone := *value
+	return &clone
+}
+
+func cloneIntPtr(value *int) *int {
+	if value == nil {
+		return nil
+	}
+
+	clone := *value
+	return &clone
+}

--- a/internal/domain/journal/aggregate.go
+++ b/internal/domain/journal/aggregate.go
@@ -48,7 +48,7 @@ func Rehydrate(state State) (*Aggregate, error) {
 // Update applies mutable field changes.
 func (a *Aggregate) Update(input UpdateInput) error {
 	if a == nil {
-		return nil
+		return ErrNilAggregate
 	}
 
 	if input.Content != nil {

--- a/internal/domain/journal/aggregate.go
+++ b/internal/domain/journal/aggregate.go
@@ -63,8 +63,7 @@ func (a *Aggregate) Update(input UpdateInput) error {
 		a.state.ExpenseAmount = &value
 	}
 	if input.ExpenseDescription != nil {
-		value := strings.TrimSpace(*input.ExpenseDescription)
-		a.state.ExpenseDescription = &value
+		a.state.ExpenseDescription = trimOptionalString(input.ExpenseDescription)
 	}
 
 	return nil
@@ -105,6 +104,9 @@ func trimOptionalString(value *string) *string {
 	}
 
 	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
 	return &trimmed
 }
 

--- a/internal/domain/journal/aggregate_test.go
+++ b/internal/domain/journal/aggregate_test.go
@@ -1,0 +1,15 @@
+package journal
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAggregateUpdateRejectsNilReceiver(t *testing.T) {
+	var aggregate *Aggregate
+
+	err := aggregate.Update(UpdateInput{})
+	if !errors.Is(err, ErrNilAggregate) {
+		t.Fatalf("Update() error = %v, want ErrNilAggregate", err)
+	}
+}

--- a/internal/domain/journal/aggregate_test.go
+++ b/internal/domain/journal/aggregate_test.go
@@ -13,3 +13,67 @@ func TestAggregateUpdateRejectsNilReceiver(t *testing.T) {
 		t.Fatalf("Update() error = %v, want ErrNilAggregate", err)
 	}
 }
+
+func TestAggregateStateReturnsImmutablePointerSnapshot(t *testing.T) {
+	roomID := "20000000-0000-0000-0000-000000000001"
+	amount := 3500
+	description := "Pipe repair"
+	aggregate, err := New(State{
+		PropertyID:         "10000000-0000-0000-0000-000000000001",
+		RoomID:             &roomID,
+		AuthorID:           "00000000-0000-0000-0000-000000000002",
+		Content:            "Bathroom repair",
+		ExpenseAmount:      &amount,
+		ExpenseDescription: &description,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	snapshot := aggregate.State()
+	*snapshot.RoomID = "20000000-0000-0000-0000-000000000099"
+	*snapshot.ExpenseAmount = 9999
+	*snapshot.ExpenseDescription = "Changed"
+
+	state := aggregate.State()
+	if state.RoomID == nil || *state.RoomID != roomID {
+		t.Fatalf("RoomID = %v, want %s", state.RoomID, roomID)
+	}
+	if state.ExpenseAmount == nil || *state.ExpenseAmount != amount {
+		t.Fatalf("ExpenseAmount = %v, want %d", state.ExpenseAmount, amount)
+	}
+	if state.ExpenseDescription == nil || *state.ExpenseDescription != description {
+		t.Fatalf("ExpenseDescription = %v, want %s", state.ExpenseDescription, description)
+	}
+}
+
+func TestAggregateNormalizesBlankOptionalStringsToNil(t *testing.T) {
+	roomID := " "
+	description := " "
+	aggregate, err := New(State{
+		PropertyID:         "10000000-0000-0000-0000-000000000001",
+		RoomID:             &roomID,
+		AuthorID:           "00000000-0000-0000-0000-000000000002",
+		Content:            "Bathroom repair",
+		ExpenseDescription: &description,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	state := aggregate.State()
+	if state.RoomID != nil {
+		t.Fatalf("RoomID = %v, want nil", *state.RoomID)
+	}
+	if state.ExpenseDescription != nil {
+		t.Fatalf("ExpenseDescription = %v, want nil", *state.ExpenseDescription)
+	}
+
+	if err := aggregate.Update(UpdateInput{ExpenseDescription: &description}); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	state = aggregate.State()
+	if state.ExpenseDescription != nil {
+		t.Fatalf("ExpenseDescription after update = %v, want nil", *state.ExpenseDescription)
+	}
+}

--- a/internal/domain/journal/errors.go
+++ b/internal/domain/journal/errors.go
@@ -1,0 +1,7 @@
+package journal
+
+import "errors"
+
+var (
+	ErrContentRequired = errors.New("journal content required")
+)

--- a/internal/domain/journal/errors.go
+++ b/internal/domain/journal/errors.go
@@ -4,4 +4,5 @@ import "errors"
 
 var (
 	ErrContentRequired = errors.New("journal content required")
+	ErrNilAggregate    = errors.New("journal aggregate is nil")
 )

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -13,6 +13,7 @@ import (
 
 	appiam "stds_backend/internal/application/iam"
 	appjobs "stds_backend/internal/application/jobs"
+	appjournal "stds_backend/internal/application/journal"
 	applease "stds_backend/internal/application/lease"
 	appproperty "stds_backend/internal/application/property"
 	apprepair "stds_backend/internal/application/repair"
@@ -62,6 +63,7 @@ type APIServer struct {
 	forceTerminateSvc *applease.ForceTerminateLeaseService
 	getForceTermSvc   *applease.GetForceTerminationService
 	billing           BillingServices
+	journal           JournalServices
 	repair            RepairServices
 }
 
@@ -85,6 +87,15 @@ type BillingServices struct {
 	PropertyMeters   BillingPropertyMeterService
 	RoomMeters       BillingRoomMeterService
 	FinancialReports BillingFinancialReportService
+}
+
+// JournalServices groups journal log application services used by the transport layer.
+type JournalServices struct {
+	List   *appjournal.ListService
+	Get    *appjournal.GetService
+	Create *appjournal.CreateService
+	Update *appjournal.UpdateService
+	Delete *appjournal.DeleteService
 }
 
 // RepairServices groups repair request application services used by the transport layer.
@@ -282,6 +293,7 @@ func NewAPIServer(
 	createTenantSvc *apptenant.CreateTenantService,
 	updateTenantSvc *apptenant.UpdateTenantService,
 	createLeaseSvc *applease.CreateLeaseService,
+	journalServices JournalServices,
 	repairServices RepairServices,
 	leaseCommands ...LeaseCommandServices,
 ) *APIServer {
@@ -308,6 +320,7 @@ func NewAPIServer(
 		createTenantSvc:   createTenantSvc,
 		updateTenantSvc:   updateTenantSvc,
 		createLeaseSvc:    createLeaseSvc,
+		journal:           journalServices,
 		repair:            repairServices,
 	}
 	if len(leaseCommands) > 0 {
@@ -589,11 +602,102 @@ func (s *APIServer) RunOverdueBillsScanJob(c *gin.Context, params api.RunOverdue
 
 // ListJournalLogs handles the journal log listing endpoint.
 func (s *APIServer) ListJournalLogs(c *gin.Context, params api.ListJournalLogsParams) {
-	writeNotImplemented(c)
+	if s.journal.List == nil {
+		writeNotImplemented(c)
+		return
+	}
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	pagination, err := queryparams.NormalizePagination(params.Page, params.Limit)
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	var propertyID *string
+	if authorizedPropertyID := requestctx.GetPropertyID(c); authorizedPropertyID != "" {
+		propertyID = &authorizedPropertyID
+	}
+	roomID, err := queryparams.NormalizeOptionalUUID(params.RoomId, "room_id")
+	if err != nil {
+		c.Error(err)
+		return
+	}
+	var dateFrom *time.Time
+	if params.DateFrom != nil {
+		value := params.DateFrom.Time
+		dateFrom = &value
+	}
+	var dateTo *time.Time
+	if params.DateTo != nil {
+		value := params.DateTo.Time
+		dateTo = &value
+	}
+
+	items, err := s.journal.List.Execute(c.Request.Context(), appjournal.ListInput{
+		ActorRole:           principal.Role,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		PropertyID:          propertyID,
+		RoomID:              roomID,
+		DateFrom:            dateFrom,
+		DateTo:              dateTo,
+		Limit:               pagination.Limit,
+		Offset:              pagination.Offset,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	responses := make([]api.JournalLogResponse, 0, len(items))
+	for i := range items {
+		responses = append(responses, toJournalLogResponse(&items[i]))
+	}
+	c.JSON(http.StatusOK, api.JournalLogListResponse{Data: &responses})
 }
 
 // CreateJournalLog handles journal log creation.
-func (s *APIServer) CreateJournalLog(c *gin.Context) { writeNotImplemented(c) }
+func (s *APIServer) CreateJournalLog(c *gin.Context) {
+	if s.journal.Create == nil {
+		writeNotImplemented(c)
+		return
+	}
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+	var request api.CreateJournalLogRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	var roomID *string
+	if request.RoomId != nil {
+		value := request.RoomId.String()
+		roomID = &value
+	}
+	journalLog, err := s.journal.Create.Execute(c.Request.Context(), appjournal.CreateInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+		PropertyID:          request.PropertyId.String(),
+		RoomID:              roomID,
+		Content:             request.Content,
+		ExpenseAmount:       request.ExpenseAmount,
+		ExpenseDescription:  request.ExpenseDescription,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, toJournalLogResponse(journalLog))
+}
 
 // ListJournalLogAttachments handles journal log attachment listing.
 func (s *APIServer) ListJournalLogAttachments(c *gin.Context, id openapi_types.UUID) {
@@ -606,13 +710,59 @@ func (s *APIServer) CreateJournalLogAttachment(c *gin.Context, id openapi_types.
 }
 
 // DeleteJournalLog handles journal log deletion.
-func (s *APIServer) DeleteJournalLog(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) DeleteJournalLog(c *gin.Context, id string) {
+	if s.journal.Delete == nil {
+		writeNotImplemented(c)
+		return
+	}
+	if err := s.journal.Delete.Execute(c.Request.Context(), appjournal.DeleteInput{ID: id}); err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
 
 // GetJournalLog handles journal log detail retrieval.
-func (s *APIServer) GetJournalLog(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) GetJournalLog(c *gin.Context, id string) {
+	if s.journal.Get == nil {
+		writeNotImplemented(c)
+		return
+	}
+	journalLog, err := s.journal.Get.Execute(c.Request.Context(), appjournal.GetInput{ID: id})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toJournalLogResponse(journalLog))
+}
 
 // UpdateJournalLog handles journal log updates.
-func (s *APIServer) UpdateJournalLog(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) UpdateJournalLog(c *gin.Context, id string) {
+	if s.journal.Update == nil {
+		writeNotImplemented(c)
+		return
+	}
+	var request api.UpdateJournalLogRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	journalLog, err := s.journal.Update.Execute(c.Request.Context(), appjournal.UpdateInput{
+		ID:                 id,
+		Content:            request.Content,
+		ExpenseAmount:      request.ExpenseAmount,
+		ExpenseDescription: request.ExpenseDescription,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toJournalLogResponse(journalLog))
+}
 
 // ListLeases handles the lease listing endpoint.
 func (s *APIServer) ListLeases(c *gin.Context, params api.ListLeasesParams) {
@@ -2228,6 +2378,44 @@ func toFinancialReportSummaryItem(summary BillingFinancialReportSummary) api.Fin
 		TotalExpense: &totalExpense,
 		Net:          &net,
 	}
+}
+
+func toJournalLogResponse(journalLog *appjournal.JournalLog) api.JournalLogResponse {
+	if journalLog == nil {
+		return api.JournalLogResponse{}
+	}
+
+	id, idOK := parseUUID(journalLog.ID)
+	propertyID, propertyOK := parseUUID(journalLog.PropertyID)
+	authorID, authorOK := parseUUID(journalLog.AuthorID)
+	content := journalLog.Content
+	createdAt := journalLog.CreatedAt
+	updatedAt := journalLog.UpdatedAt
+
+	response := api.JournalLogResponse{
+		Content:            &content,
+		CreatedAt:          &createdAt,
+		ExpenseAmount:      journalLog.ExpenseAmount,
+		ExpenseDescription: journalLog.ExpenseDescription,
+		UpdatedAt:          &updatedAt,
+	}
+	if idOK {
+		response.Id = &id
+	}
+	if propertyOK {
+		response.PropertyId = &propertyID
+	}
+	if authorOK {
+		response.AuthorId = &authorID
+	}
+	if journalLog.RoomID != nil {
+		roomID, roomOK := parseUUID(*journalLog.RoomID)
+		if roomOK {
+			response.RoomId = &roomID
+		}
+	}
+
+	return response
 }
 
 func toFinancialReportResponse(report *BillingFinancialReport) api.FinancialReportResponse {

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -70,6 +70,7 @@ func New(
 	createTenantService *apptenant.CreateTenantService,
 	updateTenantService *apptenant.UpdateTenantService,
 	createLeaseService *applease.CreateLeaseService,
+	journalServices handler.JournalServices,
 	repairServices handler.RepairServices,
 	leaseCommands ...handler.LeaseCommandServices,
 ) *gin.Engine {
@@ -88,7 +89,7 @@ func New(
 	engine.GET("/openapi.yaml", docsHandler.OpenAPI)
 	engine.GET("/scalar", docsHandler.Scalar)
 
-	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, repairQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, repairServices, leaseCommands...), api.GinServerOptions{
+	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, repairQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, journalServices, repairServices, leaseCommands...), api.GinServerOptions{
 		BaseURL: "/api/v1",
 		Middlewares: []api.MiddlewareFunc{
 			protectedAPIMiddleware(appCfg, authenticator, userRepo, authzRepos),
@@ -199,7 +200,7 @@ func routePolicies(authzRepos AuthorizationRepositories) []routePolicy {
 		{method: "POST", path: "/api/v1/internal/jobs/overdue-bills/reminders", authStrategy: authStrategyScheduler},
 		{method: "POST", path: "/api/v1/internal/jobs/overdue-bills/scan", authStrategy: authStrategyScheduler},
 
-		{method: "GET", path: "/api/v1/journal-logs", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
+		{method: "GET", path: "/api/v1/journal-logs", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.QueryPropertyID("property_id")},
 		{method: "POST", path: "/api/v1/journal-logs", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "GET", path: "/api/v1/journal-logs/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByJournalLogID, apperr.ErrJournalLogNotFound)},
 		{method: "POST", path: "/api/v1/journal-logs/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByJournalLogID, apperr.ErrJournalLogNotFound)},

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -2341,6 +2341,31 @@ func TestListBillsRejectsUnassignedPropertyFilter(t *testing.T) {
 	}
 }
 
+func TestListJournalLogsRejectsUnassignedPropertyFilter(t *testing.T) {
+	engine := newTestEngine(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID2}},
+		fakePropertyRepo{
+			ownerByPropertyID: map[string]string{
+				testPropertyID1: "owner-1",
+			},
+		},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/journal-logs?property_id="+testPropertyID1, nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
 func TestListPropertyRoomsReturnsAccessibleRooms(t *testing.T) {
 	call := &listRoomsCall{}
 	propertyQueryRepo := fakePropertyQueryRepo{
@@ -4478,6 +4503,7 @@ func newTestEngineWithAllServices(userRepo fakeUserRepo, authenticator fakeAuthe
 		createTenantService,
 		updateTenantService,
 		createLeaseService,
+		handler.JournalServices{},
 		handler.RepairServices{},
 		leaseCommands...,
 	)
@@ -4540,6 +4566,7 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		handler.JournalServices{},
 		handler.RepairServices{},
 	)
 }
@@ -4582,6 +4609,7 @@ func newTestEngineWithRoomServices(userRepo fakeUserRepo, authenticator fakeAuth
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		handler.JournalServices{},
 		handler.RepairServices{},
 	)
 }

--- a/internal/platform/database/journal/repository.go
+++ b/internal/platform/database/journal/repository.go
@@ -1,0 +1,324 @@
+package journal
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	appjournal "stds_backend/internal/application/journal"
+)
+
+// SQLRepository persists and reads journal log state.
+type SQLRepository struct {
+	db *sql.DB
+}
+
+// NewRepository returns a journal repository backed by db.
+func NewRepository(db *sql.DB) *SQLRepository {
+	return &SQLRepository{db: db}
+}
+
+// List returns active journal logs visible to the actor scope.
+func (r *SQLRepository) List(ctx context.Context, query appjournal.ListQuery) ([]appjournal.JournalLog, error) {
+	base := selectJournalLogColumns + `
+FROM journal_logs jl
+WHERE jl.deleted_at IS NULL
+`
+	args := make([]any, 0)
+
+	switch strings.TrimSpace(query.ActorRole) {
+	case "organizer", "staff":
+		if len(query.AssignedPropertyIDs) == 0 {
+			return []appjournal.JournalLog{}, nil
+		}
+		placeholders := make([]string, 0, len(query.AssignedPropertyIDs))
+		for _, id := range query.AssignedPropertyIDs {
+			args = append(args, id)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		base += "\n  AND jl.property_id IN (" + strings.Join(placeholders, ", ") + ")"
+	case "admin":
+	default:
+		return []appjournal.JournalLog{}, nil
+	}
+
+	if query.PropertyID != nil {
+		args = append(args, *query.PropertyID)
+		base += fmt.Sprintf("\n  AND jl.property_id = $%d", len(args))
+	}
+	if query.RoomID != nil {
+		args = append(args, *query.RoomID)
+		base += fmt.Sprintf("\n  AND jl.room_id = $%d", len(args))
+	}
+	if query.DateFrom != nil {
+		args = append(args, query.DateFrom.UTC())
+		base += fmt.Sprintf("\n  AND jl.created_at >= $%d", len(args))
+	}
+	if query.DateTo != nil {
+		args = append(args, query.DateTo.UTC().AddDate(0, 0, 1))
+		base += fmt.Sprintf("\n  AND jl.created_at < $%d", len(args))
+	}
+
+	args = append(args, query.Limit, query.Offset)
+	base += fmt.Sprintf("\nORDER BY jl.created_at DESC, jl.id DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
+
+	rows, err := r.db.QueryContext(ctx, base, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list journal logs: %w", err)
+	}
+	defer rows.Close()
+
+	items := []appjournal.JournalLog{}
+	for rows.Next() {
+		item, err := scanJournalLog(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan journal log: %w", err)
+		}
+		items = append(items, *item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate journal logs: %w", err)
+	}
+
+	return items, nil
+}
+
+// FindByID returns one active journal log.
+func (r *SQLRepository) FindByID(ctx context.Context, id string) (*appjournal.JournalLog, error) {
+	query := selectJournalLogColumns + `
+FROM journal_logs jl
+WHERE jl.id = $1
+  AND jl.deleted_at IS NULL
+LIMIT 1
+`
+	journalLog, err := scanJournalLog(r.db.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, appjournal.ErrJournalLogNotFound
+		}
+		return nil, fmt.Errorf("query journal log by id: %w", err)
+	}
+
+	return journalLog, nil
+}
+
+// FindByIDForUpdate locks one active journal log for command use.
+func (r *SQLRepository) FindByIDForUpdate(ctx context.Context, tx *sql.Tx, id string) (*appjournal.JournalLog, error) {
+	query := selectJournalLogColumns + `
+FROM journal_logs jl
+WHERE jl.id = $1
+  AND jl.deleted_at IS NULL
+FOR UPDATE
+`
+	journalLog, err := scanJournalLog(tx.QueryRowContext(ctx, query, id))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, appjournal.ErrJournalLogNotFound
+		}
+		return nil, fmt.Errorf("query journal log by id for update: %w", err)
+	}
+
+	return journalLog, nil
+}
+
+// EnsurePropertyExists verifies that an active property exists for journal writes.
+func (r *SQLRepository) EnsurePropertyExists(ctx context.Context, tx *sql.Tx, id string) error {
+	const query = `
+SELECT 1
+FROM properties
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+	var exists int
+	if err := tx.QueryRowContext(ctx, query, id).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return appjournal.ErrPropertyNotFound
+		}
+		return fmt.Errorf("query journal property by id: %w", err)
+	}
+
+	return nil
+}
+
+// FindRoomByID returns an active room's owning property.
+func (r *SQLRepository) FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*appjournal.Room, error) {
+	const query = `
+SELECT id, property_id
+FROM rooms
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+	var room appjournal.Room
+	if err := tx.QueryRowContext(ctx, query, id).Scan(&room.ID, &room.PropertyID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, appjournal.ErrRoomNotFound
+		}
+		return nil, fmt.Errorf("query journal room by id: %w", err)
+	}
+
+	return &room, nil
+}
+
+// Create inserts a journal log.
+func (r *SQLRepository) Create(ctx context.Context, tx *sql.Tx, params appjournal.CreateParams) (*appjournal.JournalLog, error) {
+	query := `
+INSERT INTO journal_logs (
+	property_id,
+	room_id,
+	author_id,
+	content,
+	expense_amount,
+	expense_description
+) VALUES ($1, $2, $3, $4, $5, $6)
+` + returningJournalLogColumns
+
+	journalLog, err := scanJournalLog(tx.QueryRowContext(ctx, query,
+		params.PropertyID,
+		nullableString(params.RoomID),
+		params.AuthorID,
+		params.Content,
+		nullableInt(params.ExpenseAmount),
+		nullableString(params.ExpenseDescription),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("create journal log: %w", err)
+	}
+
+	return journalLog, nil
+}
+
+// Update persists mutable journal log fields.
+func (r *SQLRepository) Update(ctx context.Context, tx *sql.Tx, params appjournal.UpdateParams) (*appjournal.JournalLog, error) {
+	query := `
+UPDATE journal_logs
+SET content = $2,
+    expense_amount = $3,
+    expense_description = $4,
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+` + returningJournalLogColumns
+
+	journalLog, err := scanJournalLog(tx.QueryRowContext(ctx, query,
+		params.ID,
+		params.Content,
+		nullableInt(params.ExpenseAmount),
+		nullableString(params.ExpenseDescription),
+	))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, appjournal.ErrJournalLogNotFound
+		}
+		return nil, fmt.Errorf("update journal log: %w", err)
+	}
+
+	return journalLog, nil
+}
+
+// SoftDelete marks a journal log deleted.
+func (r *SQLRepository) SoftDelete(ctx context.Context, tx *sql.Tx, id string) error {
+	const query = `
+UPDATE journal_logs
+SET deleted_at = now(),
+    updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+`
+	result, err := tx.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("soft delete journal log: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("soft delete journal log rows affected: %w", err)
+	}
+	if affected == 0 {
+		return appjournal.ErrJournalLogNotFound
+	}
+
+	return nil
+}
+
+const selectJournalLogColumns = `
+SELECT
+	jl.id,
+	jl.property_id,
+	jl.room_id,
+	jl.author_id,
+	jl.content,
+	jl.expense_amount,
+	jl.expense_description,
+	jl.created_at,
+	jl.updated_at
+`
+
+const returningJournalLogColumns = `
+RETURNING
+	id,
+	property_id,
+	room_id,
+	author_id,
+	content,
+	expense_amount,
+	expense_description,
+	created_at,
+	updated_at
+`
+
+type journalLogScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanJournalLog(scanner journalLogScanner) (*appjournal.JournalLog, error) {
+	var item appjournal.JournalLog
+	var roomID sql.NullString
+	var expenseAmount sql.NullInt64
+	var expenseDescription sql.NullString
+
+	if err := scanner.Scan(
+		&item.ID,
+		&item.PropertyID,
+		&roomID,
+		&item.AuthorID,
+		&item.Content,
+		&expenseAmount,
+		&expenseDescription,
+		&item.CreatedAt,
+		&item.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	if roomID.Valid {
+		item.RoomID = &roomID.String
+	}
+	if expenseAmount.Valid {
+		value := int(expenseAmount.Int64)
+		item.ExpenseAmount = &value
+	}
+	if expenseDescription.Valid {
+		item.ExpenseDescription = &expenseDescription.String
+	}
+
+	return &item, nil
+}
+
+func nullableString(value *string) any {
+	if value == nil {
+		return nil
+	}
+
+	return *value
+}
+
+func nullableInt(value *int) any {
+	if value == nil {
+		return nil
+	}
+
+	return *value
+}

--- a/internal/platform/database/journal/repository_test.go
+++ b/internal/platform/database/journal/repository_test.go
@@ -1,0 +1,212 @@
+package journal
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	appjournal "stds_backend/internal/application/journal"
+)
+
+func TestListAppliesFiltersPaginationAndScope(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	dateFrom := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	propertyID := "10000000-0000-0000-0000-000000000001"
+	roomID := "20000000-0000-0000-0000-000000000001"
+	createdAt := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	updatedAt := createdAt
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM journal_logs jl")).
+		WithArgs(propertyID, propertyID, roomID, dateFrom, dateTo.AddDate(0, 0, 1), 20, 40).
+		WillReturnRows(journalLogRows().
+			AddRow("60000000-0000-0000-0000-000000000001", propertyID, roomID, "00000000-0000-0000-0000-000000000002", "Inspection", nil, nil, createdAt, updatedAt))
+
+	items, err := repo.List(context.Background(), appjournal.ListQuery{
+		ActorRole:           "staff",
+		AssignedPropertyIDs: []string{propertyID},
+		PropertyID:          &propertyID,
+		RoomID:              &roomID,
+		DateFrom:            &dateFrom,
+		DateTo:              &dateTo,
+		Limit:               20,
+		Offset:              40,
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("items = %d, want 1", len(items))
+	}
+	if items[0].RoomID == nil || *items[0].RoomID != roomID {
+		t.Fatalf("RoomID = %v, want %s", items[0].RoomID, roomID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListReturnsEmptyForUnscopedStaff(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	items, err := repo.List(context.Background(), appjournal.ListQuery{
+		ActorRole: "staff",
+		Limit:     20,
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("items = %d, want 0", len(items))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestFindByIDMapsNoRowsToNotFound(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	id := "60000000-0000-0000-0000-000000000099"
+	mock.ExpectQuery(regexp.QuoteMeta("FROM journal_logs jl")).
+		WithArgs(id).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.FindByID(context.Background(), id)
+	if !errors.Is(err, appjournal.ErrJournalLogNotFound) {
+		t.Fatalf("FindByID() error = %v, want ErrJournalLogNotFound", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestEnsurePropertyExistsMapsNoRowsToNotFound(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin() error = %v", err)
+	}
+	propertyID := "10000000-0000-0000-0000-000000000099"
+	mock.ExpectQuery(regexp.QuoteMeta("FROM properties")).
+		WithArgs(propertyID).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectRollback()
+
+	err = repo.EnsurePropertyExists(context.Background(), tx, propertyID)
+	if !errors.Is(err, appjournal.ErrPropertyNotFound) {
+		t.Fatalf("EnsurePropertyExists() error = %v, want ErrPropertyNotFound", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestSoftDeleteMapsZeroRowsToNotFound(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin() error = %v", err)
+	}
+	id := "60000000-0000-0000-0000-000000000099"
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE journal_logs")).
+		WithArgs(id).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	err = repo.SoftDelete(context.Background(), tx, id)
+	if !errors.Is(err, appjournal.ErrJournalLogNotFound) {
+		t.Fatalf("SoftDelete() error = %v, want ErrJournalLogNotFound", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func newJournalRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+
+	return db, mock, NewRepository(db)
+}
+
+func journalLogRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"property_id",
+		"room_id",
+		"author_id",
+		"content",
+		"expense_amount",
+		"expense_description",
+		"created_at",
+		"updated_at",
+	})
+}
+
+func TestListQueryContainsSoftDeletePredicate(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectQuery("(?s)"+regexp.QuoteMeta("FROM journal_logs jl")+".*"+regexp.QuoteMeta("WHERE jl.deleted_at IS NULL")).
+		WithArgs(20, 0).
+		WillReturnRows(journalLogRows())
+
+	if _, err := repo.List(context.Background(), appjournal.ListQuery{
+		ActorRole: "admin",
+		Limit:     20,
+		Offset:    0,
+	}); err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListOrdersByCreatedAtAndID(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	orderPattern := strings.ReplaceAll("ORDER BY jl.created_at DESC, jl.id DESC LIMIT", " ", `\s+`)
+	mock.ExpectQuery("(?s)"+orderPattern).
+		WithArgs(20, 0).
+		WillReturnRows(journalLogRows())
+
+	if _, err := repo.List(context.Background(), appjournal.ListQuery{
+		ActorRole: "admin",
+		Limit:     20,
+		Offset:    0,
+	}); err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}

--- a/internal/server/billing_adapters.go
+++ b/internal/server/billing_adapters.go
@@ -32,6 +32,13 @@ func newBillingServices(db *sql.DB, txRunner *dbtxrunner.Runner, publisher domai
 	}
 }
 
+func newJournalExpenseRecordedHandler(db *sql.DB, txRunner *dbtxrunner.Runner) *appbilling.JournalExpenseRecordedHandler {
+	repo := dbbilling.NewRepository(db)
+	accountingRepo := billingAccountingRepositoryAdapter{repo: repo}
+
+	return appbilling.NewJournalExpenseRecordedHandler(accountingRepo, txRunner)
+}
+
 type billingQueryServiceAdapter struct {
 	listBills *appbilling.ListBillsService
 	getBill   *appbilling.GetBillService

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,6 +9,7 @@ import (
 
 	appiam "stds_backend/internal/application/iam"
 	appjobs "stds_backend/internal/application/jobs"
+	appjournal "stds_backend/internal/application/journal"
 	applease "stds_backend/internal/application/lease"
 	appnotification "stds_backend/internal/application/notification"
 	appproperty "stds_backend/internal/application/property"
@@ -19,6 +20,7 @@ import (
 	"stds_backend/internal/http/router"
 	"stds_backend/internal/platform/database"
 	dbjobruns "stds_backend/internal/platform/database/jobruns"
+	dbjournal "stds_backend/internal/platform/database/journal"
 	dbleasequery "stds_backend/internal/platform/database/leasequery"
 	dbleases "stds_backend/internal/platform/database/leases"
 	dbproperties "stds_backend/internal/platform/database/properties"
@@ -63,6 +65,7 @@ func New(cfg *config.Config) (*Server, error) {
 	leaseRepo := dbleases.NewRepository(db)
 	propertyQueryRepo := dbpropertyquery.NewRepository(db)
 	leaseQueryRepo := dbleasequery.NewRepository(db)
+	journalRepo := dbjournal.NewRepository(db)
 	repairRepo := dbrepair.NewRepository(db)
 	tenantRepo := dbtenants.NewRepository(db)
 	tenantQueryRepo := dbtenantquery.NewRepository(db)
@@ -114,20 +117,29 @@ func New(cfg *config.Config) (*Server, error) {
 		Delete:   apprepair.NewDeleteService(repairRepo, txRunner),
 		Workflow: apprepair.NewWorkflowService(repairRepo, txRunner),
 	}
+	journalServices := handler.JournalServices{
+		List:   appjournal.NewListService(journalRepo),
+		Get:    appjournal.NewGetService(journalRepo),
+		Create: appjournal.NewCreateService(journalRepo, txRunner),
+		Update: appjournal.NewUpdateService(journalRepo, txRunner),
+		Delete: appjournal.NewDeleteService(journalRepo, txRunner),
+	}
 	occupyRoomOnLeaseCreated := applease.NewOccupyRoomOnLeaseCreatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	activateTenantOnLeaseCreated := applease.NewActivateTenantOnLeaseCreatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	releaseRoomOnLeaseTerminated := applease.NewReleaseRoomOnLeaseTerminatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	deactivateTenantOnLeaseTerminated := applease.NewDeactivateTenantOnLeaseTerminatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
+	recordJournalExpense := newJournalExpenseRecordedHandler(db, txRunner)
 	jobTriggerService := appjobs.NewTriggerService(jobRunStoreAdapter{repo: jobRunsRepo}, nil, cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)
 	eventbus.Subscribe(bus, occupyRoomOnLeaseCreated.HandleLeaseCreated)
 	eventbus.Subscribe(bus, activateTenantOnLeaseCreated.HandleLeaseCreated)
 	eventbus.Subscribe(bus, releaseRoomOnLeaseTerminated.HandleLeaseTerminated)
 	eventbus.Subscribe(bus, deactivateTenantOnLeaseTerminated.HandleLeaseTerminated)
+	eventbus.Subscribe(bus, recordJournalExpense.HandleJournalExpenseRecorded)
 
 	engine := router.New(cfg.App, logger, db, authenticator, userRepo, router.AuthorizationRepositories{
 		Properties:        propertyRepo,
 		ResourceOwnership: resourceOwnershipRepo,
-	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, repairRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, repairServices, handler.LeaseCommandServices{
+	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, repairRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, journalServices, repairServices, handler.LeaseCommandServices{
 		UpdateLease:         updateLeaseService,
 		UpdateDeposit:       updateDepositService,
 		ReplaceLease:        replaceLeaseService,


### PR DESCRIPTION
## Summary

Implements issue #20 journal log APIs for list, detail, create, update, and soft delete.

## Changes

- Added Journal application services, domain aggregate, SQL repository, and API handler wiring.
- Added property-scoped list filtering and resource-scoped router authorization for journal logs.
- Added `JournalExpenseRecorded` event publication after journal creation with `expense_amount`.
- Wired the billing subscriber to record journal expenses into accounting entries after commit.
- Added focused application, repository, billing subscriber, and router authorization tests.

## Validation

- `go test ./...`
- `git diff --check`
- Coverage spot check: `go test -cover ./internal/application/journal ./internal/platform/database/journal ./internal/application/billing ./internal/application/repair ./internal/platform/database/billing ./internal/platform/database/repair ./internal/http/router`