### PR TITLE
[codex] Implement property dashboard endpoint

### DIFF
--- a/internal/application/property/dashboard.go
+++ b/internal/application/property/dashboard.go
@@ -22,7 +22,16 @@ type DashboardService struct {
 	now  func() time.Time
 }
 
-var taiwanDashboardLocation = time.FixedZone("Asia/Taipei", 8*60*60)
+var taiwanDashboardLocation = loadTaiwanDashboardLocation()
+
+func loadTaiwanDashboardLocation() *time.Location {
+	location, err := time.LoadLocation("Asia/Taipei")
+	if err != nil {
+		return time.FixedZone("Asia/Taipei", 8*60*60)
+	}
+
+	return location
+}
 
 // NewDashboardService returns a DashboardService.
 func NewDashboardService(repo DashboardRepository) *DashboardService {

--- a/internal/application/property/dashboard.go
+++ b/internal/application/property/dashboard.go
@@ -1,0 +1,57 @@
+package property
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+// DashboardInput is the query payload for retrieving a property dashboard.
+type DashboardInput struct {
+	PropertyID string
+}
+
+// DashboardService retrieves the property dashboard read model.
+type DashboardService struct {
+	repo DashboardRepository
+	now  func() time.Time
+}
+
+var taiwanDashboardLocation = time.FixedZone("Asia/Taipei", 8*60*60)
+
+// NewDashboardService returns a DashboardService.
+func NewDashboardService(repo DashboardRepository) *DashboardService {
+	return &DashboardService{
+		repo: repo,
+		now:  time.Now,
+	}
+}
+
+// Execute validates input and returns the current property dashboard.
+func (s *DashboardService) Execute(ctx context.Context, input DashboardInput) (*Dashboard, error) {
+	propertyID := strings.TrimSpace(input.PropertyID)
+	if propertyID == "" {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "property_id"})
+	}
+	if _, err := uuid.Parse(propertyID); err != nil {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "property_id"}).WithCause(err)
+	}
+
+	current := s.now().In(taiwanDashboardLocation)
+	dashboard, err := s.repo.GetDashboard(ctx, propertyID, current.Year(), int(current.Month()))
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrPropertyNotFound):
+			return nil, apperr.ErrPropertyNotFound.WithCause(err)
+		default:
+			return nil, apperr.ErrInternalServerError.WithCause(err)
+		}
+	}
+
+	return dashboard, nil
+}

--- a/internal/application/property/dashboard_test.go
+++ b/internal/application/property/dashboard_test.go
@@ -1,0 +1,95 @@
+package property
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+func TestDashboardServiceUsesCurrentMonth(t *testing.T) {
+	repo := &dashboardRepositoryStub{
+		dashboard: &Dashboard{PropertyID: "10000000-0000-0000-0000-000000000001"},
+	}
+	service := NewDashboardService(repo)
+	service.now = func() time.Time {
+		return time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	}
+
+	dashboard, err := service.Execute(context.Background(), DashboardInput{
+		PropertyID: "10000000-0000-0000-0000-000000000001",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if dashboard.PropertyID != "10000000-0000-0000-0000-000000000001" {
+		t.Fatalf("unexpected dashboard: %+v", dashboard)
+	}
+	if repo.propertyID != "10000000-0000-0000-0000-000000000001" || repo.year != 2026 || repo.month != 4 {
+		t.Fatalf("unexpected repository query: propertyID=%s year=%d month=%d", repo.propertyID, repo.year, repo.month)
+	}
+}
+
+func TestDashboardServiceCurrentMonthUsesTaiwanTimezone(t *testing.T) {
+	repo := &dashboardRepositoryStub{
+		dashboard: &Dashboard{PropertyID: "10000000-0000-0000-0000-000000000001"},
+	}
+	service := NewDashboardService(repo)
+	service.now = func() time.Time {
+		return time.Date(2026, 3, 31, 16, 30, 0, 0, time.UTC)
+	}
+
+	_, err := service.Execute(context.Background(), DashboardInput{
+		PropertyID: "10000000-0000-0000-0000-000000000001",
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if repo.year != 2026 || repo.month != 4 {
+		t.Fatalf("unexpected repository period: year=%d month=%d", repo.year, repo.month)
+	}
+}
+
+func TestDashboardServiceMapsPropertyNotFound(t *testing.T) {
+	service := NewDashboardService(&dashboardRepositoryStub{err: ErrPropertyNotFound})
+	service.now = func() time.Time {
+		return time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+	}
+
+	_, err := service.Execute(context.Background(), DashboardInput{
+		PropertyID: "10000000-0000-0000-0000-000000000099",
+	})
+	if !errors.Is(err, apperr.ErrPropertyNotFound) {
+		t.Fatalf("expected property not found, got %v", err)
+	}
+}
+
+func TestDashboardServiceRejectsInvalidPropertyID(t *testing.T) {
+	service := NewDashboardService(&dashboardRepositoryStub{})
+
+	_, err := service.Execute(context.Background(), DashboardInput{PropertyID: "not-a-uuid"})
+	if !errors.Is(err, apperr.ErrBadRequest) {
+		t.Fatalf("expected bad request, got %v", err)
+	}
+}
+
+type dashboardRepositoryStub struct {
+	propertyID string
+	year       int
+	month      int
+	dashboard  *Dashboard
+	err        error
+}
+
+func (r *dashboardRepositoryStub) GetDashboard(_ context.Context, propertyID string, year int, month int) (*Dashboard, error) {
+	r.propertyID = propertyID
+	r.year = year
+	r.month = month
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return r.dashboard, nil
+}

--- a/internal/application/property/repository.go
+++ b/internal/application/property/repository.go
@@ -50,6 +50,36 @@ type RepairRequest struct {
 	UpdatedAt   time.Time
 }
 
+// Dashboard contains the property owner dashboard read model.
+type Dashboard struct {
+	PropertyID     string
+	Rooms          []DashboardRoom
+	MonthlySummary DashboardMonthlySummary
+	RecentJournals []DashboardRecentJournal
+}
+
+// DashboardRoom contains one room row in the dashboard.
+type DashboardRoom struct {
+	ID     string
+	Name   string
+	Status string
+}
+
+// DashboardMonthlySummary contains current-month rent and overdue bill totals.
+type DashboardMonthlySummary struct {
+	ExpectedRent     int
+	CollectedRent    int
+	OverdueBillCount int
+}
+
+// DashboardRecentJournal contains one recent journal entry in the dashboard.
+type DashboardRecentJournal struct {
+	ID        string
+	Type      string
+	Content   string
+	CreatedAt time.Time
+}
+
 // CreatePropertyParams contains the writable fields required to create a
 // property.
 type CreatePropertyParams struct {
@@ -118,4 +148,9 @@ type Repository interface {
 // property creation needs from billing.
 type PropertyAccountRepository interface {
 	CreatePropertyAccount(ctx context.Context, tx *sql.Tx, params CreatePropertyAccountParams) error
+}
+
+// DashboardRepository defines the read model needed by the property dashboard.
+type DashboardRepository interface {
+	GetDashboard(ctx context.Context, propertyID string, year int, month int) (*Dashboard, error)
 }

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -44,6 +44,7 @@ type APIServer struct {
 	assignProperties  *appiam.AssignUserPropertiesService
 	jobTriggerService *appjobs.TriggerService
 	propertyQueryRepo dbpropertyquery.Repository
+	propertyDashboard *appproperty.DashboardService
 	leaseQueryRepo    dbleasequery.Repository
 	repairQueryRepo   RepairQueryRepository
 	tenantQueryRepo   dbtenantquery.Repository
@@ -283,6 +284,7 @@ func NewAPIServer(
 	assignProperties *appiam.AssignUserPropertiesService,
 	jobTriggerService *appjobs.TriggerService,
 	propertyQueryRepo dbpropertyquery.Repository,
+	propertyDashboard *appproperty.DashboardService,
 	leaseQueryRepo dbleasequery.Repository,
 	repairQueryRepo RepairQueryRepository,
 	tenantQueryRepo dbtenantquery.Repository,
@@ -310,6 +312,7 @@ func NewAPIServer(
 		assignProperties:  assignProperties,
 		jobTriggerService: jobTriggerService,
 		propertyQueryRepo: propertyQueryRepo,
+		propertyDashboard: propertyDashboard,
 		leaseQueryRepo:    leaseQueryRepo,
 		repairQueryRepo:   repairQueryRepo,
 		tenantQueryRepo:   tenantQueryRepo,
@@ -1322,7 +1325,22 @@ func (s *APIServer) UpdateProperty(c *gin.Context, id string) {
 }
 
 // GetPropertyDashboard handles property dashboard retrieval.
-func (s *APIServer) GetPropertyDashboard(c *gin.Context, id string) { writeNotImplemented(c) }
+func (s *APIServer) GetPropertyDashboard(c *gin.Context, id string) {
+	if s.propertyDashboard == nil {
+		c.Error(apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "property_dashboard"}))
+		return
+	}
+
+	dashboard, err := s.propertyDashboard.Execute(c.Request.Context(), appproperty.DashboardInput{
+		PropertyID: id,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toDashboardResponse(dashboard))
+}
 
 // GetPropertyFinancialReportSummary handles financial report summary retrieval
 // for a property.
@@ -2624,6 +2642,70 @@ func toFinancialReportEntryItem(entry BillingFinancialReportEntry) api.Financial
 		Category:    &category,
 		Description: entry.Description,
 	}
+}
+
+func toDashboardResponse(dashboard *appproperty.Dashboard) api.DashboardResponse {
+	propertyID, propertyOK := parseUUID(dashboard.PropertyID)
+	rooms := make([]api.DashboardRoomItem, 0, len(dashboard.Rooms))
+	for i := range dashboard.Rooms {
+		rooms = append(rooms, toDashboardRoomItem(dashboard.Rooms[i]))
+	}
+	recentJournals := make([]api.DashboardRecentJournalItem, 0, len(dashboard.RecentJournals))
+	for i := range dashboard.RecentJournals {
+		recentJournals = append(recentJournals, toDashboardRecentJournalItem(dashboard.RecentJournals[i]))
+	}
+
+	expectedRent := dashboard.MonthlySummary.ExpectedRent
+	collectedRent := dashboard.MonthlySummary.CollectedRent
+	overdueBillCount := dashboard.MonthlySummary.OverdueBillCount
+	response := api.DashboardResponse{
+		MonthlySummary: &api.DashboardMonthlySummary{
+			ExpectedRent:     &expectedRent,
+			CollectedRent:    &collectedRent,
+			OverdueBillCount: &overdueBillCount,
+		},
+		RecentJournals: &recentJournals,
+		Rooms:          &rooms,
+	}
+	if propertyOK {
+		response.PropertyId = &propertyID
+	}
+
+	return response
+}
+
+func toDashboardRoomItem(room appproperty.DashboardRoom) api.DashboardRoomItem {
+	id, idOK := parseUUID(room.ID)
+	name := room.Name
+	status := api.DashboardRoomItemStatus(room.Status)
+
+	response := api.DashboardRoomItem{
+		Name:   &name,
+		Status: &status,
+	}
+	if idOK {
+		response.Id = &id
+	}
+
+	return response
+}
+
+func toDashboardRecentJournalItem(journal appproperty.DashboardRecentJournal) api.DashboardRecentJournalItem {
+	id, idOK := parseUUID(journal.ID)
+	content := journal.Content
+	createdAt := journal.CreatedAt
+	itemType := journal.Type
+
+	response := api.DashboardRecentJournalItem{
+		Content:   &content,
+		CreatedAt: &createdAt,
+		Type:      &itemType,
+	}
+	if idOK {
+		response.Id = &id
+	}
+
+	return response
 }
 
 func (s *APIServer) runJob(c *gin.Context, jobKey appjobs.JobKey, windowKey string) {

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -102,7 +102,7 @@ func TestGetPropertyDashboardReturnsDashboardResponse(t *testing.T) {
 	server := &APIServer{propertyDashboard: appproperty.NewDashboardService(repo)}
 	recorder := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(recorder)
-	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/properties/"+propertyID+"/dashboard", nil)
+	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/properties/"+propertyID+"/dashboard", nil)
 
 	server.GetPropertyDashboard(c, propertyID)
 

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -15,6 +15,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	appattachment "stds_backend/internal/application/attachment"
+	appproperty "stds_backend/internal/application/property"
 	apprepair "stds_backend/internal/application/repair"
 	"stds_backend/internal/http/api"
 	"stds_backend/internal/http/middleware"
@@ -74,6 +75,59 @@ func TestToRoomResponseAllowsNilOptionalFields(t *testing.T) {
 		if value, ok := payload[field]; !ok || value != nil {
 			t.Fatalf("expected %s null, got %v", field, payload[field])
 		}
+	}
+}
+
+func TestGetPropertyDashboardReturnsDashboardResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	propertyID := "10000000-0000-0000-0000-000000000001"
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	repo := &recordingDashboardRepository{
+		dashboard: &appproperty.Dashboard{
+			PropertyID: propertyID,
+			Rooms: []appproperty.DashboardRoom{
+				{ID: "20000000-0000-0000-0000-000000000001", Name: "101 Room", Status: "occupied"},
+			},
+			MonthlySummary: appproperty.DashboardMonthlySummary{
+				ExpectedRent:     50000,
+				CollectedRent:    40000,
+				OverdueBillCount: 2,
+			},
+			RecentJournals: []appproperty.DashboardRecentJournal{
+				{ID: "60000000-0000-0000-0000-000000000001", Type: "journal_log", Content: "Changed lobby light", CreatedAt: createdAt},
+			},
+		},
+	}
+	server := &APIServer{propertyDashboard: appproperty.NewDashboardService(repo)}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/properties/"+propertyID+"/dashboard", nil)
+
+	server.GetPropertyDashboard(c, propertyID)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if repo.propertyID != propertyID {
+		t.Fatalf("unexpected dashboard query: %+v", repo)
+	}
+
+	var response api.DashboardResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.PropertyId == nil || response.PropertyId.String() != propertyID {
+		t.Fatalf("unexpected dashboard response: %+v", response)
+	}
+	if response.MonthlySummary == nil || response.MonthlySummary.ExpectedRent == nil || *response.MonthlySummary.ExpectedRent != 50000 {
+		t.Fatalf("unexpected monthly summary: %+v", response.MonthlySummary)
+	}
+	if response.Rooms == nil || len(*response.Rooms) != 1 || (*response.Rooms)[0].Status == nil || string(*(*response.Rooms)[0].Status) != "occupied" {
+		t.Fatalf("unexpected rooms: %+v", response.Rooms)
+	}
+	if response.RecentJournals == nil || len(*response.RecentJournals) != 1 || (*response.RecentJournals)[0].Type == nil || *(*response.RecentJournals)[0].Type != "journal_log" {
+		t.Fatalf("unexpected recent journals: %+v", response.RecentJournals)
 	}
 }
 
@@ -718,6 +772,25 @@ func (r *recordingFinancialReports) GetFinancialReport(_ context.Context, input 
 func (r *recordingFinancialReports) SendFinancialReport(_ context.Context, input BillingFinancialReportInput) (*BillingFinancialReport, error) {
 	r.sendInput = input
 	return &r.sentReport, nil
+}
+
+type recordingDashboardRepository struct {
+	propertyID string
+	year       int
+	month      int
+	dashboard  *appproperty.Dashboard
+	err        error
+}
+
+func (r *recordingDashboardRepository) GetDashboard(_ context.Context, propertyID string, year int, month int) (*appproperty.Dashboard, error) {
+	r.propertyID = propertyID
+	r.year = year
+	r.month = month
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return r.dashboard, nil
 }
 
 type recordingRepairQueryRepo struct {

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -57,6 +57,7 @@ func New(
 	assignUserPropertiesService *appiam.AssignUserPropertiesService,
 	jobTriggerService *appjobs.TriggerService,
 	propertyQueryRepo dbpropertyquery.Repository,
+	propertyDashboard *appproperty.DashboardService,
 	leaseQueryRepo dbleasequery.Repository,
 	repairQueryRepo handler.RepairQueryRepository,
 	tenantQueryRepo dbtenantquery.Repository,
@@ -89,7 +90,7 @@ func New(
 	engine.GET("/openapi.yaml", docsHandler.OpenAPI)
 	engine.GET("/scalar", docsHandler.Scalar)
 
-	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, repairQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, journalServices, repairServices, leaseCommands...), api.GinServerOptions{
+	api.RegisterHandlersWithOptions(engine, handler.NewAPIServer(userRepo, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, propertyDashboard, leaseQueryRepo, repairQueryRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, journalServices, repairServices, leaseCommands...), api.GinServerOptions{
 		BaseURL: "/api/v1",
 		Middlewares: []api.MiddlewareFunc{
 			protectedAPIMiddleware(appCfg, authenticator, userRepo, authzRepos),

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -769,6 +769,7 @@ func TestCreateLeaseReturnsCreatedLease(t *testing.T) {
 			findRoomID:   &findRoomID,
 			createParams: &createParams,
 		}, dbtxrunner.New(db, nil)),
+		nil,
 	)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/leases", strings.NewReader(`{
@@ -899,6 +900,7 @@ func TestCreateLeaseRejectsUnassignedRoomProperty(t *testing.T) {
 				DefaultElectricityBillingCadence: "monthly",
 			},
 		}, dbtxrunner.New(db, nil)),
+		nil,
 	)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/leases", strings.NewReader(`{
@@ -2370,6 +2372,119 @@ func TestListJournalLogsRejectsUnassignedPropertyFilter(t *testing.T) {
 	}
 }
 
+func TestGetPropertyDashboardReturnsAccessibleDashboard(t *testing.T) {
+	dashboardRepo := &fakeDashboardRepository{
+		dashboard: &appproperty.Dashboard{
+			PropertyID: testPropertyID1,
+			Rooms: []appproperty.DashboardRoom{
+				{ID: testRoomID1, Name: "101 Room", Status: "occupied"},
+			},
+			MonthlySummary: appproperty.DashboardMonthlySummary{
+				ExpectedRent:     50000,
+				CollectedRent:    40000,
+				OverdueBillCount: 2,
+			},
+			RecentJournals: []appproperty.DashboardRecentJournal{
+				{ID: "60000000-0000-0000-0000-000000000001", Type: "journal_log", Content: "Changed lobby light", CreatedAt: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)},
+				{ID: "70000000-0000-0000-0000-000000000001", Type: "repair_request", Content: "Fix leak", CreatedAt: time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC)},
+			},
+		},
+	}
+	engine := newTestEngineWithPropertyDashboard(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{
+			ownerByPropertyID: map[string]string{
+				testPropertyID1: "owner-1",
+			},
+		},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		appproperty.NewDashboardService(dashboardRepo),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/properties/"+testPropertyID1+"/dashboard", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if dashboardRepo.propertyID != testPropertyID1 {
+		t.Fatalf("unexpected dashboard property id %q", dashboardRepo.propertyID)
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["property_id"] != testPropertyID1 {
+		t.Fatalf("expected property_id %s, got %v", testPropertyID1, payload["property_id"])
+	}
+	recent, ok := payload["recent_journals"].([]any)
+	if !ok || len(recent) != 2 {
+		t.Fatalf("expected 2 recent items, got %v", payload["recent_journals"])
+	}
+}
+
+func TestGetPropertyDashboardRejectsUnassignedProperty(t *testing.T) {
+	engine := newTestEngineWithPropertyDashboard(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID2}},
+		fakePropertyRepo{
+			ownerByPropertyID: map[string]string{
+				testPropertyID1: "owner-1",
+			},
+		},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		appproperty.NewDashboardService(&fakeDashboardRepository{}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/properties/"+testPropertyID1+"/dashboard", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestGetPropertyDashboardReturnsPropertyNotFound(t *testing.T) {
+	engine := newTestEngineWithPropertyDashboard(
+		fakeUserRepo{role: "admin"},
+		fakeAuthenticator{role: "admin"},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		appproperty.NewDashboardService(&fakeDashboardRepository{}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/properties/"+testMissingPropertyID+"/dashboard", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["error_code"] != apperr.CodePropertyNotFound {
+		t.Fatalf("expected PROPERTY_NOT_FOUND, got %v", payload["error_code"])
+	}
+}
+
 func TestListPropertyRoomsReturnsAccessibleRooms(t *testing.T) {
 	call := &listRoomsCall{}
 	propertyQueryRepo := fakePropertyQueryRepo{
@@ -2739,6 +2854,7 @@ func TestGetForceTerminationReturnsNotFoundWhenRecordMissing(t *testing.T) {
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		nil,
 		handler.LeaseCommandServices{
 			GetForceTermination: applease.NewGetForceTerminationService(leaseRepo, dbtxrunner.New(db, nil)),
 		},
@@ -3111,6 +3227,28 @@ type fakePropertyQueryRepo struct {
 	rooms          []dbpropertyquery.Room
 	listRoomsCall  *listRoomsCall
 	findRoomIDSink *string
+}
+
+type fakeDashboardRepository struct {
+	propertyID string
+	year       int
+	month      int
+	dashboard  *appproperty.Dashboard
+	err        error
+}
+
+func (r *fakeDashboardRepository) GetDashboard(_ context.Context, propertyID string, year int, month int) (*appproperty.Dashboard, error) {
+	r.propertyID = propertyID
+	r.year = year
+	r.month = month
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.dashboard == nil {
+		return nil, appproperty.ErrPropertyNotFound
+	}
+
+	return r.dashboard, nil
 }
 
 type fakeTenantRepo struct {
@@ -4484,12 +4622,31 @@ func newTestEngineWithBilling(userRepo fakeUserRepo, authenticator fakeAuthentic
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		nil,
 		handler.LeaseCommandServices{Billing: billing},
 	)
 }
 
 func newTestEngineWithPropertyQueryRepo(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository) *gin.Engine {
 	return newTestEngineWithAllQueryRepos(userRepo, authenticator, propertyRepo, ownershipRepo, schedulerKey, jobRunsRepo, propertyQueryRepo, fakeLeaseQueryRepo{}, fakeTenantQueryRepo{})
+}
+
+func newTestEngineWithPropertyDashboard(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyDashboard *appproperty.DashboardService) *gin.Engine {
+	return newTestEngineWithAllServices(
+		userRepo,
+		authenticator,
+		propertyRepo,
+		ownershipRepo,
+		schedulerKey,
+		jobRunsRepo,
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
+		fakeTenantQueryRepo{},
+		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		propertyDashboard,
+	)
 }
 
 func newTestEngineWithQueryRepos(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, tenantQueryRepo dbtenantquery.Repository) *gin.Engine {
@@ -4520,6 +4677,7 @@ func newTestEngineWithAllQueryRepos(userRepo fakeUserRepo, authenticator fakeAut
 		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
 		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		nil,
 	)
 }
 
@@ -4537,10 +4695,11 @@ func newTestEngineWithTenantServices(userRepo fakeUserRepo, authenticator fakeAu
 		createTenantService,
 		updateTenantService,
 		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		nil,
 	)
 }
 
-func newTestEngineWithAllServices(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, leaseQueryRepo dbleasequery.Repository, tenantQueryRepo dbtenantquery.Repository, createTenantService *apptenant.CreateTenantService, updateTenantService *apptenant.UpdateTenantService, createLeaseService *applease.CreateLeaseService, leaseCommands ...handler.LeaseCommandServices) *gin.Engine {
+func newTestEngineWithAllServices(userRepo fakeUserRepo, authenticator fakeAuthenticator, propertyRepo fakePropertyRepo, ownershipRepo fakeResourceOwnershipRepo, schedulerKey string, jobRunsRepo fakeJobRunsRepo, propertyQueryRepo dbpropertyquery.Repository, leaseQueryRepo dbleasequery.Repository, tenantQueryRepo dbtenantquery.Repository, createTenantService *apptenant.CreateTenantService, updateTenantService *apptenant.UpdateTenantService, createLeaseService *applease.CreateLeaseService, propertyDashboard *appproperty.DashboardService, leaseCommands ...handler.LeaseCommandServices) *gin.Engine {
 	repo := &userRepo
 	userAccountRepo := testUserAccountRepositoryAdapter{repo: repo}
 	return New(
@@ -4565,6 +4724,7 @@ func newTestEngineWithAllServices(userRepo fakeUserRepo, authenticator fakeAuthe
 		),
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		propertyQueryRepo,
+		propertyDashboard,
 		leaseQueryRepo,
 		fakeRepairQueryRepo{},
 		tenantQueryRepo,
@@ -4628,6 +4788,7 @@ func newTestEngineWithNotificationSender(userRepo fakeUserRepo, authenticator fa
 		),
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		propertyQueryRepo,
+		nil,
 		fakeLeaseQueryRepo{},
 		fakeRepairQueryRepo{},
 		fakeTenantQueryRepo{},
@@ -4671,6 +4832,7 @@ func newTestEngineWithRoomServices(userRepo fakeUserRepo, authenticator fakeAuth
 		),
 		appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		propertyQueryRepo,
+		nil,
 		fakeLeaseQueryRepo{},
 		fakeRepairQueryRepo{},
 		fakeTenantQueryRepo{},

--- a/internal/platform/database/propertydashboard/repository.go
+++ b/internal/platform/database/propertydashboard/repository.go
@@ -103,7 +103,7 @@ func (r *SQLRepository) getMonthlySummary(ctx context.Context, propertyID string
 SELECT
 	COALESCE(SUM(CASE WHEN type = 'rent' AND status NOT IN ('voided', 'written_off') AND period_start >= $2 AND period_start < $3 THEN amount ELSE 0 END), 0) AS expected_rent,
 	COALESCE(SUM(CASE WHEN type = 'rent' AND period_start >= $2 AND period_start < $3 AND status = 'paid' THEN paid_amount ELSE 0 END), 0) AS collected_rent,
-	COUNT(*) FILTER (WHERE status = 'overdue') AS overdue_bill_count
+	COUNT(*) FILTER (WHERE status = 'overdue' AND period_start >= $2 AND period_start < $3) AS overdue_bill_count
 FROM bills
 WHERE property_id = $1
   AND deleted_at IS NULL

--- a/internal/platform/database/propertydashboard/repository.go
+++ b/internal/platform/database/propertydashboard/repository.go
@@ -1,0 +1,159 @@
+package propertydashboard
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	appproperty "stds_backend/internal/application/property"
+)
+
+// SQLRepository reads the property dashboard from PostgreSQL.
+type SQLRepository struct {
+	db *sql.DB
+}
+
+// NewRepository returns a PostgreSQL-backed dashboard repository.
+func NewRepository(db *sql.DB) *SQLRepository {
+	return &SQLRepository{db: db}
+}
+
+// GetDashboard returns one property's dashboard read model.
+func (r *SQLRepository) GetDashboard(ctx context.Context, propertyID string, year int, month int) (*appproperty.Dashboard, error) {
+	if err := r.ensurePropertyExists(ctx, propertyID); err != nil {
+		return nil, err
+	}
+
+	rooms, err := r.listRooms(ctx, propertyID)
+	if err != nil {
+		return nil, err
+	}
+	summary, err := r.getMonthlySummary(ctx, propertyID, year, month)
+	if err != nil {
+		return nil, err
+	}
+	journals, err := r.listRecentJournals(ctx, propertyID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &appproperty.Dashboard{
+		PropertyID:     propertyID,
+		Rooms:          rooms,
+		MonthlySummary: summary,
+		RecentJournals: journals,
+	}, nil
+}
+
+func (r *SQLRepository) ensurePropertyExists(ctx context.Context, propertyID string) error {
+	const query = `
+SELECT 1
+FROM properties
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`
+	var exists int
+	if err := r.db.QueryRowContext(ctx, query, propertyID).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return appproperty.ErrPropertyNotFound
+		}
+		return fmt.Errorf("query dashboard property: %w", err)
+	}
+
+	return nil
+}
+
+func (r *SQLRepository) listRooms(ctx context.Context, propertyID string) ([]appproperty.DashboardRoom, error) {
+	const query = `
+SELECT id, name, status
+FROM rooms
+WHERE property_id = $1
+  AND deleted_at IS NULL
+ORDER BY created_at DESC, id DESC
+`
+	rows, err := r.db.QueryContext(ctx, query, propertyID)
+	if err != nil {
+		return nil, fmt.Errorf("list dashboard rooms: %w", err)
+	}
+	defer rows.Close()
+
+	rooms := make([]appproperty.DashboardRoom, 0)
+	for rows.Next() {
+		var room appproperty.DashboardRoom
+		if err := rows.Scan(&room.ID, &room.Name, &room.Status); err != nil {
+			return nil, fmt.Errorf("scan dashboard room: %w", err)
+		}
+		rooms = append(rooms, room)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate dashboard rooms: %w", err)
+	}
+
+	return rooms, nil
+}
+
+func (r *SQLRepository) getMonthlySummary(ctx context.Context, propertyID string, year int, month int) (appproperty.DashboardMonthlySummary, error) {
+	periodStart := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := periodStart.AddDate(0, 1, 0)
+
+	const query = `
+SELECT
+	COALESCE(SUM(CASE WHEN type = 'rent' AND status NOT IN ('voided', 'written_off') AND period_start >= $2 AND period_start < $3 THEN amount ELSE 0 END), 0) AS expected_rent,
+	COALESCE(SUM(CASE WHEN type = 'rent' AND period_start >= $2 AND period_start < $3 AND status = 'paid' THEN paid_amount ELSE 0 END), 0) AS collected_rent,
+	COUNT(*) FILTER (WHERE status = 'overdue') AS overdue_bill_count
+FROM bills
+WHERE property_id = $1
+  AND deleted_at IS NULL
+`
+	var summary appproperty.DashboardMonthlySummary
+	if err := r.db.QueryRowContext(ctx, query, propertyID, periodStart, periodEnd).Scan(
+		&summary.ExpectedRent,
+		&summary.CollectedRent,
+		&summary.OverdueBillCount,
+	); err != nil {
+		return appproperty.DashboardMonthlySummary{}, fmt.Errorf("query dashboard monthly summary: %w", err)
+	}
+
+	return summary, nil
+}
+
+func (r *SQLRepository) listRecentJournals(ctx context.Context, propertyID string) ([]appproperty.DashboardRecentJournal, error) {
+	const query = `
+SELECT id, type, content, created_at
+FROM (
+	SELECT id, 'journal_log' AS type, content, created_at
+	FROM journal_logs
+	WHERE property_id = $1
+	  AND deleted_at IS NULL
+	UNION ALL
+	SELECT id, 'repair_request' AS type, title AS content, created_at
+	FROM repair_requests
+	WHERE property_id = $1
+	  AND deleted_at IS NULL
+) recent_activity
+ORDER BY created_at DESC, id DESC
+LIMIT 5
+`
+	rows, err := r.db.QueryContext(ctx, query, propertyID)
+	if err != nil {
+		return nil, fmt.Errorf("list dashboard recent journals: %w", err)
+	}
+	defer rows.Close()
+
+	journals := make([]appproperty.DashboardRecentJournal, 0)
+	for rows.Next() {
+		var journal appproperty.DashboardRecentJournal
+		if err := rows.Scan(&journal.ID, &journal.Type, &journal.Content, &journal.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan dashboard recent journal: %w", err)
+		}
+		journals = append(journals, journal)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate dashboard recent journals: %w", err)
+	}
+
+	return journals, nil
+}

--- a/internal/platform/database/propertydashboard/repository_test.go
+++ b/internal/platform/database/propertydashboard/repository_test.go
@@ -1,0 +1,97 @@
+package propertydashboard
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	appproperty "stds_backend/internal/application/property"
+)
+
+func TestGetDashboardReturnsPropertyDashboard(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	propertyID := "10000000-0000-0000-0000-000000000001"
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1\nFROM properties")).
+		WithArgs(propertyID).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(1))
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, status\nFROM rooms")).
+		WithArgs(propertyID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "status"}).
+			AddRow("20000000-0000-0000-0000-000000000001", "101 Room", "occupied"))
+	mock.ExpectQuery("(?s)type = 'rent' AND status NOT IN \\('voided', 'written_off'\\).*AS expected_rent").
+		WithArgs(
+			propertyID,
+			time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"expected_rent", "collected_rent", "overdue_bill_count"}).
+			AddRow(50000, 40000, 2))
+	mock.ExpectQuery("(?s)FROM journal_logs.*UNION ALL.*FROM repair_requests").
+		WithArgs(propertyID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "type", "content", "created_at"}).
+			AddRow("70000000-0000-0000-0000-000000000001", "repair_request", "Fix leak", createdAt.Add(time.Minute)).
+			AddRow("60000000-0000-0000-0000-000000000001", "journal_log", "Changed lobby light", createdAt))
+
+	dashboard, err := repo.GetDashboard(context.Background(), propertyID, 2026, 4)
+	if err != nil {
+		t.Fatalf("GetDashboard: %v", err)
+	}
+	if dashboard.PropertyID != propertyID {
+		t.Fatalf("PropertyID = %s", dashboard.PropertyID)
+	}
+	if len(dashboard.Rooms) != 1 || dashboard.Rooms[0].Status != "occupied" {
+		t.Fatalf("unexpected rooms: %+v", dashboard.Rooms)
+	}
+	if dashboard.MonthlySummary.ExpectedRent != 50000 || dashboard.MonthlySummary.CollectedRent != 40000 || dashboard.MonthlySummary.OverdueBillCount != 2 {
+		t.Fatalf("unexpected monthly summary: %+v", dashboard.MonthlySummary)
+	}
+	if len(dashboard.RecentJournals) != 2 {
+		t.Fatalf("unexpected recent journals: %+v", dashboard.RecentJournals)
+	}
+	if dashboard.RecentJournals[0].Type != "repair_request" || dashboard.RecentJournals[0].Content != "Fix leak" {
+		t.Fatalf("expected repair request first, got %+v", dashboard.RecentJournals[0])
+	}
+	if dashboard.RecentJournals[1].Type != "journal_log" || dashboard.RecentJournals[1].Content != "Changed lobby light" {
+		t.Fatalf("expected journal log second, got %+v", dashboard.RecentJournals[1])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestGetDashboardMapsMissingProperty(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	propertyID := "10000000-0000-0000-0000-000000000099"
+
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1\nFROM properties")).
+		WithArgs(propertyID).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}))
+
+	_, err = repo.GetDashboard(context.Background(), propertyID, 2026, 4)
+	if !errors.Is(err, appproperty.ErrPropertyNotFound) {
+		t.Fatalf("expected ErrPropertyNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}

--- a/internal/platform/database/propertydashboard/repository_test.go
+++ b/internal/platform/database/propertydashboard/repository_test.go
@@ -30,7 +30,7 @@ func TestGetDashboardReturnsPropertyDashboard(t *testing.T) {
 		WithArgs(propertyID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "status"}).
 			AddRow("20000000-0000-0000-0000-000000000001", "101 Room", "occupied"))
-	mock.ExpectQuery("(?s)type = 'rent' AND status NOT IN \\('voided', 'written_off'\\).*AS expected_rent").
+	mock.ExpectQuery("(?s)type = 'rent' AND status NOT IN \\('voided', 'written_off'\\).*AS expected_rent.*status = 'overdue' AND period_start >= \\$2 AND period_start < \\$3.*AS overdue_bill_count").
 		WithArgs(
 			propertyID,
 			time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,7 @@ import (
 	dbleasequery "stds_backend/internal/platform/database/leasequery"
 	dbleases "stds_backend/internal/platform/database/leases"
 	dbproperties "stds_backend/internal/platform/database/properties"
+	dbpropertydashboard "stds_backend/internal/platform/database/propertydashboard"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
 	dbrepair "stds_backend/internal/platform/database/repair"
 	dbresourceownership "stds_backend/internal/platform/database/resourceownership"
@@ -69,6 +70,7 @@ func New(cfg *config.Config) (*Server, error) {
 	propertyRepo := dbproperties.NewRepository(db)
 	billingRepo := dbbilling.NewRepository(db)
 	leaseRepo := dbleases.NewRepository(db)
+	propertyDashboardRepo := dbpropertydashboard.NewRepository(db)
 	propertyQueryRepo := dbpropertyquery.NewRepository(db)
 	leaseQueryRepo := dbleasequery.NewRepository(db)
 	journalRepo := dbjournal.NewRepository(db)
@@ -116,6 +118,7 @@ func New(cfg *config.Config) (*Server, error) {
 	updateRoomService := appproperty.NewUpdateRoomService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	deleteRoomService := appproperty.NewDeleteRoomService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	setRoomMaintenanceService := appproperty.NewSetRoomMaintenanceService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
+	propertyDashboardService := appproperty.NewDashboardService(propertyDashboardRepo)
 	createTenantService := apptenant.NewCreateTenantService(tenantRepositoryAdapter{repo: tenantRepo}, txRunner)
 	updateTenantService := apptenant.NewUpdateTenantService(tenantRepositoryAdapter{repo: tenantRepo}, txRunner)
 	createLeaseService := applease.NewCreateLeaseService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
@@ -160,7 +163,7 @@ func New(cfg *config.Config) (*Server, error) {
 	engine := router.New(cfg.App, logger, db, authenticator, userRepo, router.AuthorizationRepositories{
 		Properties:        propertyRepo,
 		ResourceOwnership: resourceOwnershipRepo,
-	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, leaseQueryRepo, repairRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, journalServices, repairServices, handler.LeaseCommandServices{
+	}, createUserService, sendPasswordResetService, syncAuthService, updateCurrentUserService, updateUserService, assignUserPropertiesService, jobTriggerService, propertyQueryRepo, propertyDashboardService, leaseQueryRepo, repairRepo, tenantQueryRepo, createPropertyService, updatePropertyService, deletePropertyService, createRoomService, updateRoomService, deleteRoomService, setRoomMaintenanceService, createTenantService, updateTenantService, createLeaseService, journalServices, repairServices, handler.LeaseCommandServices{
 		UpdateLease:         updateLeaseService,
 		UpdateDeposit:       updateDepositService,
 		ReplaceLease:        replaceLeaseService,


### PR DESCRIPTION
## Summary

- Implement `GET /properties/{id}/dashboard` using a property dashboard application service and cross-BC read-model repository.
- Return room status, current-month rent summary, overdue bill count, and recent activity from journal logs plus repair requests.
- Preserve existing property-scoped authorization by keeping access checks in router middleware.

## Notes

- Current month is resolved in Asia/Taipei to match financial report behavior.
- Expected rent excludes `voided` and `written_off` rent bills.
- Recent activity keeps the existing OpenAPI response shape and uses `type` values `journal_log` and `repair_request`.

## Validation

- `env GOCACHE=/tmp/go-cache go test ./internal/application/property ./internal/platform/database/propertydashboard ./internal/http/handler ./internal/http/router ./internal/architecture`
- `env GOCACHE=/tmp/go-cache go test ./...`
- `git diff --check`