### PR TITLE
Add baseline PR CI

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -62,7 +62,9 @@ jobs:
         run: npm run openapi:generate
 
       - name: Check generated OpenAPI artifacts are committed
-        run: git diff --exit-code -- docs/spec/openapi.yaml internal/http/api/openapi.gen.go
+        run: |
+          git diff --check --exit-code -- docs/spec/openapi.yaml internal/http/api/openapi.gen.go
+          git diff --exit-code -- docs/spec/openapi.yaml internal/http/api/openapi.gen.go
 
   migration-smoke:
     name: Migration smoke test

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -35,16 +35,16 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -85,10 +85,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,99 @@
+name: PR CI
+
+on:
+  pull_request:
+    branches:
+      - dev
+  push:
+    branches:
+      - dev
+
+jobs:
+  go:
+    name: Go test and build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run Go tests
+        run: go test ./...
+
+      - name: Build API
+        run: go build -o /tmp/stds-api ./cmd/api
+
+  openapi:
+    name: OpenAPI lint and generated sync
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install oapi-codegen
+        run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
+
+      - name: Lint OpenAPI source
+        run: npm run openapi:lint
+
+      - name: Regenerate OpenAPI artifacts
+        run: npm run openapi:generate
+
+      - name: Check generated OpenAPI artifacts are committed
+        run: git diff --exit-code -- docs/spec/openapi.yaml internal/http/api/openapi.gen.go
+
+  migration-smoke:
+    name: Migration smoke test
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: stds_backend
+          POSTGRES_USER: stds
+          POSTGRES_PASSWORD: stds
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U stds -d stds_backend"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run migrations against empty PostgreSQL
+        env:
+          DATABASE_URL: postgres://stds:stds@localhost:5432/stds_backend?sslmode=disable
+        run: go run ./cmd/migrate up

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .env
 /bin
+api
 /dist
 /tmp
 /coverage.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 .env
 /bin
-api
+/api
 /dist
 /tmp
 /coverage.out

--- a/README.md
+++ b/README.md
@@ -128,6 +128,24 @@ go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
 
 The generated Go bindings live in `internal/http/api/openapi.gen.go`.
 
+## CI checks
+
+The PR CI gate runs these checks for pull requests targeting `dev` and pushes to `dev`:
+
+```bash
+go test ./...
+go build -o /tmp/stds-api ./cmd/api
+npm ci
+go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
+npm run openapi:lint
+npm run openapi:generate
+git diff --exit-code -- docs/spec/openapi.yaml internal/http/api/openapi.gen.go
+docker exec stds-postgres psql -U stds -d postgres -c "DROP DATABASE IF EXISTS ci_migration_smoke"
+docker exec stds-postgres psql -U stds -d postgres -c "CREATE DATABASE ci_migration_smoke"
+DATABASE_URL=postgres://stds:stds@localhost:5432/ci_migration_smoke?sslmode=disable go run ./cmd/migrate up
+docker exec stds-postgres psql -U stds -d postgres -c "DROP DATABASE IF EXISTS ci_migration_smoke"
+```
+
 ## Database migrations
 
 - Run all pending migrations: `go run ./cmd/migrate up`

--- a/docs/spec/schema.sql
+++ b/docs/spec/schema.sql
@@ -10,6 +10,9 @@
 -- ============================================================
 
 
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+
 -- ============================================================
 -- Table: users
 -- Aggregate: User Aggregate（Identity & Access BC）
@@ -21,8 +24,8 @@ CREATE TABLE users (
     id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
     -- firebase_uid：對應 Firebase Auth 中的使用者 UID，由 Firebase 管理認證
     -- v3.0：取代原本的 password_hash，後端不儲存密碼
-    firebase_uid    VARCHAR(128) NOT NULL UNIQUE,
-    email           VARCHAR(255) NOT NULL UNIQUE,
+    firebase_uid    VARCHAR(128) NOT NULL,
+    email           VARCHAR(255) NOT NULL,
     name            VARCHAR(100) NOT NULL,
     -- role 為 Value Object，展開為欄位；RBAC 授權模型基礎
     -- role 與 assigned_property_ids 也透過 Firebase Custom Claims 存於 ID token
@@ -61,7 +64,7 @@ CREATE TABLE properties (
     address                 TEXT         NOT NULL,
     -- electricityUnitPrice：台幣正數/度，物業層級電價，可接受小數
     electricity_unit_price  NUMERIC(10,4) CHECK (electricity_unit_price > 0),
-    default_electricity_billing_cadence VARCHAR(20) NOT NULL CHECK (default_electricity_billing_cadence IN ('monthly', 'bimonthly')),
+    default_electricity_billing_cadence VARCHAR(20) NOT NULL DEFAULT 'monthly' CHECK (default_electricity_billing_cadence IN ('monthly', 'bimonthly')),
     -- owner_id：業主帳號，resource-based 存取控制用
     owner_id                UUID         NOT NULL REFERENCES users(id),
     subtitle                VARCHAR(200),
@@ -163,7 +166,7 @@ CREATE TABLE leases (
     rent_amount             INTEGER      NOT NULL CHECK (rent_amount > 0),  -- BR-02
     start_date              DATE         NOT NULL,
     end_date                DATE         NOT NULL,
-    electricity_billing_cadence VARCHAR(20) NOT NULL CHECK (electricity_billing_cadence IN ('monthly', 'bimonthly')),
+    electricity_billing_cadence VARCHAR(20) NOT NULL DEFAULT 'monthly' CHECK (electricity_billing_cadence IN ('monthly', 'bimonthly')),
     -- status：active | expired | terminated | force_terminated
     status                  VARCHAR(30)  NOT NULL CHECK (status IN ('active', 'expired', 'terminated', 'force_terminated'))
                                          DEFAULT 'active',
@@ -244,7 +247,8 @@ CREATE TABLE bills (
     deleted_at          TIMESTAMPTZ,
     created_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
     updated_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
-    version             INTEGER      NOT NULL DEFAULT 1
+    version             INTEGER      NOT NULL DEFAULT 1,
+    CONSTRAINT bills_period_range_check CHECK (period_start <= period_end)
 );
 
 -- Index 說明:
@@ -422,6 +426,29 @@ CREATE INDEX idx_repair_requests_property_status ON repair_requests (property_id
 CREATE INDEX idx_repair_requests_room_id ON repair_requests (room_id) WHERE deleted_at IS NULL;
 -- idx_repair_requests_assigned_to: 外鍵關聯
 CREATE INDEX idx_repair_requests_assigned_to ON repair_requests (assigned_to) WHERE deleted_at IS NULL AND assigned_to IS NOT NULL;
+
+
+-- ============================================================
+-- Table: scheduler_job_runs
+-- 說明: 排程任務執行紀錄，用於 job window 去重與重試追蹤
+-- ============================================================
+
+CREATE TABLE scheduler_job_runs (
+    id          UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    job_key     VARCHAR(100) NOT NULL,
+    window_key  VARCHAR(100) NOT NULL,
+    request_id  VARCHAR(100),
+    retry_count INTEGER      NOT NULL DEFAULT 0,
+    status      VARCHAR(20)  NOT NULL CHECK (status IN ('started', 'completed', 'failed', 'skipped')),
+    message     TEXT,
+    started_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    finished_at TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    UNIQUE (job_key, window_key)
+);
+
+CREATE INDEX idx_scheduler_job_runs_job_window ON scheduler_job_runs (job_key, window_key);
 
 
 -- ============================================================


### PR DESCRIPTION
## Summary

- Add a baseline GitHub Actions PR CI workflow for pull requests targeting `dev` and pushes to `dev`.
- Run Go tests, API build, OpenAPI lint/generated sync checks, and a PostgreSQL migration smoke test.
- Align `docs/spec/schema.sql` with the current migration-built schema so schema documentation and CI checks agree.
- Document the local CI-equivalent checks in `README.md` and ignore the local `api` build artifact.

## Validation

- `go test ./...`
- `go build -o /tmp/stds-api ./cmd/api`
- `npm ci`
- `go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1`
- `npm run openapi:lint`
- `npm run openapi:generate`
- `git diff --exit-code -- docs/spec/openapi.yaml internal/http/api/openapi.gen.go`
- Migration smoke test against an isolated temporary PostgreSQL database
- `git diff --check`

Closes #63
Closes #64