### PR TITLE
[codex] Implement scheduler job batch flows

### DIFF
--- a/internal/application/jobs/batch.go
+++ b/internal/application/jobs/batch.go
@@ -1,0 +1,380 @@
+package jobs
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"stds_backend/internal/platform/database/txrunner"
+)
+
+var ErrInvalidWindowKey = errors.New("invalid scheduler window_key")
+
+// TransactionRunner is the transaction surface required by scheduler jobs.
+type TransactionRunner interface {
+	WithinTransaction(ctx context.Context, fn func(context.Context, *sql.Tx, *txrunner.EventRecorder) error) error
+}
+
+type BillingJobRepository interface {
+	ListOverdueScanCandidates(ctx context.Context, today time.Time) ([]BillCandidate, error)
+	MarkBillOverdue(ctx context.Context, tx *sql.Tx, billID string, expectedVersion int) error
+	ListOverdueReminderCandidates(ctx context.Context) ([]OverdueReminderCandidate, error)
+	IncrementOverdueNoticeCount(ctx context.Context, tx *sql.Tx, billID string, expectedVersion int) error
+	ListMonthlySnapshotProperties(ctx context.Context) ([]MonthlySnapshotProperty, error)
+	MonthlySnapshotExists(ctx context.Context, tx *sql.Tx, propertyID string, year int, month int) (bool, error)
+	CreateMonthlySnapshot(ctx context.Context, tx *sql.Tx, propertyID string, year int, month int) error
+}
+
+type LeaseJobRepository interface {
+	ListLeaseExpiryCandidates(ctx context.Context, today time.Time) ([]LeaseCandidate, error)
+	MarkLeaseExpired(ctx context.Context, tx *sql.Tx, leaseID string, expectedVersion int) error
+	ListLeaseExpiringSoonCandidates(ctx context.Context, targetDate time.Time) ([]LeaseExpiringSoonCandidate, error)
+	ListLeaseExpiringSoonRecipients(ctx context.Context, propertyID string) ([]NotificationRecipient, error)
+}
+
+type ForceTerminationJobRepository interface {
+	ListInProgressForceTerminations(ctx context.Context) ([]ForceTerminationCandidate, error)
+	ListPendingForceTerminationBillIDs(ctx context.Context, tx *sql.Tx, forceTerminationID string) ([]string, error)
+	WriteOffBills(ctx context.Context, tx *sql.Tx, billIDs []string, reason string) (int, error)
+	MarkForceTerminationBillsDone(ctx context.Context, tx *sql.Tx, forceTerminationID string, billIDs []string) error
+	CompleteForceTermination(ctx context.Context, tx *sql.Tx, forceTerminationID string) error
+}
+
+type NotificationSender interface {
+	SendOverdueBillReminder(ctx context.Context, recipient NotificationRecipient, bill OverdueReminderCandidate) error
+	SendLeaseExpiringSoon(ctx context.Context, recipient NotificationRecipient, lease LeaseExpiringSoonCandidate) error
+}
+
+type BillCandidate struct {
+	ID      string
+	Version int
+}
+
+type OverdueReminderCandidate struct {
+	ID                 string
+	TenantID           string
+	TenantEmail        *string
+	Amount             *int
+	DueDate            time.Time
+	OverdueNoticeCount int
+	Version            int
+}
+
+type MonthlySnapshotProperty struct {
+	PropertyID string
+}
+
+type LeaseCandidate struct {
+	ID      string
+	Version int
+}
+
+type LeaseExpiringSoonCandidate struct {
+	ID         string
+	PropertyID string
+	TenantID   string
+	RoomID     string
+	EndDate    time.Time
+}
+
+type ForceTerminationCandidate struct {
+	ID     string
+	Reason string
+}
+
+type NotificationRecipient struct {
+	Email string
+	Name  string
+}
+
+func NewRunners(billing BillingJobRepository, leases LeaseJobRepository, forceTerminations ForceTerminationJobRepository, notifier NotificationSender, txRunner TransactionRunner) map[JobKey]Runner {
+	return map[JobKey]Runner{
+		JobOverdueBillsScan:             NewOverdueBillsScanRunner(billing, txRunner),
+		JobOverdueBillReminders:         NewOverdueBillReminderRunner(billing, notifier, txRunner),
+		JobLeaseExpiryScan:              NewLeaseExpiryRunner(leases, txRunner),
+		JobLeaseExpiringSoonReminder:    NewLeaseExpiringSoonReminderRunner(leases, notifier),
+		JobMonthlySnapshot:              NewMonthlySnapshotRunner(billing, txRunner),
+		JobForceTerminationCompensation: NewForceTerminationCompensationRunner(forceTerminations, txRunner),
+	}
+}
+
+func NewOverdueBillsScanRunner(repo BillingJobRepository, txRunner TransactionRunner) Runner {
+	return func(ctx context.Context, windowKey string) (*ExecutionSummary, error) {
+		today, err := parseDailyWindowKey(windowKey)
+		if err != nil {
+			return nil, err
+		}
+		candidates, err := repo.ListOverdueScanCandidates(ctx, today)
+		if err != nil {
+			return nil, err
+		}
+
+		summary := &ExecutionSummary{}
+		for _, candidate := range candidates {
+			err := txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+				return repo.MarkBillOverdue(ctx, tx, candidate.ID, candidate.Version)
+			})
+			switch {
+			case err == nil:
+				summary.ProcessedCount++
+			case errors.Is(err, ErrConcurrentUpdate):
+				summary.SkippedCount++
+			default:
+				summary.FailedCount++
+			}
+		}
+		summary.Note = "job completed"
+		return summary, nil
+	}
+}
+
+func NewOverdueBillReminderRunner(repo BillingJobRepository, notifier NotificationSender, txRunner TransactionRunner) Runner {
+	return func(ctx context.Context, windowKey string) (*ExecutionSummary, error) {
+		if _, err := parseDailyWindowKey(windowKey); err != nil {
+			return nil, err
+		}
+		candidates, err := repo.ListOverdueReminderCandidates(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		summary := &ExecutionSummary{}
+		for _, candidate := range candidates {
+			email := strings.TrimSpace(stringValue(candidate.TenantEmail))
+			if email == "" {
+				summary.SkippedCount++
+				continue
+			}
+			if notifier == nil {
+				summary.FailedCount++
+				continue
+			}
+
+			err := txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+				if err := repo.IncrementOverdueNoticeCount(ctx, tx, candidate.ID, candidate.Version); err != nil {
+					return err
+				}
+				return notifier.SendOverdueBillReminder(ctx, NotificationRecipient{Email: email}, candidate)
+			})
+			switch {
+			case err == nil:
+				summary.ProcessedCount++
+			case errors.Is(err, ErrConcurrentUpdate):
+				summary.SkippedCount++
+			default:
+				summary.FailedCount++
+			}
+		}
+		summary.Note = "job completed"
+		return summary, nil
+	}
+}
+
+func NewLeaseExpiryRunner(repo LeaseJobRepository, txRunner TransactionRunner) Runner {
+	return func(ctx context.Context, windowKey string) (*ExecutionSummary, error) {
+		today, err := parseDailyWindowKey(windowKey)
+		if err != nil {
+			return nil, err
+		}
+		candidates, err := repo.ListLeaseExpiryCandidates(ctx, today)
+		if err != nil {
+			return nil, err
+		}
+
+		summary := &ExecutionSummary{}
+		for _, candidate := range candidates {
+			err := txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+				return repo.MarkLeaseExpired(ctx, tx, candidate.ID, candidate.Version)
+			})
+			switch {
+			case err == nil:
+				summary.ProcessedCount++
+			case errors.Is(err, ErrConcurrentUpdate):
+				summary.SkippedCount++
+			default:
+				summary.FailedCount++
+			}
+		}
+		summary.Note = "job completed"
+		return summary, nil
+	}
+}
+
+func NewLeaseExpiringSoonReminderRunner(repo LeaseJobRepository, notifier NotificationSender) Runner {
+	return func(ctx context.Context, windowKey string) (*ExecutionSummary, error) {
+		today, err := parseDailyWindowKey(windowKey)
+		if err != nil {
+			return nil, err
+		}
+		candidates, err := repo.ListLeaseExpiringSoonCandidates(ctx, today.AddDate(0, 0, 30))
+		if err != nil {
+			return nil, err
+		}
+
+		summary := &ExecutionSummary{}
+		for _, candidate := range candidates {
+			recipients, err := repo.ListLeaseExpiringSoonRecipients(ctx, candidate.PropertyID)
+			if err != nil {
+				summary.FailedCount++
+				continue
+			}
+			recipients = filterRecipients(recipients)
+			if len(recipients) == 0 {
+				summary.SkippedCount++
+				continue
+			}
+			if notifier == nil {
+				summary.FailedCount++
+				continue
+			}
+
+			failed := false
+			for _, recipient := range recipients {
+				if err := notifier.SendLeaseExpiringSoon(ctx, recipient, candidate); err != nil {
+					failed = true
+				}
+			}
+			if failed {
+				summary.FailedCount++
+				continue
+			}
+			summary.ProcessedCount++
+		}
+		summary.Note = "job completed"
+		return summary, nil
+	}
+}
+
+func NewMonthlySnapshotRunner(repo BillingJobRepository, txRunner TransactionRunner) Runner {
+	return func(ctx context.Context, windowKey string) (*ExecutionSummary, error) {
+		year, month, err := parseMonthlyWindowKey(windowKey)
+		if err != nil {
+			return nil, err
+		}
+		properties, err := repo.ListMonthlySnapshotProperties(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		summary := &ExecutionSummary{}
+		for _, property := range properties {
+			err := txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+				exists, err := repo.MonthlySnapshotExists(ctx, tx, property.PropertyID, year, month)
+				if err != nil {
+					return err
+				}
+				if exists {
+					return ErrAlreadyProcessed
+				}
+				return repo.CreateMonthlySnapshot(ctx, tx, property.PropertyID, year, month)
+			})
+			switch {
+			case err == nil:
+				summary.ProcessedCount++
+			case errors.Is(err, ErrAlreadyProcessed):
+				summary.SkippedCount++
+			default:
+				summary.FailedCount++
+			}
+		}
+		summary.Note = "job completed"
+		return summary, nil
+	}
+}
+
+func NewForceTerminationCompensationRunner(repo ForceTerminationJobRepository, txRunner TransactionRunner) Runner {
+	return func(ctx context.Context, windowKey string) (*ExecutionSummary, error) {
+		if _, err := parseDailyWindowKey(windowKey); err != nil {
+			return nil, err
+		}
+		candidates, err := repo.ListInProgressForceTerminations(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		summary := &ExecutionSummary{}
+		for _, candidate := range candidates {
+			err := txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+				billIDs, err := repo.ListPendingForceTerminationBillIDs(ctx, tx, candidate.ID)
+				if err != nil {
+					return err
+				}
+				updated, err := repo.WriteOffBills(ctx, tx, billIDs, candidate.Reason)
+				if err != nil {
+					return err
+				}
+				if updated != len(billIDs) {
+					return ErrConcurrentUpdate
+				}
+				if err := repo.MarkForceTerminationBillsDone(ctx, tx, candidate.ID, billIDs); err != nil {
+					return err
+				}
+				return repo.CompleteForceTermination(ctx, tx, candidate.ID)
+			})
+			if err != nil {
+				summary.FailedCount++
+				continue
+			}
+			summary.ProcessedCount++
+		}
+		summary.Note = "job completed"
+		return summary, nil
+	}
+}
+
+var (
+	ErrConcurrentUpdate = errors.New("concurrent update conflict")
+	ErrAlreadyProcessed = errors.New("job item already processed")
+)
+
+func parseDailyWindowKey(windowKey string) (time.Time, error) {
+	value := strings.TrimSpace(windowKey)
+	if value == "" {
+		return time.Time{}, ErrInvalidWindowKey
+	}
+	parsed, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%w: expected YYYY-MM-DD", ErrInvalidWindowKey)
+	}
+	return parsed, nil
+}
+
+func parseMonthlyWindowKey(windowKey string) (int, int, error) {
+	value := strings.TrimSpace(windowKey)
+	if value == "" {
+		return 0, 0, ErrInvalidWindowKey
+	}
+	parsed, err := time.Parse("2006-01", value)
+	if err != nil {
+		return 0, 0, fmt.Errorf("%w: expected YYYY-MM", ErrInvalidWindowKey)
+	}
+	return parsed.Year(), int(parsed.Month()), nil
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func filterRecipients(recipients []NotificationRecipient) []NotificationRecipient {
+	filtered := make([]NotificationRecipient, 0, len(recipients))
+	seen := map[string]struct{}{}
+	for _, recipient := range recipients {
+		email := strings.TrimSpace(recipient.Email)
+		if email == "" {
+			continue
+		}
+		if _, ok := seen[email]; ok {
+			continue
+		}
+		seen[email] = struct{}{}
+		recipient.Email = email
+		filtered = append(filtered, recipient)
+	}
+	return filtered
+}

--- a/internal/application/jobs/batch_test.go
+++ b/internal/application/jobs/batch_test.go
@@ -1,0 +1,400 @@
+package jobs
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"stds_backend/internal/platform/database/txrunner"
+)
+
+func TestOverdueBillsScanSkipsConcurrentUpdate(t *testing.T) {
+	repo := &batchBillingRepoStub{
+		overdueScanCandidates: []BillCandidate{{ID: "bill-1", Version: 3}},
+		markBillErr:           ErrConcurrentUpdate,
+	}
+	runner := NewOverdueBillsScanRunner(repo, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.SkippedCount != 1 || summary.ProcessedCount != 0 || summary.FailedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if repo.markBillID != "bill-1" || repo.markBillVersion != 3 {
+		t.Fatalf("unexpected mark call: bill=%s version=%d", repo.markBillID, repo.markBillVersion)
+	}
+}
+
+func TestOverdueBillReminderSkipsMissingTenantEmail(t *testing.T) {
+	repo := &batchBillingRepoStub{
+		overdueReminderCandidates: []OverdueReminderCandidate{
+			{ID: "bill-1", Version: 1},
+		},
+	}
+	notifier := &jobNotifierStub{}
+	runner := NewOverdueBillReminderRunner(repo, notifier, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.SkippedCount != 1 || summary.ProcessedCount != 0 || summary.FailedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if notifier.overdueCalls != 0 {
+		t.Fatalf("expected no notification calls, got %d", notifier.overdueCalls)
+	}
+	if repo.incrementCalls != 0 {
+		t.Fatalf("expected no increment calls, got %d", repo.incrementCalls)
+	}
+}
+
+func TestOverdueBillReminderIncrementsAfterSuccessfulSend(t *testing.T) {
+	email := "tenant@example.com"
+	repo := &batchBillingRepoStub{
+		overdueReminderCandidates: []OverdueReminderCandidate{
+			{ID: "bill-1", TenantEmail: &email, Version: 7},
+		},
+	}
+	notifier := &jobNotifierStub{}
+	runner := NewOverdueBillReminderRunner(repo, notifier, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.ProcessedCount != 1 || summary.SkippedCount != 0 || summary.FailedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if notifier.overdueCalls != 1 {
+		t.Fatalf("expected one notification call, got %d", notifier.overdueCalls)
+	}
+	if repo.incrementBillID != "bill-1" || repo.incrementVersion != 7 {
+		t.Fatalf("unexpected increment call: bill=%s version=%d", repo.incrementBillID, repo.incrementVersion)
+	}
+}
+
+func TestOverdueBillReminderSkipsConcurrentUpdateWithoutSending(t *testing.T) {
+	email := "tenant@example.com"
+	repo := &batchBillingRepoStub{
+		overdueReminderCandidates: []OverdueReminderCandidate{
+			{ID: "bill-1", TenantEmail: &email, Version: 7},
+		},
+		incrementErr: ErrConcurrentUpdate,
+	}
+	notifier := &jobNotifierStub{}
+	runner := NewOverdueBillReminderRunner(repo, notifier, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.SkippedCount != 1 || summary.ProcessedCount != 0 || summary.FailedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if notifier.overdueCalls != 0 {
+		t.Fatalf("expected no notification calls, got %d", notifier.overdueCalls)
+	}
+}
+
+func TestLeaseExpiringSoonReminderSendsToFilteredRecipients(t *testing.T) {
+	repo := &batchLeaseRepoStub{
+		expiringSoonCandidates: []LeaseExpiringSoonCandidate{
+			{ID: "lease-1", PropertyID: "property-1", EndDate: time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC)},
+		},
+		recipients: []NotificationRecipient{
+			{Email: "organizer@example.com", Name: "Organizer"},
+			{Email: "staff@example.com", Name: "Staff"},
+			{Email: "staff@example.com", Name: "Staff"},
+			{Email: " "},
+		},
+	}
+	notifier := &jobNotifierStub{}
+	runner := NewLeaseExpiringSoonReminderRunner(repo, notifier)
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.ProcessedCount != 1 || summary.SkippedCount != 0 || summary.FailedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if notifier.leaseCalls != 2 {
+		t.Fatalf("expected two unique notification calls, got %d", notifier.leaseCalls)
+	}
+	if repo.recipientPropertyID != "property-1" {
+		t.Fatalf("expected property-1 recipient lookup, got %q", repo.recipientPropertyID)
+	}
+}
+
+func TestLeaseExpiryMarksEligibleLeaseExpired(t *testing.T) {
+	repo := &batchLeaseRepoStub{
+		expiryCandidates: []LeaseCandidate{{ID: "lease-1", Version: 4}},
+	}
+	runner := NewLeaseExpiryRunner(repo, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.ProcessedCount != 1 || summary.SkippedCount != 0 || summary.FailedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if repo.markLeaseID != "lease-1" || repo.markLeaseVersion != 4 {
+		t.Fatalf("unexpected mark call: lease=%s version=%d", repo.markLeaseID, repo.markLeaseVersion)
+	}
+}
+
+func TestMonthlySnapshotSkipsExistingSnapshot(t *testing.T) {
+	repo := &batchBillingRepoStub{
+		snapshotProperties: []MonthlySnapshotProperty{{PropertyID: "property-1"}},
+		snapshotExists:     true,
+	}
+	runner := NewMonthlySnapshotRunner(repo, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.SkippedCount != 1 || summary.ProcessedCount != 0 || summary.FailedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if repo.createSnapshotCalls != 0 {
+		t.Fatalf("expected no snapshot creation, got %d", repo.createSnapshotCalls)
+	}
+}
+
+func TestMonthlySnapshotCreatesMissingSnapshot(t *testing.T) {
+	repo := &batchBillingRepoStub{
+		snapshotProperties: []MonthlySnapshotProperty{{PropertyID: "property-1"}},
+	}
+	runner := NewMonthlySnapshotRunner(repo, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.ProcessedCount != 1 || summary.SkippedCount != 0 || summary.FailedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if repo.createSnapshotCalls != 1 {
+		t.Fatalf("expected one snapshot creation, got %d", repo.createSnapshotCalls)
+	}
+}
+
+func TestDailyRunnerRejectsInvalidWindowKey(t *testing.T) {
+	runner := NewLeaseExpiryRunner(&batchLeaseRepoStub{}, txRunnerStub{})
+
+	_, err := runner(context.Background(), "2026-04")
+	if !errors.Is(err, ErrInvalidWindowKey) {
+		t.Fatalf("expected ErrInvalidWindowKey, got %v", err)
+	}
+}
+
+func TestForceTerminationCompensationFailsWhenWriteOffDoesNotCoverAllBills(t *testing.T) {
+	repo := &batchForceTerminationRepoStub{
+		candidates: []ForceTerminationCandidate{{ID: "force-termination-1", Reason: "legacy cleanup"}},
+		billIDs:    []string{"bill-1", "bill-2"},
+		writeOffs:  1,
+	}
+	runner := NewForceTerminationCompensationRunner(repo, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.FailedCount != 1 || summary.ProcessedCount != 0 || summary.SkippedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if repo.markDoneCalls != 0 {
+		t.Fatalf("expected no done markers, got %d", repo.markDoneCalls)
+	}
+	if repo.completeCalls != 0 {
+		t.Fatalf("expected no completion, got %d", repo.completeCalls)
+	}
+}
+
+func TestForceTerminationCompensationCompletesWhenAllPendingBillsWrittenOff(t *testing.T) {
+	repo := &batchForceTerminationRepoStub{
+		candidates: []ForceTerminationCandidate{{ID: "force-termination-1", Reason: "legacy cleanup"}},
+		billIDs:    []string{"bill-1", "bill-2"},
+		writeOffs:  2,
+	}
+	runner := NewForceTerminationCompensationRunner(repo, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.ProcessedCount != 1 || summary.FailedCount != 0 || summary.SkippedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if repo.markDoneCalls != 1 {
+		t.Fatalf("expected one done marker, got %d", repo.markDoneCalls)
+	}
+	if repo.completeCalls != 1 {
+		t.Fatalf("expected one completion, got %d", repo.completeCalls)
+	}
+}
+
+func TestForceTerminationCompensationCompletesWhenNoPendingBillsRemain(t *testing.T) {
+	repo := &batchForceTerminationRepoStub{
+		candidates: []ForceTerminationCandidate{{ID: "force-termination-1", Reason: "legacy cleanup"}},
+	}
+	runner := NewForceTerminationCompensationRunner(repo, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.ProcessedCount != 1 || summary.FailedCount != 0 || summary.SkippedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if repo.completeCalls != 1 {
+		t.Fatalf("expected one completion, got %d", repo.completeCalls)
+	}
+}
+
+type txRunnerStub struct{}
+
+func (txRunnerStub) WithinTransaction(ctx context.Context, fn func(context.Context, *sql.Tx, *txrunner.EventRecorder) error) error {
+	return fn(ctx, nil, nil)
+}
+
+type batchBillingRepoStub struct {
+	overdueScanCandidates     []BillCandidate
+	overdueReminderCandidates []OverdueReminderCandidate
+	snapshotProperties        []MonthlySnapshotProperty
+	snapshotExists            bool
+	markBillID                string
+	markBillVersion           int
+	markBillErr               error
+	incrementCalls            int
+	incrementBillID           string
+	incrementVersion          int
+	incrementErr              error
+	createSnapshotCalls       int
+}
+
+func (s *batchBillingRepoStub) ListOverdueScanCandidates(context.Context, time.Time) ([]BillCandidate, error) {
+	return s.overdueScanCandidates, nil
+}
+
+func (s *batchBillingRepoStub) MarkBillOverdue(_ context.Context, _ *sql.Tx, billID string, expectedVersion int) error {
+	s.markBillID = billID
+	s.markBillVersion = expectedVersion
+	return s.markBillErr
+}
+
+func (s *batchBillingRepoStub) ListOverdueReminderCandidates(context.Context) ([]OverdueReminderCandidate, error) {
+	return s.overdueReminderCandidates, nil
+}
+
+func (s *batchBillingRepoStub) IncrementOverdueNoticeCount(_ context.Context, _ *sql.Tx, billID string, expectedVersion int) error {
+	s.incrementCalls++
+	s.incrementBillID = billID
+	s.incrementVersion = expectedVersion
+	return s.incrementErr
+}
+
+func (s *batchBillingRepoStub) ListMonthlySnapshotProperties(context.Context) ([]MonthlySnapshotProperty, error) {
+	return s.snapshotProperties, nil
+}
+
+func (s *batchBillingRepoStub) MonthlySnapshotExists(context.Context, *sql.Tx, string, int, int) (bool, error) {
+	return s.snapshotExists, nil
+}
+
+func (s *batchBillingRepoStub) CreateMonthlySnapshot(context.Context, *sql.Tx, string, int, int) error {
+	s.createSnapshotCalls++
+	return nil
+}
+
+type batchLeaseRepoStub struct {
+	expiryCandidates       []LeaseCandidate
+	expiringSoonCandidates []LeaseExpiringSoonCandidate
+	recipients             []NotificationRecipient
+	recipientPropertyID    string
+	markLeaseID            string
+	markLeaseVersion       int
+	markLeaseErr           error
+}
+
+func (s *batchLeaseRepoStub) ListLeaseExpiryCandidates(context.Context, time.Time) ([]LeaseCandidate, error) {
+	return s.expiryCandidates, nil
+}
+
+func (s *batchLeaseRepoStub) MarkLeaseExpired(_ context.Context, _ *sql.Tx, leaseID string, expectedVersion int) error {
+	s.markLeaseID = leaseID
+	s.markLeaseVersion = expectedVersion
+	return s.markLeaseErr
+}
+
+func (s *batchLeaseRepoStub) ListLeaseExpiringSoonCandidates(context.Context, time.Time) ([]LeaseExpiringSoonCandidate, error) {
+	return s.expiringSoonCandidates, nil
+}
+
+func (s *batchLeaseRepoStub) ListLeaseExpiringSoonRecipients(_ context.Context, propertyID string) ([]NotificationRecipient, error) {
+	s.recipientPropertyID = propertyID
+	return s.recipients, nil
+}
+
+type batchForceTerminationRepoStub struct {
+	candidates    []ForceTerminationCandidate
+	billIDs       []string
+	writeOffs     int
+	markDoneCalls int
+	completeCalls int
+}
+
+func (s *batchForceTerminationRepoStub) ListInProgressForceTerminations(context.Context) ([]ForceTerminationCandidate, error) {
+	return s.candidates, nil
+}
+
+func (s *batchForceTerminationRepoStub) ListPendingForceTerminationBillIDs(context.Context, *sql.Tx, string) ([]string, error) {
+	return s.billIDs, nil
+}
+
+func (s *batchForceTerminationRepoStub) WriteOffBills(context.Context, *sql.Tx, []string, string) (int, error) {
+	return s.writeOffs, nil
+}
+
+func (s *batchForceTerminationRepoStub) MarkForceTerminationBillsDone(context.Context, *sql.Tx, string, []string) error {
+	s.markDoneCalls++
+	return nil
+}
+
+func (s *batchForceTerminationRepoStub) CompleteForceTermination(context.Context, *sql.Tx, string) error {
+	s.completeCalls++
+	return nil
+}
+
+type jobNotifierStub struct {
+	overdueCalls int
+	leaseCalls   int
+}
+
+func (s *jobNotifierStub) SendOverdueBillReminder(context.Context, NotificationRecipient, OverdueReminderCandidate) error {
+	s.overdueCalls++
+	return nil
+}
+
+func (s *jobNotifierStub) SendLeaseExpiringSoon(context.Context, NotificationRecipient, LeaseExpiringSoonCandidate) error {
+	s.leaseCalls++
+	return nil
+}

--- a/internal/application/jobs/trigger.go
+++ b/internal/application/jobs/trigger.go
@@ -27,8 +27,8 @@ type ExecutionSummary struct {
 	Note           string
 }
 
-// Runner executes a concrete job.
-type Runner func(context.Context) (*ExecutionSummary, error)
+// Runner executes a concrete job for one scheduler window.
+type Runner func(context.Context, string) (*ExecutionSummary, error)
 
 // TriggerResult is the transport-neutral result for a scheduler trigger call.
 type TriggerResult struct {
@@ -107,7 +107,7 @@ func (s *TriggerService) Execute(ctx context.Context, jobKey JobKey, windowKey s
 	defer cancel()
 
 	startedAt := time.Now()
-	summary, err := runner(runCtx)
+	summary, err := runner(runCtx, windowKey)
 	result.DurationMs = time.Since(startedAt).Milliseconds()
 	if summary == nil {
 		summary = &ExecutionSummary{}
@@ -137,11 +137,23 @@ func (s *TriggerService) Execute(ctx context.Context, jobKey JobKey, windowKey s
 
 func defaultRunners() map[JobKey]Runner {
 	return map[JobKey]Runner{
-		JobOverdueBillsScan:             func(context.Context) (*ExecutionSummary, error) { return &ExecutionSummary{Note: "job completed"}, nil },
-		JobOverdueBillReminders:         func(context.Context) (*ExecutionSummary, error) { return &ExecutionSummary{Note: "job completed"}, nil },
-		JobLeaseExpiryScan:              func(context.Context) (*ExecutionSummary, error) { return &ExecutionSummary{Note: "job completed"}, nil },
-		JobLeaseExpiringSoonReminder:    func(context.Context) (*ExecutionSummary, error) { return &ExecutionSummary{Note: "job completed"}, nil },
-		JobMonthlySnapshot:              func(context.Context) (*ExecutionSummary, error) { return &ExecutionSummary{Note: "job completed"}, nil },
-		JobForceTerminationCompensation: func(context.Context) (*ExecutionSummary, error) { return &ExecutionSummary{Note: "job completed"}, nil },
+		JobOverdueBillsScan: func(context.Context, string) (*ExecutionSummary, error) {
+			return &ExecutionSummary{Note: "job completed"}, nil
+		},
+		JobOverdueBillReminders: func(context.Context, string) (*ExecutionSummary, error) {
+			return &ExecutionSummary{Note: "job completed"}, nil
+		},
+		JobLeaseExpiryScan: func(context.Context, string) (*ExecutionSummary, error) {
+			return &ExecutionSummary{Note: "job completed"}, nil
+		},
+		JobLeaseExpiringSoonReminder: func(context.Context, string) (*ExecutionSummary, error) {
+			return &ExecutionSummary{Note: "job completed"}, nil
+		},
+		JobMonthlySnapshot: func(context.Context, string) (*ExecutionSummary, error) {
+			return &ExecutionSummary{Note: "job completed"}, nil
+		},
+		JobForceTerminationCompensation: func(context.Context, string) (*ExecutionSummary, error) {
+			return &ExecutionSummary{Note: "job completed"}, nil
+		},
 	}
 }

--- a/internal/application/jobs/trigger_test.go
+++ b/internal/application/jobs/trigger_test.go
@@ -29,7 +29,7 @@ func TestTriggerServiceReturnsSkippedForDuplicateWindow(t *testing.T) {
 			StartedAt: time.Unix(1, 0),
 		},
 	}, map[JobKey]Runner{
-		JobOverdueBillsScan: func(context.Context) (*ExecutionSummary, error) {
+		JobOverdueBillsScan: func(context.Context, string) (*ExecutionSummary, error) {
 			called = true
 			return &ExecutionSummary{}, nil
 		},
@@ -58,7 +58,7 @@ func TestTriggerServiceReturnsRunnerError(t *testing.T) {
 			StartedAt: time.Unix(1, 0),
 		},
 	}, map[JobKey]Runner{
-		JobOverdueBillsScan: func(context.Context) (*ExecutionSummary, error) {
+		JobOverdueBillsScan: func(context.Context, string) (*ExecutionSummary, error) {
 			return nil, expectedErr
 		},
 	}, time.Minute, 3)

--- a/internal/application/notification/service.go
+++ b/internal/application/notification/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	domainevents "stds_backend/internal/domain/events"
 	platformnotification "stds_backend/internal/platform/notification"
@@ -24,6 +25,21 @@ type UserPasswordResetEmailInput struct {
 	Email    string
 	Name     string
 	ResetURL string
+}
+
+// OverdueBillReminderEmailInput contains the email inputs for overdue reminders.
+type OverdueBillReminderEmailInput struct {
+	Email   string
+	Amount  *int
+	DueDate time.Time
+}
+
+// LeaseExpiringSoonEmailInput contains the email inputs for lease expiration reminders.
+type LeaseExpiringSoonEmailInput struct {
+	Email   string
+	Name    string
+	LeaseID string
+	EndDate time.Time
 }
 
 // NewService returns a notification application service.
@@ -57,6 +73,63 @@ func (s *Service) SendUserPasswordResetEmail(ctx context.Context, input UserPass
 		Channel: platformnotification.ChannelEmail,
 		Email: &platformnotification.EmailMessage{
 			To:      []string{email},
+			Subject: subject,
+			HTML:    html,
+			Text:    text,
+		},
+	}); err != nil {
+		return ErrNotificationSendFailed.WithCause(err)
+	}
+
+	return nil
+}
+
+// SendOverdueBillReminderEmail sends one overdue bill reminder email.
+func (s *Service) SendOverdueBillReminderEmail(ctx context.Context, input OverdueBillReminderEmailInput) error {
+	if s == nil || s.sender == nil {
+		return ErrNotificationSenderNotConfigured
+	}
+
+	amount := "the outstanding amount"
+	if input.Amount != nil {
+		amount = fmt.Sprintf("NT$%d", *input.Amount)
+	}
+	dueDate := input.DueDate.Format("2006-01-02")
+	subject := "Overdue bill reminder"
+	html := fmt.Sprintf("<p>Hello,</p><p>Your bill for %s was due on %s. Please complete payment as soon as possible.</p>", htmlEscape(amount), htmlEscape(dueDate))
+	text := fmt.Sprintf("Hello,\n\nYour bill for %s was due on %s. Please complete payment as soon as possible.\n", amount, dueDate)
+
+	if err := s.sender.Send(ctx, platformnotification.SendCommand{
+		Channel: platformnotification.ChannelEmail,
+		Email: &platformnotification.EmailMessage{
+			To:      []string{strings.TrimSpace(input.Email)},
+			Subject: subject,
+			HTML:    html,
+			Text:    text,
+		},
+	}); err != nil {
+		return ErrNotificationSendFailed.WithCause(err)
+	}
+
+	return nil
+}
+
+// SendLeaseExpiringSoonEmail sends one lease expiration reminder email.
+func (s *Service) SendLeaseExpiringSoonEmail(ctx context.Context, input LeaseExpiringSoonEmailInput) error {
+	if s == nil || s.sender == nil {
+		return ErrNotificationSenderNotConfigured
+	}
+
+	name := defaultName(strings.TrimSpace(input.Name))
+	endDate := input.EndDate.Format("2006-01-02")
+	subject := "Lease expiring soon"
+	html := fmt.Sprintf("<p>Hello %s,</p><p>Lease %s is scheduled to end on %s.</p>", htmlEscape(name), htmlEscape(input.LeaseID), htmlEscape(endDate))
+	text := fmt.Sprintf("Hello %s,\n\nLease %s is scheduled to end on %s.\n", name, input.LeaseID, endDate)
+
+	if err := s.sender.Send(ctx, platformnotification.SendCommand{
+		Channel: platformnotification.ChannelEmail,
+		Email: &platformnotification.EmailMessage{
+			To:      []string{strings.TrimSpace(input.Email)},
 			Subject: subject,
 			HTML:    html,
 			Text:    text,

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -2634,6 +2634,10 @@ func (s *APIServer) runJob(c *gin.Context, jobKey appjobs.JobKey, windowKey stri
 
 	result, err := s.jobTriggerService.Execute(c.Request.Context(), jobKey, windowKey, requestctx.GetRequestID(c))
 	if err != nil {
+		if errors.Is(err, appjobs.ErrInvalidWindowKey) {
+			c.Error(apperr.ErrBadRequest.WithCause(err).WithDetails(map[string]interface{}{"field": "window_key"}))
+			return
+		}
 		c.Error(apperr.ErrInternalServerError.WithCause(err))
 		return
 	}

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -168,7 +168,7 @@ func NewRepository(db *sql.DB) *SQLRepository {
 }
 
 // ListOverdueScanCandidates returns pending-payment bills that should become overdue.
-func (r *SQLRepository) ListOverdueScanCandidates(ctx context.Context, today time.Time) ([]JobBillCandidate, error) {
+func (r *SQLRepository) ListOverdueScanCandidates(ctx context.Context, today time.Time) (candidates []JobBillCandidate, err error) {
 	const query = `
 SELECT id, version
 FROM bills
@@ -182,9 +182,13 @@ ORDER BY due_date ASC, id ASC
 	if err != nil {
 		return nil, fmt.Errorf("list overdue scan candidates: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close overdue scan candidate rows: %w", cerr)
+		}
+	}()
 
-	candidates := make([]JobBillCandidate, 0)
+	candidates = make([]JobBillCandidate, 0)
 	for rows.Next() {
 		var candidate JobBillCandidate
 		if err := rows.Scan(&candidate.ID, &candidate.Version); err != nil {
@@ -228,7 +232,7 @@ WHERE id = $1
 }
 
 // ListOverdueReminderCandidates returns overdue bills that have remaining reminder attempts.
-func (r *SQLRepository) ListOverdueReminderCandidates(ctx context.Context) ([]JobOverdueReminderCandidate, error) {
+func (r *SQLRepository) ListOverdueReminderCandidates(ctx context.Context) (candidates []JobOverdueReminderCandidate, err error) {
 	const query = `
 SELECT
 	b.id,
@@ -250,9 +254,13 @@ ORDER BY b.due_date ASC, b.id ASC
 	if err != nil {
 		return nil, fmt.Errorf("list overdue reminder candidates: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close overdue reminder candidate rows: %w", cerr)
+		}
+	}()
 
-	candidates := make([]JobOverdueReminderCandidate, 0)
+	candidates = make([]JobOverdueReminderCandidate, 0)
 	for rows.Next() {
 		var candidate JobOverdueReminderCandidate
 		if err := rows.Scan(
@@ -305,7 +313,7 @@ WHERE id = $1
 }
 
 // ListMonthlySnapshotProperties returns active property accounts for non-deleted properties.
-func (r *SQLRepository) ListMonthlySnapshotProperties(ctx context.Context) ([]JobMonthlySnapshotProperty, error) {
+func (r *SQLRepository) ListMonthlySnapshotProperties(ctx context.Context) (properties []JobMonthlySnapshotProperty, err error) {
 	const query = `
 SELECT pa.property_id
 FROM property_accounts pa
@@ -318,9 +326,13 @@ ORDER BY pa.property_id ASC
 	if err != nil {
 		return nil, fmt.Errorf("list monthly snapshot properties: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close monthly snapshot property rows: %w", cerr)
+		}
+	}()
 
-	properties := make([]JobMonthlySnapshotProperty, 0)
+	properties = make([]JobMonthlySnapshotProperty, 0)
 	for rows.Next() {
 		var property JobMonthlySnapshotProperty
 		if err := rows.Scan(&property.PropertyID); err != nil {

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -133,6 +133,30 @@ type FinancialReportEntry struct {
 	CreatedAt   time.Time
 }
 
+// JobBillCandidate is the minimal bill state needed by scheduler jobs.
+type JobBillCandidate struct {
+	ID      string
+	Version int
+}
+
+// JobOverdueReminderCandidate is the bill and tenant state needed to send an
+// overdue reminder.
+type JobOverdueReminderCandidate struct {
+	ID                 string
+	TenantID           string
+	TenantEmail        *string
+	Amount             *int
+	DueDate            time.Time
+	OverdueNoticeCount int
+	Version            int
+}
+
+// JobMonthlySnapshotProperty identifies one active property account to
+// materialize into monthly snapshots.
+type JobMonthlySnapshotProperty struct {
+	PropertyID string
+}
+
 // SQLRepository persists and reads billing data from PostgreSQL.
 type SQLRepository struct {
 	db *sql.DB
@@ -141,6 +165,276 @@ type SQLRepository struct {
 // NewRepository returns a PostgreSQL-backed billing repository.
 func NewRepository(db *sql.DB) *SQLRepository {
 	return &SQLRepository{db: db}
+}
+
+// ListOverdueScanCandidates returns pending-payment bills that should become overdue.
+func (r *SQLRepository) ListOverdueScanCandidates(ctx context.Context, today time.Time) ([]JobBillCandidate, error) {
+	const query = `
+SELECT id, version
+FROM bills
+WHERE due_date < $1
+  AND status = 'pending_payment'
+  AND deleted_at IS NULL
+ORDER BY due_date ASC, id ASC
+`
+
+	rows, err := r.db.QueryContext(ctx, query, today)
+	if err != nil {
+		return nil, fmt.Errorf("list overdue scan candidates: %w", err)
+	}
+	defer rows.Close()
+
+	candidates := make([]JobBillCandidate, 0)
+	for rows.Next() {
+		var candidate JobBillCandidate
+		if err := rows.Scan(&candidate.ID, &candidate.Version); err != nil {
+			return nil, fmt.Errorf("scan overdue scan candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate overdue scan candidates: %w", err)
+	}
+
+	return candidates, nil
+}
+
+// MarkBillOverdue updates a single bill with optimistic locking.
+func (r *SQLRepository) MarkBillOverdue(ctx context.Context, tx *sql.Tx, billID string, expectedVersion int) error {
+	const query = `
+UPDATE bills
+SET status = 'overdue',
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $2
+  AND status = 'pending_payment'
+  AND deleted_at IS NULL
+`
+
+	result, err := tx.ExecContext(ctx, query, billID, expectedVersion)
+	if err != nil {
+		return fmt.Errorf("mark bill overdue: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read mark bill overdue affected rows: %w", err)
+	}
+	if affected == 0 {
+		return ErrConcurrentUpdate
+	}
+
+	return nil
+}
+
+// ListOverdueReminderCandidates returns overdue bills that have remaining reminder attempts.
+func (r *SQLRepository) ListOverdueReminderCandidates(ctx context.Context) ([]JobOverdueReminderCandidate, error) {
+	const query = `
+SELECT
+	b.id,
+	b.tenant_id,
+	t.email,
+	b.amount,
+	b.due_date,
+	b.overdue_notice_count,
+	b.version
+FROM bills b
+JOIN tenants t ON t.id = b.tenant_id AND t.deleted_at IS NULL
+WHERE b.status = 'overdue'
+  AND b.overdue_notice_count < 3
+  AND b.deleted_at IS NULL
+ORDER BY b.due_date ASC, b.id ASC
+`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list overdue reminder candidates: %w", err)
+	}
+	defer rows.Close()
+
+	candidates := make([]JobOverdueReminderCandidate, 0)
+	for rows.Next() {
+		var candidate JobOverdueReminderCandidate
+		if err := rows.Scan(
+			&candidate.ID,
+			&candidate.TenantID,
+			&candidate.TenantEmail,
+			&candidate.Amount,
+			&candidate.DueDate,
+			&candidate.OverdueNoticeCount,
+			&candidate.Version,
+		); err != nil {
+			return nil, fmt.Errorf("scan overdue reminder candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate overdue reminder candidates: %w", err)
+	}
+
+	return candidates, nil
+}
+
+// IncrementOverdueNoticeCount records a successful overdue reminder delivery.
+func (r *SQLRepository) IncrementOverdueNoticeCount(ctx context.Context, tx *sql.Tx, billID string, expectedVersion int) error {
+	const query = `
+UPDATE bills
+SET overdue_notice_count = overdue_notice_count + 1,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $2
+  AND status = 'overdue'
+  AND overdue_notice_count < 3
+  AND deleted_at IS NULL
+`
+
+	result, err := tx.ExecContext(ctx, query, billID, expectedVersion)
+	if err != nil {
+		return fmt.Errorf("increment overdue notice count: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read overdue notice count affected rows: %w", err)
+	}
+	if affected == 0 {
+		return ErrConcurrentUpdate
+	}
+
+	return nil
+}
+
+// ListMonthlySnapshotProperties returns active property accounts for non-deleted properties.
+func (r *SQLRepository) ListMonthlySnapshotProperties(ctx context.Context) ([]JobMonthlySnapshotProperty, error) {
+	const query = `
+SELECT pa.property_id
+FROM property_accounts pa
+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL
+WHERE pa.deleted_at IS NULL
+ORDER BY pa.property_id ASC
+`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list monthly snapshot properties: %w", err)
+	}
+	defer rows.Close()
+
+	properties := make([]JobMonthlySnapshotProperty, 0)
+	for rows.Next() {
+		var property JobMonthlySnapshotProperty
+		if err := rows.Scan(&property.PropertyID); err != nil {
+			return nil, fmt.Errorf("scan monthly snapshot property: %w", err)
+		}
+		properties = append(properties, property)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate monthly snapshot properties: %w", err)
+	}
+
+	return properties, nil
+}
+
+// MonthlySnapshotExists checks whether a finalized snapshot already exists.
+func (r *SQLRepository) MonthlySnapshotExists(ctx context.Context, tx *sql.Tx, propertyID string, year int, month int) (bool, error) {
+	const query = `
+SELECT 1
+FROM monthly_snapshots
+WHERE property_id = $1
+  AND year = $2
+  AND month = $3
+LIMIT 1
+`
+
+	var marker int
+	if err := tx.QueryRowContext(ctx, query, propertyID, year, month).Scan(&marker); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("check monthly snapshot exists: %w", err)
+	}
+
+	return true, nil
+}
+
+// CreateMonthlySnapshot materializes one property's accounting entries for a month.
+func (r *SQLRepository) CreateMonthlySnapshot(ctx context.Context, tx *sql.Tx, propertyID string, year int, month int) error {
+	const insertSnapshot = `
+INSERT INTO monthly_snapshots (
+	property_id,
+	year,
+	month,
+	total_income,
+	total_expense,
+	net
+)
+SELECT
+	pa.property_id,
+	$2,
+	$3,
+	COALESCE(SUM(CASE WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_income,
+	COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_expense,
+	COALESCE(SUM(CASE WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount) ELSE 0 END), 0)
+		- COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS net
+FROM property_accounts pa
+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL
+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id
+  AND ae.year = $2
+  AND ae.month = $3
+WHERE pa.property_id = $1
+  AND pa.deleted_at IS NULL
+GROUP BY pa.property_id
+RETURNING id
+`
+
+	var snapshotID string
+	if err := tx.QueryRowContext(ctx, insertSnapshot, propertyID, year, month).Scan(&snapshotID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("insert monthly snapshot: %w", err)
+	}
+
+	const insertEntries = `
+INSERT INTO monthly_snapshot_entries (
+	snapshot_id,
+	category,
+	description,
+	amount,
+	source_ref
+)
+SELECT
+	$1,
+	ae.category,
+	ae.description,
+	ae.amount,
+	ae.source_ref
+FROM accounting_entries ae
+JOIN property_accounts pa ON pa.id = ae.property_account_id
+WHERE pa.property_id = $2
+  AND pa.deleted_at IS NULL
+  AND ae.year = $3
+  AND ae.month = $4
+ORDER BY ae.created_at ASC, ae.id ASC
+`
+	if _, err := tx.ExecContext(ctx, insertEntries, snapshotID, propertyID, year, month); err != nil {
+		return fmt.Errorf("insert monthly snapshot entries: %w", err)
+	}
+
+	const deleteEntries = `
+DELETE FROM accounting_entries ae
+USING property_accounts pa
+WHERE pa.id = ae.property_account_id
+  AND pa.property_id = $1
+  AND pa.deleted_at IS NULL
+  AND ae.year = $2
+  AND ae.month = $3
+`
+	if _, err := tx.ExecContext(ctx, deleteEntries, propertyID, year, month); err != nil {
+		return fmt.Errorf("delete finalized accounting entries: %w", err)
+	}
+
+	return nil
 }
 
 // ListAccessible returns active bills visible to the provided scope.

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -354,12 +354,17 @@ SELECT 1
 FROM monthly_snapshots
 WHERE property_id = $1
   AND year = $2
-  AND month = $3
+	AND month = $3
 LIMIT 1
 `
 
+	queryer := rowQueryer(r.db)
+	if tx != nil {
+		queryer = tx
+	}
+
 	var marker int
-	if err := tx.QueryRowContext(ctx, query, propertyID, year, month).Scan(&marker); err != nil {
+	if err := queryer.QueryRowContext(ctx, query, propertyID, year, month).Scan(&marker); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
 		}
@@ -413,14 +418,16 @@ INSERT INTO monthly_snapshot_entries (
 	category,
 	description,
 	amount,
-	source_ref
+	source_ref,
+	created_at
 )
 SELECT
 	$1,
 	ae.category,
 	ae.description,
 	ae.amount,
-	ae.source_ref
+	ae.source_ref,
+	ae.created_at
 FROM accounting_entries ae
 JOIN property_accounts pa ON pa.id = ae.property_account_id
 WHERE pa.property_id = $2

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -631,7 +631,6 @@ func TestMarkBillOverdueReturnsConcurrentUpdateWhenNoRowsAffected(t *testing.T) 
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)
 	tx := beginBillingTx(t, db, mock)
-	defer tx.Rollback()
 
 	mock.ExpectExec(regexp.QuoteMeta(`UPDATE bills
 SET status = 'overdue',
@@ -649,6 +648,10 @@ WHERE id = $1
 		t.Fatalf("expected ErrConcurrentUpdate, got %v", err)
 	}
 
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
 	}
@@ -658,7 +661,6 @@ func TestMonthlySnapshotExistsReturnsTrue(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)
 	tx := beginBillingTx(t, db, mock)
-	defer tx.Rollback()
 
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT 1
 FROM monthly_snapshots
@@ -677,6 +679,10 @@ LIMIT 1`)).
 		t.Fatal("expected snapshot to exist")
 	}
 
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
 	}

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -688,6 +688,83 @@ LIMIT 1`)).
 	}
 }
 
+func TestMonthlySnapshotExistsSupportsNilTransaction(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT 1
+FROM monthly_snapshots
+WHERE property_id = $1
+  AND year = $2
+  AND month = $3
+LIMIT 1`)).
+		WithArgs("property-1", 2026, 4).
+		WillReturnRows(sqlmock.NewRows([]string{"marker"}).AddRow(1))
+
+	exists, err := repo.MonthlySnapshotExists(context.Background(), nil, "property-1", 2026, 4)
+	if err != nil {
+		t.Fatalf("MonthlySnapshotExists: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected snapshot to exist")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateMonthlySnapshotPreservesEntryCreatedAt(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+	tx := beginBillingTx(t, db, mock)
+
+	mock.ExpectQuery("INSERT INTO monthly_snapshots").
+		WithArgs("property-1", 2026, 4).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("snapshot-1"))
+
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO monthly_snapshot_entries (
+	snapshot_id,
+	category,
+	description,
+	amount,
+	source_ref,
+	created_at
+)
+SELECT
+	$1,
+	ae.category,
+	ae.description,
+	ae.amount,
+	ae.source_ref,
+	ae.created_at
+FROM accounting_entries ae
+JOIN property_accounts pa ON pa.id = ae.property_account_id
+WHERE pa.property_id = $2
+  AND pa.deleted_at IS NULL
+  AND ae.year = $3
+  AND ae.month = $4
+ORDER BY ae.created_at ASC, ae.id ASC`)).
+		WithArgs("snapshot-1", "property-1", 2026, 4).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
+	mock.ExpectExec("DELETE FROM accounting_entries").
+		WithArgs("property-1", 2026, 4).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
+	if err := repo.CreateMonthlySnapshot(context.Background(), tx, "property-1", 2026, 4); err != nil {
+		t.Fatalf("CreateMonthlySnapshot: %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func newBillingRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
 	t.Helper()
 

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -627,6 +627,61 @@ func TestListFinancialReportSummariesIncludesEmptyLiveMonthWhenAccountExists(t *
 	}
 }
 
+func TestMarkBillOverdueReturnsConcurrentUpdateWhenNoRowsAffected(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+	tx := beginBillingTx(t, db, mock)
+	defer tx.Rollback()
+
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE bills
+SET status = 'overdue',
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $2
+  AND status = 'pending_payment'
+  AND deleted_at IS NULL`)).
+		WithArgs("bill-1", 3).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.MarkBillOverdue(context.Background(), tx, "bill-1", 3)
+	if !errors.Is(err, ErrConcurrentUpdate) {
+		t.Fatalf("expected ErrConcurrentUpdate, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestMonthlySnapshotExistsReturnsTrue(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+	tx := beginBillingTx(t, db, mock)
+	defer tx.Rollback()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT 1
+FROM monthly_snapshots
+WHERE property_id = $1
+  AND year = $2
+  AND month = $3
+LIMIT 1`)).
+		WithArgs("property-1", 2026, 4).
+		WillReturnRows(sqlmock.NewRows([]string{"marker"}).AddRow(1))
+
+	exists, err := repo.MonthlySnapshotExists(context.Background(), tx, "property-1", 2026, 4)
+	if err != nil {
+		t.Fatalf("MonthlySnapshotExists: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected snapshot to exist")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func newBillingRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
 	t.Helper()
 

--- a/internal/platform/database/leases/repository.go
+++ b/internal/platform/database/leases/repository.go
@@ -205,7 +205,7 @@ func NewRepository(db *sql.DB) *SQLRepository {
 }
 
 // ListLeaseExpiryCandidates returns active leases that should be marked expired.
-func (r *SQLRepository) ListLeaseExpiryCandidates(ctx context.Context, today time.Time) ([]JobLeaseCandidate, error) {
+func (r *SQLRepository) ListLeaseExpiryCandidates(ctx context.Context, today time.Time) (candidates []JobLeaseCandidate, err error) {
 	const query = `
 SELECT id, version
 FROM leases
@@ -219,9 +219,13 @@ ORDER BY end_date ASC, id ASC
 	if err != nil {
 		return nil, fmt.Errorf("list lease expiry candidates: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close lease expiry candidate rows: %w", cerr)
+		}
+	}()
 
-	candidates := make([]JobLeaseCandidate, 0)
+	candidates = make([]JobLeaseCandidate, 0)
 	for rows.Next() {
 		var candidate JobLeaseCandidate
 		if err := rows.Scan(&candidate.ID, &candidate.Version); err != nil {
@@ -265,7 +269,7 @@ WHERE id = $1
 }
 
 // ListLeaseExpiringSoonCandidates returns active leases ending on targetDate.
-func (r *SQLRepository) ListLeaseExpiringSoonCandidates(ctx context.Context, targetDate time.Time) ([]JobLeaseExpiringSoonCandidate, error) {
+func (r *SQLRepository) ListLeaseExpiringSoonCandidates(ctx context.Context, targetDate time.Time) (candidates []JobLeaseExpiringSoonCandidate, err error) {
 	const query = `
 SELECT id, property_id, tenant_id, room_id, end_date
 FROM leases
@@ -279,9 +283,13 @@ ORDER BY property_id ASC, end_date ASC, id ASC
 	if err != nil {
 		return nil, fmt.Errorf("list lease expiring soon candidates: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close lease expiring soon candidate rows: %w", cerr)
+		}
+	}()
 
-	candidates := make([]JobLeaseExpiringSoonCandidate, 0)
+	candidates = make([]JobLeaseExpiringSoonCandidate, 0)
 	for rows.Next() {
 		var candidate JobLeaseExpiringSoonCandidate
 		if err := rows.Scan(&candidate.ID, &candidate.PropertyID, &candidate.TenantID, &candidate.RoomID, &candidate.EndDate); err != nil {
@@ -297,7 +305,7 @@ ORDER BY property_id ASC, end_date ASC, id ASC
 }
 
 // ListInProgressForceTerminations returns legacy force-termination rows that need compensation.
-func (r *SQLRepository) ListInProgressForceTerminations(ctx context.Context) ([]JobForceTerminationCandidate, error) {
+func (r *SQLRepository) ListInProgressForceTerminations(ctx context.Context) (candidates []JobForceTerminationCandidate, err error) {
 	const query = `
 SELECT id, reason
 FROM force_terminations
@@ -309,9 +317,13 @@ ORDER BY created_at ASC, id ASC
 	if err != nil {
 		return nil, fmt.Errorf("list in-progress force terminations: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close in-progress force termination rows: %w", cerr)
+		}
+	}()
 
-	candidates := make([]JobForceTerminationCandidate, 0)
+	candidates = make([]JobForceTerminationCandidate, 0)
 	for rows.Next() {
 		var candidate JobForceTerminationCandidate
 		if err := rows.Scan(&candidate.ID, &candidate.Reason); err != nil {
@@ -327,7 +339,7 @@ ORDER BY created_at ASC, id ASC
 }
 
 // ListPendingForceTerminationBillIDs locks pending force-termination bills.
-func (r *SQLRepository) ListPendingForceTerminationBillIDs(ctx context.Context, tx *sql.Tx, forceTerminationID string) ([]string, error) {
+func (r *SQLRepository) ListPendingForceTerminationBillIDs(ctx context.Context, tx *sql.Tx, forceTerminationID string) (billIDs []string, err error) {
 	const query = `
 SELECT bill_id
 FROM force_termination_bills
@@ -341,9 +353,13 @@ FOR UPDATE
 	if err != nil {
 		return nil, fmt.Errorf("list pending force termination bills: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close pending force termination bill rows: %w", cerr)
+		}
+	}()
 
-	billIDs := make([]string, 0)
+	billIDs = make([]string, 0)
 	for rows.Next() {
 		var billID string
 		if err := rows.Scan(&billID); err != nil {

--- a/internal/platform/database/leases/repository.go
+++ b/internal/platform/database/leases/repository.go
@@ -137,6 +137,27 @@ type ForceTerminationBill struct {
 	Status string
 }
 
+// JobLeaseCandidate is the minimal lease state needed by scheduler jobs.
+type JobLeaseCandidate struct {
+	ID      string
+	Version int
+}
+
+// JobLeaseExpiringSoonCandidate is the lease state needed for expiration reminders.
+type JobLeaseExpiringSoonCandidate struct {
+	ID         string
+	PropertyID string
+	TenantID   string
+	RoomID     string
+	EndDate    time.Time
+}
+
+// JobForceTerminationCandidate is a legacy in-progress force-termination row.
+type JobForceTerminationCandidate struct {
+	ID     string
+	Reason string
+}
+
 // UpdateLeaseParams contains supported normal lease-condition update fields.
 type UpdateLeaseParams struct {
 	LeaseID    string
@@ -181,6 +202,160 @@ type SQLRepository struct {
 // NewRepository returns a CommandRepository backed by the provided database handle.
 func NewRepository(db *sql.DB) *SQLRepository {
 	return &SQLRepository{db: db}
+}
+
+// ListLeaseExpiryCandidates returns active leases that should be marked expired.
+func (r *SQLRepository) ListLeaseExpiryCandidates(ctx context.Context, today time.Time) ([]JobLeaseCandidate, error) {
+	const query = `
+SELECT id, version
+FROM leases
+WHERE end_date < $1
+  AND status = 'active'
+  AND deleted_at IS NULL
+ORDER BY end_date ASC, id ASC
+`
+
+	rows, err := r.db.QueryContext(ctx, query, today)
+	if err != nil {
+		return nil, fmt.Errorf("list lease expiry candidates: %w", err)
+	}
+	defer rows.Close()
+
+	candidates := make([]JobLeaseCandidate, 0)
+	for rows.Next() {
+		var candidate JobLeaseCandidate
+		if err := rows.Scan(&candidate.ID, &candidate.Version); err != nil {
+			return nil, fmt.Errorf("scan lease expiry candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate lease expiry candidates: %w", err)
+	}
+
+	return candidates, nil
+}
+
+// MarkLeaseExpired updates a lease to expired without changing room occupancy.
+func (r *SQLRepository) MarkLeaseExpired(ctx context.Context, tx *sql.Tx, leaseID string, expectedVersion int) error {
+	const query = `
+UPDATE leases
+SET status = 'expired',
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $2
+  AND status = 'active'
+  AND deleted_at IS NULL
+`
+
+	result, err := tx.ExecContext(ctx, query, leaseID, expectedVersion)
+	if err != nil {
+		return fmt.Errorf("mark lease expired: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("read mark lease expired affected rows: %w", err)
+	}
+	if affected == 0 {
+		return ErrLeaseNotFound
+	}
+
+	return nil
+}
+
+// ListLeaseExpiringSoonCandidates returns active leases ending on targetDate.
+func (r *SQLRepository) ListLeaseExpiringSoonCandidates(ctx context.Context, targetDate time.Time) ([]JobLeaseExpiringSoonCandidate, error) {
+	const query = `
+SELECT id, property_id, tenant_id, room_id, end_date
+FROM leases
+WHERE end_date = $1
+  AND status = 'active'
+  AND deleted_at IS NULL
+ORDER BY property_id ASC, end_date ASC, id ASC
+`
+
+	rows, err := r.db.QueryContext(ctx, query, targetDate)
+	if err != nil {
+		return nil, fmt.Errorf("list lease expiring soon candidates: %w", err)
+	}
+	defer rows.Close()
+
+	candidates := make([]JobLeaseExpiringSoonCandidate, 0)
+	for rows.Next() {
+		var candidate JobLeaseExpiringSoonCandidate
+		if err := rows.Scan(&candidate.ID, &candidate.PropertyID, &candidate.TenantID, &candidate.RoomID, &candidate.EndDate); err != nil {
+			return nil, fmt.Errorf("scan lease expiring soon candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate lease expiring soon candidates: %w", err)
+	}
+
+	return candidates, nil
+}
+
+// ListInProgressForceTerminations returns legacy force-termination rows that need compensation.
+func (r *SQLRepository) ListInProgressForceTerminations(ctx context.Context) ([]JobForceTerminationCandidate, error) {
+	const query = `
+SELECT id, reason
+FROM force_terminations
+WHERE status = 'in_progress'
+ORDER BY created_at ASC, id ASC
+`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list in-progress force terminations: %w", err)
+	}
+	defer rows.Close()
+
+	candidates := make([]JobForceTerminationCandidate, 0)
+	for rows.Next() {
+		var candidate JobForceTerminationCandidate
+		if err := rows.Scan(&candidate.ID, &candidate.Reason); err != nil {
+			return nil, fmt.Errorf("scan force termination candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate force termination candidates: %w", err)
+	}
+
+	return candidates, nil
+}
+
+// ListPendingForceTerminationBillIDs locks pending force-termination bills.
+func (r *SQLRepository) ListPendingForceTerminationBillIDs(ctx context.Context, tx *sql.Tx, forceTerminationID string) ([]string, error) {
+	const query = `
+SELECT bill_id
+FROM force_termination_bills
+WHERE force_termination_id = $1
+  AND status = 'pending'
+ORDER BY created_at ASC, bill_id ASC
+FOR UPDATE
+`
+
+	rows, err := tx.QueryContext(ctx, query, forceTerminationID)
+	if err != nil {
+		return nil, fmt.Errorf("list pending force termination bills: %w", err)
+	}
+	defer rows.Close()
+
+	billIDs := make([]string, 0)
+	for rows.Next() {
+		var billID string
+		if err := rows.Scan(&billID); err != nil {
+			return nil, fmt.Errorf("scan pending force termination bill: %w", err)
+		}
+		billIDs = append(billIDs, billID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate pending force termination bills: %w", err)
+	}
+
+	return billIDs, nil
 }
 
 func (r *SQLRepository) FindTenantByID(ctx context.Context, tx *sql.Tx, tenantID string) (*Tenant, error) {
@@ -504,8 +679,13 @@ INSERT INTO force_termination_bills (
 }
 
 func (r *SQLRepository) WriteOffBills(ctx context.Context, tx *sql.Tx, billIDs []string, reason string) error {
+	_, err := r.WriteOffBillsWithCount(ctx, tx, billIDs, reason)
+	return err
+}
+
+func (r *SQLRepository) WriteOffBillsWithCount(ctx context.Context, tx *sql.Tx, billIDs []string, reason string) (int, error) {
 	if len(billIDs) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	placeholders, args := placeholdersForStrings(2, billIDs)
@@ -516,16 +696,21 @@ SET status = 'written_off',
 	updated_at = now(),
 	version = version + 1
 WHERE id IN (` + strings.Join(placeholders, ", ") + `)
-  AND status NOT IN ('paid', 'voided', 'written_off')
+  AND status NOT IN ('paid', 'voided')
   AND deleted_at IS NULL
 `
 	args = append([]any{reason}, args...)
 
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-		return fmt.Errorf("write off bills: %w", err)
+	result, err := tx.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("write off bills: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("read write off bills affected rows: %w", err)
 	}
 
-	return nil
+	return int(affected), nil
 }
 
 func (r *SQLRepository) MarkForceTerminationBillsDone(ctx context.Context, tx *sql.Tx, forceTerminationID string, billIDs []string) error {

--- a/internal/platform/database/leases/repository_test.go
+++ b/internal/platform/database/leases/repository_test.go
@@ -12,9 +12,8 @@ import (
 
 func TestMarkLeaseExpiredReturnsNotFoundWhenNoRowsAffected(t *testing.T) {
 	db, mock, repo := newLeaseRepoTest(t)
-	defer db.Close()
+	defer closeLeaseDB(t, db)
 	tx := beginLeaseTx(t, db, mock)
-	defer tx.Rollback()
 
 	mock.ExpectExec(regexp.QuoteMeta(`UPDATE leases
 SET status = 'expired',
@@ -32,6 +31,10 @@ WHERE id = $1
 		t.Fatalf("expected ErrLeaseNotFound, got %v", err)
 	}
 
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
 	}
@@ -39,9 +42,8 @@ WHERE id = $1
 
 func TestListPendingForceTerminationBillIDsLocksPendingRows(t *testing.T) {
 	db, mock, repo := newLeaseRepoTest(t)
-	defer db.Close()
+	defer closeLeaseDB(t, db)
 	tx := beginLeaseTx(t, db, mock)
-	defer tx.Rollback()
 
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT bill_id
 FROM force_termination_bills
@@ -60,6 +62,10 @@ FOR UPDATE`)).
 		t.Fatalf("unexpected bill ids: %+v", billIDs)
 	}
 
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
 	}
@@ -67,9 +73,8 @@ FOR UPDATE`)).
 
 func TestWriteOffBillsWithCountReturnsAffectedRows(t *testing.T) {
 	db, mock, repo := newLeaseRepoTest(t)
-	defer db.Close()
+	defer closeLeaseDB(t, db)
 	tx := beginLeaseTx(t, db, mock)
-	defer tx.Rollback()
 
 	mock.ExpectExec(regexp.QuoteMeta(`UPDATE bills
 SET status = 'written_off',
@@ -90,6 +95,10 @@ WHERE id IN ($2, $3)
 		t.Fatalf("expected 1 affected row, got %d", affected)
 	}
 
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
 	}
@@ -104,6 +113,14 @@ func newLeaseRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
 	}
 
 	return db, mock, NewRepository(db)
+}
+
+func closeLeaseDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	if err := db.Close(); err != nil {
+		t.Logf("db.Close: %v", err)
+	}
 }
 
 func beginLeaseTx(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.Tx {

--- a/internal/platform/database/leases/repository_test.go
+++ b/internal/platform/database/leases/repository_test.go
@@ -1,0 +1,118 @@
+package leases
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestMarkLeaseExpiredReturnsNotFoundWhenNoRowsAffected(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer db.Close()
+	tx := beginLeaseTx(t, db, mock)
+	defer tx.Rollback()
+
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE leases
+SET status = 'expired',
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $2
+  AND status = 'active'
+  AND deleted_at IS NULL`)).
+		WithArgs("lease-1", 4).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.MarkLeaseExpired(context.Background(), tx, "lease-1", 4)
+	if !errors.Is(err, ErrLeaseNotFound) {
+		t.Fatalf("expected ErrLeaseNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListPendingForceTerminationBillIDsLocksPendingRows(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer db.Close()
+	tx := beginLeaseTx(t, db, mock)
+	defer tx.Rollback()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT bill_id
+FROM force_termination_bills
+WHERE force_termination_id = $1
+  AND status = 'pending'
+ORDER BY created_at ASC, bill_id ASC
+FOR UPDATE`)).
+		WithArgs("force-termination-1").
+		WillReturnRows(sqlmock.NewRows([]string{"bill_id"}).AddRow("bill-1").AddRow("bill-2"))
+
+	billIDs, err := repo.ListPendingForceTerminationBillIDs(context.Background(), tx, "force-termination-1")
+	if err != nil {
+		t.Fatalf("ListPendingForceTerminationBillIDs: %v", err)
+	}
+	if len(billIDs) != 2 || billIDs[0] != "bill-1" || billIDs[1] != "bill-2" {
+		t.Fatalf("unexpected bill ids: %+v", billIDs)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestWriteOffBillsWithCountReturnsAffectedRows(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer db.Close()
+	tx := beginLeaseTx(t, db, mock)
+	defer tx.Rollback()
+
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE bills
+SET status = 'written_off',
+	written_off_reason = $1,
+	updated_at = now(),
+	version = version + 1
+WHERE id IN ($2, $3)
+  AND status NOT IN ('paid', 'voided')
+  AND deleted_at IS NULL`)).
+		WithArgs("legacy cleanup", "bill-1", "bill-2").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	affected, err := repo.WriteOffBillsWithCount(context.Background(), tx, []string{"bill-1", "bill-2"}, "legacy cleanup")
+	if err != nil {
+		t.Fatalf("WriteOffBillsWithCount: %v", err)
+	}
+	if affected != 1 {
+		t.Fatalf("expected 1 affected row, got %d", affected)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func newLeaseRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+
+	return db, mock, NewRepository(db)
+}
+
+func beginLeaseTx(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.Tx {
+	t.Helper()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	return tx
+}

--- a/internal/platform/database/users/repository.go
+++ b/internal/platform/database/users/repository.go
@@ -92,7 +92,7 @@ func NewRepository(db *sql.DB) *SQLRepository {
 
 // ListLeaseExpiringSoonRecipients returns all organizers and property-assigned
 // staff who should receive lease expiration reminders.
-func (r *SQLRepository) ListLeaseExpiringSoonRecipients(ctx context.Context, propertyID string) ([]JobNotificationRecipient, error) {
+func (r *SQLRepository) ListLeaseExpiringSoonRecipients(ctx context.Context, propertyID string) (recipients []JobNotificationRecipient, err error) {
 	const query = `
 SELECT email, name
 FROM users
@@ -111,9 +111,13 @@ ORDER BY role ASC, created_at ASC, id ASC
 	if err != nil {
 		return nil, fmt.Errorf("list lease expiring soon recipients: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if cerr := rows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close lease expiring soon recipient rows: %w", cerr)
+		}
+	}()
 
-	recipients := make([]JobNotificationRecipient, 0)
+	recipients = make([]JobNotificationRecipient, 0)
 	for rows.Next() {
 		var recipient JobNotificationRecipient
 		if err := rows.Scan(&recipient.Email, &recipient.Name); err != nil {

--- a/internal/platform/database/users/repository.go
+++ b/internal/platform/database/users/repository.go
@@ -36,6 +36,12 @@ type User struct {
 	Version             int
 }
 
+// JobNotificationRecipient is the active user shape needed by scheduler notifications.
+type JobNotificationRecipient struct {
+	Email string
+	Name  string
+}
+
 // CreateUserParams contains the writable fields required to persist a new user.
 type CreateUserParams struct {
 	FirebaseUID string
@@ -82,6 +88,44 @@ type SQLRepository struct {
 // NewRepository returns a Repository backed by the provided database handle.
 func NewRepository(db *sql.DB) *SQLRepository {
 	return &SQLRepository{db: db}
+}
+
+// ListLeaseExpiringSoonRecipients returns all organizers and property-assigned
+// staff who should receive lease expiration reminders.
+func (r *SQLRepository) ListLeaseExpiringSoonRecipients(ctx context.Context, propertyID string) ([]JobNotificationRecipient, error) {
+	const query = `
+SELECT email, name
+FROM users
+WHERE deleted_at IS NULL
+  AND (
+    role = 'organizer'
+    OR (
+      role = 'staff'
+      AND assigned_property_ids @> jsonb_build_array($1::text)
+    )
+  )
+ORDER BY role ASC, created_at ASC, id ASC
+`
+
+	rows, err := r.db.QueryContext(ctx, query, propertyID)
+	if err != nil {
+		return nil, fmt.Errorf("list lease expiring soon recipients: %w", err)
+	}
+	defer rows.Close()
+
+	recipients := make([]JobNotificationRecipient, 0)
+	for rows.Next() {
+		var recipient JobNotificationRecipient
+		if err := rows.Scan(&recipient.Email, &recipient.Name); err != nil {
+			return nil, fmt.Errorf("scan lease expiring soon recipient: %w", err)
+		}
+		recipients = append(recipients, recipient)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate lease expiring soon recipients: %w", err)
+	}
+
+	return recipients, nil
 }
 
 // FindByFirebaseUID returns the user with the given Firebase UID when it has

--- a/internal/platform/database/users/repository_test.go
+++ b/internal/platform/database/users/repository_test.go
@@ -295,3 +295,44 @@ RETURNING
 		t.Fatalf("ExpectationsWereMet: %v", err)
 	}
 }
+
+func TestListLeaseExpiringSoonRecipientsReturnsOrganizersAndAssignedStaff(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT email, name
+FROM users
+WHERE deleted_at IS NULL
+  AND (
+    role = 'organizer'
+    OR (
+      role = 'staff'
+      AND assigned_property_ids @> jsonb_build_array($1::text)
+    )
+  )
+ORDER BY role ASC, created_at ASC, id ASC`)).
+		WithArgs("property-1").
+		WillReturnRows(sqlmock.NewRows([]string{"email", "name"}).
+			AddRow("organizer@studio.com", "Organizer").
+			AddRow("staff@studio.com", "Staff"))
+
+	recipients, err := repo.ListLeaseExpiringSoonRecipients(context.Background(), "property-1")
+	if err != nil {
+		t.Fatalf("ListLeaseExpiringSoonRecipients: %v", err)
+	}
+	if len(recipients) != 2 {
+		t.Fatalf("expected 2 recipients, got %d", len(recipients))
+	}
+	if recipients[0].Email != "organizer@studio.com" || recipients[1].Email != "staff@studio.com" {
+		t.Fatalf("unexpected recipients: %+v", recipients)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}

--- a/internal/server/jobs_adapters.go
+++ b/internal/server/jobs_adapters.go
@@ -2,13 +2,21 @@ package server
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"time"
 
 	appjobs "stds_backend/internal/application/jobs"
+	appnotification "stds_backend/internal/application/notification"
+	dbbilling "stds_backend/internal/platform/database/billing"
 	dbjobruns "stds_backend/internal/platform/database/jobruns"
+	dbleases "stds_backend/internal/platform/database/leases"
+	dbtxrunner "stds_backend/internal/platform/database/txrunner"
+	dbusers "stds_backend/internal/platform/database/users"
 )
 
 type jobRunStoreAdapter struct {
-	repo dbjobruns.Repository
+	repo *dbjobruns.SQLRepository
 }
 
 func (a jobRunStoreAdapter) Start(ctx context.Context, jobKey string, windowKey string, requestID string, maxRetries int) (*appjobs.StartResult, error) {
@@ -16,7 +24,6 @@ func (a jobRunStoreAdapter) Start(ctx context.Context, jobKey string, windowKey 
 	if err != nil {
 		return nil, err
 	}
-
 	return &appjobs.StartResult{
 		RunID:      result.RunID,
 		Status:     string(result.Status),
@@ -37,4 +44,198 @@ func (a jobRunStoreAdapter) Fail(ctx context.Context, runID string, message stri
 
 func (a jobRunStoreAdapter) Skip(ctx context.Context, runID string, message string) error {
 	return a.repo.Skip(ctx, runID, message)
+}
+
+func newJobRunners(db *sql.DB, txRunner *dbtxrunner.Runner, notificationService *appnotification.Service) map[appjobs.JobKey]appjobs.Runner {
+	billingRepo := dbbilling.NewRepository(db)
+	leaseRepo := dbleases.NewRepository(db)
+	userRepo := dbusers.NewRepository(db)
+
+	return appjobs.NewRunners(
+		billingJobRepositoryAdapter{repo: billingRepo},
+		leaseJobRepositoryAdapter{leases: leaseRepo, users: userRepo},
+		forceTerminationJobRepositoryAdapter{repo: leaseRepo},
+		jobNotificationAdapter{service: notificationService},
+		txRunner,
+	)
+}
+
+type billingJobRepositoryAdapter struct {
+	repo *dbbilling.SQLRepository
+}
+
+func (a billingJobRepositoryAdapter) ListOverdueScanCandidates(ctx context.Context, today time.Time) ([]appjobs.BillCandidate, error) {
+	candidates, err := a.repo.ListOverdueScanCandidates(ctx, today)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]appjobs.BillCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, appjobs.BillCandidate{ID: candidate.ID, Version: candidate.Version})
+	}
+	return result, nil
+}
+
+func (a billingJobRepositoryAdapter) MarkBillOverdue(ctx context.Context, tx *sql.Tx, billID string, expectedVersion int) error {
+	err := a.repo.MarkBillOverdue(ctx, tx, billID, expectedVersion)
+	if errors.Is(err, dbbilling.ErrConcurrentUpdate) {
+		return appjobs.ErrConcurrentUpdate
+	}
+	return err
+}
+
+func (a billingJobRepositoryAdapter) ListOverdueReminderCandidates(ctx context.Context) ([]appjobs.OverdueReminderCandidate, error) {
+	candidates, err := a.repo.ListOverdueReminderCandidates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]appjobs.OverdueReminderCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, appjobs.OverdueReminderCandidate{
+			ID:                 candidate.ID,
+			TenantID:           candidate.TenantID,
+			TenantEmail:        candidate.TenantEmail,
+			Amount:             candidate.Amount,
+			DueDate:            candidate.DueDate,
+			OverdueNoticeCount: candidate.OverdueNoticeCount,
+			Version:            candidate.Version,
+		})
+	}
+	return result, nil
+}
+
+func (a billingJobRepositoryAdapter) IncrementOverdueNoticeCount(ctx context.Context, tx *sql.Tx, billID string, expectedVersion int) error {
+	err := a.repo.IncrementOverdueNoticeCount(ctx, tx, billID, expectedVersion)
+	if errors.Is(err, dbbilling.ErrConcurrentUpdate) {
+		return appjobs.ErrConcurrentUpdate
+	}
+	return err
+}
+
+func (a billingJobRepositoryAdapter) ListMonthlySnapshotProperties(ctx context.Context) ([]appjobs.MonthlySnapshotProperty, error) {
+	properties, err := a.repo.ListMonthlySnapshotProperties(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]appjobs.MonthlySnapshotProperty, 0, len(properties))
+	for _, property := range properties {
+		result = append(result, appjobs.MonthlySnapshotProperty{PropertyID: property.PropertyID})
+	}
+	return result, nil
+}
+
+func (a billingJobRepositoryAdapter) MonthlySnapshotExists(ctx context.Context, tx *sql.Tx, propertyID string, year int, month int) (bool, error) {
+	return a.repo.MonthlySnapshotExists(ctx, tx, propertyID, year, month)
+}
+
+func (a billingJobRepositoryAdapter) CreateMonthlySnapshot(ctx context.Context, tx *sql.Tx, propertyID string, year int, month int) error {
+	return a.repo.CreateMonthlySnapshot(ctx, tx, propertyID, year, month)
+}
+
+type leaseJobRepositoryAdapter struct {
+	leases *dbleases.SQLRepository
+	users  *dbusers.SQLRepository
+}
+
+func (a leaseJobRepositoryAdapter) ListLeaseExpiryCandidates(ctx context.Context, today time.Time) ([]appjobs.LeaseCandidate, error) {
+	candidates, err := a.leases.ListLeaseExpiryCandidates(ctx, today)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]appjobs.LeaseCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, appjobs.LeaseCandidate{ID: candidate.ID, Version: candidate.Version})
+	}
+	return result, nil
+}
+
+func (a leaseJobRepositoryAdapter) MarkLeaseExpired(ctx context.Context, tx *sql.Tx, leaseID string, expectedVersion int) error {
+	err := a.leases.MarkLeaseExpired(ctx, tx, leaseID, expectedVersion)
+	if errors.Is(err, dbleases.ErrLeaseNotFound) {
+		return appjobs.ErrConcurrentUpdate
+	}
+	return err
+}
+
+func (a leaseJobRepositoryAdapter) ListLeaseExpiringSoonCandidates(ctx context.Context, targetDate time.Time) ([]appjobs.LeaseExpiringSoonCandidate, error) {
+	candidates, err := a.leases.ListLeaseExpiringSoonCandidates(ctx, targetDate)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]appjobs.LeaseExpiringSoonCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, appjobs.LeaseExpiringSoonCandidate{
+			ID:         candidate.ID,
+			PropertyID: candidate.PropertyID,
+			TenantID:   candidate.TenantID,
+			RoomID:     candidate.RoomID,
+			EndDate:    candidate.EndDate,
+		})
+	}
+	return result, nil
+}
+
+func (a leaseJobRepositoryAdapter) ListLeaseExpiringSoonRecipients(ctx context.Context, propertyID string) ([]appjobs.NotificationRecipient, error) {
+	recipients, err := a.users.ListLeaseExpiringSoonRecipients(ctx, propertyID)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]appjobs.NotificationRecipient, 0, len(recipients))
+	for _, recipient := range recipients {
+		result = append(result, appjobs.NotificationRecipient{Email: recipient.Email, Name: recipient.Name})
+	}
+	return result, nil
+}
+
+type forceTerminationJobRepositoryAdapter struct {
+	repo *dbleases.SQLRepository
+}
+
+func (a forceTerminationJobRepositoryAdapter) ListInProgressForceTerminations(ctx context.Context) ([]appjobs.ForceTerminationCandidate, error) {
+	candidates, err := a.repo.ListInProgressForceTerminations(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]appjobs.ForceTerminationCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, appjobs.ForceTerminationCandidate{ID: candidate.ID, Reason: candidate.Reason})
+	}
+	return result, nil
+}
+
+func (a forceTerminationJobRepositoryAdapter) ListPendingForceTerminationBillIDs(ctx context.Context, tx *sql.Tx, forceTerminationID string) ([]string, error) {
+	return a.repo.ListPendingForceTerminationBillIDs(ctx, tx, forceTerminationID)
+}
+
+func (a forceTerminationJobRepositoryAdapter) WriteOffBills(ctx context.Context, tx *sql.Tx, billIDs []string, reason string) (int, error) {
+	return a.repo.WriteOffBillsWithCount(ctx, tx, billIDs, reason)
+}
+
+func (a forceTerminationJobRepositoryAdapter) MarkForceTerminationBillsDone(ctx context.Context, tx *sql.Tx, forceTerminationID string, billIDs []string) error {
+	return a.repo.MarkForceTerminationBillsDone(ctx, tx, forceTerminationID, billIDs)
+}
+
+func (a forceTerminationJobRepositoryAdapter) CompleteForceTermination(ctx context.Context, tx *sql.Tx, forceTerminationID string) error {
+	return a.repo.CompleteForceTermination(ctx, tx, forceTerminationID)
+}
+
+type jobNotificationAdapter struct {
+	service *appnotification.Service
+}
+
+func (a jobNotificationAdapter) SendOverdueBillReminder(ctx context.Context, recipient appjobs.NotificationRecipient, bill appjobs.OverdueReminderCandidate) error {
+	return a.service.SendOverdueBillReminderEmail(ctx, appnotification.OverdueBillReminderEmailInput{
+		Email:   recipient.Email,
+		Amount:  bill.Amount,
+		DueDate: bill.DueDate,
+	})
+}
+
+func (a jobNotificationAdapter) SendLeaseExpiringSoon(ctx context.Context, recipient appjobs.NotificationRecipient, lease appjobs.LeaseExpiringSoonCandidate) error {
+	return a.service.SendLeaseExpiringSoonEmail(ctx, appnotification.LeaseExpiringSoonEmailInput{
+		Email:   recipient.Email,
+		Name:    recipient.Name,
+		LeaseID: lease.ID,
+		EndDate: lease.EndDate,
+	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -148,7 +148,7 @@ func New(cfg *config.Config) (*Server, error) {
 	releaseRoomOnLeaseTerminated := applease.NewReleaseRoomOnLeaseTerminatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	deactivateTenantOnLeaseTerminated := applease.NewDeactivateTenantOnLeaseTerminatedHandler(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	recordJournalExpense := newJournalExpenseRecordedHandler(db, txRunner)
-	jobTriggerService := appjobs.NewTriggerService(jobRunStoreAdapter{repo: jobRunsRepo}, nil, cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)
+	jobTriggerService := appjobs.NewTriggerService(jobRunStoreAdapter{repo: jobRunsRepo}, newJobRunners(db, txRunner, notificationService), cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)
 	eventbus.Subscribe(bus, occupyRoomOnLeaseCreated.HandleLeaseCreated)
 	eventbus.Subscribe(bus, activateTenantOnLeaseCreated.HandleLeaseCreated)
 	eventbus.Subscribe(bus, releaseRoomOnLeaseTerminated.HandleLeaseTerminated)


### PR DESCRIPTION
Closes #23

## Summary
- Implement concrete scheduler job runners for overdue bill scan/reminders, lease expiry/reminders, monthly snapshots, and force-termination compensation.
- Wire scheduler runners through the server composition root and preserve scheduler-key/window-key endpoint behavior.
- Add batch repository queries/updates and notification integration for reminder jobs.
- Fix job review issues so overdue reminder conflicts do not send duplicate emails, and force-termination compensation only completes after all pending bills are actually written off.

## Validation
- `go test ./...`