### PR TITLE
Add external adapter contract tests

### DIFF
--- a/internal/platform/firebase/auth.go
+++ b/internal/platform/firebase/auth.go
@@ -44,8 +44,17 @@ type UserProvisioner interface {
 
 // Client is the Firebase-backed implementation of Authenticator.
 type Client struct {
-	auth                     *firebaseauth.Client
+	auth                     firebaseAuthClient
 	passwordResetRedirectURL string
+}
+
+type firebaseAuthClient interface {
+	VerifyIDToken(ctx context.Context, token string) (*firebaseauth.Token, error)
+	SetCustomUserClaims(ctx context.Context, uid string, customClaims map[string]interface{}) error
+	CreateUser(ctx context.Context, user *firebaseauth.UserToCreate) (*firebaseauth.UserRecord, error)
+	PasswordResetLink(ctx context.Context, email string) (string, error)
+	PasswordResetLinkWithSettings(ctx context.Context, email string, settings *firebaseauth.ActionCodeSettings) (string, error)
+	DeleteUser(ctx context.Context, uid string) error
 }
 
 // New creates a Firebase auth client from the provided configuration.

--- a/internal/platform/firebase/auth_test.go
+++ b/internal/platform/firebase/auth_test.go
@@ -1,7 +1,14 @@
 package firebase
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+
+	firebaseauth "firebase.google.com/go/v4/auth"
 
 	"stds_backend/internal/config"
 )
@@ -27,4 +34,255 @@ func TestShouldLoadCredentials(t *testing.T) {
 			t.Fatal("expected credentials to be skipped in emulator mode")
 		}
 	})
+}
+
+func TestClientVerifyIDTokenParsesClaims(t *testing.T) {
+	authClient := &fakeFirebaseAuthClient{
+		token: &firebaseauth.Token{
+			UID: "firebase-uid",
+			Claims: map[string]interface{}{
+				"role":                  "admin",
+				"assigned_property_ids": []interface{}{"property-1", "", "property-2", 3},
+			},
+		},
+	}
+	client := &Client{auth: authClient}
+
+	claims, err := client.VerifyIDToken(context.Background(), "id-token")
+	if err != nil {
+		t.Fatalf("verify token: %v", err)
+	}
+
+	if authClient.verifyToken != "id-token" {
+		t.Fatalf("expected token to be forwarded, got %q", authClient.verifyToken)
+	}
+	if claims.UID != "firebase-uid" {
+		t.Fatalf("expected uid to be parsed, got %q", claims.UID)
+	}
+	if claims.Role != "admin" {
+		t.Fatalf("expected role to be parsed, got %q", claims.Role)
+	}
+	if len(claims.AssignedPropertyIDs) != 2 || claims.AssignedPropertyIDs[0] != "property-1" || claims.AssignedPropertyIDs[1] != "property-2" {
+		t.Fatalf("unexpected assigned property ids: %#v", claims.AssignedPropertyIDs)
+	}
+}
+
+func TestClientSetCustomClaimsPayload(t *testing.T) {
+	authClient := &fakeFirebaseAuthClient{}
+	client := &Client{auth: authClient}
+
+	err := client.SetCustomClaims(context.Background(), "firebase-uid", "staff", []string{"property-1", "property-2"})
+	if err != nil {
+		t.Fatalf("set custom claims: %v", err)
+	}
+
+	if authClient.claimsUID != "firebase-uid" {
+		t.Fatalf("expected uid to be forwarded, got %q", authClient.claimsUID)
+	}
+	if authClient.claims["role"] != "staff" {
+		t.Fatalf("expected role claim, got %#v", authClient.claims["role"])
+	}
+	propertyIDs, ok := authClient.claims["assigned_property_ids"].([]string)
+	if !ok {
+		t.Fatalf("expected assigned_property_ids []string, got %T", authClient.claims["assigned_property_ids"])
+	}
+	if len(propertyIDs) != 2 || propertyIDs[0] != "property-1" || propertyIDs[1] != "property-2" {
+		t.Fatalf("unexpected assigned_property_ids claim: %#v", propertyIDs)
+	}
+}
+
+func TestClientCreateEmailPasswordUser(t *testing.T) {
+	t.Run("returns created uid", func(t *testing.T) {
+		authClient := &fakeFirebaseAuthClient{
+			userRecord: &firebaseauth.UserRecord{
+				UserInfo: &firebaseauth.UserInfo{UID: "firebase-uid"},
+			},
+		}
+		client := &Client{auth: authClient}
+
+		uid, err := client.CreateEmailPasswordUser(context.Background(), "user@example.com", "User Name")
+		if err != nil {
+			t.Fatalf("create user: %v", err)
+		}
+
+		if uid != "firebase-uid" {
+			t.Fatalf("expected created uid, got %q", uid)
+		}
+		if authClient.createUser == nil {
+			t.Fatal("expected create user request")
+		}
+	})
+
+	t.Run("maps duplicate email", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":{"message":"EMAIL_EXISTS"}}`))
+		}))
+		defer server.Close()
+		t.Setenv("FIREBASE_AUTH_EMULATOR_HOST", "")
+
+		client, err := New(context.Background(), config.FirebaseConfig{
+			ProjectID:        "test-project",
+			AuthEmulatorHost: strings.TrimPrefix(server.URL, "http://"),
+		})
+		if err != nil {
+			t.Fatalf("new firebase client: %v", err)
+		}
+
+		uid, err := client.CreateEmailPasswordUser(context.Background(), "duplicate@example.com", "Duplicate User")
+		if uid != "" {
+			t.Fatalf("expected empty uid, got %q", uid)
+		}
+		if !errors.Is(err, ErrEmailAlreadyExists) {
+			t.Fatalf("expected duplicate email error, got %v", err)
+		}
+	})
+
+	t.Run("wraps generic create error", func(t *testing.T) {
+		createErr := errors.New("provider unavailable")
+		client := &Client{auth: &fakeFirebaseAuthClient{createUserErr: createErr}}
+
+		uid, err := client.CreateEmailPasswordUser(context.Background(), "user@example.com", "User Name")
+		if uid != "" {
+			t.Fatalf("expected empty uid, got %q", uid)
+		}
+		if !errors.Is(err, createErr) {
+			t.Fatalf("expected provider error to be wrapped, got %v", err)
+		}
+		if err == createErr {
+			t.Fatal("expected generic create error to be wrapped")
+		}
+	})
+}
+
+func TestClientGeneratePasswordResetLink(t *testing.T) {
+	t.Run("uses plain reset link without redirect url", func(t *testing.T) {
+		authClient := &fakeFirebaseAuthClient{passwordResetLink: "https://reset.example/link"}
+		client := &Client{auth: authClient}
+
+		link, err := client.GeneratePasswordResetLink(context.Background(), "user@example.com")
+		if err != nil {
+			t.Fatalf("generate reset link: %v", err)
+		}
+
+		if link != "https://reset.example/link" {
+			t.Fatalf("unexpected reset link: %q", link)
+		}
+		if authClient.passwordResetEmail != "user@example.com" {
+			t.Fatalf("expected email to be forwarded, got %q", authClient.passwordResetEmail)
+		}
+		if authClient.passwordResetSettings != nil {
+			t.Fatalf("expected no action code settings, got %#v", authClient.passwordResetSettings)
+		}
+	})
+
+	t.Run("uses settings when redirect url is configured", func(t *testing.T) {
+		authClient := &fakeFirebaseAuthClient{passwordResetLink: "https://reset.example/link"}
+		client := &Client{
+			auth:                     authClient,
+			passwordResetRedirectURL: "https://app.example/reset",
+		}
+
+		link, err := client.GeneratePasswordResetLink(context.Background(), "user@example.com")
+		if err != nil {
+			t.Fatalf("generate reset link: %v", err)
+		}
+
+		if link != "https://reset.example/link" {
+			t.Fatalf("unexpected reset link: %q", link)
+		}
+		if authClient.passwordResetEmail != "user@example.com" {
+			t.Fatalf("expected email to be forwarded, got %q", authClient.passwordResetEmail)
+		}
+		if authClient.passwordResetSettings == nil || authClient.passwordResetSettings.URL != "https://app.example/reset" {
+			t.Fatalf("unexpected action code settings: %#v", authClient.passwordResetSettings)
+		}
+	})
+
+	t.Run("wraps provider error", func(t *testing.T) {
+		resetErr := errors.New("reset unavailable")
+		client := &Client{auth: &fakeFirebaseAuthClient{passwordResetErr: resetErr}}
+
+		link, err := client.GeneratePasswordResetLink(context.Background(), "user@example.com")
+		if link != "" {
+			t.Fatalf("expected empty link, got %q", link)
+		}
+		if !errors.Is(err, resetErr) {
+			t.Fatalf("expected reset error to be wrapped, got %v", err)
+		}
+		if err == resetErr {
+			t.Fatal("expected reset error to be wrapped")
+		}
+	})
+}
+
+func TestClientDeleteUserWrapsProviderError(t *testing.T) {
+	deleteErr := errors.New("delete unavailable")
+	client := &Client{auth: &fakeFirebaseAuthClient{deleteErr: deleteErr}}
+
+	err := client.DeleteUser(context.Background(), "firebase-uid")
+	if !errors.Is(err, deleteErr) {
+		t.Fatalf("expected delete error to be wrapped, got %v", err)
+	}
+	if err == deleteErr {
+		t.Fatal("expected delete error to be wrapped")
+	}
+}
+
+type fakeFirebaseAuthClient struct {
+	token                 *firebaseauth.Token
+	verifyToken           string
+	claimsUID             string
+	claims                map[string]interface{}
+	userRecord            *firebaseauth.UserRecord
+	createUser            *firebaseauth.UserToCreate
+	createUserErr         error
+	passwordResetEmail    string
+	passwordResetSettings *firebaseauth.ActionCodeSettings
+	passwordResetLink     string
+	passwordResetErr      error
+	deleteErr             error
+}
+
+func (f *fakeFirebaseAuthClient) VerifyIDToken(_ context.Context, token string) (*firebaseauth.Token, error) {
+	f.verifyToken = token
+	return f.token, nil
+}
+
+func (f *fakeFirebaseAuthClient) SetCustomUserClaims(_ context.Context, uid string, customClaims map[string]interface{}) error {
+	f.claimsUID = uid
+	f.claims = customClaims
+	return nil
+}
+
+func (f *fakeFirebaseAuthClient) CreateUser(_ context.Context, user *firebaseauth.UserToCreate) (*firebaseauth.UserRecord, error) {
+	f.createUser = user
+	if f.createUserErr != nil {
+		return nil, f.createUserErr
+	}
+
+	return f.userRecord, nil
+}
+
+func (f *fakeFirebaseAuthClient) PasswordResetLink(_ context.Context, email string) (string, error) {
+	f.passwordResetEmail = email
+	if f.passwordResetErr != nil {
+		return "", f.passwordResetErr
+	}
+
+	return f.passwordResetLink, nil
+}
+
+func (f *fakeFirebaseAuthClient) PasswordResetLinkWithSettings(_ context.Context, email string, settings *firebaseauth.ActionCodeSettings) (string, error) {
+	f.passwordResetEmail = email
+	f.passwordResetSettings = settings
+	if f.passwordResetErr != nil {
+		return "", f.passwordResetErr
+	}
+
+	return f.passwordResetLink, nil
+}
+
+func (f *fakeFirebaseAuthClient) DeleteUser(_ context.Context, _ string) error {
+	return f.deleteErr
 }

--- a/internal/platform/notification/dispatcher_test.go
+++ b/internal/platform/notification/dispatcher_test.go
@@ -26,6 +26,98 @@ func TestDispatcherRoutesEmail(t *testing.T) {
 	}
 }
 
+func TestDispatcherMissingPayload(t *testing.T) {
+	t.Run("email", func(t *testing.T) {
+		dispatcher := NewDispatcher(&fakeEmailSender{}, StubLineSender{})
+
+		err := dispatcher.Send(context.Background(), SendCommand{Channel: ChannelEmail})
+		if !errors.Is(err, ErrEmailMessageRequired) {
+			t.Fatalf("expected email message required, got %v", err)
+		}
+	})
+
+	t.Run("line", func(t *testing.T) {
+		dispatcher := NewDispatcher(&fakeEmailSender{}, StubLineSender{})
+
+		err := dispatcher.Send(context.Background(), SendCommand{Channel: ChannelLine})
+		if !errors.Is(err, ErrLineMessageRequired) {
+			t.Fatalf("expected line message required, got %v", err)
+		}
+	})
+}
+
+func TestDispatcherUnsupportedSender(t *testing.T) {
+	t.Run("nil dispatcher", func(t *testing.T) {
+		var dispatcher *Dispatcher
+
+		err := dispatcher.Send(context.Background(), SendCommand{
+			Channel: ChannelEmail,
+			Email: &EmailMessage{
+				To:      []string{"user@example.com"},
+				Subject: "subject",
+			},
+		})
+		if !errors.Is(err, ErrUnsupportedChannel) {
+			t.Fatalf("expected unsupported channel, got %v", err)
+		}
+	})
+
+	t.Run("nil email sender", func(t *testing.T) {
+		dispatcher := NewDispatcher(nil, StubLineSender{})
+
+		err := dispatcher.Send(context.Background(), SendCommand{
+			Channel: ChannelEmail,
+			Email: &EmailMessage{
+				To:      []string{"user@example.com"},
+				Subject: "subject",
+			},
+		})
+		if !errors.Is(err, ErrUnsupportedChannel) {
+			t.Fatalf("expected unsupported channel, got %v", err)
+		}
+	})
+
+	t.Run("nil line sender", func(t *testing.T) {
+		dispatcher := NewDispatcher(&fakeEmailSender{}, nil)
+
+		err := dispatcher.Send(context.Background(), SendCommand{
+			Channel: ChannelLine,
+			Line: &LineMessage{
+				To:   "user-1",
+				Text: "hello",
+			},
+		})
+		if !errors.Is(err, ErrUnsupportedChannel) {
+			t.Fatalf("expected unsupported channel, got %v", err)
+		}
+	})
+}
+
+func TestDispatcherUnsupportedChannel(t *testing.T) {
+	dispatcher := NewDispatcher(&fakeEmailSender{}, StubLineSender{})
+
+	err := dispatcher.Send(context.Background(), SendCommand{Channel: Channel("sms")})
+	if !errors.Is(err, ErrUnsupportedChannel) {
+		t.Fatalf("expected unsupported channel, got %v", err)
+	}
+}
+
+func TestDispatcherPropagatesSenderFailure(t *testing.T) {
+	sendErr := errors.New("provider failed")
+	dispatcher := NewDispatcher(&fakeEmailSender{err: sendErr}, StubLineSender{})
+
+	err := dispatcher.Send(context.Background(), SendCommand{
+		Channel: ChannelEmail,
+		Email: &EmailMessage{
+			To:      []string{"user@example.com"},
+			Subject: "subject",
+		},
+	})
+	if !errors.Is(err, sendErr) {
+		t.Fatalf("expected sender error to propagate, got %v", err)
+	}
+}
+
 func TestDispatcherReturnsLineStubError(t *testing.T) {
 	dispatcher := NewDispatcher(&fakeEmailSender{}, StubLineSender{})
 
@@ -43,9 +135,10 @@ func TestDispatcherReturnsLineStubError(t *testing.T) {
 
 type fakeEmailSender struct {
 	message EmailMessage
+	err     error
 }
 
 func (f *fakeEmailSender) Send(_ context.Context, message EmailMessage) error {
 	f.message = message
-	return nil
+	return f.err
 }

--- a/internal/platform/notification/line_test.go
+++ b/internal/platform/notification/line_test.go
@@ -1,0 +1,16 @@
+package notification
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestStubLineSenderReturnsNotImplemented(t *testing.T) {
+	err := StubLineSender{}.Send(t.Context(), LineMessage{
+		To:   "user-1",
+		Text: "hello",
+	})
+	if !errors.Is(err, ErrLineNotImplemented) {
+		t.Fatalf("expected line not implemented error, got %v", err)
+	}
+}

--- a/internal/platform/notification/resend_test.go
+++ b/internal/platform/notification/resend_test.go
@@ -4,10 +4,42 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"stds_backend/internal/config"
 )
+
+func TestNewResendSenderValidation(t *testing.T) {
+	t.Run("missing api key", func(t *testing.T) {
+		_, err := NewResendSender(config.NotificationConfig{
+			ResendFromEmail: "onboarding@example.com",
+		})
+		if err == nil || err.Error() != "RESEND_API_KEY is required" {
+			t.Fatalf("expected missing api key error, got %v", err)
+		}
+	})
+
+	t.Run("missing from email", func(t *testing.T) {
+		_, err := NewResendSender(config.NotificationConfig{
+			ResendAPIKey: "key",
+		})
+		if err == nil || err.Error() != "RESEND_FROM_EMAIL is required" {
+			t.Fatalf("expected missing from email error, got %v", err)
+		}
+	})
+
+	t.Run("invalid base url", func(t *testing.T) {
+		_, err := NewResendSender(config.NotificationConfig{
+			ResendAPIKey:    "key",
+			ResendFromEmail: "onboarding@example.com",
+			ResendBaseURL:   "%",
+		})
+		if err == nil || !strings.Contains(err.Error(), "parse resend base url") {
+			t.Fatalf("expected invalid base url error, got %v", err)
+		}
+	})
+}
 
 func TestResendSenderSend(t *testing.T) {
 	var payload map[string]any
@@ -51,7 +83,71 @@ func TestResendSenderSend(t *testing.T) {
 	if payload["from"] != "STDS <onboarding@example.com>" {
 		t.Fatalf("unexpected from payload: %v", payload["from"])
 	}
+	to, ok := payload["to"].([]any)
+	if !ok {
+		t.Fatalf("expected to payload array, got %T", payload["to"])
+	}
+	if len(to) != 1 || to[0] != "user@example.com" {
+		t.Fatalf("unexpected to payload: %#v", to)
+	}
 	if payload["subject"] != "Hello" {
 		t.Fatalf("unexpected subject payload: %v", payload["subject"])
+	}
+	if payload["html"] != "<p>Hello</p>" {
+		t.Fatalf("unexpected html payload: %v", payload["html"])
+	}
+	if payload["text"] != "Hello" {
+		t.Fatalf("unexpected text payload: %v", payload["text"])
+	}
+}
+
+func TestResendSenderSendRequiresConfiguredClient(t *testing.T) {
+	t.Run("nil sender", func(t *testing.T) {
+		var sender *ResendSender
+
+		err := sender.Send(t.Context(), EmailMessage{
+			To:      []string{"user@example.com"},
+			Subject: "Hello",
+		})
+		if err == nil || err.Error() != "resend sender is not configured" {
+			t.Fatalf("expected not configured error, got %v", err)
+		}
+	})
+
+	t.Run("nil client", func(t *testing.T) {
+		sender := &ResendSender{}
+
+		err := sender.Send(t.Context(), EmailMessage{
+			To:      []string{"user@example.com"},
+			Subject: "Hello",
+		})
+		if err == nil || err.Error() != "resend sender is not configured" {
+			t.Fatalf("expected not configured error, got %v", err)
+		}
+	})
+}
+
+func TestResendSenderSendWrapsProviderFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"provider failed"}`))
+	}))
+	defer server.Close()
+
+	sender, err := NewResendSender(config.NotificationConfig{
+		ResendAPIKey:    "key",
+		ResendFromEmail: "onboarding@example.com",
+		ResendBaseURL:   server.URL,
+	})
+	if err != nil {
+		t.Fatalf("new resend sender: %v", err)
+	}
+
+	err = sender.Send(t.Context(), EmailMessage{
+		To:      []string{"user@example.com"},
+		Subject: "Hello",
+	})
+	if err == nil || !strings.Contains(err.Error(), "send email via resend") {
+		t.Fatalf("expected resend failure to be wrapped, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Addresses #78 by adding focused contract coverage for first-launch-critical external adapters without calling real providers in normal test runs.

## What changed

- Added a narrow package-private Firebase auth client seam inside `internal/platform/firebase` so the adapter can be tested with fakes instead of real Firebase.
- Covered Firebase adapter behavior for:
  - ID token custom claim parsing into local `Claims`
  - custom claims payload construction for `role` and `assigned_property_ids`
  - email/password user creation success and duplicate-email mapping
  - generic create/reset/delete provider error wrapping
  - password reset link generation with and without configured redirect URL
- Added notification adapter/provider tests for:
  - dispatcher missing payload behavior
  - nil dispatcher/sender and unsupported channel behavior
  - sender failure propagation
  - Resend config validation
  - Resend request payload construction through `httptest`
  - Resend provider failure wrapping
  - LINE stub `ErrLineNotImplemented` contract

## Production change scope

The only production code change is a small Firebase seam: `Client.auth` now depends on a package-private interface containing only the Firebase Admin SDK methods this adapter already uses. `New` still constructs the real Firebase Admin SDK client and keeps the external behavior unchanged.

Notification production code was not changed.

## Validation

- `go test ./internal/platform/firebase ./internal/platform/notification`
- `go test ./...`
- `git diff --check`