### PR TITLE
[codex] Guarantee property account creation

### DIFF
--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -187,7 +187,7 @@ Lease 於建立時決定 `electricityBillingCadence`（`monthly | bimonthly`）�
   - `category: rent_payment | electricity_payment | deposit_refund | deposit_deduction | journal_expense`（財報分類用）
 - **寫入邊界**：只載入當月資料，不載入歷史分錄
 - **月結快照**：每月月底排程執行，將當月 AccountingEntry 封存為 `monthly_snapshot_entries`，清空 Aggregate 內當月暫存資料
-- **初始化**：物業建立時應自動建立，生命週期與物業綁定；目前 runtime 尚未實作，未來應優先由 property creation command direct orchestration 保證
+- **初始化**：物業建立時由 property creation command direct orchestration 自動建立，生命週期與物業綁定
 - **刪除策略**：物業軟刪除時 PropertyAccount 封存，MonthlySnapshot 永久保留
 - **讀取策略**：
   - 當月：讀取 PropertyAccount 當月 AccountingEntry
@@ -261,7 +261,7 @@ Lease 於建立時決定 `electricityBillingCadence`（`monthly | bimonthly`）�
 | `BillPaid` receipt notification | `BillPaid` is recorded; no receipt notification subscriber exists | published-only/reserved | Receipt notification is not committed as required behavior now; do not overload accounting event semantics | No implementation commitment |
 | `MeterRecorded` bill amount / status update | `RecordMeterService` directly calculates amount and updates bill state, then records `MeterRecorded` | command-owned direct orchestration and intentionally kept | Meter command's core output is the updated bill; it must be atomic | Event remains trace/reserved |
 | `JournalExpenseRecorded -> accounting entry` | `JournalExpenseRecordedHandler` is wired and creates AccountingEntry in a separate post-commit transaction | implemented pub/sub but future consistency concern | Journal expense and accounting entry can diverge if subscriber fails; accounting state should eventually move into direct orchestration | Future issue should migrate to direct accounting |
-| `PropertyCreated -> PropertyAccount` | `PropertyCreated` is recorded by property creation, but PropertyAccount creation is not guaranteed yet | command-owned direct orchestration and intentionally kept | PropertyAccount lifecycle should be strongly tied to property creation | Future implementation should add direct orchestration |
+| `PropertyCreated -> PropertyAccount` | Property creation directly creates PropertyAccount in the same command transaction, then records `PropertyCreated` as trace / future extension | command-owned direct orchestration and intentionally kept | PropertyAccount lifecycle is strongly tied to property creation | No subscriber needed |
 | `RoomSetToMaintenance` | `SetRoomMaintenanceService` directly creates room-scoped RepairRequest and sets room to maintenance, then records event | command-owned direct orchestration and intentionally kept | Room state and repair request creation must be atomic | Event remains trace/reserved; no subscriber needed |
 | `RepairCompleted` / `RepairCancelled -> room vacant` | Repair workflow records events, but room status recovery is not implemented yet | command-owned direct orchestration and intentionally kept | Room recovery affects Property aggregate state and should be strongly consistent with repair workflow | Future implementation should add direct orchestration |
 | `TenantInfoUpdated` | Tenant update records event; no runtime subscriber | published-only/reserved | No required downstream behavior currently exists | No implementation commitment |

--- a/internal/application/property/create_property.go
+++ b/internal/application/property/create_property.go
@@ -24,17 +24,19 @@ type CreatePropertyInput struct {
 // CreatePropertyService creates properties in a transaction and publishes the
 // resulting event only after commit.
 type CreatePropertyService struct {
-	propertyRepo Repository
-	txRunner     *txrunner.Runner
-	now          func() time.Time
+	propertyRepo        Repository
+	propertyAccountRepo PropertyAccountRepository
+	txRunner            *txrunner.Runner
+	now                 func() time.Time
 }
 
 // NewCreatePropertyService returns a CreatePropertyService.
-func NewCreatePropertyService(propertyRepo Repository, txRunner *txrunner.Runner) *CreatePropertyService {
+func NewCreatePropertyService(propertyRepo Repository, propertyAccountRepo PropertyAccountRepository, txRunner *txrunner.Runner) *CreatePropertyService {
 	return &CreatePropertyService{
-		propertyRepo: propertyRepo,
-		txRunner:     txRunner,
-		now:          time.Now,
+		propertyRepo:        propertyRepo,
+		propertyAccountRepo: propertyAccountRepo,
+		txRunner:            txRunner,
+		now:                 time.Now,
 	}
 }
 
@@ -71,6 +73,10 @@ func (s *CreatePropertyService) Execute(ctx context.Context, input CreatePropert
 			OwnerID:                          state.OwnerID,
 		})
 		if err != nil {
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+
+		if err := s.propertyAccountRepo.CreatePropertyAccount(ctx, tx, CreatePropertyAccountParams{PropertyID: property.ID}); err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)
 		}
 

--- a/internal/application/property/create_property.go
+++ b/internal/application/property/create_property.go
@@ -77,7 +77,10 @@ func (s *CreatePropertyService) Execute(ctx context.Context, input CreatePropert
 		}
 
 		if err := s.propertyAccountRepo.CreatePropertyAccount(ctx, tx, CreatePropertyAccountParams{PropertyID: property.ID}); err != nil {
-			return apperr.ErrInternalServerError.WithCause(err)
+			return apperr.ErrInternalServerError.WithCause(err).WithDetails(map[string]interface{}{
+				"property_id": property.ID,
+				"operation":   "create_property_account",
+			})
 		}
 
 		recorder.Record(domainevents.PropertyCreated{

--- a/internal/application/property/create_property_test.go
+++ b/internal/application/property/create_property_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 
 	domainevents "stds_backend/internal/domain/events"
+	dbbilling "stds_backend/internal/platform/database/billing"
 	dbproperties "stds_backend/internal/platform/database/properties"
 	dbtxrunner "stds_backend/internal/platform/database/txrunner"
 )
@@ -26,9 +27,12 @@ func TestCreatePropertyServiceCreatesProperty(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{
 			"id", "name", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id", "created_at", "updated_at", "version",
 		}).AddRow("property-1", "Property A", "Address A", 4.5, "monthly", "owner-1", time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), 1))
+	mock.ExpectExec("INSERT INTO property_accounts").
+		WithArgs("property-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
-	service := NewCreatePropertyService(sqlPropertyRepositoryAdapter{repo: dbproperties.NewRepository(db)}, dbtxrunner.New(db, domainevents.NoopPublisher{}))
+	service := NewCreatePropertyService(sqlPropertyRepositoryAdapter{repo: dbproperties.NewRepository(db)}, sqlPropertyAccountRepositoryAdapter{repo: dbbilling.NewRepository(db)}, dbtxrunner.New(db, domainevents.NoopPublisher{}))
 	property, err := service.Execute(context.Background(), CreatePropertyInput{
 		Name:                             "Property A",
 		Address:                          "Address A",
@@ -59,6 +63,14 @@ type sqlPropertyRepositoryAdapter struct {
 	repo dbproperties.CommandRepository
 }
 
+type sqlPropertyAccountRepositoryAdapter struct {
+	repo *dbbilling.SQLRepository
+}
+
+func (a sqlPropertyAccountRepositoryAdapter) CreatePropertyAccount(ctx context.Context, tx *sql.Tx, params CreatePropertyAccountParams) error {
+	return a.repo.CreatePropertyAccount(ctx, tx, params.PropertyID)
+}
+
 func (a sqlPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params CreatePropertyParams) (*Property, error) {
 	property, err := a.repo.Create(ctx, tx, dbproperties.CreatePropertyParams{
 		Name:                             params.Name,
@@ -85,7 +97,7 @@ func (a sqlPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, pa
 }
 
 func TestCreatePropertyServiceValidatesInput(t *testing.T) {
-	service := NewCreatePropertyService(nil, nil)
+	service := NewCreatePropertyService(nil, nil, nil)
 
 	if _, err := service.Execute(context.Background(), CreatePropertyInput{}); err == nil {
 		t.Fatal("expected validation error, got nil")

--- a/internal/application/property/property_service_test.go
+++ b/internal/application/property/property_service_test.go
@@ -45,6 +45,16 @@ type propertyRepoStub struct {
 	deleteRoomErr   error
 }
 
+type propertyAccountRepoStub struct {
+	propertyID string
+	err        error
+}
+
+func (s *propertyAccountRepoStub) CreatePropertyAccount(_ context.Context, _ *sql.Tx, params CreatePropertyAccountParams) error {
+	s.propertyID = params.PropertyID
+	return s.err
+}
+
 func (s propertyRepoStub) Create(context.Context, *sql.Tx, CreatePropertyParams) (*Property, error) {
 	return s.created, s.createErr
 }
@@ -112,6 +122,7 @@ func TestCreatePropertyServicePublishesPropertyCreatedAfterCommit(t *testing.T) 
 
 	publisher := &recordingPublisher{}
 	electricityUnitPrice := 4.5
+	accountRepo := &propertyAccountRepoStub{}
 	service := NewCreatePropertyService(propertyRepoStub{
 		created: &Property{
 			ID:                               "property-1",
@@ -124,7 +135,7 @@ func TestCreatePropertyServicePublishesPropertyCreatedAfterCommit(t *testing.T) 
 			UpdatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 			Version:                          1,
 		},
-	}, dbtxrunner.New(db, publisher))
+	}, accountRepo, dbtxrunner.New(db, publisher))
 
 	if _, err := service.Execute(context.Background(), CreatePropertyInput{
 		Name:                             "Property A",
@@ -141,6 +152,54 @@ func TestCreatePropertyServicePublishesPropertyCreatedAfterCommit(t *testing.T) 
 	}
 	if _, ok := publisher.events[0].(domainevents.PropertyCreated); !ok {
 		t.Fatalf("expected PropertyCreated event, got %T", publisher.events[0])
+	}
+	if accountRepo.propertyID != "property-1" {
+		t.Fatalf("expected property account for property-1, got %q", accountRepo.propertyID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreatePropertyServiceRollsBackWhenPropertyAccountCreateFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	publisher := &recordingPublisher{}
+	electricityUnitPrice := 4.5
+	service := NewCreatePropertyService(propertyRepoStub{
+		created: &Property{
+			ID:                               "property-1",
+			Name:                             "Property A",
+			Address:                          "Address A",
+			ElectricityUnitPrice:             &electricityUnitPrice,
+			DefaultElectricityBillingCadence: domainproperty.BillingCadenceMonthly,
+			OwnerID:                          "owner-1",
+			CreatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+			UpdatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+			Version:                          1,
+		},
+	}, &propertyAccountRepoStub{err: errors.New("create property account failed")}, dbtxrunner.New(db, publisher))
+
+	if _, err := service.Execute(context.Background(), CreatePropertyInput{
+		Name:                             "Property A",
+		Address:                          "Address A",
+		ElectricityUnitPrice:             4.5,
+		DefaultElectricityBillingCadence: domainproperty.BillingCadenceMonthly,
+		OwnerID:                          "owner-1",
+	}); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if len(publisher.events) != 0 {
+		t.Fatalf("expected no published events, got %d", len(publisher.events))
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/application/property/repository.go
+++ b/internal/application/property/repository.go
@@ -60,6 +60,12 @@ type CreatePropertyParams struct {
 	OwnerID                          string
 }
 
+// CreatePropertyAccountParams contains the fields required to create the
+// accounting lifecycle record for a property.
+type CreatePropertyAccountParams struct {
+	PropertyID string
+}
+
 // UpdatePropertyParams contains the writable fields required to persist a
 // property update.
 type UpdatePropertyParams struct {
@@ -106,4 +112,10 @@ type Repository interface {
 	UpdateRoom(ctx context.Context, tx *sql.Tx, params UpdateRoomParams) (*Room, error)
 	SoftDeleteRoom(ctx context.Context, tx *sql.Tx, id string) error
 	CreateRepairRequest(ctx context.Context, tx *sql.Tx, params CreateRepairRequestParams) (*RepairRequest, error)
+}
+
+// PropertyAccountRepository defines the strong-consistency lifecycle operation
+// property creation needs from billing.
+type PropertyAccountRepository interface {
+	CreatePropertyAccount(ctx context.Context, tx *sql.Tx, params CreatePropertyAccountParams) error
 }

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -26,6 +26,7 @@ import (
 	"stds_backend/internal/config"
 	domainusers "stds_backend/internal/domain/users"
 	"stds_backend/internal/http/handler"
+	dbbilling "stds_backend/internal/platform/database/billing"
 	dbleasequery "stds_backend/internal/platform/database/leasequery"
 	dbproperties "stds_backend/internal/platform/database/properties"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
@@ -1376,7 +1377,7 @@ func TestTriggerUserPasswordResetReturnsNoContent(t *testing.T) {
 		fakeJobRunsRepo{},
 		notificationSender,
 		fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		appproperty.NewCreatePropertyService(fakePropertyRepo{}, fakePropertyAccountRepo{}, dbtxrunner.New(nil, nil)),
 		appproperty.NewUpdatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
 		appproperty.NewDeletePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
 	)
@@ -1540,7 +1541,7 @@ func TestCreateUserReturnsNotificationErrorCodeWhenDispatchFails(t *testing.T) {
 		fakeJobRunsRepo{},
 		&testNotificationSender{sendErr: errors.New("resend down")},
 		fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		appproperty.NewCreatePropertyService(fakePropertyRepo{}, fakePropertyAccountRepo{}, dbtxrunner.New(nil, nil)),
 		appproperty.NewUpdatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
 		appproperty.NewDeletePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
 	)
@@ -1627,7 +1628,7 @@ func TestCreatePropertyRoomReturnsCreatedRoom(t *testing.T) {
 	repo := fakeUserRepo{}
 	propertyRepo := fakePropertyRepo{}
 	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{}, propertyRepo, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreatePropertyService(propertyRepo, fakePropertyAccountRepo{}, dbtxrunner.New(db, nil)),
 		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
@@ -1672,7 +1673,7 @@ func TestUpdateRoomReturnsUpdatedRoom(t *testing.T) {
 	repo := fakeUserRepo{}
 	propertyRepo := fakePropertyRepo{}
 	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreatePropertyService(propertyRepo, fakePropertyAccountRepo{}, dbtxrunner.New(db, nil)),
 		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
@@ -1726,7 +1727,7 @@ func TestDeleteRoomRejectsMaintenanceRoom(t *testing.T) {
 		},
 	}
 	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{role: "admin"}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreatePropertyService(propertyRepo, fakePropertyAccountRepo{}, dbtxrunner.New(db, nil)),
 		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
@@ -1771,7 +1772,7 @@ func TestDeleteRoomRejectsOccupiedRoom(t *testing.T) {
 		},
 	}
 	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{role: "admin"}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreatePropertyService(propertyRepo, fakePropertyAccountRepo{}, dbtxrunner.New(db, nil)),
 		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
@@ -1807,7 +1808,7 @@ func TestCreateRoomMaintenanceReturnsCompositeResponse(t *testing.T) {
 	repo := fakeUserRepo{}
 	propertyRepo := fakePropertyRepo{}
 	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreatePropertyService(propertyRepo, fakePropertyAccountRepo{}, dbtxrunner.New(db, nil)),
 		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
@@ -1873,7 +1874,7 @@ func TestCreateRoomMaintenanceRejectsOccupiedRoom(t *testing.T) {
 		},
 	}
 	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreatePropertyService(propertyRepo, fakePropertyAccountRepo{}, dbtxrunner.New(db, nil)),
 		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
@@ -1919,7 +1920,7 @@ func TestCreateRoomMaintenanceRejectsMaintenanceRoom(t *testing.T) {
 		},
 	}
 	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreatePropertyService(propertyRepo, fakePropertyAccountRepo{}, dbtxrunner.New(db, nil)),
 		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
 		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
@@ -1966,10 +1967,13 @@ func TestCreatePropertyAcceptsDecimalElectricityPrice(t *testing.T) {
 			time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 			1,
 		))
+	mock.ExpectExec("INSERT INTO property_accounts").
+		WithArgs("property-new").
+		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
 	repo := fakeUserRepo{}
-	createPropertyService := appproperty.NewCreatePropertyService(testSQLPropertyRepositoryAdapter{repo: dbproperties.NewRepository(db)}, dbtxrunner.New(db, nil))
+	createPropertyService := appproperty.NewCreatePropertyService(testSQLPropertyRepositoryAdapter{repo: dbproperties.NewRepository(db)}, testSQLPropertyAccountRepositoryAdapter{repo: dbbilling.NewRepository(db)}, dbtxrunner.New(db, nil))
 	engine := newTestEngineWithCreatePropertyService(
 		repo,
 		fakeAuthenticator{},
@@ -2049,7 +2053,7 @@ func TestUpdatePropertyRejectsStaffElectricityPriceMutation(t *testing.T) {
 		"",
 		fakeJobRunsRepo{},
 		fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		appproperty.NewCreatePropertyService(fakePropertyRepo{}, fakePropertyAccountRepo{}, dbtxrunner.New(nil, nil)),
 		updatePropertyService,
 		appproperty.NewDeletePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
 	)
@@ -2113,7 +2117,7 @@ func TestDeletePropertyReturnsOccupiedRoomDetails(t *testing.T) {
 		"",
 		fakeJobRunsRepo{},
 		fakePropertyQueryRepo{},
-		appproperty.NewCreatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+		appproperty.NewCreatePropertyService(fakePropertyRepo{}, fakePropertyAccountRepo{}, dbtxrunner.New(nil, nil)),
 		appproperty.NewUpdatePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
 		deletePropertyService,
 	)
@@ -3092,6 +3096,12 @@ type fakePropertyRepo struct {
 	roomByID          map[string]*appproperty.Room
 }
 
+type fakePropertyAccountRepo struct{}
+
+func (fakePropertyAccountRepo) CreatePropertyAccount(context.Context, *sql.Tx, appproperty.CreatePropertyAccountParams) error {
+	return nil
+}
+
 type fakePropertyQueryRepo struct {
 	property       *dbpropertyquery.Property
 	propertyErr    error
@@ -3200,6 +3210,10 @@ type fakeResourceOwnershipRepo struct {
 
 type testSQLPropertyRepositoryAdapter struct {
 	repo dbproperties.CommandRepository
+}
+
+type testSQLPropertyAccountRepositoryAdapter struct {
+	repo *dbbilling.SQLRepository
 }
 
 type fakeJobRunsRepo struct {
@@ -3699,6 +3713,10 @@ func (a testSQLPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,
 	}, nil
+}
+
+func (a testSQLPropertyAccountRepositoryAdapter) CreatePropertyAccount(ctx context.Context, tx *sql.Tx, params appproperty.CreatePropertyAccountParams) error {
+	return a.repo.CreatePropertyAccount(ctx, tx, params.PropertyID)
 }
 
 func (a testSQLPropertyRepositoryAdapter) FindByID(ctx context.Context, tx *sql.Tx, id string) (*appproperty.Property, error) {
@@ -4550,7 +4568,7 @@ func newTestEngineWithAllServices(userRepo fakeUserRepo, authenticator fakeAuthe
 		leaseQueryRepo,
 		fakeRepairQueryRepo{},
 		tenantQueryRepo,
-		appproperty.NewCreatePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
+		appproperty.NewCreatePropertyService(propertyRepo, fakePropertyAccountRepo{}, dbtxrunner.New(nil, nil)),
 		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
 		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(nil, nil)),
 		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(nil, nil)),

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -167,6 +167,21 @@ func NewRepository(db *sql.DB) *SQLRepository {
 	return &SQLRepository{db: db}
 }
 
+// CreatePropertyAccount creates the accounting lifecycle record for a property.
+func (r *SQLRepository) CreatePropertyAccount(ctx context.Context, tx *sql.Tx, propertyID string) error {
+	const query = `
+INSERT INTO property_accounts (
+	property_id
+) VALUES ($1)
+`
+
+	if _, err := tx.ExecContext(ctx, query, propertyID); err != nil {
+		return fmt.Errorf("create property account: %w", err)
+	}
+
+	return nil
+}
+
 // ListOverdueScanCandidates returns pending-payment bills that should become overdue.
 func (r *SQLRepository) ListOverdueScanCandidates(ctx context.Context, today time.Time) (candidates []JobBillCandidate, err error) {
 	const query = `

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -429,6 +429,28 @@ func TestInsertAccountingEntryWritesCategoryAmountSourceRefYearAndMonth(t *testi
 	}
 }
 
+func TestCreatePropertyAccountInsertsPropertyAccount(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	tx := beginBillingTx(t, db, mock)
+	mock.ExpectExec(`(?s)INSERT INTO property_accounts \(\s+property_id\s+\) VALUES \(\$1\)`).
+		WithArgs("property-1").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	if err := repo.CreatePropertyAccount(context.Background(), tx, "property-1"); err != nil {
+		t.Fatalf("CreatePropertyAccount: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func TestGetFinancialReportFinalizedMapsSnapshotEntries(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)

--- a/internal/server/property_adapters.go
+++ b/internal/server/property_adapters.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 
 	appproperty "stds_backend/internal/application/property"
+	dbbilling "stds_backend/internal/platform/database/billing"
 	dbproperties "stds_backend/internal/platform/database/properties"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
 	"stds_backend/internal/shared/apperr"
@@ -28,6 +29,14 @@ func (a propertyExistenceCheckerAdapter) Exists(ctx context.Context, propertyID 
 
 type propertyRepositoryAdapter struct {
 	repo dbproperties.CommandRepository
+}
+
+type propertyAccountRepositoryAdapter struct {
+	repo *dbbilling.SQLRepository
+}
+
+func (a propertyAccountRepositoryAdapter) CreatePropertyAccount(ctx context.Context, tx *sql.Tx, params appproperty.CreatePropertyAccountParams) error {
+	return a.repo.CreatePropertyAccount(ctx, tx, params.PropertyID)
 }
 
 func (a propertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params appproperty.CreatePropertyParams) (*appproperty.Property, error) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,6 +21,7 @@ import (
 	"stds_backend/internal/http/router"
 	"stds_backend/internal/platform/database"
 	dbattachments "stds_backend/internal/platform/database/attachments"
+	dbbilling "stds_backend/internal/platform/database/billing"
 	dbjobruns "stds_backend/internal/platform/database/jobruns"
 	dbjournal "stds_backend/internal/platform/database/journal"
 	dbleasequery "stds_backend/internal/platform/database/leasequery"
@@ -66,6 +67,7 @@ func New(cfg *config.Config) (*Server, error) {
 
 	userRepo := dbusers.NewRepository(db)
 	propertyRepo := dbproperties.NewRepository(db)
+	billingRepo := dbbilling.NewRepository(db)
 	leaseRepo := dbleases.NewRepository(db)
 	propertyQueryRepo := dbpropertyquery.NewRepository(db)
 	leaseQueryRepo := dbleasequery.NewRepository(db)
@@ -107,7 +109,7 @@ func New(cfg *config.Config) (*Server, error) {
 		customClaimsService,
 	)
 	txRunner := dbtxrunner.New(db, bus)
-	createPropertyService := appproperty.NewCreatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
+	createPropertyService := appproperty.NewCreatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, propertyAccountRepositoryAdapter{repo: billingRepo}, txRunner)
 	updatePropertyService := appproperty.NewUpdatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	deletePropertyService := appproperty.NewDeletePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	createRoomService := appproperty.NewCreateRoomService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)


### PR DESCRIPTION
## Summary

- Create a PropertyAccount directly in the property creation transaction.
- Keep PropertyCreated as a post-commit trace / future-extension event without adding a subscriber.
- Update focused tests and the event boundary documentation for issue #50.

## Why

PropertyAccount lifecycle is strongly tied to property creation. Relying on a future event subscriber would allow property and accounting lifecycle state to diverge, so the creation guarantee belongs in direct command orchestration.

## Validation

- `go test ./internal/application/property ./internal/platform/database/billing ./internal/http/router ./internal/server`
- `go test ./...`

Closes #50