### PR TITLE
[codex] Strengthen repair application and domain tests

### DIFF
--- a/internal/application/repair/workflow_test.go
+++ b/internal/application/repair/workflow_test.go
@@ -14,6 +14,188 @@ import (
 	"stds_backend/internal/shared/apperr"
 )
 
+func TestCreatePersistsTrimmedRoomScopedRepair(t *testing.T) {
+	repo := &workflowRepoStub{
+		room: &Room{ID: testRoomID, PropertyID: testPropertyID},
+	}
+	service := NewCreateService(repo, fakeTxRunner{})
+
+	repairRequest, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:           " organizer ",
+		ActorUserID:         testOrganizerID,
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          testPropertyID,
+		RoomID:              testRoomID,
+		Title:               " Leak ",
+		Description:         " Bathroom leak ",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if repo.createParams.PropertyID != testPropertyID {
+		t.Fatalf("expected property_id %s, got %s", testPropertyID, repo.createParams.PropertyID)
+	}
+	if repo.createParams.RoomID != testRoomID {
+		t.Fatalf("expected room_id %s, got %s", testRoomID, repo.createParams.RoomID)
+	}
+	if repo.createParams.SubmittedBy != testOrganizerID {
+		t.Fatalf("expected submitted_by %s, got %s", testOrganizerID, repo.createParams.SubmittedBy)
+	}
+	if repo.createParams.Title != "Leak" {
+		t.Fatalf("expected trimmed title, got %q", repo.createParams.Title)
+	}
+	if repo.createParams.Description != "Bathroom leak" {
+		t.Fatalf("expected trimmed description, got %q", repo.createParams.Description)
+	}
+	if repairRequest.Status != "submitted" {
+		t.Fatalf("expected submitted status, got %s", repairRequest.Status)
+	}
+}
+
+func TestCreateRejectsBlankTitle(t *testing.T) {
+	service := NewCreateService(&workflowRepoStub{}, fakeTxRunner{})
+
+	_, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:           "organizer",
+		ActorUserID:         testOrganizerID,
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          testPropertyID,
+		RoomID:              testRoomID,
+		Title:               " ",
+	})
+
+	if !errors.Is(err, ErrValidationRepairTitleRequired) {
+		t.Fatalf("expected title validation error, got %v", err)
+	}
+}
+
+func TestCreateRejectsActorOutsideProperty(t *testing.T) {
+	service := NewCreateService(&workflowRepoStub{}, fakeTxRunner{})
+
+	_, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:           "staff",
+		ActorUserID:         testStaffID,
+		AssignedPropertyIDs: []string{testOtherPropertyID},
+		PropertyID:          testPropertyID,
+		RoomID:              testRoomID,
+		Title:               "Leak",
+	})
+
+	if !errors.Is(err, apperr.ErrForbidden) {
+		t.Fatalf("expected forbidden, got %v", err)
+	}
+}
+
+func TestCreateRejectsRoomOutsideProperty(t *testing.T) {
+	repo := &workflowRepoStub{
+		room: &Room{ID: testRoomID, PropertyID: testOtherPropertyID},
+	}
+	service := NewCreateService(repo, fakeTxRunner{})
+
+	_, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:           "organizer",
+		ActorUserID:         testOrganizerID,
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          testPropertyID,
+		RoomID:              testRoomID,
+		Title:               "Leak",
+	})
+
+	if !errors.Is(err, apperr.ErrBadRequest) {
+		t.Fatalf("expected bad request, got %v", err)
+	}
+}
+
+func TestUpdatePersistsTrimmedDescriptiveFields(t *testing.T) {
+	repo := &workflowRepoStub{repairRequest: submittedRepairRequest()}
+	service := NewUpdateService(repo, fakeTxRunner{})
+	title := " Updated leak "
+	description := " Updated description "
+
+	repairRequest, err := service.Execute(context.Background(), UpdateInput{
+		ID:          testRepairID,
+		Title:       &title,
+		Description: &description,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	if repo.updateParams.Title != "Updated leak" {
+		t.Fatalf("expected trimmed title, got %q", repo.updateParams.Title)
+	}
+	if repo.updateParams.Description != "Updated description" {
+		t.Fatalf("expected trimmed description, got %q", repo.updateParams.Description)
+	}
+	if repairRequest.Title != "Updated leak" {
+		t.Fatalf("expected updated repair title, got %q", repairRequest.Title)
+	}
+}
+
+func TestUpdateRejectsNoFields(t *testing.T) {
+	service := NewUpdateService(&workflowRepoStub{}, fakeTxRunner{})
+
+	_, err := service.Execute(context.Background(), UpdateInput{ID: testRepairID})
+
+	if !errors.Is(err, apperr.ErrBadRequest) {
+		t.Fatalf("expected bad request, got %v", err)
+	}
+}
+
+func TestUpdateRejectsBlankTitle(t *testing.T) {
+	repo := &workflowRepoStub{repairRequest: submittedRepairRequest()}
+	service := NewUpdateService(repo, fakeTxRunner{})
+	title := " "
+
+	_, err := service.Execute(context.Background(), UpdateInput{
+		ID:    testRepairID,
+		Title: &title,
+	})
+
+	if !errors.Is(err, ErrValidationRepairTitleRequired) {
+		t.Fatalf("expected title validation error, got %v", err)
+	}
+}
+
+func TestUpdateMapsMissingRepair(t *testing.T) {
+	service := NewUpdateService(&workflowRepoStub{}, fakeTxRunner{})
+	title := "Leak"
+
+	_, err := service.Execute(context.Background(), UpdateInput{
+		ID:    testRepairID,
+		Title: &title,
+	})
+
+	if !errors.Is(err, apperr.ErrRepairRequestNotFound) {
+		t.Fatalf("expected repair request not found, got %v", err)
+	}
+}
+
+func TestDeleteSoftDeletesRepair(t *testing.T) {
+	repo := &workflowRepoStub{}
+	service := NewDeleteService(repo, fakeTxRunner{})
+
+	if err := service.Execute(context.Background(), DeleteInput{ID: testRepairID}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	if repo.softDeleteID != testRepairID {
+		t.Fatalf("expected soft delete id %s, got %s", testRepairID, repo.softDeleteID)
+	}
+}
+
+func TestDeleteMapsMissingRepair(t *testing.T) {
+	repo := &workflowRepoStub{softDeleteErr: ErrRepairRequestNotFound}
+	service := NewDeleteService(repo, fakeTxRunner{})
+
+	err := service.Execute(context.Background(), DeleteInput{ID: testRepairID})
+
+	if !errors.Is(err, apperr.ErrRepairRequestNotFound) {
+		t.Fatalf("expected repair request not found, got %v", err)
+	}
+}
+
 func TestAssignRejectsStaffAssigningAnotherUser(t *testing.T) {
 	service := NewWorkflowService(&workflowRepoStub{}, fakeTxRunner{})
 
@@ -96,6 +278,27 @@ func TestAssignRejectsOwnerAssignee(t *testing.T) {
 	}
 }
 
+func TestAssignRejectsInvalidRepairStatus(t *testing.T) {
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "assigned"
+	repo := &workflowRepoStub{
+		user:          &User{ID: testOrganizerID, Role: "organizer", AssignedPropertyIDs: []string{testPropertyID}},
+		repairRequest: repairRequest,
+	}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Assign(context.Background(), AssignInput{
+		ActorRole:   "organizer",
+		ActorUserID: testOrganizerID,
+		ID:          testRepairID,
+		AssignedTo:  testOrganizerID,
+	})
+
+	if !errors.Is(err, ErrInvalidStatusForAssign) {
+		t.Fatalf("expected invalid assign status, got %v", err)
+	}
+}
+
 func TestProgressRejectsNonAssignedRepair(t *testing.T) {
 	repo := &workflowRepoStub{repairRequest: submittedRepairRequest()}
 	service := NewWorkflowService(repo, fakeTxRunner{})
@@ -104,6 +307,72 @@ func TestProgressRejectsNonAssignedRepair(t *testing.T) {
 
 	if !errors.Is(err, ErrInvalidStatusForProgress) {
 		t.Fatalf("expected invalid progress status, got %v", err)
+	}
+}
+
+func TestProgressPersistsAssignedRepair(t *testing.T) {
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "assigned"
+	repo := &workflowRepoStub{repairRequest: repairRequest}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	updated, err := service.Progress(context.Background(), testRepairID)
+	if err != nil {
+		t.Fatalf("Progress: %v", err)
+	}
+
+	if repo.progressID != testRepairID {
+		t.Fatalf("expected progress id %s, got %s", testRepairID, repo.progressID)
+	}
+	if updated.Status != "in_progress" {
+		t.Fatalf("expected in_progress status, got %s", updated.Status)
+	}
+}
+
+func TestCompleteRejectsNonInProgressRepair(t *testing.T) {
+	repo := &workflowRepoStub{repairRequest: submittedRepairRequest()}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Complete(context.Background(), testRepairID)
+
+	if !errors.Is(err, ErrInvalidStatusForComplete) {
+		t.Fatalf("expected invalid complete status, got %v", err)
+	}
+}
+
+func TestCompletePersistsCompletedAt(t *testing.T) {
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "in_progress"
+	repo := &workflowRepoStub{repairRequest: repairRequest}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+	service.now = func() time.Time { return testNow }
+
+	_, err := service.Complete(context.Background(), testRepairID)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	if repo.completeParams.ID != testRepairID {
+		t.Fatalf("expected complete id %s, got %s", testRepairID, repo.completeParams.ID)
+	}
+	if !repo.completeParams.CompletedAt.Equal(testNow) {
+		t.Fatalf("expected completed_at %s, got %s", testNow, repo.completeParams.CompletedAt)
+	}
+}
+
+func TestCompleteReturnsRestoreRoomFailure(t *testing.T) {
+	repairRequest := submittedRepairRequest()
+	repairRequest.Status = "in_progress"
+	repo := &workflowRepoStub{
+		repairRequest: repairRequest,
+		restoreErr:    errors.New("restore failed"),
+	}
+	service := NewWorkflowService(repo, fakeTxRunner{})
+
+	_, err := service.Complete(context.Background(), testRepairID)
+
+	if !errors.Is(err, apperr.ErrInternalServerError) {
+		t.Fatalf("expected internal server error, got %v", err)
 	}
 }
 
@@ -297,13 +566,14 @@ func TestCancelPublishesRepairCancelledAfterCommit(t *testing.T) {
 }
 
 const (
-	testRepairID      = "70000000-0000-0000-0000-000000000001"
-	testOtherRepairID = "70000000-0000-0000-0000-000000000002"
-	testPropertyID    = "10000000-0000-0000-0000-000000000001"
-	testRoomID        = "20000000-0000-0000-0000-000000000001"
-	testStaffID       = "00000000-0000-0000-0000-000000000002"
-	testOrganizerID   = "00000000-0000-0000-0000-000000000003"
-	testOwnerID       = "00000000-0000-0000-0000-000000000004"
+	testRepairID        = "70000000-0000-0000-0000-000000000001"
+	testOtherRepairID   = "70000000-0000-0000-0000-000000000002"
+	testPropertyID      = "10000000-0000-0000-0000-000000000001"
+	testOtherPropertyID = "10000000-0000-0000-0000-000000000099"
+	testRoomID          = "20000000-0000-0000-0000-000000000001"
+	testStaffID         = "00000000-0000-0000-0000-000000000002"
+	testOrganizerID     = "00000000-0000-0000-0000-000000000003"
+	testOwnerID         = "00000000-0000-0000-0000-000000000004"
 )
 
 var testNow = time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
@@ -325,12 +595,20 @@ func (p *repairRecordingPublisher) Publish(_ context.Context, event any) error {
 
 type workflowRepoStub struct {
 	user           *User
+	room           *Room
 	repairRequest  *RepairRequest
 	repairRequests map[string]*RepairRequest
 	roomStatus     string
+	createParams   CreateParams
+	updateParams   UpdateParams
 	assignParams   AssignParams
+	progressID     string
+	completeParams CompleteParams
 	cancelParams   CancelParams
+	softDeleteID   string
+	softDeleteErr  error
 	restoreRoomID  string
+	restoreErr     error
 }
 
 func (r *workflowRepoStub) List(context.Context, ListQuery) ([]RepairRequest, error) {
@@ -356,6 +634,9 @@ func (r *workflowRepoStub) FindByIDForUpdate(_ context.Context, _ *sql.Tx, id st
 }
 
 func (r *workflowRepoStub) FindRoomByID(context.Context, *sql.Tx, string) (*Room, error) {
+	if r.room != nil {
+		return r.room, nil
+	}
 	return &Room{ID: testRoomID, PropertyID: testPropertyID}, nil
 }
 
@@ -366,16 +647,33 @@ func (r *workflowRepoStub) FindUserByID(context.Context, *sql.Tx, string) (*User
 	return r.user, nil
 }
 
-func (r *workflowRepoStub) Create(context.Context, *sql.Tx, CreateParams) (*RepairRequest, error) {
-	return nil, nil
+func (r *workflowRepoStub) Create(_ context.Context, _ *sql.Tx, params CreateParams) (*RepairRequest, error) {
+	r.createParams = params
+	return &RepairRequest{
+		ID:          testRepairID,
+		PropertyID:  params.PropertyID,
+		RoomID:      params.RoomID,
+		SubmittedBy: params.SubmittedBy,
+		Title:       params.Title,
+		Description: params.Description,
+		Status:      "submitted",
+		SubmittedAt: testNow,
+		CreatedAt:   testNow,
+		UpdatedAt:   testNow,
+	}, nil
 }
 
-func (r *workflowRepoStub) Update(context.Context, *sql.Tx, UpdateParams) (*RepairRequest, error) {
-	return nil, nil
+func (r *workflowRepoStub) Update(_ context.Context, _ *sql.Tx, params UpdateParams) (*RepairRequest, error) {
+	r.updateParams = params
+	repairRequest := submittedRepairRequest()
+	repairRequest.Title = params.Title
+	repairRequest.Description = params.Description
+	return repairRequest, nil
 }
 
-func (r *workflowRepoStub) SoftDelete(context.Context, *sql.Tx, string) error {
-	return nil
+func (r *workflowRepoStub) SoftDelete(_ context.Context, _ *sql.Tx, id string) error {
+	r.softDeleteID = id
+	return r.softDeleteErr
 }
 
 func (r *workflowRepoStub) Assign(_ context.Context, _ *sql.Tx, params AssignParams) (*RepairRequest, error) {
@@ -387,13 +685,15 @@ func (r *workflowRepoStub) Assign(_ context.Context, _ *sql.Tx, params AssignPar
 	return repairRequest, nil
 }
 
-func (r *workflowRepoStub) Progress(context.Context, *sql.Tx, string) (*RepairRequest, error) {
+func (r *workflowRepoStub) Progress(_ context.Context, _ *sql.Tx, id string) (*RepairRequest, error) {
+	r.progressID = id
 	repairRequest := submittedRepairRequest()
 	repairRequest.Status = "in_progress"
 	return repairRequest, nil
 }
 
 func (r *workflowRepoStub) Complete(_ context.Context, _ *sql.Tx, params CompleteParams) (*RepairRequest, error) {
+	r.completeParams = params
 	if r.repairRequests != nil {
 		repairRequest := r.repairRequests[params.ID]
 		if repairRequest == nil {
@@ -428,6 +728,9 @@ func (r *workflowRepoStub) Cancel(_ context.Context, _ *sql.Tx, params CancelPar
 
 func (r *workflowRepoStub) RestoreRoomVacantIfNoActiveRepairs(_ context.Context, _ *sql.Tx, roomID string) error {
 	r.restoreRoomID = roomID
+	if r.restoreErr != nil {
+		return r.restoreErr
+	}
 	if r.repairRequests == nil || r.roomStatus != "maintenance" {
 		return nil
 	}

--- a/internal/domain/repair/aggregate_test.go
+++ b/internal/domain/repair/aggregate_test.go
@@ -1,0 +1,320 @@
+package repair
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestNewNormalizesCreateState(t *testing.T) {
+	aggregate, err := New(State{
+		ID:          " repair-1 ",
+		PropertyID:  " property-1 ",
+		RoomID:      " room-1 ",
+		SubmittedBy: " user-1 ",
+		Title:       " Leak ",
+		Description: " Bathroom leak ",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	state := aggregate.State()
+	if state.ID != "repair-1" {
+		t.Fatalf("expected trimmed id, got %q", state.ID)
+	}
+	if state.PropertyID != "property-1" {
+		t.Fatalf("expected trimmed property id, got %q", state.PropertyID)
+	}
+	if state.RoomID != "room-1" {
+		t.Fatalf("expected trimmed room id, got %q", state.RoomID)
+	}
+	if state.SubmittedBy != "user-1" {
+		t.Fatalf("expected trimmed submitted by, got %q", state.SubmittedBy)
+	}
+	if state.Title != "Leak" {
+		t.Fatalf("expected trimmed title, got %q", state.Title)
+	}
+	if state.Description != "Bathroom leak" {
+		t.Fatalf("expected trimmed description, got %q", state.Description)
+	}
+	if state.Status != StatusSubmitted {
+		t.Fatalf("expected submitted status, got %q", state.Status)
+	}
+}
+
+func TestNewRejectsInvalidCreateState(t *testing.T) {
+	t.Run("blank title", func(t *testing.T) {
+		_, err := New(State{Title: " "})
+		if !errors.Is(err, ErrTitleRequired) {
+			t.Fatalf("expected title required, got %v", err)
+		}
+	})
+
+	t.Run("invalid status", func(t *testing.T) {
+		_, err := New(State{Title: "Leak", Status: "done"})
+		if !errors.Is(err, ErrInvalidStatus) {
+			t.Fatalf("expected invalid status, got %v", err)
+		}
+	})
+}
+
+func TestRehydrateNormalizesExistingState(t *testing.T) {
+	assignedTo := " staff-1 "
+	cancelReason := " owner deferred "
+	assignedAt := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	completedAt := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+
+	aggregate, err := Rehydrate(State{
+		Title:        " Leak ",
+		Description:  " Bathroom leak ",
+		Status:       StatusCompleted,
+		AssignedTo:   &assignedTo,
+		AssignedAt:   &assignedAt,
+		CompletedAt:  &completedAt,
+		CancelReason: &cancelReason,
+	})
+	if err != nil {
+		t.Fatalf("Rehydrate: %v", err)
+	}
+
+	state := aggregate.State()
+	if state.Title != "Leak" {
+		t.Fatalf("expected trimmed title, got %q", state.Title)
+	}
+	if state.Description != "Bathroom leak" {
+		t.Fatalf("expected trimmed description, got %q", state.Description)
+	}
+	if state.AssignedTo == nil || *state.AssignedTo != "staff-1" {
+		t.Fatalf("expected trimmed assigned_to, got %#v", state.AssignedTo)
+	}
+	if state.CancelReason == nil || *state.CancelReason != "owner deferred" {
+		t.Fatalf("expected trimmed cancel reason, got %#v", state.CancelReason)
+	}
+	if state.AssignedAt == nil || !state.AssignedAt.Equal(assignedAt) {
+		t.Fatalf("expected assigned_at %s, got %#v", assignedAt, state.AssignedAt)
+	}
+	if state.CompletedAt == nil || !state.CompletedAt.Equal(completedAt) {
+		t.Fatalf("expected completed_at %s, got %#v", completedAt, state.CompletedAt)
+	}
+}
+
+func TestRehydrateRejectsInvalidExistingState(t *testing.T) {
+	_, err := Rehydrate(State{Title: "Leak", Status: "done"})
+	if !errors.Is(err, ErrInvalidStatus) {
+		t.Fatalf("expected invalid status, got %v", err)
+	}
+}
+
+func TestUpdateAppliesDescriptiveChanges(t *testing.T) {
+	aggregate := mustRepairAggregate(t, StatusSubmitted)
+	title := " Updated leak "
+	description := " Updated description "
+
+	err := aggregate.Update(UpdateInput{
+		Title:       &title,
+		Description: &description,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	state := aggregate.State()
+	if state.Title != "Updated leak" {
+		t.Fatalf("expected updated title, got %q", state.Title)
+	}
+	if state.Description != "Updated description" {
+		t.Fatalf("expected updated description, got %q", state.Description)
+	}
+}
+
+func TestUpdateRejectsBlankTitle(t *testing.T) {
+	aggregate := mustRepairAggregate(t, StatusSubmitted)
+	title := " "
+
+	err := aggregate.Update(UpdateInput{Title: &title})
+	if !errors.Is(err, ErrTitleRequired) {
+		t.Fatalf("expected title required, got %v", err)
+	}
+}
+
+func TestUpdateNilAggregateIsNoop(t *testing.T) {
+	var aggregate *Aggregate
+
+	if err := aggregate.Update(UpdateInput{}); err != nil {
+		t.Fatalf("Update nil aggregate: %v", err)
+	}
+}
+
+func TestRepairStatusTransitions(t *testing.T) {
+	assignedAt := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	completedAt := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+
+	aggregate := mustRepairAggregate(t, StatusSubmitted)
+	if err := aggregate.Assign(" staff-1 ", assignedAt); err != nil {
+		t.Fatalf("Assign: %v", err)
+	}
+	state := aggregate.State()
+	if state.Status != StatusAssigned {
+		t.Fatalf("expected assigned status, got %q", state.Status)
+	}
+	if state.AssignedTo == nil || *state.AssignedTo != "staff-1" {
+		t.Fatalf("expected assigned_to staff-1, got %#v", state.AssignedTo)
+	}
+	if state.AssignedAt == nil || !state.AssignedAt.Equal(assignedAt) {
+		t.Fatalf("expected assigned_at %s, got %#v", assignedAt, state.AssignedAt)
+	}
+
+	if err := aggregate.Progress(); err != nil {
+		t.Fatalf("Progress: %v", err)
+	}
+	if state := aggregate.State(); state.Status != StatusInProgress {
+		t.Fatalf("expected in_progress status, got %q", state.Status)
+	}
+
+	if err := aggregate.Complete(completedAt); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	state = aggregate.State()
+	if state.Status != StatusCompleted {
+		t.Fatalf("expected completed status, got %q", state.Status)
+	}
+	if state.CompletedAt == nil || !state.CompletedAt.Equal(completedAt) {
+		t.Fatalf("expected completed_at %s, got %#v", completedAt, state.CompletedAt)
+	}
+}
+
+func TestCancelActiveRepairStatuses(t *testing.T) {
+	for _, status := range []string{StatusSubmitted, StatusAssigned, StatusInProgress} {
+		t.Run(status, func(t *testing.T) {
+			reason := " owner deferred "
+			aggregate := mustRepairAggregate(t, status)
+
+			if err := aggregate.Cancel(&reason); err != nil {
+				t.Fatalf("Cancel: %v", err)
+			}
+
+			state := aggregate.State()
+			if state.Status != StatusCancelled {
+				t.Fatalf("expected cancelled status, got %q", state.Status)
+			}
+			if state.CancelReason == nil || *state.CancelReason != "owner deferred" {
+				t.Fatalf("expected trimmed cancel reason, got %#v", state.CancelReason)
+			}
+		})
+	}
+}
+
+func TestRejectsInvalidStatusTransitions(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  string
+		command func(*Aggregate) error
+		wantErr error
+	}{
+		{
+			name:    "assign non-submitted",
+			status:  StatusAssigned,
+			command: func(aggregate *Aggregate) error { return aggregate.Assign("staff-1", time.Now()) },
+			wantErr: ErrInvalidStatusForAssign,
+		},
+		{
+			name:    "progress non-assigned",
+			status:  StatusSubmitted,
+			command: func(aggregate *Aggregate) error { return aggregate.Progress() },
+			wantErr: ErrInvalidStatusForProgress,
+		},
+		{
+			name:    "complete non-in-progress",
+			status:  StatusAssigned,
+			command: func(aggregate *Aggregate) error { return aggregate.Complete(time.Now()) },
+			wantErr: ErrInvalidStatusForComplete,
+		},
+		{
+			name:    "cancel completed",
+			status:  StatusCompleted,
+			command: func(aggregate *Aggregate) error { return aggregate.Cancel(nil) },
+			wantErr: ErrRepairAlreadyCompleted,
+		},
+		{
+			name:    "cancel cancelled",
+			status:  StatusCancelled,
+			command: func(aggregate *Aggregate) error { return aggregate.Cancel(nil) },
+			wantErr: ErrInvalidStatusForCancel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aggregate := mustRepairAggregate(t, tt.status)
+
+			err := tt.command(aggregate)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("expected %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestStateReturnsDefensiveCopies(t *testing.T) {
+	assignedTo := "staff-1"
+	assignedAt := time.Date(2026, 5, 1, 9, 0, 0, 0, time.UTC)
+	completedAt := time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC)
+	cancelReason := "owner deferred"
+	aggregate, err := Rehydrate(State{
+		Title:        "Leak",
+		Status:       StatusCompleted,
+		AssignedTo:   &assignedTo,
+		AssignedAt:   &assignedAt,
+		CompletedAt:  &completedAt,
+		CancelReason: &cancelReason,
+	})
+	if err != nil {
+		t.Fatalf("Rehydrate: %v", err)
+	}
+
+	state := aggregate.State()
+	*state.AssignedTo = "changed"
+	*state.AssignedAt = state.AssignedAt.Add(time.Hour)
+	*state.CompletedAt = state.CompletedAt.Add(time.Hour)
+	*state.CancelReason = "changed"
+
+	unchanged := aggregate.State()
+	if unchanged.AssignedTo == nil || *unchanged.AssignedTo != assignedTo {
+		t.Fatalf("expected assigned_to unchanged, got %#v", unchanged.AssignedTo)
+	}
+	if unchanged.AssignedAt == nil || !unchanged.AssignedAt.Equal(assignedAt) {
+		t.Fatalf("expected assigned_at unchanged, got %#v", unchanged.AssignedAt)
+	}
+	if unchanged.CompletedAt == nil || !unchanged.CompletedAt.Equal(completedAt) {
+		t.Fatalf("expected completed_at unchanged, got %#v", unchanged.CompletedAt)
+	}
+	if unchanged.CancelReason == nil || *unchanged.CancelReason != cancelReason {
+		t.Fatalf("expected cancel_reason unchanged, got %#v", unchanged.CancelReason)
+	}
+}
+
+func TestNilAggregateStateReturnsZeroValue(t *testing.T) {
+	var aggregate *Aggregate
+
+	if state := aggregate.State(); state != (State{}) {
+		t.Fatalf("expected zero state, got %+v", state)
+	}
+}
+
+func mustRepairAggregate(t *testing.T, status string) *Aggregate {
+	t.Helper()
+
+	aggregate, err := Rehydrate(State{
+		ID:          "repair-1",
+		PropertyID:  "property-1",
+		RoomID:      "room-1",
+		SubmittedBy: "user-1",
+		Title:       "Leak",
+		Status:      status,
+	})
+	if err != nil {
+		t.Fatalf("Rehydrate: %v", err)
+	}
+	return aggregate
+}


### PR DESCRIPTION
## Summary

- Add focused repair domain aggregate tests for creation, rehydration, updates, transitions, rejected transitions, and `State()` defensive copies.
- Extend repair application tests for create/update/delete and workflow coverage, including validation, property/room mismatch, missing repair mapping, progress/complete paths, and room restore failure mapping.

## Validation

- `go test ./internal/domain/repair ./internal/application/repair`
- `go test ./...`

Closes #69.