### PR TITLE
Restore room vacancy after repair closure

### DIFF
--- a/internal/application/repair/repository.go
+++ b/internal/application/repair/repository.go
@@ -112,4 +112,5 @@ type Repository interface {
 	Progress(ctx context.Context, tx *sql.Tx, id string) (*RepairRequest, error)
 	Complete(ctx context.Context, tx *sql.Tx, params CompleteParams) (*RepairRequest, error)
 	Cancel(ctx context.Context, tx *sql.Tx, params CancelParams) (*RepairRequest, error)
+	RestoreRoomVacantIfNoActiveRepairs(ctx context.Context, tx *sql.Tx, roomID string) error
 }

--- a/internal/application/repair/workflow.go
+++ b/internal/application/repair/workflow.go
@@ -115,7 +115,7 @@ func (s *WorkflowService) Progress(ctx context.Context, id string) (*RepairReque
 		return aggregate.Progress()
 	}, func(ctx context.Context, tx *sql.Tx, state domainrepair.State) (*RepairRequest, error) {
 		return s.repo.Progress(ctx, tx, state.ID)
-	})
+	}, nil)
 }
 
 // Complete marks an in-progress repair request completed and emits RepairCompleted.
@@ -125,6 +125,8 @@ func (s *WorkflowService) Complete(ctx context.Context, id string) (*RepairReque
 		return aggregate.Complete(completedAt)
 	}, func(ctx context.Context, tx *sql.Tx, state domainrepair.State) (*RepairRequest, error) {
 		return s.repo.Complete(ctx, tx, CompleteParams{ID: state.ID, CompletedAt: completedAt})
+	}, func(ctx context.Context, tx *sql.Tx, updated *RepairRequest) error {
+		return s.repo.RestoreRoomVacantIfNoActiveRepairs(ctx, tx, updated.RoomID)
 	}, func(updated *RepairRequest, recorder *txrunner.EventRecorder) {
 		recorder.Record(domainevents.RepairCompleted{
 			RepairRequestID: updated.ID,
@@ -143,6 +145,8 @@ func (s *WorkflowService) Cancel(ctx context.Context, input CancelInput) (*Repai
 		return aggregate.Cancel(reason)
 	}, func(ctx context.Context, tx *sql.Tx, state domainrepair.State) (*RepairRequest, error) {
 		return s.repo.Cancel(ctx, tx, CancelParams{ID: state.ID, CancelReason: state.CancelReason})
+	}, func(ctx context.Context, tx *sql.Tx, updated *RepairRequest) error {
+		return s.repo.RestoreRoomVacantIfNoActiveRepairs(ctx, tx, updated.RoomID)
 	}, func(updated *RepairRequest, recorder *txrunner.EventRecorder) {
 		recorder.Record(domainevents.RepairCancelled{
 			RepairRequestID: updated.ID,
@@ -158,6 +162,7 @@ func (s *WorkflowService) transition(
 	rawID string,
 	mutate func(*domainrepair.Aggregate, *txrunner.EventRecorder) error,
 	persist func(context.Context, *sql.Tx, domainrepair.State) (*RepairRequest, error),
+	afterPersistInTx func(context.Context, *sql.Tx, *RepairRequest) error,
 	afterPersist ...func(*RepairRequest, *txrunner.EventRecorder),
 ) (*RepairRequest, error) {
 	id, err := normalizeRequiredUUID(rawID, "id", ErrRepairRequestNotFound)
@@ -187,6 +192,11 @@ func (s *WorkflowService) transition(
 		repairRequest, err := persist(ctx, tx, state)
 		if err != nil {
 			return mapRepositoryError(err)
+		}
+		if afterPersistInTx != nil {
+			if err := afterPersistInTx(ctx, tx, repairRequest); err != nil {
+				return mapRepositoryError(err)
+			}
 		}
 		for _, fn := range afterPersist {
 			fn(repairRequest, recorder)

--- a/internal/application/repair/workflow_test.go
+++ b/internal/application/repair/workflow_test.go
@@ -128,6 +128,80 @@ func TestCancelPersistsReason(t *testing.T) {
 	}
 }
 
+func TestCompleteRestoresRoomVacantWhenNoActiveRepairsRemain(t *testing.T) {
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "in_progress"
+	repo := &workflowRepoStub{
+		repairRequests: map[string]*RepairRequest{testRepairID: repairRequest},
+		roomStatus:     "maintenance",
+	}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Complete(context.Background(), testRepairID)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	if repo.restoreRoomID != testRoomID {
+		t.Fatalf("expected restore room %s, got %s", testRoomID, repo.restoreRoomID)
+	}
+	if repo.roomStatus != "vacant" {
+		t.Fatalf("expected room vacant, got %s", repo.roomStatus)
+	}
+}
+
+func TestCancelRestoresRoomVacantWhenNoActiveRepairsRemain(t *testing.T) {
+	repo := &workflowRepoStub{
+		repairRequests: map[string]*RepairRequest{testRepairID: submittedRepairRequest()},
+		roomStatus:     "maintenance",
+	}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Cancel(context.Background(), CancelInput{ID: testRepairID})
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	if repo.restoreRoomID != testRoomID {
+		t.Fatalf("expected restore room %s, got %s", testRoomID, repo.restoreRoomID)
+	}
+	if repo.roomStatus != "vacant" {
+		t.Fatalf("expected room vacant, got %s", repo.roomStatus)
+	}
+}
+
+func TestRoomStaysMaintenanceUntilAllRoomRepairsAreCompletedOrCancelled(t *testing.T) {
+	first := submittedRepairRequest()
+	first.Status = "in_progress"
+	second := submittedRepairRequest()
+	second.ID = testOtherRepairID
+	second.Status = "assigned"
+	repo := &workflowRepoStub{
+		repairRequests: map[string]*RepairRequest{
+			testRepairID:      first,
+			testOtherRepairID: second,
+		},
+		roomStatus: "maintenance",
+	}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Complete(context.Background(), testRepairID)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if repo.roomStatus != "maintenance" {
+		t.Fatalf("expected room to remain maintenance while another repair is active, got %s", repo.roomStatus)
+	}
+
+	_, err = service.Cancel(context.Background(), CancelInput{ID: testOtherRepairID})
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if repo.roomStatus != "vacant" {
+		t.Fatalf("expected room vacant after all repairs are closed, got %s", repo.roomStatus)
+	}
+}
+
 func TestCancelCompletedRepairReturnsAlreadyCompleted(t *testing.T) {
 	repairRequest := submittedRepairRequest()
 	repairRequest.Status = "completed"
@@ -223,12 +297,13 @@ func TestCancelPublishesRepairCancelledAfterCommit(t *testing.T) {
 }
 
 const (
-	testRepairID    = "70000000-0000-0000-0000-000000000001"
-	testPropertyID  = "10000000-0000-0000-0000-000000000001"
-	testRoomID      = "20000000-0000-0000-0000-000000000001"
-	testStaffID     = "00000000-0000-0000-0000-000000000002"
-	testOrganizerID = "00000000-0000-0000-0000-000000000003"
-	testOwnerID     = "00000000-0000-0000-0000-000000000004"
+	testRepairID      = "70000000-0000-0000-0000-000000000001"
+	testOtherRepairID = "70000000-0000-0000-0000-000000000002"
+	testPropertyID    = "10000000-0000-0000-0000-000000000001"
+	testRoomID        = "20000000-0000-0000-0000-000000000001"
+	testStaffID       = "00000000-0000-0000-0000-000000000002"
+	testOrganizerID   = "00000000-0000-0000-0000-000000000003"
+	testOwnerID       = "00000000-0000-0000-0000-000000000004"
 )
 
 var testNow = time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
@@ -249,10 +324,13 @@ func (p *repairRecordingPublisher) Publish(_ context.Context, event any) error {
 }
 
 type workflowRepoStub struct {
-	user          *User
-	repairRequest *RepairRequest
-	assignParams  AssignParams
-	cancelParams  CancelParams
+	user           *User
+	repairRequest  *RepairRequest
+	repairRequests map[string]*RepairRequest
+	roomStatus     string
+	assignParams   AssignParams
+	cancelParams   CancelParams
+	restoreRoomID  string
 }
 
 func (r *workflowRepoStub) List(context.Context, ListQuery) ([]RepairRequest, error) {
@@ -263,12 +341,18 @@ func (r *workflowRepoStub) FindByID(context.Context, string) (*RepairRequest, er
 	return r.repairRequest, nil
 }
 
-func (r *workflowRepoStub) FindByIDForUpdate(context.Context, *sql.Tx, string) (*RepairRequest, error) {
+func (r *workflowRepoStub) FindByIDForUpdate(_ context.Context, _ *sql.Tx, id string) (*RepairRequest, error) {
+	if r.repairRequests != nil {
+		repairRequest := r.repairRequests[id]
+		if repairRequest == nil {
+			return nil, ErrRepairRequestNotFound
+		}
+		return cloneRepairRequest(repairRequest), nil
+	}
 	if r.repairRequest == nil {
 		return nil, ErrRepairRequestNotFound
 	}
-	cloned := *r.repairRequest
-	return &cloned, nil
+	return cloneRepairRequest(r.repairRequest), nil
 }
 
 func (r *workflowRepoStub) FindRoomByID(context.Context, *sql.Tx, string) (*Room, error) {
@@ -309,18 +393,63 @@ func (r *workflowRepoStub) Progress(context.Context, *sql.Tx, string) (*RepairRe
 	return repairRequest, nil
 }
 
-func (r *workflowRepoStub) Complete(context.Context, *sql.Tx, CompleteParams) (*RepairRequest, error) {
+func (r *workflowRepoStub) Complete(_ context.Context, _ *sql.Tx, params CompleteParams) (*RepairRequest, error) {
+	if r.repairRequests != nil {
+		repairRequest := r.repairRequests[params.ID]
+		if repairRequest == nil {
+			return nil, ErrRepairRequestNotFound
+		}
+		repairRequest.Status = "completed"
+		repairRequest.CompletedAt = &params.CompletedAt
+		return cloneRepairRequest(repairRequest), nil
+	}
 	repairRequest := submittedRepairRequest()
 	repairRequest.Status = "completed"
+	repairRequest.CompletedAt = &params.CompletedAt
 	return repairRequest, nil
 }
 
 func (r *workflowRepoStub) Cancel(_ context.Context, _ *sql.Tx, params CancelParams) (*RepairRequest, error) {
 	r.cancelParams = params
+	if r.repairRequests != nil {
+		repairRequest := r.repairRequests[params.ID]
+		if repairRequest == nil {
+			return nil, ErrRepairRequestNotFound
+		}
+		repairRequest.Status = "cancelled"
+		repairRequest.CancelReason = params.CancelReason
+		return cloneRepairRequest(repairRequest), nil
+	}
 	repairRequest := submittedRepairRequest()
 	repairRequest.Status = "cancelled"
 	repairRequest.CancelReason = params.CancelReason
 	return repairRequest, nil
+}
+
+func (r *workflowRepoStub) RestoreRoomVacantIfNoActiveRepairs(_ context.Context, _ *sql.Tx, roomID string) error {
+	r.restoreRoomID = roomID
+	if r.repairRequests == nil || r.roomStatus != "maintenance" {
+		return nil
+	}
+	for _, repairRequest := range r.repairRequests {
+		if repairRequest.RoomID == roomID && isActiveRepairStatus(repairRequest.Status) {
+			return nil
+		}
+	}
+	r.roomStatus = "vacant"
+	return nil
+}
+
+func isActiveRepairStatus(status string) bool {
+	return status != "completed" && status != "cancelled"
+}
+
+func cloneRepairRequest(repairRequest *RepairRequest) *RepairRequest {
+	if repairRequest == nil {
+		return nil
+	}
+	cloned := *repairRequest
+	return &cloned
 }
 
 func submittedRepairRequest() *RepairRequest {

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -863,6 +863,10 @@ func (r *handlerRepairRepositoryStub) Cancel(context.Context, *sql.Tx, apprepair
 	return nil, nil
 }
 
+func (r *handlerRepairRepositoryStub) RestoreRoomVacantIfNoActiveRepairs(context.Context, *sql.Tx, string) error {
+	return nil
+}
+
 func testBillingBill() BillingBill {
 	amount := 12000
 	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)

--- a/internal/platform/database/repair/repository.go
+++ b/internal/platform/database/repair/repository.go
@@ -293,6 +293,37 @@ WHERE id = $1
 	return r.scanUpdated(tx.QueryRowContext(ctx, query, params.ID, params.CancelReason), "cancel repair request")
 }
 
+// RestoreRoomVacantIfNoActiveRepairs restores a maintenance room when no active repairs remain.
+func (r *SQLRepository) RestoreRoomVacantIfNoActiveRepairs(ctx context.Context, tx *sql.Tx, roomID string) error {
+	const query = `
+WITH locked_room AS (
+  SELECT id
+  FROM rooms
+  WHERE id = $1
+    AND status = 'maintenance'
+    AND deleted_at IS NULL
+  FOR UPDATE
+)
+UPDATE rooms
+SET status = 'vacant',
+    updated_at = now()
+FROM locked_room
+WHERE rooms.id = locked_room.id
+  AND NOT EXISTS (
+    SELECT 1
+    FROM repair_requests
+    WHERE room_id = $1
+      AND deleted_at IS NULL
+      AND status NOT IN ('completed', 'cancelled')
+  )
+`
+	if _, err := tx.ExecContext(ctx, query, roomID); err != nil {
+		return fmt.Errorf("restore room vacant after repair workflow: %w", err)
+	}
+
+	return nil
+}
+
 func (r *SQLRepository) scanUpdated(row rowScanner, operation string) (*apprepair.RepairRequest, error) {
 	repairRequest, err := scanRepairRequest(row)
 	if err != nil {

--- a/internal/platform/database/repair/repository.go
+++ b/internal/platform/database/repair/repository.go
@@ -295,20 +295,29 @@ WHERE id = $1
 
 // RestoreRoomVacantIfNoActiveRepairs restores a maintenance room when no active repairs remain.
 func (r *SQLRepository) RestoreRoomVacantIfNoActiveRepairs(ctx context.Context, tx *sql.Tx, roomID string) error {
-	const query = `
-WITH locked_room AS (
-  SELECT id
-  FROM rooms
-  WHERE id = $1
-    AND status = 'maintenance'
-    AND deleted_at IS NULL
-  FOR UPDATE
-)
+	const lockQuery = `
+SELECT id
+FROM rooms
+WHERE id = $1
+  AND status = 'maintenance'
+  AND deleted_at IS NULL
+FOR UPDATE
+`
+	var lockedRoomID string
+	if err := tx.QueryRowContext(ctx, lockQuery, roomID).Scan(&lockedRoomID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("lock maintenance room before restore vacant: %w", err)
+	}
+
+	const updateQuery = `
 UPDATE rooms
 SET status = 'vacant',
     updated_at = now()
-FROM locked_room
-WHERE rooms.id = locked_room.id
+WHERE id = $1
+  AND status = 'maintenance'
+  AND deleted_at IS NULL
   AND NOT EXISTS (
     SELECT 1
     FROM repair_requests
@@ -317,7 +326,7 @@ WHERE rooms.id = locked_room.id
       AND status NOT IN ('completed', 'cancelled')
   )
 `
-	if _, err := tx.ExecContext(ctx, query, roomID); err != nil {
+	if _, err := tx.ExecContext(ctx, updateQuery, roomID); err != nil {
 		return fmt.Errorf("restore room vacant after repair workflow: %w", err)
 	}
 

--- a/internal/platform/database/repair/repository_test.go
+++ b/internal/platform/database/repair/repository_test.go
@@ -2,6 +2,7 @@ package repair
 
 import (
 	"context"
+	"database/sql"
 	"regexp"
 	"testing"
 	"time"
@@ -125,7 +126,10 @@ func TestRestoreRoomVacantIfNoActiveRepairsUpdatesMaintenanceRoom(t *testing.T) 
 	defer db.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`WITH locked_room AS \([\s\S]+AND status = 'maintenance'[\s\S]+AND deleted_at IS NULL[\s\S]+FOR UPDATE[\s\S]+UPDATE rooms[\s\S]+FROM locked_room[\s\S]+NOT EXISTS[\s\S]+status NOT IN \('completed', 'cancelled'\)`).
+	mock.ExpectQuery(`SELECT id[\s\S]+FROM rooms[\s\S]+AND status = 'maintenance'[\s\S]+AND deleted_at IS NULL[\s\S]+FOR UPDATE`).
+		WithArgs(testRoomID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(testRoomID))
+	mock.ExpectExec(`UPDATE rooms[\s\S]+AND status = 'maintenance'[\s\S]+AND deleted_at IS NULL[\s\S]+NOT EXISTS[\s\S]+status NOT IN \('completed', 'cancelled'\)`).
 		WithArgs(testRoomID).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
@@ -154,9 +158,41 @@ func TestRestoreRoomVacantIfNoActiveRepairsAllowsRemainingActiveRepair(t *testin
 	defer db.Close()
 
 	mock.ExpectBegin()
-	mock.ExpectExec(`WITH locked_room AS \([\s\S]+FOR UPDATE[\s\S]+UPDATE rooms[\s\S]+NOT EXISTS[\s\S]+status NOT IN \('completed', 'cancelled'\)`).
+	mock.ExpectQuery(`SELECT id[\s\S]+FROM rooms[\s\S]+FOR UPDATE`).
+		WithArgs(testRoomID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(testRoomID))
+	mock.ExpectExec(`UPDATE rooms[\s\S]+NOT EXISTS[\s\S]+status NOT IN \('completed', 'cancelled'\)`).
 		WithArgs(testRoomID).
 		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	repo := NewRepository(db)
+	if err := repo.RestoreRoomVacantIfNoActiveRepairs(context.Background(), tx, testRoomID); err != nil {
+		t.Fatalf("RestoreRoomVacantIfNoActiveRepairs: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestRestoreRoomVacantIfNoActiveRepairsSkipsNonMaintenanceRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT id[\s\S]+FROM rooms[\s\S]+FOR UPDATE`).
+		WithArgs(testRoomID).
+		WillReturnError(sql.ErrNoRows)
 	mock.ExpectCommit()
 
 	tx, err := db.BeginTx(context.Background(), nil)

--- a/internal/platform/database/repair/repository_test.go
+++ b/internal/platform/database/repair/repository_test.go
@@ -117,6 +117,64 @@ func TestCancelPersistsCancelReason(t *testing.T) {
 	}
 }
 
+func TestRestoreRoomVacantIfNoActiveRepairsUpdatesMaintenanceRoom(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`WITH locked_room AS \([\s\S]+AND status = 'maintenance'[\s\S]+AND deleted_at IS NULL[\s\S]+FOR UPDATE[\s\S]+UPDATE rooms[\s\S]+FROM locked_room[\s\S]+NOT EXISTS[\s\S]+status NOT IN \('completed', 'cancelled'\)`).
+		WithArgs(testRoomID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	repo := NewRepository(db)
+	if err := repo.RestoreRoomVacantIfNoActiveRepairs(context.Background(), tx, testRoomID); err != nil {
+		t.Fatalf("RestoreRoomVacantIfNoActiveRepairs: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestRestoreRoomVacantIfNoActiveRepairsAllowsRemainingActiveRepair(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(`WITH locked_room AS \([\s\S]+FOR UPDATE[\s\S]+UPDATE rooms[\s\S]+NOT EXISTS[\s\S]+status NOT IN \('completed', 'cancelled'\)`).
+		WithArgs(testRoomID).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectCommit()
+
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	repo := NewRepository(db)
+	if err := repo.RestoreRoomVacantIfNoActiveRepairs(context.Background(), tx, testRoomID); err != nil {
+		t.Fatalf("RestoreRoomVacantIfNoActiveRepairs: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func TestFindUserByIDLoadsAssignedPropertyIDs(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Restore maintenance rooms to `vacant` from the repair workflow command after complete/cancel.
- Keep the room recovery decision in the same transaction as repair status changes.
- Serialize same-room recovery checks by locking the maintenance room row before checking active repairs.

## Notes

This intentionally keeps the behavior as command-owned direct orchestration and does not add `RepairCompleted` or `RepairCancelled` subscribers.

## Validation

- `go test ./internal/application/repair ./internal/platform/database/repair`
- `go test ./...`