### PR TITLE
[codex] Add attachment boundary tests

### DIFF
--- a/internal/application/attachment/service_test.go
+++ b/internal/application/attachment/service_test.go
@@ -380,6 +380,89 @@ func TestRegisterAttachmentRejectsRevokedResourceAccess(t *testing.T) {
 	assertAppErrorCode(t, err, apperr.CodeForbidden)
 }
 
+func TestListAttachmentsReturnsRepositoryAttachments(t *testing.T) {
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	repo := &attachmentRepoStub{
+		listAttachments: []Attachment{
+			{
+				ID:           "10000000-0000-0000-0000-000000000011",
+				ResourceType: ResourceTypeProperty,
+				ResourceID:   testPropertyID,
+				ObjectPath:   "attachments/property/object.pdf",
+				FileName:     "object.pdf",
+				CreatedAt:    now,
+			},
+		},
+	}
+	service := newTestService(repo, &storageStub{}, &resourceAccessStub{}, now)
+
+	attachments, err := service.ListAttachments(context.Background(), ResourceTypeProperty, testPropertyID)
+	if err != nil {
+		t.Fatalf("ListAttachments returned error: %v", err)
+	}
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if attachments[0].ID != "10000000-0000-0000-0000-000000000011" {
+		t.Fatalf("unexpected attachment: %#v", attachments[0])
+	}
+	if repo.listResourceType != ResourceTypeProperty || repo.listResourceID != testPropertyID {
+		t.Fatalf("unexpected list params: %s %s", repo.listResourceType, repo.listResourceID)
+	}
+}
+
+func TestListAttachmentsRejectsInvalidResourceType(t *testing.T) {
+	service := newTestService(&attachmentRepoStub{}, &storageStub{}, &resourceAccessStub{}, time.Now().UTC())
+
+	_, err := service.ListAttachments(context.Background(), ResourceType("invalid"), testPropertyID)
+	assertAppErrorCode(t, err, apperr.CodeBadRequest)
+}
+
+func TestListAttachmentsRejectsInvalidResourceID(t *testing.T) {
+	service := newTestService(&attachmentRepoStub{}, &storageStub{}, &resourceAccessStub{}, time.Now().UTC())
+
+	_, err := service.ListAttachments(context.Background(), ResourceTypeProperty, "not-a-uuid")
+	assertAppErrorCode(t, err, apperr.CodeBadRequest)
+}
+
+func TestListAttachmentsMapsRepositoryNotFoundToResourceNotFound(t *testing.T) {
+	service := newTestService(&attachmentRepoStub{listErr: ErrResourceNotFound}, &storageStub{}, &resourceAccessStub{}, time.Now().UTC())
+
+	_, err := service.ListAttachments(context.Background(), ResourceTypeRoom, "10000000-0000-0000-0000-000000000004")
+	assertAppErrorCode(t, err, apperr.CodeRoomNotFound)
+}
+
+func TestDeleteAttachmentSoftDeletesRepositoryRow(t *testing.T) {
+	repo := &attachmentRepoStub{}
+	service := newTestService(repo, &storageStub{}, &resourceAccessStub{}, time.Now().UTC())
+
+	err := service.DeleteAttachment(context.Background(), "10000000-0000-0000-0000-000000000011")
+	if err != nil {
+		t.Fatalf("DeleteAttachment returned error: %v", err)
+	}
+	if repo.deletedAttachmentID != "10000000-0000-0000-0000-000000000011" {
+		t.Fatalf("expected deleted attachment id to be captured, got %q", repo.deletedAttachmentID)
+	}
+}
+
+func TestDeleteAttachmentRejectsInvalidID(t *testing.T) {
+	repo := &attachmentRepoStub{}
+	service := newTestService(repo, &storageStub{}, &resourceAccessStub{}, time.Now().UTC())
+
+	err := service.DeleteAttachment(context.Background(), "not-a-uuid")
+	assertAppErrorCode(t, err, apperr.CodeBadRequest)
+	if repo.deletedAttachmentID != "" {
+		t.Fatalf("expected repository not to be called, got %q", repo.deletedAttachmentID)
+	}
+}
+
+func TestDeleteAttachmentMapsRepositoryNotFoundToAttachmentNotFound(t *testing.T) {
+	service := newTestService(&attachmentRepoStub{softDeleteErr: ErrNotFound}, &storageStub{}, &resourceAccessStub{}, time.Now().UTC())
+
+	err := service.DeleteAttachment(context.Background(), "10000000-0000-0000-0000-000000000011")
+	assertAppErrorCode(t, err, apperr.CodeAttachmentNotFound)
+}
+
 func newTestService(repo *attachmentRepoStub, storage *storageStub, access *resourceAccessStub, now time.Time) *Service {
 	service := NewService(repo, storage, access, fakeTxRunner{}, 15*time.Minute)
 	service.now = func() time.Time { return now }
@@ -411,6 +494,12 @@ type attachmentRepoStub struct {
 	createAttachmentParams *CreateAttachmentParams
 	deletedToken           bool
 	deleteErr              error
+	listAttachments        []Attachment
+	listResourceType       ResourceType
+	listResourceID         string
+	listErr                error
+	deletedAttachmentID    string
+	softDeleteErr          error
 }
 
 func (r *attachmentRepoStub) CreateUploadToken(_ context.Context, _ *sql.Tx, params CreateUploadTokenParams) (*UploadToken, error) {
@@ -443,8 +532,13 @@ func (r *attachmentRepoStub) DeleteUploadTokenByNonce(_ context.Context, _ *sql.
 	return nil
 }
 
-func (r *attachmentRepoStub) ListByResource(_ context.Context, _ ResourceType, _ string) ([]Attachment, error) {
-	return nil, nil
+func (r *attachmentRepoStub) ListByResource(_ context.Context, resourceType ResourceType, resourceID string) ([]Attachment, error) {
+	r.listResourceType = resourceType
+	r.listResourceID = resourceID
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return r.listAttachments, nil
 }
 
 func (r *attachmentRepoStub) CreateAttachment(_ context.Context, _ *sql.Tx, params CreateAttachmentParams) (*Attachment, error) {
@@ -465,7 +559,11 @@ func (r *attachmentRepoStub) CreateAttachment(_ context.Context, _ *sql.Tx, para
 	}, nil
 }
 
-func (r *attachmentRepoStub) SoftDeleteAttachmentByID(_ context.Context, _ *sql.Tx, _ string) error {
+func (r *attachmentRepoStub) SoftDeleteAttachmentByID(_ context.Context, _ *sql.Tx, attachmentID string) error {
+	r.deletedAttachmentID = attachmentID
+	if r.softDeleteErr != nil {
+		return r.softDeleteErr
+	}
 	return nil
 }
 

--- a/internal/platform/database/attachments/repository.go
+++ b/internal/platform/database/attachments/repository.go
@@ -77,6 +77,16 @@ var resourceSpecs = map[ResourceType]resourceSpec{
 	},
 }
 
+var softDeleteResourceOrder = []ResourceType{
+	ResourceTypeProperty,
+	ResourceTypeRoom,
+	ResourceTypeTenant,
+	ResourceTypeLease,
+	ResourceTypeJournalLog,
+	ResourceTypeRepairRequest,
+	ResourceTypeBill,
+}
+
 // Attachment is the persistence model shared by all attachment tables.
 type Attachment struct {
 	ID           string
@@ -388,7 +398,8 @@ func (r *SQLRepository) SoftDeleteAttachmentByID(ctx context.Context, tx *sql.Tx
 		return errors.New("soft delete attachment requires transaction")
 	}
 
-	for resourceType, spec := range resourceSpecs {
+	for _, resourceType := range softDeleteResourceOrder {
+		spec := resourceSpecs[resourceType]
 		query := fmt.Sprintf(`
 UPDATE %s
 SET deleted_at = now()

--- a/internal/platform/database/attachments/repository_test.go
+++ b/internal/platform/database/attachments/repository_test.go
@@ -3,12 +3,195 @@ package attachments
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"regexp"
 	"testing"
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 )
+
+func TestCreateFindAndDeleteUploadTokenLifecycle(t *testing.T) {
+	db, mock, repo := newAttachmentRepoTest(t)
+	tx := beginAttachmentTx(t, db, mock)
+	expiresAt := time.Date(2026, 4, 28, 10, 15, 0, 0, time.UTC)
+	createdAt := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO attachment_upload_tokens (
+	nonce,
+	object_path,
+	issued_to,
+	resource_type,
+	resource_id,
+	expires_at
+) VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING
+	id,
+	nonce,
+	object_path,
+	issued_to,
+	resource_type,
+	resource_id,
+	expires_at,
+	created_at
+`)).
+		WithArgs(
+			"nonce-1",
+			"attachments/property/object.pdf",
+			"10000000-0000-0000-0000-000000000001",
+			"property",
+			"10000000-0000-0000-0000-000000000002",
+			expiresAt,
+		).
+		WillReturnRows(uploadTokenRows().AddRow(
+			"90000000-0000-0000-0000-000000000001",
+			"nonce-1",
+			"attachments/property/object.pdf",
+			"10000000-0000-0000-0000-000000000001",
+			"property",
+			"10000000-0000-0000-0000-000000000002",
+			expiresAt,
+			createdAt,
+		))
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM attachment_upload_tokens WHERE nonce = $1`)).
+		WithArgs("nonce-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	token, err := repo.CreateUploadToken(context.Background(), tx, CreateUploadTokenParams{
+		Nonce:        "nonce-1",
+		ObjectPath:   "attachments/property/object.pdf",
+		IssuedTo:     "10000000-0000-0000-0000-000000000001",
+		ResourceType: ResourceTypeProperty,
+		ResourceID:   "10000000-0000-0000-0000-000000000002",
+		ExpiresAt:    expiresAt,
+	})
+	if err != nil {
+		t.Fatalf("CreateUploadToken returned error: %v", err)
+	}
+	if token.ResourceType != ResourceTypeProperty || token.ExpiresAt != expiresAt {
+		t.Fatalf("unexpected upload token: %#v", token)
+	}
+	if err := repo.DeleteUploadTokenByNonce(context.Background(), tx, "nonce-1"); err != nil {
+		t.Fatalf("DeleteUploadTokenByNonce returned error: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("tx.Commit: %v", err)
+	}
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT
+	id,
+	nonce,
+	object_path,
+	issued_to,
+	resource_type,
+	resource_id,
+	expires_at,
+	created_at
+FROM attachment_upload_tokens
+WHERE nonce = $1
+LIMIT 1
+`)).
+		WithArgs("nonce-1").
+		WillReturnRows(uploadTokenRows().AddRow(
+			"90000000-0000-0000-0000-000000000001",
+			"nonce-1",
+			"attachments/property/object.pdf",
+			"10000000-0000-0000-0000-000000000001",
+			"property",
+			"10000000-0000-0000-0000-000000000002",
+			expiresAt,
+			createdAt,
+		))
+
+	found, err := repo.FindUploadTokenByNonce(context.Background(), "nonce-1")
+	if err != nil {
+		t.Fatalf("FindUploadTokenByNonce returned error: %v", err)
+	}
+	if found.ID != "90000000-0000-0000-0000-000000000001" {
+		t.Fatalf("unexpected found token: %#v", found)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestFindUploadTokenByNonceMapsNoRowsToNotFound(t *testing.T) {
+	_, mock, repo := newAttachmentRepoTest(t)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT
+	id,
+	nonce,
+	object_path,
+	issued_to,
+	resource_type,
+	resource_id,
+	expires_at,
+	created_at
+FROM attachment_upload_tokens
+WHERE nonce = $1
+LIMIT 1
+`)).
+		WithArgs("missing").
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.FindUploadTokenByNonce(context.Background(), "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestDeleteUploadTokenByNonceRowsAffectedZeroMapsToNotFound(t *testing.T) {
+	db, mock, repo := newAttachmentRepoTest(t)
+	tx := beginAttachmentTx(t, db, mock)
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM attachment_upload_tokens WHERE nonce = $1`)).
+		WithArgs("missing").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectRollback()
+
+	err := repo.DeleteUploadTokenByNonce(context.Background(), tx, "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("tx.Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestDeleteExpiredUploadTokensReturnsRowsAffected(t *testing.T) {
+	db, mock, repo := newAttachmentRepoTest(t)
+	tx := beginAttachmentTx(t, db, mock)
+	before := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM attachment_upload_tokens WHERE expires_at < $1`)).
+		WithArgs(before).
+		WillReturnResult(sqlmock.NewResult(0, 3))
+	mock.ExpectCommit()
+
+	count, err := repo.DeleteExpiredUploadTokens(context.Background(), tx, before)
+	if err != nil {
+		t.Fatalf("DeleteExpiredUploadTokens returned error: %v", err)
+	}
+	if count != 3 {
+		t.Fatalf("expected 3 deleted tokens, got %d", count)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("tx.Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
 
 func TestCreateRepairRequestAttachmentDefaultsNilSortOrderToZero(t *testing.T) {
 	db, mock, err := sqlmock.New()
@@ -98,6 +281,202 @@ RETURNING
 	}
 }
 
+func TestCreatePropertyAttachmentUsesPropertyTable(t *testing.T) {
+	db, mock, repo := newAttachmentRepoTest(t)
+	tx := beginAttachmentTx(t, db, mock)
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	uploadedBy := "10000000-0000-0000-0000-000000000001"
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO property_attachments (
+	property_id,
+	object_path,
+	file_name,
+	uploaded_by
+) VALUES ($1, $2, $3, $4)
+RETURNING
+	id,
+	property_id,
+	object_path,
+	file_name,
+	uploaded_by,
+	NULL AS sort_order,
+	NULL AS photo_stage,
+	created_at,
+	deleted_at
+`)).
+		WithArgs(
+			"10000000-0000-0000-0000-000000000002",
+			"attachments/property/object.pdf",
+			"object.pdf",
+			&uploadedBy,
+		).
+		WillReturnRows(attachmentRows("property_id").AddRow(
+			"80000000-0000-0000-0000-000000000001",
+			"10000000-0000-0000-0000-000000000002",
+			"attachments/property/object.pdf",
+			"object.pdf",
+			uploadedBy,
+			nil,
+			nil,
+			now,
+			nil,
+		))
+	mock.ExpectCommit()
+
+	attachment, err := repo.CreateAttachment(context.Background(), tx, CreateAttachmentParams{
+		ResourceType: ResourceTypeProperty,
+		ResourceID:   "10000000-0000-0000-0000-000000000002",
+		ObjectPath:   "attachments/property/object.pdf",
+		FileName:     "object.pdf",
+		UploadedBy:   &uploadedBy,
+	})
+	if err != nil {
+		t.Fatalf("CreateAttachment returned error: %v", err)
+	}
+	if attachment.ResourceType != ResourceTypeProperty || attachment.UploadedBy == nil || *attachment.UploadedBy != uploadedBy {
+		t.Fatalf("unexpected attachment: %#v", attachment)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("tx.Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestListByResourceUsesRepairRequestSortOrder(t *testing.T) {
+	_, mock, repo := newAttachmentRepoTest(t)
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT
+	id,
+	repair_request_id,
+	object_path,
+	file_name,
+	uploaded_by,
+	sort_order,
+	photo_stage,
+	created_at,
+	deleted_at
+FROM repair_request_attachments
+WHERE repair_request_id = $1
+  AND deleted_at IS NULL
+ORDER BY sort_order ASC, created_at ASC
+`)).
+		WithArgs("70000000-0000-0000-0000-000000000001").
+		WillReturnRows(attachmentRows("repair_request_id").AddRow(
+			"80000000-0000-0000-0000-000000000001",
+			"70000000-0000-0000-0000-000000000001",
+			"attachments/repair_request/object.jpg",
+			"object.jpg",
+			nil,
+			1,
+			"before",
+			now,
+			nil,
+		))
+
+	attachments, err := repo.ListByResource(context.Background(), ResourceTypeRepairRequest, "70000000-0000-0000-0000-000000000001")
+	if err != nil {
+		t.Fatalf("ListByResource returned error: %v", err)
+	}
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if attachments[0].SortOrder == nil || *attachments[0].SortOrder != 1 {
+		t.Fatalf("unexpected sort order: %#v", attachments[0])
+	}
+	if attachments[0].PhotoStage == nil || *attachments[0].PhotoStage != PhotoStageBefore {
+		t.Fatalf("unexpected photo stage: %#v", attachments[0])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestListByResourceRejectsUnsupportedResourceType(t *testing.T) {
+	_, mock, repo := newAttachmentRepoTest(t)
+
+	_, err := repo.ListByResource(context.Background(), ResourceType("unsupported"), "10000000-0000-0000-0000-000000000001")
+	if err == nil {
+		t.Fatal("expected unsupported resource type error")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestSoftDeleteAttachmentByIDUsesDeterministicResourceOrder(t *testing.T) {
+	db, mock, repo := newAttachmentRepoTest(t)
+	tx := beginAttachmentTx(t, db, mock)
+	attachmentID := "80000000-0000-0000-0000-000000000001"
+
+	expectSoftDelete(mock, "property_attachments", attachmentID, 0)
+	expectSoftDelete(mock, "room_attachments", attachmentID, 0)
+	expectSoftDelete(mock, "tenant_attachments", attachmentID, 0)
+	expectSoftDelete(mock, "lease_attachments", attachmentID, 0)
+	expectSoftDelete(mock, "journal_log_attachments", attachmentID, 0)
+	expectSoftDelete(mock, "repair_request_attachments", attachmentID, 1)
+	mock.ExpectCommit()
+
+	if err := repo.SoftDeleteAttachmentByID(context.Background(), tx, attachmentID); err != nil {
+		t.Fatalf("SoftDeleteAttachmentByID returned error: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("tx.Commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestSoftDeleteAttachmentByIDRowsAffectedZeroMapsToNotFound(t *testing.T) {
+	db, mock, repo := newAttachmentRepoTest(t)
+	tx := beginAttachmentTx(t, db, mock)
+	attachmentID := "80000000-0000-0000-0000-000000000001"
+
+	for _, table := range []string{
+		"property_attachments",
+		"room_attachments",
+		"tenant_attachments",
+		"lease_attachments",
+		"journal_log_attachments",
+		"repair_request_attachments",
+		"bill_attachments",
+	} {
+		expectSoftDelete(mock, table, attachmentID, 0)
+	}
+	mock.ExpectRollback()
+
+	err := repo.SoftDeleteAttachmentByID(context.Background(), tx, attachmentID)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("tx.Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func newAttachmentRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	t.Cleanup(func() {
+		mock.ExpectClose()
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close: %v", err)
+		}
+	})
+	return db, mock, NewRepository(db)
+}
+
 func beginAttachmentTx(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.Tx {
 	t.Helper()
 	mock.ExpectBegin()
@@ -106,4 +485,42 @@ func beginAttachmentTx(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.Tx {
 		t.Fatalf("db.Begin: %v", err)
 	}
 	return tx
+}
+
+func uploadTokenRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"nonce",
+		"object_path",
+		"issued_to",
+		"resource_type",
+		"resource_id",
+		"expires_at",
+		"created_at",
+	})
+}
+
+func attachmentRows(resourceIDColumn string) *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		resourceIDColumn,
+		"object_path",
+		"file_name",
+		"uploaded_by",
+		"sort_order",
+		"photo_stage",
+		"created_at",
+		"deleted_at",
+	})
+}
+
+func expectSoftDelete(mock sqlmock.Sqlmock, table string, attachmentID string, rowsAffected int64) {
+	mock.ExpectExec(regexp.QuoteMeta(`
+UPDATE ` + table + `
+SET deleted_at = now()
+WHERE id = $1
+  AND deleted_at IS NULL
+`)).
+		WithArgs(attachmentID).
+		WillReturnResult(sqlmock.NewResult(0, rowsAffected))
 }

--- a/internal/platform/storage/gcs.go
+++ b/internal/platform/storage/gcs.go
@@ -17,9 +17,23 @@ import (
 
 // GCSStorage implements attachment storage operations with Google Cloud Storage.
 type GCSStorage struct {
-	client       *gcstorage.Client
-	bucketName   string
+	client      *gcstorage.Client
+	bucketName  string
+	attrsReader gcsAttrsReader
+
 	emulatorHost string
+}
+
+type gcsAttrsReader interface {
+	Attrs(ctx context.Context, bucketName string, objectPath string) (*gcstorage.ObjectAttrs, error)
+}
+
+type gcsClientAttrsReader struct {
+	client *gcstorage.Client
+}
+
+func (r gcsClientAttrsReader) Attrs(ctx context.Context, bucketName string, objectPath string) (*gcstorage.ObjectAttrs, error) {
+	return r.client.Bucket(bucketName).Object(objectPath).Attrs(ctx)
 }
 
 // NewGCSStorage creates a Cloud Storage-backed attachment storage adapter.
@@ -42,6 +56,7 @@ func NewGCSStorage(ctx context.Context, cfg config.StorageConfig) (*GCSStorage, 
 	return &GCSStorage{
 		client:       client,
 		bucketName:   cfg.GCSBucketName,
+		attrsReader:  gcsClientAttrsReader{client: client},
 		emulatorHost: strings.TrimRight(cfg.GCSEmulatorHost, "/"),
 	}, nil
 }
@@ -70,7 +85,12 @@ func (s *GCSStorage) GenerateUploadURL(ctx context.Context, objectPath string, c
 
 // GetObjectMetadata returns metadata for an uploaded object.
 func (s *GCSStorage) GetObjectMetadata(ctx context.Context, objectPath string) (*appattachment.ObjectMetadata, error) {
-	attrs, err := s.client.Bucket(s.bucketName).Object(objectPath).Attrs(ctx)
+	attrsReader := s.attrsReader
+	if attrsReader == nil {
+		attrsReader = gcsClientAttrsReader{client: s.client}
+	}
+
+	attrs, err := attrsReader.Attrs(ctx, s.bucketName, objectPath)
 	if err != nil {
 		if errors.Is(err, gcstorage.ErrObjectNotExist) {
 			return nil, appattachment.ErrStorageObjectMissing

--- a/internal/platform/storage/gcs_test.go
+++ b/internal/platform/storage/gcs_test.go
@@ -1,0 +1,99 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	gcstorage "cloud.google.com/go/storage"
+
+	appattachment "stds_backend/internal/application/attachment"
+)
+
+func TestGenerateUploadURLEmulatorDoesNotRequireSignedURL(t *testing.T) {
+	storage := &GCSStorage{
+		bucketName:   "test-bucket",
+		emulatorHost: "http://127.0.0.1:9023",
+	}
+
+	uploadURL, err := storage.GenerateUploadURL(
+		context.Background(),
+		"attachments/property/10000000-0000-0000-0000-000000000001/object.pdf",
+		"application/pdf",
+		time.Date(2026, 4, 28, 10, 15, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("GenerateUploadURL returned error: %v", err)
+	}
+
+	want := "http://127.0.0.1:9023/test-bucket/attachments/property/10000000-0000-0000-0000-000000000001/object.pdf"
+	if uploadURL != want {
+		t.Fatalf("expected emulator upload URL %q, got %q", want, uploadURL)
+	}
+}
+
+func TestGetObjectMetadataMapsAttrs(t *testing.T) {
+	reader := &fakeGCSAttrsReader{
+		attrs: &gcstorage.ObjectAttrs{
+			ContentType: "application/pdf",
+			Size:        1024,
+		},
+	}
+	storage := &GCSStorage{
+		bucketName:  "test-bucket",
+		attrsReader: reader,
+	}
+
+	metadata, err := storage.GetObjectMetadata(context.Background(), "attachments/property/object.pdf")
+	if err != nil {
+		t.Fatalf("GetObjectMetadata returned error: %v", err)
+	}
+	if reader.bucketName != "test-bucket" || reader.objectPath != "attachments/property/object.pdf" {
+		t.Fatalf("unexpected attrs lookup: bucket=%q object=%q", reader.bucketName, reader.objectPath)
+	}
+	if metadata.ContentType != "application/pdf" || metadata.Size != 1024 {
+		t.Fatalf("unexpected metadata: %#v", metadata)
+	}
+}
+
+func TestGetObjectMetadataMapsMissingObject(t *testing.T) {
+	storage := &GCSStorage{
+		bucketName:  "test-bucket",
+		attrsReader: &fakeGCSAttrsReader{err: gcstorage.ErrObjectNotExist},
+	}
+
+	_, err := storage.GetObjectMetadata(context.Background(), "attachments/property/missing.pdf")
+	if !errors.Is(err, appattachment.ErrStorageObjectMissing) {
+		t.Fatalf("expected ErrStorageObjectMissing, got %v", err)
+	}
+}
+
+func TestGetObjectMetadataWrapsOtherErrors(t *testing.T) {
+	backendErr := errors.New("storage unavailable")
+	storage := &GCSStorage{
+		bucketName:  "test-bucket",
+		attrsReader: &fakeGCSAttrsReader{err: backendErr},
+	}
+
+	_, err := storage.GetObjectMetadata(context.Background(), "attachments/property/object.pdf")
+	if !errors.Is(err, backendErr) {
+		t.Fatalf("expected wrapped backend error, got %v", err)
+	}
+}
+
+type fakeGCSAttrsReader struct {
+	attrs      *gcstorage.ObjectAttrs
+	err        error
+	bucketName string
+	objectPath string
+}
+
+func (r *fakeGCSAttrsReader) Attrs(_ context.Context, bucketName string, objectPath string) (*gcstorage.ObjectAttrs, error) {
+	r.bucketName = bucketName
+	r.objectPath = objectPath
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.attrs, nil
+}


### PR DESCRIPTION
## Summary

Closed #77 
Addresses #77 by adding focused first-launch coverage for attachment behavior across the application service, repository, and storage adapter boundaries.

This PR covers:

- Attachment application `ListAttachments` behavior, including success, invalid input validation, and resource not-found mapping.
- Attachment application `DeleteAttachment` behavior, including successful soft delete forwarding, invalid ID validation, and attachment not-found mapping.
- Attachment repository upload-token lifecycle behavior: create, find by nonce, delete by nonce, expired-token cleanup count, and missing-token semantics.
- Attachment repository list/create/delete contracts, including resource table selection, repair-request ordering, `RowsAffected()==0` not-found behavior, and unsupported resource type handling.
- Storage adapter behavior needed by attachment flows, including emulator upload URLs, metadata mapping, missing-object mapping, and wrapped backend errors without real GCS calls.

## Small Production Changes

Two small codebase changes were included so the contracts are deterministic and testable:

- `SoftDeleteAttachmentByID` now uses a fixed resource-type order instead of ranging over the `resourceSpecs` map. This keeps cross-table soft-delete behavior deterministic and makes the repository contract test stable.
- `GCSStorage` now has a narrow attrs-reader seam around the GCS object `Attrs` call. Production still uses the same GCS SDK path, while tests can fake metadata and missing-object responses without calling real cloud services.

## Out Of Scope

- No browser or E2E upload flow tests.
- No real Google Cloud Storage calls.
- No new attachment features or resource types.
- No resource ownership resolver tests.

## Validation

- `go test ./internal/application/attachment ./internal/platform/database/attachments ./internal/platform/storage`
- `go test ./...`
- `git diff --check`