### PR TITLE
[codex] Strengthen notification application tests

### DIFF
--- a/internal/application/jobs/batch_test.go
+++ b/internal/application/jobs/batch_test.go
@@ -105,6 +105,32 @@ func TestOverdueBillReminderSkipsConcurrentUpdateWithoutSending(t *testing.T) {
 	}
 }
 
+func TestOverdueBillReminderCountsNotificationErrorAsFailed(t *testing.T) {
+	email := "tenant@example.com"
+	repo := &batchBillingRepoStub{
+		overdueReminderCandidates: []OverdueReminderCandidate{
+			{ID: "bill-1", TenantEmail: &email, Version: 7},
+		},
+	}
+	notifier := &jobNotifierStub{overdueErr: errors.New("notification failed")}
+	runner := NewOverdueBillReminderRunner(repo, notifier, txRunnerStub{})
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.FailedCount != 1 || summary.ProcessedCount != 0 || summary.SkippedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if notifier.overdueCalls != 1 {
+		t.Fatalf("expected one notification call, got %d", notifier.overdueCalls)
+	}
+	if repo.incrementBillID != "bill-1" || repo.incrementVersion != 7 {
+		t.Fatalf("unexpected increment call: bill=%s version=%d", repo.incrementBillID, repo.incrementVersion)
+	}
+}
+
 func TestLeaseExpiringSoonReminderSendsToFilteredRecipients(t *testing.T) {
 	repo := &batchLeaseRepoStub{
 		expiringSoonCandidates: []LeaseExpiringSoonCandidate{
@@ -133,6 +159,31 @@ func TestLeaseExpiringSoonReminderSendsToFilteredRecipients(t *testing.T) {
 	}
 	if repo.recipientPropertyID != "property-1" {
 		t.Fatalf("expected property-1 recipient lookup, got %q", repo.recipientPropertyID)
+	}
+}
+
+func TestLeaseExpiringSoonReminderCountsNotificationErrorAsFailed(t *testing.T) {
+	repo := &batchLeaseRepoStub{
+		expiringSoonCandidates: []LeaseExpiringSoonCandidate{
+			{ID: "lease-1", PropertyID: "property-1", EndDate: time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC)},
+		},
+		recipients: []NotificationRecipient{
+			{Email: "organizer@example.com", Name: "Organizer"},
+		},
+	}
+	notifier := &jobNotifierStub{leaseErr: errors.New("notification failed")}
+	runner := NewLeaseExpiringSoonReminderRunner(repo, notifier)
+
+	summary, err := runner(context.Background(), "2026-04-16")
+	if err != nil {
+		t.Fatalf("runner: %v", err)
+	}
+
+	if summary.FailedCount != 1 || summary.ProcessedCount != 0 || summary.SkippedCount != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if notifier.leaseCalls != 1 {
+		t.Fatalf("expected one notification call, got %d", notifier.leaseCalls)
 	}
 }
 
@@ -387,14 +438,16 @@ func (s *batchForceTerminationRepoStub) CompleteForceTermination(context.Context
 type jobNotifierStub struct {
 	overdueCalls int
 	leaseCalls   int
+	overdueErr   error
+	leaseErr     error
 }
 
 func (s *jobNotifierStub) SendOverdueBillReminder(context.Context, NotificationRecipient, OverdueReminderCandidate) error {
 	s.overdueCalls++
-	return nil
+	return s.overdueErr
 }
 
 func (s *jobNotifierStub) SendLeaseExpiringSoon(context.Context, NotificationRecipient, LeaseExpiringSoonCandidate) error {
 	s.leaseCalls++
-	return nil
+	return s.leaseErr
 }

--- a/internal/application/notification/errors.go
+++ b/internal/application/notification/errors.go
@@ -11,6 +11,8 @@ const (
 	CodeNotificationSenderNotConfigured = "NOTIFICATION_SENDER_NOT_CONFIGURED"
 	// CodeNotificationSendFailed identifies a notification delivery failure.
 	CodeNotificationSendFailed = "NOTIFICATION_SEND_FAILED"
+	// CodeNotificationInvalidInput identifies invalid notification input.
+	CodeNotificationInvalidInput = "NOTIFICATION_INVALID_INPUT"
 )
 
 var (
@@ -25,5 +27,11 @@ var (
 		CodeNotificationSendFailed,
 		http.StatusInternalServerError,
 		"Notification send failed.",
+	)
+	// ErrNotificationInvalidInput is returned when notification input is invalid.
+	ErrNotificationInvalidInput = apperr.New(
+		CodeNotificationInvalidInput,
+		http.StatusInternalServerError,
+		"Notification input is invalid.",
 	)
 )

--- a/internal/application/notification/service.go
+++ b/internal/application/notification/service.go
@@ -56,6 +56,9 @@ func (s *Service) SendUserPasswordResetEmail(ctx context.Context, input UserPass
 	email := strings.TrimSpace(input.Email)
 	name := strings.TrimSpace(input.Name)
 	resetURL := strings.TrimSpace(input.ResetURL)
+	if email == "" || resetURL == "" {
+		return ErrNotificationInvalidInput
+	}
 
 	subject := "Set your STDS password"
 	html := fmt.Sprintf(
@@ -90,6 +93,11 @@ func (s *Service) SendOverdueBillReminderEmail(ctx context.Context, input Overdu
 		return ErrNotificationSenderNotConfigured
 	}
 
+	email := strings.TrimSpace(input.Email)
+	if email == "" || input.DueDate.IsZero() {
+		return ErrNotificationInvalidInput
+	}
+
 	amount := "the outstanding amount"
 	if input.Amount != nil {
 		amount = fmt.Sprintf("NT$%d", *input.Amount)
@@ -102,7 +110,7 @@ func (s *Service) SendOverdueBillReminderEmail(ctx context.Context, input Overdu
 	if err := s.sender.Send(ctx, platformnotification.SendCommand{
 		Channel: platformnotification.ChannelEmail,
 		Email: &platformnotification.EmailMessage{
-			To:      []string{strings.TrimSpace(input.Email)},
+			To:      []string{email},
 			Subject: subject,
 			HTML:    html,
 			Text:    text,
@@ -120,16 +128,22 @@ func (s *Service) SendLeaseExpiringSoonEmail(ctx context.Context, input LeaseExp
 		return ErrNotificationSenderNotConfigured
 	}
 
+	email := strings.TrimSpace(input.Email)
 	name := defaultName(strings.TrimSpace(input.Name))
+	leaseID := strings.TrimSpace(input.LeaseID)
+	if email == "" || leaseID == "" || input.EndDate.IsZero() {
+		return ErrNotificationInvalidInput
+	}
+
 	endDate := input.EndDate.Format("2006-01-02")
 	subject := "Lease expiring soon"
-	html := fmt.Sprintf("<p>Hello %s,</p><p>Lease %s is scheduled to end on %s.</p>", htmlEscape(name), htmlEscape(input.LeaseID), htmlEscape(endDate))
-	text := fmt.Sprintf("Hello %s,\n\nLease %s is scheduled to end on %s.\n", name, input.LeaseID, endDate)
+	html := fmt.Sprintf("<p>Hello %s,</p><p>Lease %s is scheduled to end on %s.</p>", htmlEscape(name), htmlEscape(leaseID), htmlEscape(endDate))
+	text := fmt.Sprintf("Hello %s,\n\nLease %s is scheduled to end on %s.\n", name, leaseID, endDate)
 
 	if err := s.sender.Send(ctx, platformnotification.SendCommand{
 		Channel: platformnotification.ChannelEmail,
 		Email: &platformnotification.EmailMessage{
-			To:      []string{strings.TrimSpace(input.Email)},
+			To:      []string{email},
 			Subject: subject,
 			HTML:    html,
 			Text:    text,

--- a/internal/application/notification/service_test.go
+++ b/internal/application/notification/service_test.go
@@ -3,7 +3,9 @@ package notification
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	domainevents "stds_backend/internal/domain/events"
 	platformnotification "stds_backend/internal/platform/notification"
@@ -11,12 +13,12 @@ import (
 )
 
 func TestServiceSendUserPasswordResetEmail(t *testing.T) {
-	t.Run("sends email command", func(t *testing.T) {
+	t.Run("sends email command with normalized input", func(t *testing.T) {
 		sender := &fakeSender{}
 		service := NewService(sender)
 
 		err := service.SendUserPasswordResetEmail(context.Background(), UserPasswordResetEmailInput{
-			Email:    "user@example.com",
+			Email:    " user@example.com ",
 			Name:     "Test User",
 			ResetURL: "https://reset.example.com",
 		})
@@ -27,12 +29,44 @@ func TestServiceSendUserPasswordResetEmail(t *testing.T) {
 		if sender.command.Channel != platformnotification.ChannelEmail {
 			t.Fatalf("expected email channel, got %s", sender.command.Channel)
 		}
-		if sender.command.Email == nil || sender.command.Email.To[0] != "user@example.com" {
-			t.Fatal("expected email recipient to be set")
+		if sender.command.Email == nil {
+			t.Fatal("expected email message")
+		}
+		if len(sender.command.Email.To) != 1 || sender.command.Email.To[0] != "user@example.com" {
+			t.Fatalf("unexpected recipients: %+v", sender.command.Email.To)
+		}
+		if sender.command.Email.Subject != "Set your STDS password" {
+			t.Fatalf("unexpected subject: %q", sender.command.Email.Subject)
+		}
+		if !strings.Contains(sender.command.Email.HTML, "Hello Test User") ||
+			!strings.Contains(sender.command.Email.HTML, "https://reset.example.com") ||
+			!strings.Contains(sender.command.Email.Text, "Hello Test User") ||
+			!strings.Contains(sender.command.Email.Text, "https://reset.example.com") {
+			t.Fatalf("expected reset email body to include name and reset URL: %+v", sender.command.Email)
 		}
 	})
 
-	t.Run("returns notification error code", func(t *testing.T) {
+	t.Run("uses fallback name when name is blank", func(t *testing.T) {
+		sender := &fakeSender{}
+		service := NewService(sender)
+
+		err := service.SendUserPasswordResetEmail(context.Background(), UserPasswordResetEmailInput{
+			Email:    "user@example.com",
+			Name:     " ",
+			ResetURL: "https://reset.example.com",
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if sender.command.Email == nil ||
+			!strings.Contains(sender.command.Email.HTML, "Hello there") ||
+			!strings.Contains(sender.command.Email.Text, "Hello there") {
+			t.Fatalf("expected fallback name in command: %+v", sender.command.Email)
+		}
+	})
+
+	t.Run("returns send failed error code", func(t *testing.T) {
 		service := NewService(&fakeSender{sendErr: errors.New("resend down")})
 
 		err := service.SendUserPasswordResetEmail(context.Background(), UserPasswordResetEmailInput{
@@ -52,6 +86,306 @@ func TestServiceSendUserPasswordResetEmail(t *testing.T) {
 			t.Fatalf("expected %s, got %s", CodeNotificationSendFailed, appErr.Code)
 		}
 	})
+
+	t.Run("returns invalid input and does not call sender", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input UserPasswordResetEmailInput
+		}{
+			{
+				name: "blank email",
+				input: UserPasswordResetEmailInput{
+					Email:    " ",
+					ResetURL: "https://reset.example.com",
+				},
+			},
+			{
+				name: "blank reset URL",
+				input: UserPasswordResetEmailInput{
+					Email:    "user@example.com",
+					ResetURL: " ",
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				sender := &fakeSender{}
+				service := NewService(sender)
+
+				err := service.SendUserPasswordResetEmail(context.Background(), tt.input)
+				assertAppErrorCode(t, err, CodeNotificationInvalidInput)
+				if sender.calls != 0 {
+					t.Fatalf("expected no sender calls, got %d", sender.calls)
+				}
+			})
+		}
+	})
+}
+
+func TestServiceSendOverdueBillReminderEmail(t *testing.T) {
+	t.Run("sends email command with amount and due date", func(t *testing.T) {
+		amount := 1200
+		sender := &fakeSender{}
+		service := NewService(sender)
+
+		err := service.SendOverdueBillReminderEmail(context.Background(), OverdueBillReminderEmailInput{
+			Email:   " tenant@example.com ",
+			Amount:  &amount,
+			DueDate: time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if sender.command.Channel != platformnotification.ChannelEmail {
+			t.Fatalf("expected email channel, got %s", sender.command.Channel)
+		}
+		if sender.command.Email == nil {
+			t.Fatal("expected email message")
+		}
+		if len(sender.command.Email.To) != 1 || sender.command.Email.To[0] != "tenant@example.com" {
+			t.Fatalf("unexpected recipients: %+v", sender.command.Email.To)
+		}
+		if sender.command.Email.Subject != "Overdue bill reminder" {
+			t.Fatalf("unexpected subject: %q", sender.command.Email.Subject)
+		}
+		if !strings.Contains(sender.command.Email.HTML, "NT$1200") ||
+			!strings.Contains(sender.command.Email.HTML, "2026-04-16") ||
+			!strings.Contains(sender.command.Email.Text, "NT$1200") ||
+			!strings.Contains(sender.command.Email.Text, "2026-04-16") {
+			t.Fatalf("expected overdue email body to include amount and due date: %+v", sender.command.Email)
+		}
+	})
+
+	t.Run("uses fallback amount when amount is nil", func(t *testing.T) {
+		sender := &fakeSender{}
+		service := NewService(sender)
+
+		err := service.SendOverdueBillReminderEmail(context.Background(), OverdueBillReminderEmailInput{
+			Email:   "tenant@example.com",
+			DueDate: time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if sender.command.Email == nil ||
+			!strings.Contains(sender.command.Email.HTML, "the outstanding amount") ||
+			!strings.Contains(sender.command.Email.Text, "the outstanding amount") {
+			t.Fatalf("expected fallback amount in command: %+v", sender.command.Email)
+		}
+	})
+
+	t.Run("returns send failed error code", func(t *testing.T) {
+		service := NewService(&fakeSender{sendErr: errors.New("resend down")})
+
+		err := service.SendOverdueBillReminderEmail(context.Background(), OverdueBillReminderEmailInput{
+			Email:   "tenant@example.com",
+			DueDate: time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+		})
+
+		assertAppErrorCode(t, err, CodeNotificationSendFailed)
+	})
+
+	t.Run("returns invalid input and does not call sender", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input OverdueBillReminderEmailInput
+		}{
+			{
+				name: "blank email",
+				input: OverdueBillReminderEmailInput{
+					Email:   " ",
+					DueDate: time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			{
+				name: "zero due date",
+				input: OverdueBillReminderEmailInput{
+					Email: "tenant@example.com",
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				sender := &fakeSender{}
+				service := NewService(sender)
+
+				err := service.SendOverdueBillReminderEmail(context.Background(), tt.input)
+				assertAppErrorCode(t, err, CodeNotificationInvalidInput)
+				if sender.calls != 0 {
+					t.Fatalf("expected no sender calls, got %d", sender.calls)
+				}
+			})
+		}
+	})
+}
+
+func TestServiceSendLeaseExpiringSoonEmail(t *testing.T) {
+	t.Run("sends email command with normalized input", func(t *testing.T) {
+		sender := &fakeSender{}
+		service := NewService(sender)
+
+		err := service.SendLeaseExpiringSoonEmail(context.Background(), LeaseExpiringSoonEmailInput{
+			Email:   " tenant@example.com ",
+			Name:    "Tenant",
+			LeaseID: "lease-1",
+			EndDate: time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC),
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if sender.command.Channel != platformnotification.ChannelEmail {
+			t.Fatalf("expected email channel, got %s", sender.command.Channel)
+		}
+		if sender.command.Email == nil {
+			t.Fatal("expected email message")
+		}
+		if len(sender.command.Email.To) != 1 || sender.command.Email.To[0] != "tenant@example.com" {
+			t.Fatalf("unexpected recipients: %+v", sender.command.Email.To)
+		}
+		if sender.command.Email.Subject != "Lease expiring soon" {
+			t.Fatalf("unexpected subject: %q", sender.command.Email.Subject)
+		}
+		if !strings.Contains(sender.command.Email.HTML, "Hello Tenant") ||
+			!strings.Contains(sender.command.Email.HTML, "lease-1") ||
+			!strings.Contains(sender.command.Email.HTML, "2026-05-16") ||
+			!strings.Contains(sender.command.Email.Text, "Hello Tenant") ||
+			!strings.Contains(sender.command.Email.Text, "lease-1") ||
+			!strings.Contains(sender.command.Email.Text, "2026-05-16") {
+			t.Fatalf("expected lease email body to include name, lease ID, and end date: %+v", sender.command.Email)
+		}
+	})
+
+	t.Run("uses fallback name when name is blank", func(t *testing.T) {
+		sender := &fakeSender{}
+		service := NewService(sender)
+
+		err := service.SendLeaseExpiringSoonEmail(context.Background(), LeaseExpiringSoonEmailInput{
+			Email:   "tenant@example.com",
+			Name:    " ",
+			LeaseID: "lease-1",
+			EndDate: time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC),
+		})
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if sender.command.Email == nil ||
+			!strings.Contains(sender.command.Email.HTML, "Hello there") ||
+			!strings.Contains(sender.command.Email.Text, "Hello there") {
+			t.Fatalf("expected fallback name in command: %+v", sender.command.Email)
+		}
+	})
+
+	t.Run("returns send failed error code", func(t *testing.T) {
+		service := NewService(&fakeSender{sendErr: errors.New("resend down")})
+
+		err := service.SendLeaseExpiringSoonEmail(context.Background(), LeaseExpiringSoonEmailInput{
+			Email:   "tenant@example.com",
+			LeaseID: "lease-1",
+			EndDate: time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC),
+		})
+
+		assertAppErrorCode(t, err, CodeNotificationSendFailed)
+	})
+
+	t.Run("returns invalid input and does not call sender", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input LeaseExpiringSoonEmailInput
+		}{
+			{
+				name: "blank email",
+				input: LeaseExpiringSoonEmailInput{
+					Email:   " ",
+					LeaseID: "lease-1",
+					EndDate: time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			{
+				name: "blank lease ID",
+				input: LeaseExpiringSoonEmailInput{
+					Email:   "tenant@example.com",
+					LeaseID: " ",
+					EndDate: time.Date(2026, 5, 16, 0, 0, 0, 0, time.UTC),
+				},
+			},
+			{
+				name: "zero end date",
+				input: LeaseExpiringSoonEmailInput{
+					Email:   "tenant@example.com",
+					LeaseID: "lease-1",
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				sender := &fakeSender{}
+				service := NewService(sender)
+
+				err := service.SendLeaseExpiringSoonEmail(context.Background(), tt.input)
+				assertAppErrorCode(t, err, CodeNotificationInvalidInput)
+				if sender.calls != 0 {
+					t.Fatalf("expected no sender calls, got %d", sender.calls)
+				}
+			})
+		}
+	})
+}
+
+func TestServiceRequiresSender(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*Service) error
+	}{
+		{
+			name: "password reset nil service",
+			run: func(service *Service) error {
+				return service.SendUserPasswordResetEmail(context.Background(), UserPasswordResetEmailInput{})
+			},
+		},
+		{
+			name: "overdue reminder nil service",
+			run: func(service *Service) error {
+				return service.SendOverdueBillReminderEmail(context.Background(), OverdueBillReminderEmailInput{})
+			},
+		},
+		{
+			name: "lease expiring soon nil service",
+			run: func(service *Service) error {
+				return service.SendLeaseExpiringSoonEmail(context.Background(), LeaseExpiringSoonEmailInput{})
+			},
+		},
+		{
+			name: "password reset nil sender",
+			run: func(*Service) error {
+				return NewService(nil).SendUserPasswordResetEmail(context.Background(), UserPasswordResetEmailInput{})
+			},
+		},
+		{
+			name: "overdue reminder nil sender",
+			run: func(*Service) error {
+				return NewService(nil).SendOverdueBillReminderEmail(context.Background(), OverdueBillReminderEmailInput{})
+			},
+		},
+		{
+			name: "lease expiring soon nil sender",
+			run: func(*Service) error {
+				return NewService(nil).SendLeaseExpiringSoonEmail(context.Background(), LeaseExpiringSoonEmailInput{})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertAppErrorCode(t, tt.run(nil), CodeNotificationSenderNotConfigured)
+		})
+	}
 }
 
 func TestServiceHandleUserPasswordResetRequested(t *testing.T) {
@@ -70,14 +404,37 @@ func TestServiceHandleUserPasswordResetRequested(t *testing.T) {
 	if sender.command.Email == nil || sender.command.Email.Subject == "" {
 		t.Fatal("expected email command to be built")
 	}
+	if sender.command.Email.To[0] != "user@example.com" ||
+		!strings.Contains(sender.command.Email.Text, "Test User") ||
+		!strings.Contains(sender.command.Email.Text, "https://reset.example.com") {
+		t.Fatalf("expected event fields to be forwarded into command: %+v", sender.command.Email)
+	}
+}
+
+func assertAppErrorCode(t *testing.T, err error, code string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) {
+		t.Fatalf("expected app error, got %T", err)
+	}
+	if appErr.Code != code {
+		t.Fatalf("expected %s, got %s", code, appErr.Code)
+	}
 }
 
 type fakeSender struct {
 	command platformnotification.SendCommand
 	sendErr error
+	calls   int
 }
 
 func (f *fakeSender) Send(_ context.Context, command platformnotification.SendCommand) error {
+	f.calls++
 	f.command = command
 	return f.sendErr
 }


### PR DESCRIPTION
## Summary

Addresses #70 by strengthening notification application coverage and making the notification input contract explicit.

## What changed

- Expanded `internal/application/notification` unit tests for:
  - password reset email command construction
  - overdue bill reminder command construction
  - lease expiring-soon command construction
  - recipient trimming and fallback text behavior
  - nil service/sender behavior
  - provider failure mapping to `NOTIFICATION_SEND_FAILED`
  - invalid required input mapping to `NOTIFICATION_INVALID_INPUT` without calling the sender
- Added focused scheduler job tests confirming notification send errors count as failed reminder executions.
- Added `NOTIFICATION_INVALID_INPUT` as an internal notification application error.
- Added fail-fast validation before dispatching notification commands:
  - password reset requires email and reset URL
  - overdue reminder requires email and due date
  - lease expiring-soon requires email, lease ID, and end date

## Contract notes

The notification service now validates the minimum fields required to construct a meaningful outbound command. It does not implement skip/no-op behavior. Skipping remains owned by caller flows such as scheduler jobs, where summary counts are part of the job contract.

`NOTIFICATION_INVALID_INPUT` is intentionally kept as an internal server error status rather than a new public 400 API contract. This avoids requiring OpenAPI changes for #70 while still protecting application code from dispatching invalid provider commands.

No real Resend, Firebase, LINE, or network provider is used in these tests.

## Validation

- `go test ./internal/application/notification`
- `go test ./internal/application/jobs`
- `go test ./...`
- `git diff --check`