### PR TITLE
[codex] Verify runtime lease subscribers

### DIFF
--- a/internal/application/lease/create_lease_test.go
+++ b/internal/application/lease/create_lease_test.go
@@ -529,18 +529,37 @@ func (s *leaseRepositoryStub) CreateBills(_ context.Context, _ *sql.Tx, params [
 }
 
 func (s *leaseRepositoryStub) MarkRoomOccupied(context.Context, *sql.Tx, string) error {
+	if s.room != nil {
+		s.room.Status = "occupied"
+	}
 	return nil
 }
 
 func (s *leaseRepositoryStub) MarkRoomVacant(context.Context, *sql.Tx, string) error {
+	if s.room != nil {
+		s.room.Status = "vacant"
+	}
 	return nil
 }
 
 func (s *leaseRepositoryStub) ActivateTenant(context.Context, *sql.Tx, string) error {
+	if s.tenant != nil && s.tenant.Status == "inactive" {
+		s.tenant.Status = "active"
+	}
 	return nil
 }
 
 func (s *leaseRepositoryStub) DeactivateTenantIfNoActiveLeases(context.Context, *sql.Tx, string) error {
+	if s.tenant == nil {
+		return nil
+	}
+	if s.lease != nil && (s.lease.Status == "active" || s.lease.Status == "expired") {
+		return nil
+	}
+	if s.createdLease != nil && (s.createdLease.Status == "active" || s.createdLease.Status == "expired") {
+		return nil
+	}
+	s.tenant.Status = "inactive"
 	return nil
 }
 

--- a/internal/application/lease/replace_lease_test.go
+++ b/internal/application/lease/replace_lease_test.go
@@ -10,6 +10,7 @@ import (
 
 	domainevents "stds_backend/internal/domain/events"
 	dbtxrunner "stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/platform/eventbus"
 	"stds_backend/internal/shared/apperr"
 )
 
@@ -71,6 +72,59 @@ func TestReplaceLeaseServiceCreatesSuccessorAndPublishesEvents(t *testing.T) {
 	}
 	if replaced.OldLeaseID != replaceLeaseTestLeaseID || replaced.NewLeaseID != "lease-successor" || replaced.DepositHandling != "carry_over" {
 		t.Fatalf("unexpected LeaseReplaced event: %+v", replaced)
+	}
+}
+
+func TestReplaceLeaseServiceSubscribersKeepReplacementRoomAndTenantActive(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := replacementRepoStub()
+	bus := eventbus.New()
+	txRunner := dbtxrunner.New(db, bus)
+	eventbus.Subscribe(bus, NewReleaseRoomOnLeaseTerminatedHandler(repo, txRunner).HandleLeaseTerminated)
+	eventbus.Subscribe(bus, NewDeactivateTenantOnLeaseTerminatedHandler(repo, txRunner).HandleLeaseTerminated)
+	eventbus.Subscribe(bus, NewOccupyRoomOnLeaseCreatedHandler(repo, txRunner).HandleLeaseCreated)
+	eventbus.Subscribe(bus, NewActivateTenantOnLeaseCreatedHandler(repo, txRunner).HandleLeaseCreated)
+	service := NewReplaceLeaseService(repo, txRunner)
+
+	_, err = service.Execute(context.Background(), ReplaceLeaseInput{
+		ActorRole:           "staff",
+		AssignedPropertyIDs: []string{"property-1"},
+		LeaseID:             replaceLeaseTestLeaseID,
+		Reason:              "cadence_change",
+		EffectiveStartDate:  time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		DepositHandling:     "carry_over",
+		NewEndDate:          time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+		NewRentAmount:       20000,
+		NewCadence:          "bimonthly",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	if repo.room.Status != "occupied" {
+		t.Fatalf("room status = %q, want occupied", repo.room.Status)
+	}
+	if repo.tenant.Status != "active" {
+		t.Fatalf("tenant status = %q, want active", repo.tenant.Status)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds an integration-style replacement test that runs the kept lease runtime subscribers through the in-process event bus.
- Updates the shared lease test stub so subscriber calls mutate room and tenant state in tests.
- Confirms replacement emits and dispatches `LeaseTerminated -> LeaseCreated -> LeaseReplaced` without leaving the room vacant or tenant inactive.

## Validation

- `go test ./internal/application/lease ./internal/application/billing ./internal/platform/eventbus ./internal/platform/database/txrunner`
- `go test ./...`

## Notes

- #49 should remain open until this PR is merged.
- `UserPasswordResetRequested` remains excluded per #47.
- `JournalExpenseRecorded` existing coverage is considered sufficient for #49; follow-up #53 tracks the future consistency migration.