### PR TITLE
[codex] add repository contract tests

### DIFF
--- a/internal/platform/database/leasequery/repository_test.go
+++ b/internal/platform/database/leasequery/repository_test.go
@@ -1,0 +1,442 @@
+package leasequery
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestListAccessibleAdminDoesNotApplyPropertyScope(t *testing.T) {
+	db, mock, repo := newLeaseQueryRepoTest(t)
+	defer closeLeaseQueryDB(t, db)
+
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	l.id,
+	l.tenant_id,
+	l.property_id,
+	l.room_id,
+	l.rent_amount,
+	l.start_date,
+	l.end_date,
+	l.electricity_billing_cadence,
+	l.status,
+	l.deposit_amount,
+	l.deposit_refund_amount,
+	l.deposit_deduction_amount,
+	l.deposit_status,
+	l.deposit_deduction_reason,
+	l.notes,
+	l.termination_reason,
+	l.settlement_detail::text,
+	l.created_at,
+	l.updated_at,
+	l.version
+FROM leases l
+WHERE l.deleted_at IS NULL
+
+ORDER BY l.created_at DESC LIMIT $1 OFFSET $2`)).
+		WithArgs(10, 20).
+		WillReturnRows(leaseQueryRows().AddRow(
+			"lease-1", "tenant-1", "property-1", "room-1", 12000, startDate, endDate,
+			"monthly", "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
+		))
+
+	leases, err := repo.ListAccessible(context.Background(), "admin", []string{"property-ignored"}, ListParams{Limit: 10, Offset: 20})
+	if err != nil {
+		t.Fatalf("ListAccessible: %v", err)
+	}
+	if len(leases) != 1 {
+		t.Fatalf("expected 1 lease, got %d", len(leases))
+	}
+	if leases[0].PropertyID != "property-1" {
+		t.Fatalf("PropertyID = %q, want property-1", leases[0].PropertyID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListAccessibleOrganizerAndStaffApplyAssignedPropertyScope(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		role string
+	}{
+		{name: "organizer", role: "organizer"},
+		{name: "staff", role: "staff"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, repo := newLeaseQueryRepoTest(t)
+			defer closeLeaseQueryDB(t, db)
+
+			mock.ExpectQuery(`(?s)WHERE l\.deleted_at IS NULL\s+AND l\.property_id IN \(\$1, \$2\)\s+ORDER BY l\.created_at DESC LIMIT \$3 OFFSET \$4`).
+				WithArgs("property-1", "property-2", 25, 50).
+				WillReturnRows(leaseQueryRows())
+
+			leases, err := repo.ListAccessible(context.Background(), tc.role, []string{"property-1", "property-2"}, ListParams{Limit: 25, Offset: 50})
+			if err != nil {
+				t.Fatalf("ListAccessible: %v", err)
+			}
+			if len(leases) != 0 {
+				t.Fatalf("expected no leases, got %d", len(leases))
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
+
+func TestListAccessibleEmptyAssignedAndUnknownRoleReturnEmptyWithoutQuery(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		role                string
+		assignedPropertyIDs []string
+	}{
+		{name: "organizer empty assigned", role: "organizer"},
+		{name: "staff empty assigned", role: "staff"},
+		{name: "unknown role", role: "viewer", assignedPropertyIDs: []string{"property-1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, repo := newLeaseQueryRepoTest(t)
+			defer closeLeaseQueryDB(t, db)
+
+			leases, err := repo.ListAccessible(context.Background(), tc.role, tc.assignedPropertyIDs, ListParams{Limit: 10})
+			if err != nil {
+				t.Fatalf("ListAccessible: %v", err)
+			}
+			if len(leases) != 0 {
+				t.Fatalf("expected empty leases, got %d", len(leases))
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
+
+func TestListAccessibleAppliesFiltersAndPagination(t *testing.T) {
+	db, mock, repo := newLeaseQueryRepoTest(t)
+	defer closeLeaseQueryDB(t, db)
+
+	propertyID := "property-filter"
+	roomID := "room-filter"
+	tenantID := "tenant-filter"
+
+	mock.ExpectQuery(`(?s)l\.property_id IN \(\$1\).*l\.property_id = \$2.*l\.room_id = \$3.*l\.tenant_id = \$4.*l\.status = \$5.*LIMIT \$6 OFFSET \$7`).
+		WithArgs("property-assigned", propertyID, roomID, tenantID, "active", 30, 60).
+		WillReturnRows(leaseQueryRows())
+
+	_, err := repo.ListAccessible(context.Background(), "staff", []string{"property-assigned"}, ListParams{
+		PropertyID: &propertyID,
+		RoomID:     &roomID,
+		TenantID:   &tenantID,
+		Status:     "active",
+		Limit:      30,
+		Offset:     60,
+	})
+	if err != nil {
+		t.Fatalf("ListAccessible: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListAccessibleScansNullableFieldsAndSettlementDetail(t *testing.T) {
+	db, mock, repo := newLeaseQueryRepoTest(t)
+	defer closeLeaseQueryDB(t, db)
+
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(`(?s)WHERE l\.deleted_at IS NULL\s+ORDER BY l\.created_at DESC LIMIT \$1 OFFSET \$2`).
+		WithArgs(10, 0).
+		WillReturnRows(leaseQueryRows().
+			AddRow(
+				"lease-1", "tenant-1", "property-1", "room-1", 12000, startDate, endDate,
+				"monthly", "terminated", 24000, 18000, 6000, "refunded", "cleaning",
+				"tenant note", "early termination", `{"refund_method":"bank","deduction":6000}`, now, now, 2,
+			).
+			AddRow(
+				"lease-2", "tenant-2", "property-2", "room-2", 15000, startDate, endDate,
+				"bi_monthly", "active", 30000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
+			))
+
+	leases, err := repo.ListAccessible(context.Background(), "admin", nil, ListParams{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListAccessible: %v", err)
+	}
+	if len(leases) != 2 {
+		t.Fatalf("expected 2 leases, got %d", len(leases))
+	}
+
+	if leases[0].DepositRefundAmount == nil || *leases[0].DepositRefundAmount != 18000 {
+		t.Fatalf("DepositRefundAmount = %v, want 18000", leases[0].DepositRefundAmount)
+	}
+	if leases[0].DepositDeductionAmount == nil || *leases[0].DepositDeductionAmount != 6000 {
+		t.Fatalf("DepositDeductionAmount = %v, want 6000", leases[0].DepositDeductionAmount)
+	}
+	if leases[0].DepositDeductionReason == nil || *leases[0].DepositDeductionReason != "cleaning" {
+		t.Fatalf("DepositDeductionReason = %v, want cleaning", leases[0].DepositDeductionReason)
+	}
+	if leases[0].Notes == nil || *leases[0].Notes != "tenant note" {
+		t.Fatalf("Notes = %v, want tenant note", leases[0].Notes)
+	}
+	if leases[0].TerminationReason == nil || *leases[0].TerminationReason != "early termination" {
+		t.Fatalf("TerminationReason = %v, want early termination", leases[0].TerminationReason)
+	}
+	if leases[0].SettlementDetail == nil || (*leases[0].SettlementDetail)["refund_method"] != "bank" || (*leases[0].SettlementDetail)["deduction"] != float64(6000) {
+		t.Fatalf("SettlementDetail = %#v, want decoded detail", leases[0].SettlementDetail)
+	}
+
+	if leases[1].DepositRefundAmount != nil {
+		t.Fatalf("DepositRefundAmount = %v, want nil", leases[1].DepositRefundAmount)
+	}
+	if leases[1].DepositDeductionAmount != nil {
+		t.Fatalf("DepositDeductionAmount = %v, want nil", leases[1].DepositDeductionAmount)
+	}
+	if leases[1].DepositDeductionReason != nil {
+		t.Fatalf("DepositDeductionReason = %v, want nil", leases[1].DepositDeductionReason)
+	}
+	if leases[1].Notes != nil {
+		t.Fatalf("Notes = %v, want nil", leases[1].Notes)
+	}
+	if leases[1].TerminationReason != nil {
+		t.Fatalf("TerminationReason = %v, want nil", leases[1].TerminationReason)
+	}
+	if leases[1].SettlementDetail != nil {
+		t.Fatalf("SettlementDetail = %#v, want nil", leases[1].SettlementDetail)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindByIDAccessibleAdminSuccess(t *testing.T) {
+	db, mock, repo := newLeaseQueryRepoTest(t)
+	defer closeLeaseQueryDB(t, db)
+
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	l.id,
+	l.tenant_id,
+	l.property_id,
+	l.room_id,
+	l.rent_amount,
+	l.start_date,
+	l.end_date,
+	l.electricity_billing_cadence,
+	l.status,
+	l.deposit_amount,
+	l.deposit_refund_amount,
+	l.deposit_deduction_amount,
+	l.deposit_status,
+	l.deposit_deduction_reason,
+	l.notes,
+	l.termination_reason,
+	l.settlement_detail::text,
+	l.created_at,
+	l.updated_at,
+	l.version
+FROM leases l
+WHERE l.id = $1
+  AND l.deleted_at IS NULL
+
+LIMIT 1`)).
+		WithArgs("lease-1").
+		WillReturnRows(leaseQueryRows().AddRow(
+			"lease-1", "tenant-1", "property-1", "room-1", 12000, startDate, endDate,
+			"monthly", "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
+		))
+
+	lease, err := repo.FindByIDAccessible(context.Background(), "lease-1", "admin", []string{"property-ignored"})
+	if err != nil {
+		t.Fatalf("FindByIDAccessible: %v", err)
+	}
+	if lease.ID != "lease-1" {
+		t.Fatalf("ID = %q, want lease-1", lease.ID)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindByIDAccessibleOrganizerAndStaffApplyAssignedPropertyScope(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		role string
+	}{
+		{name: "organizer", role: "organizer"},
+		{name: "staff", role: "staff"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, repo := newLeaseQueryRepoTest(t)
+			defer closeLeaseQueryDB(t, db)
+
+			now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+			startDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			endDate := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+
+			mock.ExpectQuery(`(?s)WHERE l\.id = \$1\s+AND l\.deleted_at IS NULL\s+AND l\.property_id IN \(\$2, \$3\)\s+LIMIT 1`).
+				WithArgs("lease-1", "property-1", "property-2").
+				WillReturnRows(leaseQueryRows().AddRow(
+					"lease-1", "tenant-1", "property-1", "room-1", 12000, startDate, endDate,
+					"monthly", "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
+				))
+
+			lease, err := repo.FindByIDAccessible(context.Background(), "lease-1", tc.role, []string{"property-1", "property-2"})
+			if err != nil {
+				t.Fatalf("FindByIDAccessible: %v", err)
+			}
+			if lease.PropertyID != "property-1" {
+				t.Fatalf("PropertyID = %q, want property-1", lease.PropertyID)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
+
+func TestFindByIDAccessibleEmptyAssignedAndUnknownRoleReturnNotFoundWithoutQuery(t *testing.T) {
+	for _, tc := range []struct {
+		name                string
+		role                string
+		assignedPropertyIDs []string
+	}{
+		{name: "organizer empty assigned", role: "organizer"},
+		{name: "staff empty assigned", role: "staff"},
+		{name: "unknown role", role: "viewer", assignedPropertyIDs: []string{"property-1"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock, repo := newLeaseQueryRepoTest(t)
+			defer closeLeaseQueryDB(t, db)
+
+			lease, err := repo.FindByIDAccessible(context.Background(), "lease-1", tc.role, tc.assignedPropertyIDs)
+			if lease != nil {
+				t.Fatalf("expected nil lease, got %#v", lease)
+			}
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("expected ErrNotFound, got %v", err)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
+
+func TestFindByIDAccessibleMapsNoRowsToErrNotFound(t *testing.T) {
+	db, mock, repo := newLeaseQueryRepoTest(t)
+	defer closeLeaseQueryDB(t, db)
+
+	mock.ExpectQuery(`(?s)WHERE l\.id = \$1\s+AND l\.deleted_at IS NULL\s+LIMIT 1`).
+		WithArgs("lease-missing").
+		WillReturnRows(leaseQueryRows())
+
+	lease, err := repo.FindByIDAccessible(context.Background(), "lease-missing", "admin", nil)
+	if lease != nil {
+		t.Fatalf("expected nil lease, got %#v", lease)
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindByIDAccessibleInvalidSettlementDetailReturnsError(t *testing.T) {
+	db, mock, repo := newLeaseQueryRepoTest(t)
+	defer closeLeaseQueryDB(t, db)
+
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(`(?s)WHERE l\.id = \$1\s+AND l\.deleted_at IS NULL\s+LIMIT 1`).
+		WithArgs("lease-1").
+		WillReturnRows(leaseQueryRows().AddRow(
+			"lease-1", "tenant-1", "property-1", "room-1", 12000, startDate, endDate,
+			"monthly", "terminated", 24000, nil, nil, "held", nil, nil, nil, `{"broken"`, now, now, 1,
+		))
+
+	lease, err := repo.FindByIDAccessible(context.Background(), "lease-1", "admin", nil)
+	if lease != nil {
+		t.Fatalf("expected nil lease, got %#v", lease)
+	}
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected decode error, got ErrNotFound")
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func newLeaseQueryRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+
+	return db, mock, NewRepository(db)
+}
+
+func closeLeaseQueryDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	_ = db.Close()
+}
+
+func leaseQueryRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"tenant_id",
+		"property_id",
+		"room_id",
+		"rent_amount",
+		"start_date",
+		"end_date",
+		"electricity_billing_cadence",
+		"status",
+		"deposit_amount",
+		"deposit_refund_amount",
+		"deposit_deduction_amount",
+		"deposit_status",
+		"deposit_deduction_reason",
+		"notes",
+		"termination_reason",
+		"settlement_detail",
+		"created_at",
+		"updated_at",
+		"version",
+	})
+}

--- a/internal/platform/database/leases/repository_test.go
+++ b/internal/platform/database/leases/repository_test.go
@@ -619,7 +619,7 @@ func TestCreateBillsPreparesAndExecsMultipleRows(t *testing.T) {
 	periodEnd := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
 	dueDate := time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC)
 
-	mock.ExpectPrepare(regexp.QuoteMeta(`INSERT INTO bills (
+	prepared := mock.ExpectPrepare(regexp.QuoteMeta(`INSERT INTO bills (
 	lease_id,
 	tenant_id,
 	room_id,
@@ -630,22 +630,11 @@ func TestCreateBillsPreparesAndExecsMultipleRows(t *testing.T) {
 	period_end,
 	due_date,
 	status
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`)).
-		ExpectExec().
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`))
+	prepared.ExpectExec().
 		WithArgs("lease-1", "tenant-1", "room-1", "property-1", "rent", amount, periodStart, periodEnd, dueDate, "pending_payment").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO bills (
-	lease_id,
-	tenant_id,
-	room_id,
-	property_id,
-	type,
-	amount,
-	period_start,
-	period_end,
-	due_date,
-	status
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`)).
+	prepared.ExpectExec().
 		WithArgs("lease-1", "tenant-1", "room-1", "property-1", "electricity", nil, periodStart, periodEnd, dueDate, "pending_meter").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 

--- a/internal/platform/database/leases/repository_test.go
+++ b/internal/platform/database/leases/repository_test.go
@@ -6,9 +6,837 @@ import (
 	"errors"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
+
+func TestFindTenantByIDReturnsNotFoundWhenNoRows(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, status
+FROM tenants
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1`)).
+		WithArgs("tenant-1").
+		WillReturnError(sql.ErrNoRows)
+
+	tenant, err := repo.FindTenantByID(context.Background(), tx, "tenant-1")
+	if !errors.Is(err, ErrTenantNotFound) {
+		t.Fatalf("expected ErrTenantNotFound, got tenant=%+v err=%v", tenant, err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindRoomByIDForUpdateLocksRoomAndScansDefaultCadence(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	r.id,
+	r.property_id,
+	r.status,
+	p.default_electricity_billing_cadence
+FROM rooms r
+JOIN properties p ON p.id = r.property_id
+WHERE r.id = $1
+  AND r.deleted_at IS NULL
+  AND p.deleted_at IS NULL
+FOR UPDATE`)).
+		WithArgs("room-1").
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "property_id", "status", "default_electricity_billing_cadence",
+		}).AddRow("room-1", "property-1", "vacant", "monthly"))
+
+	room, err := repo.FindRoomByIDForUpdate(context.Background(), tx, "room-1")
+	if err != nil {
+		t.Fatalf("FindRoomByIDForUpdate: %v", err)
+	}
+	if room.ID != "room-1" || room.PropertyID != "property-1" || room.Status != "vacant" || room.DefaultElectricityBillingCadence != "monthly" {
+		t.Fatalf("unexpected room: %+v", room)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindLeaseByIDForUpdateScansNullableFieldsAndSettlementDetail(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	now := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2027, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	id,
+	tenant_id,
+	property_id,
+	room_id,
+	rent_amount,
+	start_date,
+	end_date,
+	electricity_billing_cadence,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	deposit_deduction_reason,
+	notes,
+	termination_reason,
+	settlement_detail::text,
+	created_at,
+	updated_at,
+	version
+FROM leases
+WHERE id = $1
+  AND deleted_at IS NULL
+FOR UPDATE`)).
+		WithArgs("lease-1").
+		WillReturnRows(newLeaseRows().AddRow(
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly",
+			"terminated", 50000, 30000, 20000, "settled", "cleaning", "renewal candidate",
+			"tenant requested move-out", `{"deductions":[{"type":"cleaning","amount":20000}],"refund":30000}`,
+			now, now, 7,
+		))
+
+	lease, err := repo.FindLeaseByIDForUpdate(context.Background(), tx, "lease-1")
+	if err != nil {
+		t.Fatalf("FindLeaseByIDForUpdate: %v", err)
+	}
+	if lease.DepositRefundAmount == nil || *lease.DepositRefundAmount != 30000 {
+		t.Fatalf("unexpected deposit refund amount: %+v", lease.DepositRefundAmount)
+	}
+	if lease.DepositDeductionAmount == nil || *lease.DepositDeductionAmount != 20000 {
+		t.Fatalf("unexpected deposit deduction amount: %+v", lease.DepositDeductionAmount)
+	}
+	if lease.DepositDeductionReason == nil || *lease.DepositDeductionReason != "cleaning" {
+		t.Fatalf("unexpected deposit deduction reason: %+v", lease.DepositDeductionReason)
+	}
+	if lease.Notes == nil || *lease.Notes != "renewal candidate" {
+		t.Fatalf("unexpected notes: %+v", lease.Notes)
+	}
+	if lease.TerminationReason == nil || *lease.TerminationReason != "tenant requested move-out" {
+		t.Fatalf("unexpected termination reason: %+v", lease.TerminationReason)
+	}
+	if lease.SettlementDetail == nil || (*lease.SettlementDetail)["refund"] != float64(30000) {
+		t.Fatalf("unexpected settlement detail: %+v", lease.SettlementDetail)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateLeasePersistsHeldDepositStatusAndNotes(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	now := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2027, 4, 30, 0, 0, 0, 0, time.UTC)
+	notes := "prefers email"
+
+	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO leases (
+	tenant_id,
+	room_id,
+	property_id,
+	rent_amount,
+	start_date,
+	end_date,
+	electricity_billing_cadence,
+	deposit_amount,
+	deposit_status,
+	notes
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'held', $9)
+RETURNING
+	id,
+	tenant_id,
+	property_id,
+	room_id,
+	rent_amount,
+	start_date,
+	end_date,
+	electricity_billing_cadence,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	deposit_deduction_reason,
+	notes,
+	termination_reason,
+	settlement_detail::text,
+	created_at,
+	updated_at,
+	version`)).
+		WithArgs("tenant-1", "room-1", "property-1", 25000, startDate, endDate, "monthly", 50000, &notes).
+		WillReturnRows(newLeaseRows().AddRow(
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly",
+			"active", 50000, nil, nil, "held", nil, notes, nil, nil, now, now, 1,
+		))
+
+	lease, err := repo.CreateLease(context.Background(), tx, CreateLeaseParams{
+		TenantID:                  "tenant-1",
+		RoomID:                    "room-1",
+		PropertyID:                "property-1",
+		RentAmount:                25000,
+		StartDate:                 startDate,
+		EndDate:                   endDate,
+		ElectricityBillingCadence: "monthly",
+		DepositAmount:             50000,
+		Notes:                     &notes,
+	})
+	if err != nil {
+		t.Fatalf("CreateLease: %v", err)
+	}
+	if lease.DepositStatus != "held" {
+		t.Fatalf("expected held deposit status, got %q", lease.DepositStatus)
+	}
+	if lease.Notes == nil || *lease.Notes != notes {
+		t.Fatalf("unexpected notes: %+v", lease.Notes)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestLeaseReturningCommandsMapNoRowsToNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *SQLRepository, *sql.Tx) (*Lease, error)
+	}{
+		{
+			name: "TerminateLease",
+			run: func(ctx context.Context, repo *SQLRepository, tx *sql.Tx) (*Lease, error) {
+				endDate := time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC)
+				return repo.TerminateLease(ctx, tx, TerminateLeaseParams{
+					LeaseID:           "lease-1",
+					EndDate:           endDate,
+					TerminationReason: "tenant requested",
+				})
+			},
+		},
+		{
+			name: "ForceTerminateLease",
+			run: func(ctx context.Context, repo *SQLRepository, tx *sql.Tx) (*Lease, error) {
+				return repo.ForceTerminateLease(ctx, tx, ForceTerminateLeaseParams{
+					LeaseID:           "lease-1",
+					TerminationReason: "breach",
+					DepositStatus:     "forfeited",
+				})
+			},
+		},
+		{
+			name: "UpdateLeaseConditions",
+			run: func(ctx context.Context, repo *SQLRepository, tx *sql.Tx) (*Lease, error) {
+				return repo.UpdateLeaseConditions(ctx, tx, UpdateLeaseParams{
+					LeaseID:    "lease-1",
+					RentAmount: 28000,
+				})
+			},
+		},
+		{
+			name: "SettleDeposit",
+			run: func(ctx context.Context, repo *SQLRepository, tx *sql.Tx) (*Lease, error) {
+				reason := "cleaning"
+				return repo.SettleDeposit(ctx, tx, SettleDepositParams{
+					LeaseID:                "lease-1",
+					RefundAmount:           30000,
+					DeductionAmount:        20000,
+					DepositDeductionReason: &reason,
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, repo := newLeaseRepoTest(t)
+			defer closeLeaseDB(t, db)
+			tx := beginLeaseTx(t, db, mock)
+
+			mock.ExpectQuery("UPDATE leases").
+				WillReturnError(sql.ErrNoRows)
+
+			lease, err := tt.run(context.Background(), repo, tx)
+			if !errors.Is(err, ErrLeaseNotFound) {
+				t.Fatalf("expected ErrLeaseNotFound, got lease=%+v err=%v", lease, err)
+			}
+
+			mock.ExpectRollback()
+			if err := tx.Rollback(); err != nil {
+				t.Fatalf("Rollback: %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
+
+func TestTerminateLeaseUpdatesFieldsAndScansReturnedLease(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	now := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE leases
+SET status = 'terminated',
+	end_date = $2,
+	termination_reason = $3,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	tenant_id,
+	property_id,
+	room_id,
+	rent_amount,
+	start_date,
+	end_date,
+	electricity_billing_cadence,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	deposit_deduction_reason,
+	notes,
+	termination_reason,
+	settlement_detail::text,
+	created_at,
+	updated_at,
+	version`)).
+		WithArgs("lease-1", endDate, "tenant requested").
+		WillReturnRows(newLeaseRows().AddRow(
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly",
+			"terminated", 50000, nil, nil, "held", nil, nil, "tenant requested", nil, now, now, 2,
+		))
+
+	lease, err := repo.TerminateLease(context.Background(), tx, TerminateLeaseParams{
+		LeaseID:           "lease-1",
+		EndDate:           endDate,
+		TerminationReason: "tenant requested",
+	})
+	if err != nil {
+		t.Fatalf("TerminateLease: %v", err)
+	}
+	if lease.Status != "terminated" || lease.TerminationReason == nil || *lease.TerminationReason != "tenant requested" {
+		t.Fatalf("unexpected lease: %+v", lease)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestForceTerminateLeaseUpdatesReasonAndDepositStatus(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	now := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2027, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE leases
+SET status = 'force_terminated',
+	termination_reason = $2,
+	deposit_status = $3,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	tenant_id,
+	property_id,
+	room_id,
+	rent_amount,
+	start_date,
+	end_date,
+	electricity_billing_cadence,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	deposit_deduction_reason,
+	notes,
+	termination_reason,
+	settlement_detail::text,
+	created_at,
+	updated_at,
+	version`)).
+		WithArgs("lease-1", "breach", "forfeited").
+		WillReturnRows(newLeaseRows().AddRow(
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly",
+			"force_terminated", 50000, nil, nil, "forfeited", nil, nil, "breach", nil, now, now, 3,
+		))
+
+	lease, err := repo.ForceTerminateLease(context.Background(), tx, ForceTerminateLeaseParams{
+		LeaseID:           "lease-1",
+		TerminationReason: "breach",
+		DepositStatus:     "forfeited",
+	})
+	if err != nil {
+		t.Fatalf("ForceTerminateLease: %v", err)
+	}
+	if lease.Status != "force_terminated" || lease.DepositStatus != "forfeited" {
+		t.Fatalf("unexpected lease: %+v", lease)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdateLeaseConditionsUpdatesRentAmount(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	now := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2027, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE leases
+SET rent_amount = $2,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	tenant_id,
+	property_id,
+	room_id,
+	rent_amount,
+	start_date,
+	end_date,
+	electricity_billing_cadence,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	deposit_deduction_reason,
+	notes,
+	termination_reason,
+	settlement_detail::text,
+	created_at,
+	updated_at,
+	version`)).
+		WithArgs("lease-1", 28000).
+		WillReturnRows(newLeaseRows().AddRow(
+			"lease-1", "tenant-1", "property-1", "room-1", 28000, startDate, endDate, "monthly",
+			"active", 50000, nil, nil, "held", nil, nil, nil, nil, now, now, 4,
+		))
+
+	lease, err := repo.UpdateLeaseConditions(context.Background(), tx, UpdateLeaseParams{
+		LeaseID:    "lease-1",
+		RentAmount: 28000,
+	})
+	if err != nil {
+		t.Fatalf("UpdateLeaseConditions: %v", err)
+	}
+	if lease.RentAmount != 28000 || lease.Version != 4 {
+		t.Fatalf("unexpected lease: %+v", lease)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestSettleDepositUpdatesSettlementFields(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	now := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2027, 4, 30, 0, 0, 0, 0, time.UTC)
+	reason := "cleaning"
+
+	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE leases
+SET deposit_status = 'settled',
+	deposit_refund_amount = $2,
+	deposit_deduction_amount = $3,
+	deposit_deduction_reason = $4,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	tenant_id,
+	property_id,
+	room_id,
+	rent_amount,
+	start_date,
+	end_date,
+	electricity_billing_cadence,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	deposit_deduction_reason,
+	notes,
+	termination_reason,
+	settlement_detail::text,
+	created_at,
+	updated_at,
+	version`)).
+		WithArgs("lease-1", 30000, 20000, reason).
+		WillReturnRows(newLeaseRows().AddRow(
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly",
+			"terminated", 50000, 30000, 20000, "settled", reason, nil, nil, nil, now, now, 5,
+		))
+
+	lease, err := repo.SettleDeposit(context.Background(), tx, SettleDepositParams{
+		LeaseID:                "lease-1",
+		RefundAmount:           30000,
+		DeductionAmount:        20000,
+		DepositDeductionReason: &reason,
+	})
+	if err != nil {
+		t.Fatalf("SettleDeposit: %v", err)
+	}
+	if lease.DepositStatus != "settled" || lease.DepositRefundAmount == nil || *lease.DepositRefundAmount != 30000 {
+		t.Fatalf("unexpected lease: %+v", lease)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListBillsByLeaseIDForUpdateLocksBills(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	periodStart := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, type, status, period_start, period_end
+FROM bills
+WHERE lease_id = $1
+  AND deleted_at IS NULL
+ORDER BY period_start ASC, type ASC
+FOR UPDATE`)).
+		WithArgs("lease-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "type", "status", "period_start", "period_end"}).
+			AddRow("bill-1", "rent", "pending_payment", periodStart, periodEnd).
+			AddRow("bill-2", "electricity", "pending_meter", periodStart, periodEnd))
+
+	bills, err := repo.ListBillsByLeaseIDForUpdate(context.Background(), tx, "lease-1")
+	if err != nil {
+		t.Fatalf("ListBillsByLeaseIDForUpdate: %v", err)
+	}
+	if len(bills) != 2 || bills[0].ID != "bill-1" || bills[1].Type != "electricity" {
+		t.Fatalf("unexpected bills: %+v", bills)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateBillsNoOpsWhenEmpty(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+
+	if err := repo.CreateBills(context.Background(), tx, nil); err != nil {
+		t.Fatalf("CreateBills: %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateBillsPreparesAndExecsMultipleRows(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	amount := 25000
+	periodStart := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
+	dueDate := time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectPrepare(regexp.QuoteMeta(`INSERT INTO bills (
+	lease_id,
+	tenant_id,
+	room_id,
+	property_id,
+	type,
+	amount,
+	period_start,
+	period_end,
+	due_date,
+	status
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`)).
+		ExpectExec().
+		WithArgs("lease-1", "tenant-1", "room-1", "property-1", "rent", amount, periodStart, periodEnd, dueDate, "pending_payment").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO bills (
+	lease_id,
+	tenant_id,
+	room_id,
+	property_id,
+	type,
+	amount,
+	period_start,
+	period_end,
+	due_date,
+	status
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`)).
+		WithArgs("lease-1", "tenant-1", "room-1", "property-1", "electricity", nil, periodStart, periodEnd, dueDate, "pending_meter").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	err := repo.CreateBills(context.Background(), tx, []CreateBillParams{
+		{
+			LeaseID:     "lease-1",
+			TenantID:    "tenant-1",
+			RoomID:      "room-1",
+			PropertyID:  "property-1",
+			Type:        "rent",
+			Amount:      &amount,
+			PeriodStart: periodStart,
+			PeriodEnd:   periodEnd,
+			DueDate:     dueDate,
+			Status:      "pending_payment",
+		},
+		{
+			LeaseID:     "lease-1",
+			TenantID:    "tenant-1",
+			RoomID:      "room-1",
+			PropertyID:  "property-1",
+			Type:        "electricity",
+			PeriodStart: periodStart,
+			PeriodEnd:   periodEnd,
+			DueDate:     dueDate,
+			Status:      "pending_meter",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBills: %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestVoidRentBillsFromDueDateVoidsPendingRentBills(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	dueDate := time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE bills
+SET status = 'voided',
+	updated_at = now(),
+	version = version + 1
+WHERE lease_id = $1
+  AND type = 'rent'
+  AND due_date >= $2
+  AND status IN ('pending_payment', 'pending_meter')
+  AND deleted_at IS NULL`)).
+		WithArgs("lease-1", dueDate).
+		WillReturnResult(sqlmock.NewResult(0, 2))
+
+	if err := repo.VoidRentBillsFromDueDate(context.Background(), tx, "lease-1", dueDate); err != nil {
+		t.Fatalf("VoidRentBillsFromDueDate: %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestVoidBillsOverlappingOrAfterVoidsPendingBillsByPeriodBoundary(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	boundary := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE bills
+SET status = 'voided',
+	updated_at = now(),
+	version = version + 1
+WHERE lease_id = $1
+  AND period_end >= $2
+  AND status IN ('pending_payment', 'pending_meter')
+  AND deleted_at IS NULL`)).
+		WithArgs("lease-1", boundary).
+		WillReturnResult(sqlmock.NewResult(0, 3))
+
+	if err := repo.VoidBillsOverlappingOrAfter(context.Background(), tx, "lease-1", boundary); err != nil {
+		t.Fatalf("VoidBillsOverlappingOrAfter: %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestRoomAndTenantStatusCommandsExecuteExpectedUpdates(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		arg  string
+		run  func(context.Context, *SQLRepository, *sql.Tx, string) error
+	}{
+		{
+			name: "MarkRoomOccupied",
+			sql: `UPDATE rooms
+SET status = 'occupied',
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL`,
+			arg: "room-1",
+			run: func(ctx context.Context, repo *SQLRepository, tx *sql.Tx, id string) error {
+				return repo.MarkRoomOccupied(ctx, tx, id)
+			},
+		},
+		{
+			name: "MarkRoomVacant",
+			sql: `UPDATE rooms
+SET status = 'vacant',
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL`,
+			arg: "room-1",
+			run: func(ctx context.Context, repo *SQLRepository, tx *sql.Tx, id string) error {
+				return repo.MarkRoomVacant(ctx, tx, id)
+			},
+		},
+		{
+			name: "ActivateTenant",
+			sql: `UPDATE tenants
+SET status = 'active',
+	updated_at = now()
+WHERE id = $1
+  AND status = 'inactive'
+  AND deleted_at IS NULL`,
+			arg: "tenant-1",
+			run: func(ctx context.Context, repo *SQLRepository, tx *sql.Tx, id string) error {
+				return repo.ActivateTenant(ctx, tx, id)
+			},
+		},
+		{
+			name: "DeactivateTenantIfNoActiveLeases",
+			sql: `UPDATE tenants
+SET status = 'inactive',
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+  AND NOT EXISTS (
+	SELECT 1
+	FROM leases
+	WHERE tenant_id = $1
+	  AND status IN ('active', 'expired')
+	  AND deleted_at IS NULL
+  )`,
+			arg: "tenant-1",
+			run: func(ctx context.Context, repo *SQLRepository, tx *sql.Tx, id string) error {
+				return repo.DeactivateTenantIfNoActiveLeases(ctx, tx, id)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, repo := newLeaseRepoTest(t)
+			defer closeLeaseDB(t, db)
+			tx := beginLeaseTx(t, db, mock)
+
+			mock.ExpectExec(regexp.QuoteMeta(tt.sql)).
+				WithArgs(tt.arg).
+				WillReturnResult(sqlmock.NewResult(0, 1))
+
+			if err := tt.run(context.Background(), repo, tx, tt.arg); err != nil {
+				t.Fatalf("%s: %v", tt.name, err)
+			}
+
+			mock.ExpectRollback()
+			if err := tx.Rollback(); err != nil {
+				t.Fatalf("Rollback: %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
 
 func TestMarkLeaseExpiredReturnsNotFoundWhenNoRowsAffected(t *testing.T) {
 	db, mock, repo := newLeaseRepoTest(t)
@@ -132,4 +960,29 @@ func beginLeaseTx(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.Tx {
 		t.Fatalf("Begin: %v", err)
 	}
 	return tx
+}
+
+func newLeaseRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"tenant_id",
+		"property_id",
+		"room_id",
+		"rent_amount",
+		"start_date",
+		"end_date",
+		"electricity_billing_cadence",
+		"status",
+		"deposit_amount",
+		"deposit_refund_amount",
+		"deposit_deduction_amount",
+		"deposit_status",
+		"deposit_deduction_reason",
+		"notes",
+		"termination_reason",
+		"settlement_detail",
+		"created_at",
+		"updated_at",
+		"version",
+	})
 }

--- a/internal/platform/database/properties/repository_test.go
+++ b/internal/platform/database/properties/repository_test.go
@@ -1,0 +1,914 @@
+package properties
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestFindOwnerIDByPropertyIDReturnsOwnerID(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT owner_id
+FROM properties
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("property-1").
+		WillReturnRows(sqlmock.NewRows([]string{"owner_id"}).AddRow("owner-1"))
+
+	ownerID, err := repo.FindOwnerIDByPropertyID(context.Background(), "property-1")
+	if err != nil {
+		t.Fatalf("FindOwnerIDByPropertyID: %v", err)
+	}
+	if ownerID != "owner-1" {
+		t.Fatalf("ownerID = %q, want owner-1", ownerID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindOwnerIDByPropertyIDMapsNoRowsToNotFound(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT owner_id
+FROM properties
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("property-404").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.FindOwnerIDByPropertyID(context.Background(), "property-404")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreatePersistsPropertyInTransaction(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Minute)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO properties (
+	name,
+	address,
+	electricity_unit_price,
+	default_electricity_billing_cadence,
+	owner_id
+) VALUES ($1, $2, $3, $4, $5)
+RETURNING
+	id,
+	name,
+	address,
+	electricity_unit_price,
+	default_electricity_billing_cadence,
+	owner_id,
+	created_at,
+	updated_at,
+	version
+`)).
+		WithArgs("Green Villa", "Taipei", 4.5, "monthly", "owner-1").
+		WillReturnRows(propertyRows().AddRow(
+			"property-1",
+			"Green Villa",
+			"Taipei",
+			4.5,
+			"monthly",
+			"owner-1",
+			createdAt,
+			updatedAt,
+			1,
+		))
+
+	property, err := repo.Create(context.Background(), tx, CreatePropertyParams{
+		Name:                             "Green Villa",
+		Address:                          "Taipei",
+		ElectricityUnitPrice:             4.5,
+		DefaultElectricityBillingCadence: "monthly",
+		OwnerID:                          "owner-1",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if property.ID != "property-1" || property.Name != "Green Villa" || property.Address != "Taipei" || property.OwnerID != "owner-1" {
+		t.Fatalf("unexpected property: %+v", property)
+	}
+	if property.ElectricityUnitPrice == nil || *property.ElectricityUnitPrice != 4.5 {
+		t.Fatalf("ElectricityUnitPrice = %v, want 4.5", property.ElectricityUnitPrice)
+	}
+	if property.DefaultElectricityBillingCadence != "monthly" {
+		t.Fatalf("DefaultElectricityBillingCadence = %q, want monthly", property.DefaultElectricityBillingCadence)
+	}
+	if property.CreatedAt != createdAt || property.UpdatedAt != updatedAt || property.Version != 1 {
+		t.Fatalf("unexpected audit fields: %+v", property)
+	}
+
+	mock.ExpectCommit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindByIDScansNullableElectricityUnitPrice(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Minute)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT
+	id,
+	name,
+	address,
+	electricity_unit_price,
+	default_electricity_billing_cadence,
+	owner_id,
+	created_at,
+	updated_at,
+	version
+FROM properties
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("property-1").
+		WillReturnRows(propertyRows().AddRow(
+			"property-1",
+			"Green Villa",
+			"Taipei",
+			nil,
+			"bimonthly",
+			"owner-1",
+			createdAt,
+			updatedAt,
+			3,
+		))
+
+	property, err := repo.FindByID(context.Background(), tx, "property-1")
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if property.ElectricityUnitPrice != nil {
+		t.Fatalf("ElectricityUnitPrice = %v, want nil", property.ElectricityUnitPrice)
+	}
+	if property.DefaultElectricityBillingCadence != "bimonthly" {
+		t.Fatalf("DefaultElectricityBillingCadence = %q, want bimonthly", property.DefaultElectricityBillingCadence)
+	}
+	if property.Version != 3 {
+		t.Fatalf("Version = %d, want 3", property.Version)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindByIDMapsNoRowsToNotFound(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT
+	id,
+	name,
+	address,
+	electricity_unit_price,
+	default_electricity_billing_cadence,
+	owner_id,
+	created_at,
+	updated_at,
+	version
+FROM properties
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("property-404").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.FindByID(context.Background(), tx, "property-404")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdatePersistsPropertyWithNullableElectricityUnitPrice(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Minute)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+UPDATE properties
+SET name = $2,
+	address = $3,
+	electricity_unit_price = $4,
+	default_electricity_billing_cadence = $5,
+	owner_id = $6,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $7
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	name,
+	address,
+	electricity_unit_price,
+	default_electricity_billing_cadence,
+	owner_id,
+	created_at,
+	updated_at,
+	version
+`)).
+		WithArgs("property-1", "Green Villa Updated", "New Taipei", nil, "bimonthly", "owner-2", 3).
+		WillReturnRows(propertyRows().AddRow(
+			"property-1",
+			"Green Villa Updated",
+			"New Taipei",
+			nil,
+			"bimonthly",
+			"owner-2",
+			createdAt,
+			updatedAt,
+			4,
+		))
+
+	property, err := repo.Update(context.Background(), tx, UpdatePropertyParams{
+		ID:                               "property-1",
+		Name:                             "Green Villa Updated",
+		Address:                          "New Taipei",
+		ElectricityUnitPrice:             nil,
+		DefaultElectricityBillingCadence: "bimonthly",
+		OwnerID:                          "owner-2",
+		Version:                          3,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if property.Name != "Green Villa Updated" || property.Address != "New Taipei" || property.OwnerID != "owner-2" {
+		t.Fatalf("unexpected property: %+v", property)
+	}
+	if property.ElectricityUnitPrice != nil {
+		t.Fatalf("ElectricityUnitPrice = %v, want nil", property.ElectricityUnitPrice)
+	}
+	if property.DefaultElectricityBillingCadence != "bimonthly" || property.Version != 4 {
+		t.Fatalf("unexpected cadence/version: %+v", property)
+	}
+
+	mock.ExpectCommit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdateMapsNoRowsToNotFound(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+	unitPrice := 5.25
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+UPDATE properties
+SET name = $2,
+	address = $3,
+	electricity_unit_price = $4,
+	default_electricity_billing_cadence = $5,
+	owner_id = $6,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $7
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	name,
+	address,
+	electricity_unit_price,
+	default_electricity_billing_cadence,
+	owner_id,
+	created_at,
+	updated_at,
+	version
+`)).
+		WithArgs("property-404", "Green Villa", "Taipei", &unitPrice, "monthly", "owner-1", 9).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.Update(context.Background(), tx, UpdatePropertyParams{
+		ID:                               "property-404",
+		Name:                             "Green Villa",
+		Address:                          "Taipei",
+		ElectricityUnitPrice:             &unitPrice,
+		DefaultElectricityBillingCadence: "monthly",
+		OwnerID:                          "owner-1",
+		Version:                          9,
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestListOccupiedRoomIDsReturnsIDsInTransaction(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id
+FROM rooms
+WHERE property_id = $1
+  AND status = 'occupied'
+  AND deleted_at IS NULL
+ORDER BY id
+`)).
+		WithArgs("property-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("room-1").AddRow("room-2"))
+
+	roomIDs, err := repo.ListOccupiedRoomIDs(context.Background(), tx, "property-1")
+	if err != nil {
+		t.Fatalf("ListOccupiedRoomIDs: %v", err)
+	}
+	if len(roomIDs) != 2 || roomIDs[0] != "room-1" || roomIDs[1] != "room-2" {
+		t.Fatalf("unexpected room ids: %+v", roomIDs)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestSoftDeleteReturnsNotFoundWhenNoRowsAffected(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+UPDATE properties
+SET deleted_at = now(),
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $2
+  AND deleted_at IS NULL
+`)).
+		WithArgs("property-404", 3).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.SoftDelete(context.Background(), tx, "property-404", 3)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateRoomPersistsRoomInTransaction(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Minute)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO rooms (
+	property_id,
+	name
+) VALUES ($1, $2)
+RETURNING
+	id,
+	property_id,
+	name,
+	status,
+	created_at,
+	updated_at
+`)).
+		WithArgs("property-1", "Room A").
+		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A", "vacant", createdAt, updatedAt))
+
+	room, err := repo.CreateRoom(context.Background(), tx, CreateRoomParams{
+		PropertyID: "property-1",
+		Name:       "Room A",
+	})
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if room.ID != "room-1" || room.PropertyID != "property-1" || room.Name != "Room A" || room.Status != "vacant" {
+		t.Fatalf("unexpected room: %+v", room)
+	}
+
+	mock.ExpectCommit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindRoomByIDReturnsRoom(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Minute)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT
+	id,
+	property_id,
+	name,
+	status,
+	created_at,
+	updated_at
+FROM rooms
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("room-1").
+		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A", "occupied", createdAt, updatedAt))
+
+	room, err := repo.FindRoomByID(context.Background(), tx, "room-1")
+	if err != nil {
+		t.Fatalf("FindRoomByID: %v", err)
+	}
+	if room.ID != "room-1" || room.PropertyID != "property-1" || room.Status != "occupied" {
+		t.Fatalf("unexpected room: %+v", room)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdateRoomUsesEmptyStatusWhenStatusIsNil(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Minute)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+UPDATE rooms
+SET name = $2,
+	status = CASE WHEN $3 = '' THEN status ELSE $3 END,
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	property_id,
+	name,
+	status,
+	created_at,
+	updated_at
+`)).
+		WithArgs("room-1", "Room A Updated", "").
+		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A Updated", "occupied", createdAt, updatedAt))
+
+	room, err := repo.UpdateRoom(context.Background(), tx, UpdateRoomParams{
+		ID:   "room-1",
+		Name: "Room A Updated",
+	})
+	if err != nil {
+		t.Fatalf("UpdateRoom: %v", err)
+	}
+	if room.Name != "Room A Updated" || room.Status != "occupied" {
+		t.Fatalf("unexpected room: %+v", room)
+	}
+
+	mock.ExpectCommit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdateRoomUsesProvidedStatusWhenStatusIsNonNil(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Minute)
+	status := "maintenance"
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+UPDATE rooms
+SET name = $2,
+	status = CASE WHEN $3 = '' THEN status ELSE $3 END,
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	property_id,
+	name,
+	status,
+	created_at,
+	updated_at
+`)).
+		WithArgs("room-1", "Room A", "maintenance").
+		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A", "maintenance", createdAt, updatedAt))
+
+	room, err := repo.UpdateRoom(context.Background(), tx, UpdateRoomParams{
+		ID:     "room-1",
+		Name:   "Room A",
+		Status: &status,
+	})
+	if err != nil {
+		t.Fatalf("UpdateRoom: %v", err)
+	}
+	if room.Status != "maintenance" {
+		t.Fatalf("Status = %q, want maintenance", room.Status)
+	}
+
+	mock.ExpectCommit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdateRoomMapsNoRowsToNotFound(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+UPDATE rooms
+SET name = $2,
+	status = CASE WHEN $3 = '' THEN status ELSE $3 END,
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	property_id,
+	name,
+	status,
+	created_at,
+	updated_at
+`)).
+		WithArgs("room-404", "Room Missing", "").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.UpdateRoom(context.Background(), tx, UpdateRoomParams{
+		ID:   "room-404",
+		Name: "Room Missing",
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestSoftDeleteRoomReturnsNotFoundWhenNoRowsAffected(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+UPDATE rooms
+SET deleted_at = now(),
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+`)).
+		WithArgs("room-404").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	err := repo.SoftDeleteRoom(context.Background(), tx, "room-404")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestSoftDeleteRoomMarksRoomDeleted(t *testing.T) {
+	db, mock, repo := newPropertyRepoTest(t)
+	defer closePropertyDB(t, db)
+	tx := beginPropertyTx(t, db, mock)
+
+	mock.ExpectExec(regexp.QuoteMeta(`
+UPDATE rooms
+SET deleted_at = now(),
+	updated_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+`)).
+		WithArgs("room-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := repo.SoftDeleteRoom(context.Background(), tx, "room-1"); err != nil {
+		t.Fatalf("SoftDeleteRoom: %v", err)
+	}
+
+	mock.ExpectCommit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestCreateRepairRequestScansNullableAssignmentFields(t *testing.T) {
+	tests := []struct {
+		name              string
+		assignedTo        any
+		assignedAt        any
+		completedAt       any
+		wantAssignedTo    *string
+		wantAssignedAt    *time.Time
+		wantCompletedAt   *time.Time
+		wantStatus        string
+		wantCompletedScan bool
+	}{
+		{
+			name:        "null assignment fields",
+			assignedTo:  nil,
+			assignedAt:  nil,
+			completedAt: nil,
+			wantStatus:  "open",
+		},
+		{
+			name:              "populated assignment fields",
+			assignedTo:        "staff-1",
+			assignedAt:        time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
+			completedAt:       time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC),
+			wantAssignedTo:    stringPtr("staff-1"),
+			wantAssignedAt:    timePtr(time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC)),
+			wantCompletedAt:   timePtr(time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)),
+			wantStatus:        "completed",
+			wantCompletedScan: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, repo := newPropertyRepoTest(t)
+			defer closePropertyDB(t, db)
+			tx := beginPropertyTx(t, db, mock)
+			submittedAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+			createdAt := submittedAt.Add(time.Minute)
+			updatedAt := createdAt.Add(time.Minute)
+
+			mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO repair_requests (
+	property_id,
+	room_id,
+	submitted_by,
+	title,
+	description
+) VALUES ($1, $2, $3, $4, $5)
+RETURNING
+	id,
+	property_id,
+	room_id,
+	submitted_by,
+	assigned_to,
+	title,
+	description,
+	status,
+	submitted_at,
+	assigned_at,
+	completed_at,
+	created_at,
+	updated_at
+`)).
+				WithArgs("property-1", "room-1", "tenant-1", "Leaking sink", "Kitchen sink leaks").
+				WillReturnRows(repairRequestRows().AddRow(
+					"repair-1",
+					"property-1",
+					"room-1",
+					"tenant-1",
+					tt.assignedTo,
+					"Leaking sink",
+					"Kitchen sink leaks",
+					tt.wantStatus,
+					submittedAt,
+					tt.assignedAt,
+					tt.completedAt,
+					createdAt,
+					updatedAt,
+				))
+
+			repairRequest, err := repo.CreateRepairRequest(context.Background(), tx, CreateRepairRequestParams{
+				PropertyID:  "property-1",
+				RoomID:      "room-1",
+				SubmittedBy: "tenant-1",
+				Title:       "Leaking sink",
+				Description: "Kitchen sink leaks",
+			})
+			if err != nil {
+				t.Fatalf("CreateRepairRequest: %v", err)
+			}
+			if repairRequest.ID != "repair-1" || repairRequest.PropertyID != "property-1" || repairRequest.RoomID != "room-1" || repairRequest.SubmittedBy != "tenant-1" {
+				t.Fatalf("unexpected repair request: %+v", repairRequest)
+			}
+			assertStringPtr(t, "AssignedTo", repairRequest.AssignedTo, tt.wantAssignedTo)
+			assertTimePtr(t, "AssignedAt", repairRequest.AssignedAt, tt.wantAssignedAt)
+			assertTimePtr(t, "CompletedAt", repairRequest.CompletedAt, tt.wantCompletedAt)
+			if tt.wantCompletedScan && repairRequest.Status != "completed" {
+				t.Fatalf("Status = %q, want completed", repairRequest.Status)
+			}
+
+			mock.ExpectCommit()
+			if err := tx.Commit(); err != nil {
+				t.Fatalf("Commit: %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
+
+func newPropertyRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+
+	return db, mock, NewRepository(db)
+}
+
+func closePropertyDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	if err := db.Close(); err != nil {
+		t.Logf("db.Close: %v", err)
+	}
+}
+
+func beginPropertyTx(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.Tx {
+	t.Helper()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	return tx
+}
+
+func propertyRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"name",
+		"address",
+		"electricity_unit_price",
+		"default_electricity_billing_cadence",
+		"owner_id",
+		"created_at",
+		"updated_at",
+		"version",
+	})
+}
+
+func roomRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"property_id",
+		"name",
+		"status",
+		"created_at",
+		"updated_at",
+	})
+}
+
+func repairRequestRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"property_id",
+		"room_id",
+		"submitted_by",
+		"assigned_to",
+		"title",
+		"description",
+		"status",
+		"submitted_at",
+		"assigned_at",
+		"completed_at",
+		"created_at",
+		"updated_at",
+	})
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func timePtr(value time.Time) *time.Time {
+	return &value
+}
+
+func assertStringPtr(t *testing.T, name string, got, want *string) {
+	t.Helper()
+
+	if got == nil || want == nil {
+		if got != want {
+			t.Fatalf("%s = %v, want %v", name, got, want)
+		}
+		return
+	}
+	if *got != *want {
+		t.Fatalf("%s = %q, want %q", name, *got, *want)
+	}
+}
+
+func assertTimePtr(t *testing.T, name string, got, want *time.Time) {
+	t.Helper()
+
+	if got == nil || want == nil {
+		if got != want {
+			t.Fatalf("%s = %v, want %v", name, got, want)
+		}
+		return
+	}
+	if !got.Equal(*want) {
+		t.Fatalf("%s = %v, want %v", name, *got, *want)
+	}
+}

--- a/internal/platform/database/properties/repository_test.go
+++ b/internal/platform/database/properties/repository_test.go
@@ -694,15 +694,14 @@ WHERE id = $1
 
 func TestCreateRepairRequestScansNullableAssignmentFields(t *testing.T) {
 	tests := []struct {
-		name              string
-		assignedTo        any
-		assignedAt        any
-		completedAt       any
-		wantAssignedTo    *string
-		wantAssignedAt    *time.Time
-		wantCompletedAt   *time.Time
-		wantStatus        string
-		wantCompletedScan bool
+		name            string
+		assignedTo      any
+		assignedAt      any
+		completedAt     any
+		wantAssignedTo  *string
+		wantAssignedAt  *time.Time
+		wantCompletedAt *time.Time
+		wantStatus      string
 	}{
 		{
 			name:        "null assignment fields",
@@ -712,15 +711,14 @@ func TestCreateRepairRequestScansNullableAssignmentFields(t *testing.T) {
 			wantStatus:  "open",
 		},
 		{
-			name:              "populated assignment fields",
-			assignedTo:        "staff-1",
-			assignedAt:        time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
-			completedAt:       time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC),
-			wantAssignedTo:    stringPtr("staff-1"),
-			wantAssignedAt:    timePtr(time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC)),
-			wantCompletedAt:   timePtr(time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)),
-			wantStatus:        "completed",
-			wantCompletedScan: true,
+			name:            "populated assignment fields",
+			assignedTo:      "staff-1",
+			assignedAt:      time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
+			completedAt:     time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC),
+			wantAssignedTo:  stringPtr("staff-1"),
+			wantAssignedAt:  timePtr(time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC)),
+			wantCompletedAt: timePtr(time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)),
+			wantStatus:      "completed",
 		},
 	}
 
@@ -789,8 +787,8 @@ RETURNING
 			assertStringPtr(t, "AssignedTo", repairRequest.AssignedTo, tt.wantAssignedTo)
 			assertTimePtr(t, "AssignedAt", repairRequest.AssignedAt, tt.wantAssignedAt)
 			assertTimePtr(t, "CompletedAt", repairRequest.CompletedAt, tt.wantCompletedAt)
-			if tt.wantCompletedScan && repairRequest.Status != "completed" {
-				t.Fatalf("Status = %q, want completed", repairRequest.Status)
+			if repairRequest.Status != tt.wantStatus {
+				t.Fatalf("Status = %q, want %q", repairRequest.Status, tt.wantStatus)
 			}
 
 			mock.ExpectCommit()

--- a/internal/platform/database/tenants/repository_test.go
+++ b/internal/platform/database/tenants/repository_test.go
@@ -67,7 +67,7 @@ RETURNING
 	if tenant.ID != "tenant-1" {
 		t.Fatalf("expected tenant-1, got %s", tenant.ID)
 	}
-	if len(tenant.Contacts) != 0 {
+	if tenant.Contacts == nil || len(tenant.Contacts) != 0 {
 		t.Fatalf("expected empty contacts, got %#v", tenant.Contacts)
 	}
 

--- a/internal/platform/database/tenants/repository_test.go
+++ b/internal/platform/database/tenants/repository_test.go
@@ -1,0 +1,457 @@
+package tenants
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestCreateUsesTransactionAndMarshalsNilContactsAsEmptyArray(t *testing.T) {
+	db, mock, repo := newTenantRepoTest(t)
+	defer closeTenantDB(t, db)
+
+	tx := beginTenantTx(t, db, mock)
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO tenants (
+	name,
+	email,
+	phone,
+	contacts
+) VALUES ($1, $2, $3, $4::jsonb)
+RETURNING
+	id,
+	name,
+	email,
+	phone,
+	contacts::text,
+	birth_date,
+	national_id,
+	address,
+	occupation,
+	status,
+	created_at,
+	updated_at,
+	version
+`)).
+		WithArgs("Tenant A", nil, nil, "[]").
+		WillReturnRows(tenantRows().AddRow(
+			"tenant-1",
+			"Tenant A",
+			nil,
+			nil,
+			"[]",
+			nil,
+			nil,
+			nil,
+			nil,
+			"active",
+			now,
+			now,
+			1,
+		))
+
+	tenant, err := repo.Create(context.Background(), tx, CreateTenantParams{
+		Name: "Tenant A",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if tenant.ID != "tenant-1" {
+		t.Fatalf("expected tenant-1, got %s", tenant.ID)
+	}
+	if len(tenant.Contacts) != 0 {
+		t.Fatalf("expected empty contacts, got %#v", tenant.Contacts)
+	}
+
+	mock.ExpectCommit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindByIDScansNullableFieldsAndContacts(t *testing.T) {
+	db, mock, repo := newTenantRepoTest(t)
+	defer closeTenantDB(t, db)
+
+	tx := beginTenantTx(t, db, mock)
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	birthDate := time.Date(1990, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT
+	id,
+	name,
+	email,
+	phone,
+	contacts::text,
+	birth_date,
+	national_id,
+	address,
+	occupation,
+	status,
+	created_at,
+	updated_at,
+	version
+FROM tenants
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("tenant-1").
+		WillReturnRows(tenantRows().AddRow(
+			"tenant-1",
+			"Tenant A",
+			"tenant@example.com",
+			"0912-345-678",
+			`[{"name":"Emergency","phone":"0987-654-321"}]`,
+			birthDate,
+			"A123456789",
+			"Taipei",
+			"Teacher",
+			"active",
+			now,
+			now,
+			3,
+		))
+
+	tenant, err := repo.FindByID(context.Background(), tx, "tenant-1")
+	if err != nil {
+		t.Fatalf("FindByID: %v", err)
+	}
+	if tenant.Email == nil || *tenant.Email != "tenant@example.com" {
+		t.Fatalf("expected email pointer, got %#v", tenant.Email)
+	}
+	if tenant.Phone == nil || *tenant.Phone != "0912-345-678" {
+		t.Fatalf("expected phone pointer, got %#v", tenant.Phone)
+	}
+	if tenant.BirthDate == nil || !tenant.BirthDate.Equal(birthDate) {
+		t.Fatalf("expected birth date %v, got %#v", birthDate, tenant.BirthDate)
+	}
+	if tenant.NationalID == nil || *tenant.NationalID != "A123456789" {
+		t.Fatalf("expected national id pointer, got %#v", tenant.NationalID)
+	}
+	if tenant.Address == nil || *tenant.Address != "Taipei" {
+		t.Fatalf("expected address pointer, got %#v", tenant.Address)
+	}
+	if tenant.Occupation == nil || *tenant.Occupation != "Teacher" {
+		t.Fatalf("expected occupation pointer, got %#v", tenant.Occupation)
+	}
+	if len(tenant.Contacts) != 1 || tenant.Contacts[0]["name"] != "Emergency" {
+		t.Fatalf("expected decoded contacts, got %#v", tenant.Contacts)
+	}
+	if tenant.Version != 3 {
+		t.Fatalf("expected version 3, got %d", tenant.Version)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindByIDMapsNoRowsToErrNotFound(t *testing.T) {
+	db, mock, repo := newTenantRepoTest(t)
+	defer closeTenantDB(t, db)
+
+	tx := beginTenantTx(t, db, mock)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT
+	id,
+	name,
+	email,
+	phone,
+	contacts::text,
+	birth_date,
+	national_id,
+	address,
+	occupation,
+	status,
+	created_at,
+	updated_at,
+	version
+FROM tenants
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("missing-tenant").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.FindByID(context.Background(), tx, "missing-tenant")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdateUsesVersionConditionAndContactsJSON(t *testing.T) {
+	db, mock, repo := newTenantRepoTest(t)
+	defer closeTenantDB(t, db)
+
+	tx := beginTenantTx(t, db, mock)
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+	email := "tenant@example.com"
+	phone := "0912-345-678"
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+UPDATE tenants
+SET name = $2,
+	email = $3,
+	phone = $4,
+	contacts = $5::jsonb,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $6
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	name,
+	email,
+	phone,
+	contacts::text,
+	birth_date,
+	national_id,
+	address,
+	occupation,
+	status,
+	created_at,
+	updated_at,
+	version
+`)).
+		WithArgs(
+			"tenant-1",
+			"Tenant Updated",
+			&email,
+			&phone,
+			`[{"name":"Emergency","phone":"0987-654-321"}]`,
+			4,
+		).
+		WillReturnRows(tenantRows().AddRow(
+			"tenant-1",
+			"Tenant Updated",
+			email,
+			phone,
+			`[{"name":"Emergency","phone":"0987-654-321"}]`,
+			nil,
+			nil,
+			nil,
+			nil,
+			"active",
+			now,
+			now,
+			5,
+		))
+
+	tenant, err := repo.Update(context.Background(), tx, UpdateTenantParams{
+		ID:    "tenant-1",
+		Name:  "Tenant Updated",
+		Email: &email,
+		Phone: &phone,
+		Contacts: []map[string]interface{}{
+			{"name": "Emergency", "phone": "0987-654-321"},
+		},
+		Version: 4,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if tenant.Version != 5 {
+		t.Fatalf("expected version 5, got %d", tenant.Version)
+	}
+	if len(tenant.Contacts) != 1 || tenant.Contacts[0]["phone"] != "0987-654-321" {
+		t.Fatalf("expected decoded contacts, got %#v", tenant.Contacts)
+	}
+
+	mock.ExpectCommit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdateMapsNoRowsToErrNotFound(t *testing.T) {
+	db, mock, repo := newTenantRepoTest(t)
+	defer closeTenantDB(t, db)
+
+	tx := beginTenantTx(t, db, mock)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+UPDATE tenants
+SET name = $2,
+	email = $3,
+	phone = $4,
+	contacts = $5::jsonb,
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND version = $6
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	name,
+	email,
+	phone,
+	contacts::text,
+	birth_date,
+	national_id,
+	address,
+	occupation,
+	status,
+	created_at,
+	updated_at,
+	version
+`)).
+		WithArgs("missing-tenant", "Tenant Updated", nil, nil, "[]", 2).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.Update(context.Background(), tx, UpdateTenantParams{
+		ID:      "missing-tenant",
+		Name:    "Tenant Updated",
+		Version: 2,
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindByIDReturnsErrorWhenContactsJSONDecodeFails(t *testing.T) {
+	db, mock, repo := newTenantRepoTest(t)
+	defer closeTenantDB(t, db)
+
+	tx := beginTenantTx(t, db, mock)
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT
+	id,
+	name,
+	email,
+	phone,
+	contacts::text,
+	birth_date,
+	national_id,
+	address,
+	occupation,
+	status,
+	created_at,
+	updated_at,
+	version
+FROM tenants
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("tenant-1").
+		WillReturnRows(tenantRows().AddRow(
+			"tenant-1",
+			"Tenant A",
+			nil,
+			nil,
+			"{invalid-json",
+			nil,
+			nil,
+			nil,
+			nil,
+			"active",
+			now,
+			now,
+			1,
+		))
+
+	_, err := repo.FindByID(context.Background(), tx, "tenant-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "decode tenant contacts") {
+		t.Fatalf("expected decode context, got %q", err.Error())
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func newTenantRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+
+	return db, mock, NewRepository(db)
+}
+
+func closeTenantDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	if err := db.Close(); err != nil {
+		t.Logf("db.Close: %v", err)
+	}
+}
+
+func beginTenantTx(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.Tx {
+	t.Helper()
+
+	mock.ExpectBegin()
+	tx, err := db.BeginTx(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BeginTx: %v", err)
+	}
+	return tx
+}
+
+func tenantRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"name",
+		"email",
+		"phone",
+		"contacts",
+		"birth_date",
+		"national_id",
+		"address",
+		"occupation",
+		"status",
+		"created_at",
+		"updated_at",
+		"version",
+	})
+}


### PR DESCRIPTION
## Summary

- Add sqlmock contract tests for property repository create/read/update/delete, owner lookup, room operations, occupied room listing, and repair request scan behavior.
- Add sqlmock contract tests for tenant repository create/read/update, nullable legacy-compatible fields, contacts JSON behavior, and not-found mapping.
- Add lease command repository coverage for locking reads, lifecycle updates, deposit settlement, bill creation/voiding, and room/tenant status update statements.
- Add lease query repository coverage for admin/staff/organizer access scope, empty assigned-property behavior, filters, not-found mapping, nullable fields, and settlement detail JSON scan behavior.

## Validation

- `go test ./internal/platform/database/properties ./internal/platform/database/tenants ./internal/platform/database/leases ./internal/platform/database/leasequery`
- `go test ./...`
- `git diff --check`

Closes #66