### PR TITLE
[codex] Add resource ownership repository coverage

### DIFF
--- a/internal/application/attachment/service.go
+++ b/internal/application/attachment/service.go
@@ -320,9 +320,6 @@ func (s *Service) ensureResourceAccess(ctx context.Context, actorRole string, as
 	propertyID, err := s.resourceAccess.FindPropertyIDByResource(ctx, resourceType, resourceID)
 	if err != nil {
 		if errorsIsNotFound(err) {
-			if resourceType == ResourceTypeTenant {
-				return apperr.ErrForbidden
-			}
 			return mapResourceNotFound(resourceType)
 		}
 		return apperr.ErrInternalServerError.WithCause(err)

--- a/internal/application/attachment/service.go
+++ b/internal/application/attachment/service.go
@@ -299,6 +299,22 @@ func (s *Service) ensureResourceAccess(ctx context.Context, actorRole string, as
 		if actorRole == "admin" {
 			return nil
 		}
+
+		propertyIDs, err := s.resourceAccess.FindPropertyIDsByTenant(ctx, resourceID)
+		if err != nil {
+			if errorsIsNotFound(err) {
+				return mapResourceNotFound(resourceType)
+			}
+			return apperr.ErrInternalServerError.WithCause(err)
+		}
+		for _, propertyID := range propertyIDs {
+			for _, assignedPropertyID := range assignedPropertyIDs {
+				if assignedPropertyID == propertyID {
+					return nil
+				}
+			}
+		}
+		return apperr.ErrForbidden
 	}
 
 	propertyID, err := s.resourceAccess.FindPropertyIDByResource(ctx, resourceType, resourceID)

--- a/internal/application/attachment/service_test.go
+++ b/internal/application/attachment/service_test.go
@@ -285,6 +285,33 @@ func TestTenantUploadURLUsesGlobalTenantExistence(t *testing.T) {
 	}
 }
 
+func TestTenantUploadURLAllowsAssignedTenantPropertyWhenMatchIsNotFirstAssociation(t *testing.T) {
+	assignedPropertyID := "10000000-0000-0000-0000-000000000004"
+	unassignedPropertyID := "10000000-0000-0000-0000-000000000099"
+	access := resourceAccessStub{
+		tenantPropertyIDs: []string{unassignedPropertyID, assignedPropertyID},
+		globalTenantIDs:   map[string]bool{testTenantID: true},
+	}
+	service := newTestService(&attachmentRepoStub{}, &storageStub{uploadURL: "http://storage/upload"}, &access, time.Now().UTC())
+
+	_, err := service.CreateUploadURL(context.Background(), CreateUploadURLInput{
+		ActorRole:           "staff",
+		ActorUserID:         testActorID,
+		AssignedPropertyIDs: []string{assignedPropertyID},
+		ResourceType:        ResourceTypeTenant,
+		ResourceID:          testTenantID,
+		FileName:            "id.pdf",
+		ContentType:         "application/pdf",
+		FileSize:            1024,
+	})
+	if err != nil {
+		t.Fatalf("CreateUploadURL returned error: %v", err)
+	}
+	if !access.globalTenantChecked {
+		t.Fatal("expected global tenant existence check")
+	}
+}
+
 func TestTenantUploadURLRejectsUnassignedTenantProperty(t *testing.T) {
 	access := resourceAccessStub{
 		propertyByResource: map[ResourceType]string{ResourceTypeTenant: testPropertyID},
@@ -296,6 +323,26 @@ func TestTenantUploadURLRejectsUnassignedTenantProperty(t *testing.T) {
 		ActorRole:           "staff",
 		ActorUserID:         testActorID,
 		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000099"},
+		ResourceType:        ResourceTypeTenant,
+		ResourceID:          testTenantID,
+		FileName:            "id.pdf",
+		ContentType:         "application/pdf",
+		FileSize:            1024,
+	})
+	assertAppErrorCode(t, err, apperr.CodeForbidden)
+}
+
+func TestTenantUploadURLRejectsStaffWhenTenantExistsWithoutAssociatedProperties(t *testing.T) {
+	access := resourceAccessStub{
+		tenantPropertyIDs: []string{},
+		globalTenantIDs:   map[string]bool{testTenantID: true},
+	}
+	service := newTestService(&attachmentRepoStub{}, &storageStub{uploadURL: "http://storage/upload"}, &access, time.Now().UTC())
+
+	_, err := service.CreateUploadURL(context.Background(), CreateUploadURLInput{
+		ActorRole:           "staff",
+		ActorUserID:         testActorID,
+		AssignedPropertyIDs: []string{testPropertyID},
 		ResourceType:        ResourceTypeTenant,
 		ResourceID:          testTenantID,
 		FileName:            "id.pdf",
@@ -445,6 +492,7 @@ func (s *storageStub) GetObjectMetadata(_ context.Context, _ string) (*ObjectMet
 
 type resourceAccessStub struct {
 	propertyByResource  map[ResourceType]string
+	tenantPropertyIDs   []string
 	globalTenantIDs     map[string]bool
 	globalTenantChecked bool
 }
@@ -457,6 +505,18 @@ func (r *resourceAccessStub) FindPropertyIDByResource(_ context.Context, resourc
 		return propertyID, nil
 	}
 	return "", ErrResourceNotFound
+}
+
+func (r *resourceAccessStub) FindPropertyIDsByTenant(_ context.Context, tenantID string) ([]string, error) {
+	if r.globalTenantIDs[tenantID] {
+		if r.tenantPropertyIDs == nil {
+			if propertyID, ok := r.propertyByResource[ResourceTypeTenant]; ok {
+				return []string{propertyID}, nil
+			}
+		}
+		return r.tenantPropertyIDs, nil
+	}
+	return nil, ErrResourceNotFound
 }
 
 func (r *resourceAccessStub) EnsureGlobalTenantExists(_ context.Context, tenantID string) error {

--- a/internal/application/attachment/types.go
+++ b/internal/application/attachment/types.go
@@ -93,6 +93,7 @@ type Repository interface {
 // ResourceAccess resolves host-resource existence and property ownership.
 type ResourceAccess interface {
 	FindPropertyIDByResource(ctx context.Context, resourceType ResourceType, resourceID string) (string, error)
+	FindPropertyIDsByTenant(ctx context.Context, tenantID string) ([]string, error)
 	EnsureGlobalTenantExists(ctx context.Context, tenantID string) error
 }
 

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -948,6 +948,10 @@ func (handlerAttachmentResourceAccessStub) FindPropertyIDByResource(_ context.Co
 	return "", appattachment.ErrResourceNotFound
 }
 
+func (handlerAttachmentResourceAccessStub) FindPropertyIDsByTenant(context.Context, string) ([]string, error) {
+	return nil, appattachment.ErrResourceNotFound
+}
+
 func (handlerAttachmentResourceAccessStub) EnsureGlobalTenantExists(context.Context, string) error {
 	return appattachment.ErrResourceNotFound
 }

--- a/internal/http/middleware/authorization.go
+++ b/internal/http/middleware/authorization.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 
 	"stds_backend/internal/http/requestctx"
 	dbproperties "stds_backend/internal/platform/database/properties"
@@ -18,8 +18,15 @@ import (
 // the current request.
 type PropertyIDResolver func(*gin.Context) (string, error)
 
+// PropertyIDsResolver extracts property IDs that should be authorized for the
+// current request.
+type PropertyIDsResolver func(*gin.Context) ([]string, error)
+
 // PropertyLookup resolves a resource id to its owning property id.
 type PropertyLookup func(context.Context, string) (string, error)
+
+// PropertyIDsLookup resolves a resource id to its associated property ids.
+type PropertyIDsLookup func(context.Context, string) ([]string, error)
 
 // RequireRoles rejects requests whose authenticated principal does not match
 // one of the allowed roles.
@@ -46,6 +53,44 @@ func RequireRoles(allowedRoles ...string) gin.HandlerFunc {
 		}
 
 		c.Next()
+	}
+}
+
+// RequireAnyPropertyAccess rejects requests when none of the resolved
+// properties is assigned to the authenticated principal.
+func RequireAnyPropertyAccess(resolvePropertyIDs PropertyIDsResolver) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		principal, ok := requestctx.GetPrincipal(c)
+		if !ok {
+			c.Error(apperr.ErrUnauthorized)
+			c.Abort()
+			return
+		}
+
+		propertyIDs, err := resolvePropertyIDs(c)
+		if err != nil {
+			c.Error(mapPropertyResolverError(err))
+			c.Abort()
+			return
+		}
+
+		if principal.Role == "admin" {
+			c.Next()
+			return
+		}
+
+		for _, propertyID := range propertyIDs {
+			for _, assignedPropertyID := range principal.AssignedPropertyIDs {
+				if assignedPropertyID == propertyID {
+					requestctx.SetPropertyID(c, propertyID)
+					c.Next()
+					return
+				}
+			}
+		}
+
+		c.Error(apperr.ErrForbidden)
+		c.Abort()
 	}
 }
 
@@ -191,6 +236,36 @@ func ResourcePropertyIDWithNotFound(param string, lookup PropertyLookup, notFoun
 		}
 
 		return propertyID, nil
+	}
+}
+
+// ResourcePropertyIDsWithNotFound returns a resolver that maps a route resource
+// id to all associated property ids, translating lookup not-found results into
+// the provided application error when configured.
+func ResourcePropertyIDsWithNotFound(param string, lookup PropertyIDsLookup, notFoundErr *apperr.Error) PropertyIDsResolver {
+	return func(c *gin.Context) ([]string, error) {
+		if param == "" {
+			return nil, errors.New("resource param is required")
+		}
+		if lookup == nil {
+			return nil, errors.New("property lookup is required")
+		}
+
+		resourceID := c.Param(param)
+		if _, err := resolveUUIDParam(c, param); err != nil {
+			return nil, err
+		}
+
+		propertyIDs, err := lookup(c.Request.Context(), resourceID)
+		if err != nil {
+			if errors.Is(err, dbresourceownership.ErrNotFound) && notFoundErr != nil {
+				return nil, notFoundErr.WithCause(err)
+			}
+
+			return nil, err
+		}
+
+		return propertyIDs, nil
 	}
 }
 

--- a/internal/http/middleware/middleware_test.go
+++ b/internal/http/middleware/middleware_test.go
@@ -26,6 +26,7 @@ const (
 	testPropertyID2       = "10000000-0000-0000-0000-000000000002"
 	testPropertyID9       = "10000000-0000-0000-0000-000000000009"
 	testMissingPropertyID = "10000000-0000-0000-0000-000000000099"
+	testTenantID1         = "40000000-0000-0000-0000-000000000001"
 	testRoomID1           = "20000000-0000-0000-0000-000000000001"
 	testMissingRoomID     = "20000000-0000-0000-0000-000000000099"
 	testBillID1           = "30000000-0000-0000-0000-000000000001"
@@ -440,6 +441,95 @@ func TestRequirePropertyAccessReturnsInternalServerErrorForUnexpectedResolverFai
 	engine.ServeHTTP(resp, req)
 
 	assertErrorCode(t, resp, http.StatusInternalServerError, "INTERNAL_SERVER_ERROR")
+}
+
+func TestRequireAnyPropertyAccessAllowsNonAdminWhenAssignedPropertyMatchesAnyResolvedProperty(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	engine.Use(RequestID(), ErrorHandler(testLoggerBuffer(nil)))
+	engine.GET("/tenants/:id/attachments", func(c *gin.Context) {
+		requestctx.SetPrincipal(c, requestctx.Principal{
+			Role:                "staff",
+			AssignedPropertyIDs: []string{testPropertyID2},
+		})
+		c.Next()
+	}, RequireAnyPropertyAccess(ResourcePropertyIDsWithNotFound("id", func(_ context.Context, tenantID string) ([]string, error) {
+		if tenantID != testTenantID1 {
+			return nil, errors.New("unexpected tenant id")
+		}
+
+		return []string{testPropertyID1, testPropertyID2}, nil
+	}, apperr.ErrTenantNotFound)), func(c *gin.Context) {
+		propertyID := requestctx.GetPropertyID(c)
+		if propertyID != testPropertyID2 {
+			t.Fatalf("propertyID = %q, want %q", propertyID, testPropertyID2)
+		}
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/tenants/"+testTenantID1+"/attachments", nil)
+	resp := httptest.NewRecorder()
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestRequireAnyPropertyAccessReturnsForbiddenWhenNoResolvedPropertyIsAssigned(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	engine.Use(RequestID(), ErrorHandler(testLoggerBuffer(nil)))
+	engine.GET("/tenants/:id/attachments", func(c *gin.Context) {
+		requestctx.SetPrincipal(c, requestctx.Principal{
+			Role:                "staff",
+			AssignedPropertyIDs: []string{testPropertyID9},
+		})
+		c.Next()
+	}, RequireAnyPropertyAccess(ResourcePropertyIDsWithNotFound("id", func(_ context.Context, tenantID string) ([]string, error) {
+		if tenantID != testTenantID1 {
+			return nil, errors.New("unexpected tenant id")
+		}
+
+		return []string{testPropertyID1, testPropertyID2}, nil
+	}, apperr.ErrTenantNotFound)), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/tenants/"+testTenantID1+"/attachments", nil)
+	resp := httptest.NewRecorder()
+	engine.ServeHTTP(resp, req)
+
+	assertErrorCode(t, resp, http.StatusForbidden, "FORBIDDEN")
+}
+
+func TestRequireAnyPropertyAccessAllowsAdminWhenTenantExistsWithoutResolvedProperties(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	engine.Use(RequestID(), ErrorHandler(testLoggerBuffer(nil)))
+	engine.GET("/tenants/:id/attachments", func(c *gin.Context) {
+		requestctx.SetPrincipal(c, requestctx.Principal{Role: "admin"})
+		c.Next()
+	}, RequireAnyPropertyAccess(ResourcePropertyIDsWithNotFound("id", func(_ context.Context, tenantID string) ([]string, error) {
+		if tenantID != testTenantID1 {
+			return nil, errors.New("unexpected tenant id")
+		}
+
+		return []string{}, nil
+	}, apperr.ErrTenantNotFound)), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/tenants/"+testTenantID1+"/attachments", nil)
+	resp := httptest.NewRecorder()
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
 }
 
 func TestRequirePropertyAccessAllowsOwnerForOwnedProperty(t *testing.T) {

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -72,11 +72,12 @@ func New(
 }
 
 type routePolicy struct {
-	method           string
-	path             string
-	authStrategy     authStrategy
-	allowedRoles     []string
-	propertyResolver middleware.PropertyIDResolver
+	method              string
+	path                string
+	authStrategy        authStrategy
+	allowedRoles        []string
+	propertyResolver    middleware.PropertyIDResolver
+	propertyIDsResolver middleware.PropertyIDsResolver
 }
 
 type compiledRoutePolicy struct {
@@ -134,6 +135,9 @@ func compileRoutePolicies(appCfg config.AppConfig, authenticator platformfirebas
 		}
 		if policy.propertyResolver != nil {
 			compiled.requirePropertyAccess = middleware.RequirePropertyAccess(policy.propertyResolver, authzRepos.Properties)
+		}
+		if policy.propertyIDsResolver != nil {
+			compiled.requirePropertyAccess = middleware.RequireAnyPropertyAccess(policy.propertyIDsResolver)
 		}
 
 		policies[routePolicyKey(policy.method, policy.path)] = compiled
@@ -226,8 +230,8 @@ func routePolicies(authzRepos AuthorizationRepositories) []routePolicy {
 
 		{method: "GET", path: "/api/v1/tenants", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.QueryPropertyID("property_id")},
 		{method: "POST", path: "/api/v1/tenants", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
-		{method: "GET", path: "/api/v1/tenants/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByTenantID, apperr.ErrTenantNotFound)},
-		{method: "POST", path: "/api/v1/tenants/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByTenantID, apperr.ErrTenantNotFound)},
+		{method: "GET", path: "/api/v1/tenants/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyIDsResolver: middleware.ResourcePropertyIDsWithNotFound("id", ownership.FindPropertyIDsByTenantID, apperr.ErrTenantNotFound)},
+		{method: "POST", path: "/api/v1/tenants/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyIDsResolver: middleware.ResourcePropertyIDsWithNotFound("id", ownership.FindPropertyIDsByTenantID, apperr.ErrTenantNotFound)},
 		{method: "GET", path: "/api/v1/tenants/:id", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "PATCH", path: "/api/v1/tenants/:id", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "GET", path: "/api/v1/tenants/:id/leases", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -133,10 +133,12 @@ func compileRoutePolicies(appCfg config.AppConfig, authenticator platformfirebas
 		if len(policy.allowedRoles) > 0 {
 			compiled.requireRoles = middleware.RequireRoles(policy.allowedRoles...)
 		}
-		if policy.propertyResolver != nil {
+		switch {
+		case policy.propertyResolver != nil && policy.propertyIDsResolver != nil:
+			panic("route policy cannot set both propertyResolver and propertyIDsResolver")
+		case policy.propertyResolver != nil:
 			compiled.requirePropertyAccess = middleware.RequirePropertyAccess(policy.propertyResolver, authzRepos.Properties)
-		}
-		if policy.propertyIDsResolver != nil {
+		case policy.propertyIDsResolver != nil:
 			compiled.requirePropertyAccess = middleware.RequireAnyPropertyAccess(policy.propertyIDsResolver)
 		}
 

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -3202,11 +3202,30 @@ func TestDeleteAttachmentReturnsAttachmentNotFound(t *testing.T) {
 	}
 }
 
-func TestGetTenantAttachmentsUsesTenantPropertyAccessPolicy(t *testing.T) {
-	repo := fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}}
-	engine := newTestEngine(repo, fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}}, fakePropertyRepo{}, fakeResourceOwnershipRepo{
-		propertyByTenantID: map[string]string{
-			"10000000-0000-0000-0000-000000000111": testPropertyID1,
+func TestCompileRoutePoliciesRejectsConflictingPropertyResolvers(t *testing.T) {
+	defer func() {
+		if recovered := recover(); recovered == nil {
+			t.Fatal("expected panic for conflicting property resolvers")
+		}
+	}()
+
+	compileRoutePolicies(config.AppConfig{}, fakeAuthenticator{}, &fakeUserRepo{}, AuthorizationRepositories{Properties: fakePropertyRepo{}}, []routePolicy{
+		{
+			method:           http.MethodGet,
+			path:             "/api/v1/test",
+			propertyResolver: func(*gin.Context) (string, error) { return testPropertyID1, nil },
+			propertyIDsResolver: func(*gin.Context) ([]string, error) {
+				return []string{testPropertyID1}, nil
+			},
+		},
+	})
+}
+
+func TestGetTenantAttachmentsUsesTenantMultiPropertyAccessPolicy(t *testing.T) {
+	repo := fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}}
+	engine := newTestEngine(repo, fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID2}}, fakePropertyRepo{}, fakeResourceOwnershipRepo{
+		propertyIDsByTenantID: map[string][]string{
+			"10000000-0000-0000-0000-000000000111": []string{testPropertyID1, testPropertyID2},
 		},
 	}, "", fakeJobRunsRepo{})
 
@@ -3228,8 +3247,8 @@ func TestGetTenantAttachmentsRejectsUnauthorizedTenantProperty(t *testing.T) {
 			testPropertyID1: "user-1",
 		},
 	}, fakeResourceOwnershipRepo{
-		propertyByTenantID: map[string]string{
-			"10000000-0000-0000-0000-000000000111": testPropertyID1,
+		propertyIDsByTenantID: map[string][]string{
+			"10000000-0000-0000-0000-000000000111": []string{testPropertyID1},
 		},
 	}, "", fakeJobRunsRepo{})
 
@@ -4794,15 +4813,11 @@ func (f fakeResourceOwnershipRepo) FindPropertyIDByTenantID(_ context.Context, t
 func (f fakeResourceOwnershipRepo) FindPropertyIDsByTenantID(_ context.Context, tenantID string) ([]string, error) {
 	if f.propertyIDsByTenantID != nil {
 		if propertyIDs, ok := f.propertyIDsByTenantID[tenantID]; ok {
-			return propertyIDs, nil
+			if propertyIDs == nil {
+				return []string{}, nil
+			}
+			return append([]string(nil), propertyIDs...), nil
 		}
-	}
-	if f.propertyByTenantID != nil {
-		propertyID, err := lookupPropertyID(f.propertyByTenantID, tenantID)
-		if err != nil {
-			return nil, err
-		}
-		return []string{propertyID}, nil
 	}
 	if f.tenantExists != nil && f.tenantExists[tenantID] {
 		return []string{}, nil

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -4816,7 +4816,9 @@ func (f fakeResourceOwnershipRepo) FindPropertyIDsByTenantID(_ context.Context, 
 			if propertyIDs == nil {
 				return []string{}, nil
 			}
-			return append([]string(nil), propertyIDs...), nil
+			copied := make([]string, len(propertyIDs))
+			copy(copied, propertyIDs)
+			return copied, nil
 		}
 	}
 	if f.tenantExists != nil && f.tenantExists[tenantID] {

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -3554,6 +3554,7 @@ type fakeResourceOwnershipRepo struct {
 	propertyByRoomID             map[string]string
 	roomIDLookup                 *string
 	propertyByTenantID           map[string]string
+	propertyIDsByTenantID        map[string][]string
 	propertyByLeaseID            map[string]string
 	propertyByBillID             map[string]string
 	billIDLookup                 *string
@@ -4788,6 +4789,25 @@ func (f fakeResourceOwnershipRepo) FindPropertyIDByRoomID(_ context.Context, roo
 
 func (f fakeResourceOwnershipRepo) FindPropertyIDByTenantID(_ context.Context, tenantID string) (string, error) {
 	return lookupPropertyID(f.propertyByTenantID, tenantID)
+}
+
+func (f fakeResourceOwnershipRepo) FindPropertyIDsByTenantID(_ context.Context, tenantID string) ([]string, error) {
+	if f.propertyIDsByTenantID != nil {
+		if propertyIDs, ok := f.propertyIDsByTenantID[tenantID]; ok {
+			return propertyIDs, nil
+		}
+	}
+	if f.propertyByTenantID != nil {
+		propertyID, err := lookupPropertyID(f.propertyByTenantID, tenantID)
+		if err != nil {
+			return nil, err
+		}
+		return []string{propertyID}, nil
+	}
+	if f.tenantExists != nil && f.tenantExists[tenantID] {
+		return []string{}, nil
+	}
+	return nil, dbresourceownership.ErrNotFound
 }
 
 func (f fakeResourceOwnershipRepo) FindPropertyIDByLeaseID(_ context.Context, leaseID string) (string, error) {

--- a/internal/platform/database/resourceownership/repository.go
+++ b/internal/platform/database/resourceownership/repository.go
@@ -16,6 +16,7 @@ type Repository interface {
 	FindPropertyIDByPropertyID(ctx context.Context, propertyID string) (string, error)
 	FindPropertyIDByRoomID(ctx context.Context, roomID string) (string, error)
 	FindPropertyIDByTenantID(ctx context.Context, tenantID string) (string, error)
+	FindPropertyIDsByTenantID(ctx context.Context, tenantID string) ([]string, error)
 	FindPropertyIDByLeaseID(ctx context.Context, leaseID string) (string, error)
 	FindPropertyIDByBillID(ctx context.Context, billID string) (string, error)
 	FindPropertyIDByJournalLogID(ctx context.Context, journalLogID string) (string, error)
@@ -60,15 +61,49 @@ LIMIT 1
 }
 
 func (r *SQLRepository) FindPropertyIDByTenantID(ctx context.Context, tenantID string) (string, error) {
+	propertyIDs, err := r.FindPropertyIDsByTenantID(ctx, tenantID)
+	if err != nil {
+		return "", err
+	}
+	if len(propertyIDs) == 0 {
+		return "", ErrNotFound
+	}
+
+	return propertyIDs[0], nil
+}
+
+func (r *SQLRepository) FindPropertyIDsByTenantID(ctx context.Context, tenantID string) ([]string, error) {
+	if err := r.EnsureTenantExists(ctx, tenantID); err != nil {
+		return nil, err
+	}
+
 	const query = `
-SELECT property_id
+SELECT DISTINCT property_id
 FROM leases
 WHERE tenant_id = $1
   AND deleted_at IS NULL
-LIMIT 1
+ORDER BY property_id
 `
 
-	return r.findPropertyID(ctx, query, tenantID, "query tenant property by id")
+	rows, err := r.db.QueryContext(ctx, query, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("query tenant property ids by id: %w", err)
+	}
+	defer rows.Close()
+
+	propertyIDs := []string{}
+	for rows.Next() {
+		var propertyID string
+		if err := rows.Scan(&propertyID); err != nil {
+			return nil, fmt.Errorf("scan tenant property ids by id: %w", err)
+		}
+		propertyIDs = append(propertyIDs, propertyID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tenant property ids by id: %w", err)
+	}
+
+	return propertyIDs, nil
 }
 
 func (r *SQLRepository) FindPropertyIDByLeaseID(ctx context.Context, leaseID string) (string, error) {
@@ -138,8 +173,10 @@ SELECT property_id
 FROM (
     SELECT property_id AS property_id
     FROM property_attachments
-    WHERE id = $1
-      AND deleted_at IS NULL
+    JOIN properties ON properties.id = property_attachments.property_id
+    WHERE property_attachments.id = $1
+      AND property_attachments.deleted_at IS NULL
+      AND properties.deleted_at IS NULL
 
     UNION ALL
 
@@ -152,12 +189,14 @@ FROM (
 
     UNION ALL
 
-	    SELECT leases.property_id AS property_id
-	    FROM tenant_attachments
-	    JOIN leases ON leases.tenant_id = tenant_attachments.tenant_id
-	    WHERE tenant_attachments.id = $1
-	      AND tenant_attachments.deleted_at IS NULL
-	      AND leases.deleted_at IS NULL
+    SELECT leases.property_id AS property_id
+    FROM tenant_attachments
+    JOIN tenants ON tenants.id = tenant_attachments.tenant_id
+    JOIN leases ON leases.tenant_id = tenants.id
+    WHERE tenant_attachments.id = $1
+      AND tenant_attachments.deleted_at IS NULL
+      AND tenants.deleted_at IS NULL
+      AND leases.deleted_at IS NULL
 
     UNION ALL
 

--- a/internal/platform/database/resourceownership/repository_test.go
+++ b/internal/platform/database/resourceownership/repository_test.go
@@ -1,0 +1,459 @@
+package resourceownership
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestFindPropertyIDsByTenantIDReturnsDistinctActiveLeasePropertyIDs(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	expectTenantExists(mock, "tenant-1")
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT DISTINCT property_id
+FROM leases
+WHERE tenant_id = $1
+  AND deleted_at IS NULL
+`)).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"property_id"}).
+			AddRow("property-1").
+			AddRow("property-2"))
+
+	propertyIDs, err := repo.FindPropertyIDsByTenantID(context.Background(), "tenant-1")
+	if err != nil {
+		t.Fatalf("FindPropertyIDsByTenantID: %v", err)
+	}
+	assertStringSet(t, propertyIDs, []string{"property-1", "property-2"})
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPropertyIDsByTenantIDReturnsEmptySliceWhenTenantHasNoActiveLeaseAssociation(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	expectTenantExists(mock, "tenant-1")
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT DISTINCT property_id
+FROM leases
+WHERE tenant_id = $1
+  AND deleted_at IS NULL
+`)).
+		WithArgs("tenant-1").
+		WillReturnRows(sqlmock.NewRows([]string{"property_id"}))
+
+	propertyIDs, err := repo.FindPropertyIDsByTenantID(context.Background(), "tenant-1")
+	if err != nil {
+		t.Fatalf("FindPropertyIDsByTenantID: %v", err)
+	}
+	if propertyIDs == nil {
+		t.Fatal("propertyIDs = nil, want empty slice")
+	}
+	if len(propertyIDs) != 0 {
+		t.Fatalf("propertyIDs = %v, want empty slice", propertyIDs)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPropertyIDsByTenantIDMapsMissingTenantToNotFound(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id
+FROM tenants
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("tenant-404").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.FindPropertyIDsByTenantID(context.Background(), "tenant-404")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPropertyIDsByTenantIDWrapsUnexpectedTenantLookupError(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id
+FROM tenants
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("tenant-1").
+		WillReturnError(sqlmock.ErrCancelled)
+
+	_, err := repo.FindPropertyIDsByTenantID(context.Background(), "tenant-1")
+	if !errors.Is(err, sqlmock.ErrCancelled) {
+		t.Fatalf("expected wrapped sqlmock.ErrCancelled, got %v", err)
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected unexpected error, got ErrNotFound: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPropertyIDsByTenantIDWrapsUnexpectedAssociationLookupError(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	expectTenantExists(mock, "tenant-1")
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT DISTINCT property_id
+FROM leases
+WHERE tenant_id = $1
+  AND deleted_at IS NULL
+`)).
+		WithArgs("tenant-1").
+		WillReturnError(sqlmock.ErrCancelled)
+
+	_, err := repo.FindPropertyIDsByTenantID(context.Background(), "tenant-1")
+	if !errors.Is(err, sqlmock.ErrCancelled) {
+		t.Fatalf("expected wrapped sqlmock.ErrCancelled, got %v", err)
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected unexpected error, got ErrNotFound: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPropertyIDBySinglePropertyResourceResolversUseActiveRows(t *testing.T) {
+	tests := []struct {
+		name       string
+		resourceID string
+		wantSQL    string
+		call       func(context.Context, *SQLRepository, string) (string, error)
+	}{
+		{
+			name:       "property",
+			resourceID: "property-1",
+			wantSQL: `
+SELECT id
+FROM properties
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`,
+			call: func(ctx context.Context, repo *SQLRepository, id string) (string, error) {
+				return repo.FindPropertyIDByPropertyID(ctx, id)
+			},
+		},
+		{
+			name:       "room",
+			resourceID: "room-1",
+			wantSQL: `
+SELECT property_id
+FROM rooms
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`,
+			call: func(ctx context.Context, repo *SQLRepository, id string) (string, error) {
+				return repo.FindPropertyIDByRoomID(ctx, id)
+			},
+		},
+		{
+			name:       "lease",
+			resourceID: "lease-1",
+			wantSQL: `
+SELECT property_id
+FROM leases
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`,
+			call: func(ctx context.Context, repo *SQLRepository, id string) (string, error) {
+				return repo.FindPropertyIDByLeaseID(ctx, id)
+			},
+		},
+		{
+			name:       "bill",
+			resourceID: "bill-1",
+			wantSQL: `
+SELECT property_id
+FROM bills
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`,
+			call: func(ctx context.Context, repo *SQLRepository, id string) (string, error) {
+				return repo.FindPropertyIDByBillID(ctx, id)
+			},
+		},
+		{
+			name:       "journal log",
+			resourceID: "journal-log-1",
+			wantSQL: `
+SELECT property_id
+FROM journal_logs
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`,
+			call: func(ctx context.Context, repo *SQLRepository, id string) (string, error) {
+				return repo.FindPropertyIDByJournalLogID(ctx, id)
+			},
+		},
+		{
+			name:       "repair request",
+			resourceID: "repair-request-1",
+			wantSQL: `
+SELECT property_id
+FROM repair_requests
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`,
+			call: func(ctx context.Context, repo *SQLRepository, id string) (string, error) {
+				return repo.FindPropertyIDByRepairRequestID(ctx, id)
+			},
+		},
+		{
+			name:       "force termination",
+			resourceID: "force-termination-1",
+			wantSQL: `
+SELECT leases.property_id
+FROM force_terminations
+JOIN leases ON leases.id = force_terminations.lease_id
+WHERE force_terminations.id = $1
+  AND leases.deleted_at IS NULL
+LIMIT 1
+`,
+			call: func(ctx context.Context, repo *SQLRepository, id string) (string, error) {
+				return repo.FindPropertyIDByForceTerminationID(ctx, id)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, repo := newResourceOwnershipRepoTest(t)
+			defer closeResourceOwnershipDB(t, db)
+
+			mock.ExpectQuery(regexp.QuoteMeta(tt.wantSQL)).
+				WithArgs(tt.resourceID).
+				WillReturnRows(sqlmock.NewRows([]string{"property_id"}).AddRow("property-1"))
+
+			propertyID, err := tt.call(context.Background(), repo, tt.resourceID)
+			if err != nil {
+				t.Fatalf("resolver returned error: %v", err)
+			}
+			if propertyID != "property-1" {
+				t.Fatalf("propertyID = %q, want property-1", propertyID)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
+
+func TestFindPropertyIDBySinglePropertyResourceResolverMapsNoRowsToNotFound(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT property_id
+FROM rooms
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("room-404").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.FindPropertyIDByRoomID(context.Background(), "room-404")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPropertyIDBySinglePropertyResourceResolverWrapsUnexpectedError(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT property_id
+FROM rooms
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("room-1").
+		WillReturnError(sqlmock.ErrCancelled)
+
+	_, err := repo.FindPropertyIDByRoomID(context.Background(), "room-1")
+	if !errors.Is(err, sqlmock.ErrCancelled) {
+		t.Fatalf("expected wrapped sqlmock.ErrCancelled, got %v", err)
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected unexpected error, got ErrNotFound: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPropertyIDByAttachmentIDRequiresActiveAttachmentAndHostResource(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	mock.ExpectQuery(`(?s)` +
+		`FROM property_attachments\s+JOIN properties ON properties.id = property_attachments.property_id\s+WHERE property_attachments.id = \$1\s+AND property_attachments.deleted_at IS NULL\s+AND properties.deleted_at IS NULL.*` +
+		`FROM room_attachments\s+JOIN rooms ON rooms.id = room_attachments.room_id\s+WHERE room_attachments.id = \$1\s+AND room_attachments.deleted_at IS NULL\s+AND rooms.deleted_at IS NULL.*` +
+		`FROM tenant_attachments\s+JOIN tenants ON tenants.id = tenant_attachments.tenant_id\s+JOIN leases ON leases.tenant_id = tenants.id\s+WHERE tenant_attachments.id = \$1\s+AND tenant_attachments.deleted_at IS NULL\s+AND tenants.deleted_at IS NULL\s+AND leases.deleted_at IS NULL.*` +
+		`FROM lease_attachments\s+JOIN leases ON leases.id = lease_attachments.lease_id\s+WHERE lease_attachments.id = \$1\s+AND lease_attachments.deleted_at IS NULL\s+AND leases.deleted_at IS NULL.*` +
+		`FROM journal_log_attachments\s+JOIN journal_logs ON journal_logs.id = journal_log_attachments.journal_log_id\s+WHERE journal_log_attachments.id = \$1\s+AND journal_log_attachments.deleted_at IS NULL\s+AND journal_logs.deleted_at IS NULL.*` +
+		`FROM repair_request_attachments\s+JOIN repair_requests ON repair_requests.id = repair_request_attachments.repair_request_id\s+WHERE repair_request_attachments.id = \$1\s+AND repair_request_attachments.deleted_at IS NULL\s+AND repair_requests.deleted_at IS NULL.*` +
+		`FROM bill_attachments\s+JOIN bills ON bills.id = bill_attachments.bill_id\s+WHERE bill_attachments.id = \$1\s+AND bill_attachments.deleted_at IS NULL\s+AND bills.deleted_at IS NULL`).
+		WithArgs("attachment-1").
+		WillReturnRows(sqlmock.NewRows([]string{"property_id"}).AddRow("property-1"))
+
+	propertyID, err := repo.FindPropertyIDByAttachmentID(context.Background(), "attachment-1")
+	if err != nil {
+		t.Fatalf("FindPropertyIDByAttachmentID: %v", err)
+	}
+	if propertyID != "property-1" {
+		t.Fatalf("propertyID = %q, want property-1", propertyID)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestEnsureTenantExists(t *testing.T) {
+	tests := []struct {
+		name      string
+		tenantID  string
+		mockRows  *sqlmock.Rows
+		mockError error
+		wantError error
+	}{
+		{
+			name:     "success",
+			tenantID: "tenant-1",
+			mockRows: sqlmock.NewRows([]string{"id"}).AddRow("tenant-1"),
+		},
+		{
+			name:      "not found",
+			tenantID:  "tenant-404",
+			mockError: sql.ErrNoRows,
+			wantError: ErrNotFound,
+		},
+		{
+			name:      "unexpected error",
+			tenantID:  "tenant-1",
+			mockError: sqlmock.ErrCancelled,
+			wantError: sqlmock.ErrCancelled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, repo := newResourceOwnershipRepoTest(t)
+			defer closeResourceOwnershipDB(t, db)
+
+			expectation := mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id
+FROM tenants
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+				WithArgs(tt.tenantID)
+			if tt.mockError != nil {
+				expectation.WillReturnError(tt.mockError)
+			} else {
+				expectation.WillReturnRows(tt.mockRows)
+			}
+
+			err := repo.EnsureTenantExists(context.Background(), tt.tenantID)
+			if tt.wantError == nil && err != nil {
+				t.Fatalf("EnsureTenantExists: %v", err)
+			}
+			if tt.wantError != nil && !errors.Is(err, tt.wantError) {
+				t.Fatalf("expected %v, got %v", tt.wantError, err)
+			}
+			if tt.wantError == sqlmock.ErrCancelled && errors.Is(err, ErrNotFound) {
+				t.Fatalf("expected unexpected error, got ErrNotFound: %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("ExpectationsWereMet: %v", err)
+			}
+		})
+	}
+}
+
+func expectTenantExists(mock sqlmock.Sqlmock, tenantID string) {
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id
+FROM tenants
+WHERE id = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs(tenantID).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(tenantID))
+}
+
+func newResourceOwnershipRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+
+	return db, mock, NewRepository(db)
+}
+
+func closeResourceOwnershipDB(t *testing.T, db *sql.DB) {
+	t.Helper()
+
+	if err := db.Close(); err != nil {
+		t.Logf("db.Close: %v", err)
+	}
+}
+
+func assertStringSet(t *testing.T, got []string, want []string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	seen := make(map[string]int, len(got))
+	for _, value := range got {
+		seen[value]++
+	}
+	for _, value := range want {
+		if seen[value] != 1 {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}

--- a/internal/server/attachment_adapters.go
+++ b/internal/server/attachment_adapters.go
@@ -107,6 +107,17 @@ func (a attachmentResourceAccessAdapter) EnsureGlobalTenantExists(ctx context.Co
 	return mapAttachmentResourceError(a.ownership.EnsureTenantExists(ctx, tenantID))
 }
 
+func (a attachmentResourceAccessAdapter) FindPropertyIDsByTenant(ctx context.Context, tenantID string) ([]string, error) {
+	propertyIDs, err := a.ownership.FindPropertyIDsByTenantID(ctx, tenantID)
+	if err != nil {
+		if errors.Is(err, dbresourceownership.ErrNotFound) {
+			return nil, appattachment.ErrResourceNotFound
+		}
+		return nil, err
+	}
+	return propertyIDs, nil
+}
+
 func mapOwnershipResult(propertyID string, err error) (string, error) {
 	if err != nil {
 		if errors.Is(err, dbresourceownership.ErrNotFound) {


### PR DESCRIPTION
## Summary

Closes #75.

This PR adds focused repository contract coverage for `internal/platform/database/resourceownership` and fixes the tenant ownership behavior that the new tests exposed.

## What changed

- Added `resourceownership` repository tests covering:
  - resource-to-property resolver success paths
  - `sql.ErrNoRows` to `resourceownership.ErrNotFound`
  - unexpected database error wrapping
  - active-row / soft-delete filtering expectations
  - attachment ownership across property, room, tenant, lease, journal log, repair request, and bill attachment hosts
  - `EnsureTenantExists` semantics
- Added `FindPropertyIDsByTenantID` for tenant multi-property ownership resolution.
- Kept `FindPropertyIDByTenantID` as a deterministic single-property compatibility wrapper.
- Updated tenant attachment authorization to treat tenants as long-lived identity records whose associated properties are derived from non-deleted leases.
- Updated attachment application access checks so tenant attachments authorize against any associated property instead of an arbitrary single property.
- Added middleware/application tests for multi-property tenant authorization behavior.

## Behavior locked by this PR

- A tenant must exist and not be soft-deleted before tenant ownership is resolved.
- Tenant property association is derived from distinct non-deleted lease `property_id` values.
- Non-admin users may access tenant attachment flows when any associated tenant property intersects with their assigned properties.
- Admin users may access tenant attachment flows when the tenant exists, even if no property association currently exists.
- Tenant existence without an accessible associated property is treated as forbidden for non-admin users.
- Attachment ownership SQL now filters both the attachment row and the host resource row where applicable.

## Why

Issue #75 is first-launch-critical because HTTP authorization depends on resolving resource IDs back to property IDs before access checks run. The previous tenant lookup used a single unordered lease lookup, which could not correctly represent a tenant associated with multiple properties over time.

## Validation

- `go test ./internal/platform/database/resourceownership`
- `go test ./internal/application/attachment`
- `go test ./internal/http/middleware`
- `go test ./internal/http/router`
- `go test ./internal/http/handler`
- `go test ./internal/server`
- `go test ./...`
- `git diff --check`