### PR TITLE
[E2E] Add Go foundation harness

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -99,3 +99,86 @@ jobs:
         env:
           DATABASE_URL: postgres://stds:stds@localhost:5432/stds_backend?sslmode=disable
         run: go run ./cmd/migrate up
+
+  e2e:
+    name: E2E harness smoke
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: stds_backend_e2e
+          POSTGRES_USER: stds
+          POSTGRES_PASSWORD: stds
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U stds -d stds_backend_e2e"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Start Firebase Auth Emulator
+        run: |
+          npm install -g firebase-tools@15.14.0
+          firebase emulators:start --only auth --project demo-stds-backend > /tmp/firebase-auth-emulator.log 2>&1 &
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:9099/emulator/v1/projects/demo-stds-backend/accounts > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat /tmp/firebase-auth-emulator.log
+          exit 1
+
+      - name: Start API
+        env:
+          APP_ENV: e2e
+          APP_HOST: 127.0.0.1
+          APP_PORT: 8080
+          APP_SCHEDULER_KEY: e2e-scheduler-key
+          DATABASE_URL: postgres://stds:stds@localhost:5432/stds_backend_e2e?sslmode=disable
+          FIREBASE_PROJECT_ID: demo-stds-backend
+          FIREBASE_AUTH_EMULATOR_HOST: 127.0.0.1:9099
+          GCS_BUCKET_NAME: stds-e2e
+          STORAGE_EMULATOR_HOST: http://127.0.0.1:4443
+          RESEND_API_KEY: e2e-resend-key
+          RESEND_FROM_EMAIL: e2e@example.com
+        run: |
+          go run ./cmd/api > /tmp/stds-api.log 2>&1 &
+          for i in {1..30}; do
+            if curl -fsS http://127.0.0.1:8080/healthz > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat /tmp/stds-api.log
+          exit 1
+
+      - name: Run E2E harness smoke
+        env:
+          E2E_BASE_URL: http://127.0.0.1:8080
+          E2E_DATABASE_URL: postgres://stds:stds@localhost:5432/stds_backend_e2e?sslmode=disable
+          E2E_FIREBASE_PROJECT_ID: demo-stds-backend
+          E2E_FIREBASE_AUTH_EMULATOR_HOST: 127.0.0.1:9099
+          E2E_TEST_EMAIL: e2e-admin@example.com
+          E2E_TEST_PASSWORD: Test123!
+          E2E_SCHEDULER_KEY: e2e-scheduler-key
+        run: go test -tags=e2e ./test/e2e

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -151,6 +151,9 @@ jobs:
           cat /tmp/firebase-auth-emulator.log
           exit 1
 
+      - name: Build API for E2E
+        run: go build -o /tmp/stds-api ./cmd/api
+
       - name: Start API
         env:
           APP_ENV: e2e
@@ -165,7 +168,7 @@ jobs:
           RESEND_API_KEY: e2e-resend-key
           RESEND_FROM_EMAIL: e2e@example.com
         run: |
-          go run ./cmd/api > /tmp/stds-api.log 2>&1 &
+          /tmp/stds-api > /tmp/stds-api.log 2>&1 &
           for i in {1..30}; do
             if curl -fsS http://127.0.0.1:8080/healthz > /dev/null; then
               exit 0

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - dev
 
+permissions:
+  contents: read
+
 jobs:
   go:
     name: Go test and build
@@ -140,7 +143,7 @@ jobs:
           npm install -g firebase-tools@15.14.0
           firebase emulators:start --only auth --project demo-stds-backend > /tmp/firebase-auth-emulator.log 2>&1 &
           for i in {1..30}; do
-            if curl -fsS http://127.0.0.1:9099/emulator/v1/projects/demo-stds-backend/accounts > /dev/null; then
+            if curl -sS -o /dev/null http://127.0.0.1:9099/emulator/v1/projects/demo-stds-backend/accounts; then
               exit 0
             fi
             sleep 1

--- a/README.md
+++ b/README.md
@@ -72,6 +72,35 @@ curl -i \
 
 If the `users` table contains the same `firebase_uid`, the request will pass auth and resolve the DB user.
 
+## E2E tests
+
+The E2E suite is opt-in and uses Go `testing` with the `e2e` build tag. It calls an already-running API through HTTP, resets a dedicated PostgreSQL test database schema, runs migrations, seeds the backend user row, and obtains a real bearer token from the Firebase Auth Emulator.
+
+Use a separate database name for E2E, for example `stds_backend_e2e`. This can live in the same local PostgreSQL container as the normal development database; `docker-compose.yml` does not need a second PostgreSQL service.
+
+Start dependencies:
+
+```bash
+docker compose up -d postgres
+docker exec stds-postgres psql -U stds -d postgres -c "CREATE DATABASE stds_backend_e2e"
+firebase emulators:start --only auth
+```
+
+Start the API against the E2E database:
+
+```bash
+./scripts/e2e_api.sh
+```
+
+Run the E2E suite:
+
+```bash
+./scripts/e2e_test.sh
+```
+
+The harness refuses to reset a database unless the database name contains `e2e` or `test`.
+The local scripts provide defaults for E2E environment variables and still allow overrides, for example `APP_PORT=8081 E2E_BASE_URL=http://127.0.0.1:8081 ./scripts/e2e_test.sh`.
+
 ## Email notifications
 
 `POST /api/v1/users` now creates the Firebase Auth user, generates a Firebase password reset URL, and sends the onboarding email through Resend.
@@ -144,6 +173,7 @@ docker exec stds-postgres psql -U stds -d postgres -c "DROP DATABASE IF EXISTS c
 docker exec stds-postgres psql -U stds -d postgres -c "CREATE DATABASE ci_migration_smoke"
 DATABASE_URL=postgres://stds:stds@localhost:5432/ci_migration_smoke?sslmode=disable go run ./cmd/migrate up
 docker exec stds-postgres psql -U stds -d postgres -c "DROP DATABASE IF EXISTS ci_migration_smoke"
+go test -tags=e2e ./test/e2e
 ```
 
 ## Database migrations

--- a/cicd.md
+++ b/cicd.md
@@ -28,6 +28,7 @@ Recommended checks:
 - Run a build check.
 - Verify OpenAPI generated code is in sync with the spec.
 - Run a migration smoke test against a temporary PostgreSQL database.
+- Run the opt-in E2E harness against a dedicated PostgreSQL database and Firebase Auth Emulator.
 - Run formatting or lint checks if the project enables them.
 
 This layer should be fast, stable, and suitable for every PR.
@@ -92,6 +93,14 @@ It does not replace real environment migrations. Dev, staging, and production Cl
 ## Core E2E Scope
 
 Core E2E tests are required before the first launch because they act as end-to-end acceptance for the current backend. They do not need to cover every extreme edge case, but they should cover the main business flows and the most important rejection paths.
+
+The E2E harness runs only through an explicit command:
+
+```bash
+go test -tags=e2e ./test/e2e
+```
+
+It requires an already-running API, a dedicated non-production PostgreSQL database, the Firebase Auth Emulator, and test account credentials. The harness resets the dedicated database schema, runs migrations, seeds controlled backend user data, obtains a real Firebase emulator ID token, and then calls the API over HTTP. The database name must contain `e2e` or `test` before reset is allowed.
 
 Recommended first-launch E2E coverage:
 

--- a/scripts/e2e_api.sh
+++ b/scripts/e2e_api.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+
+export APP_ENV="${APP_ENV:-e2e}"
+export APP_HOST="${APP_HOST:-127.0.0.1}"
+export APP_PORT="${APP_PORT:-8080}"
+export APP_SCHEDULER_KEY="${APP_SCHEDULER_KEY:-e2e-scheduler-key}"
+export DATABASE_URL="${DATABASE_URL:-postgres://stds:stds@localhost:5432/stds_backend_e2e?sslmode=disable}"
+export FIREBASE_PROJECT_ID="${FIREBASE_PROJECT_ID:-demo-stds-backend}"
+export FIREBASE_AUTH_EMULATOR_HOST="${FIREBASE_AUTH_EMULATOR_HOST:-127.0.0.1:9099}"
+export GCS_BUCKET_NAME="${GCS_BUCKET_NAME:-stds-e2e}"
+export STORAGE_EMULATOR_HOST="${STORAGE_EMULATOR_HOST:-http://127.0.0.1:4443}"
+export RESEND_API_KEY="${RESEND_API_KEY:-e2e-resend-key}"
+export RESEND_FROM_EMAIL="${RESEND_FROM_EMAIL:-e2e@example.com}"
+
+cd "$REPO_ROOT"
+go run ./cmd/api

--- a/scripts/e2e_test.sh
+++ b/scripts/e2e_test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+
+export E2E_BASE_URL="${E2E_BASE_URL:-http://127.0.0.1:8080}"
+export E2E_DATABASE_URL="${E2E_DATABASE_URL:-postgres://stds:stds@localhost:5432/stds_backend_e2e?sslmode=disable}"
+export E2E_FIREBASE_PROJECT_ID="${E2E_FIREBASE_PROJECT_ID:-demo-stds-backend}"
+export E2E_FIREBASE_AUTH_EMULATOR_HOST="${E2E_FIREBASE_AUTH_EMULATOR_HOST:-127.0.0.1:9099}"
+export E2E_TEST_EMAIL="${E2E_TEST_EMAIL:-e2e-admin@example.com}"
+export E2E_TEST_PASSWORD="${E2E_TEST_PASSWORD:-Test123!}"
+export E2E_SCHEDULER_KEY="${E2E_SCHEDULER_KEY:-e2e-scheduler-key}"
+
+cd "$REPO_ROOT"
+go test -tags=e2e ./test/e2e "$@"

--- a/test/e2e/config.go
+++ b/test/e2e/config.go
@@ -1,0 +1,79 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+)
+
+type e2eConfig struct {
+	BaseURL              string
+	DatabaseURL          string
+	FirebaseProjectID    string
+	FirebaseEmulatorHost string
+	TestEmail            string
+	TestPassword         string
+	SchedulerKey         string
+}
+
+func loadE2EConfig() (e2eConfig, error) {
+	cfg := e2eConfig{
+		BaseURL:              strings.TrimRight(os.Getenv("E2E_BASE_URL"), "/"),
+		DatabaseURL:          os.Getenv("E2E_DATABASE_URL"),
+		FirebaseProjectID:    os.Getenv("E2E_FIREBASE_PROJECT_ID"),
+		FirebaseEmulatorHost: os.Getenv("E2E_FIREBASE_AUTH_EMULATOR_HOST"),
+		TestEmail:            os.Getenv("E2E_TEST_EMAIL"),
+		TestPassword:         os.Getenv("E2E_TEST_PASSWORD"),
+		SchedulerKey:         os.Getenv("E2E_SCHEDULER_KEY"),
+	}
+
+	missing := make([]string, 0)
+	required := map[string]string{
+		"E2E_BASE_URL":                    cfg.BaseURL,
+		"E2E_DATABASE_URL":                cfg.DatabaseURL,
+		"E2E_FIREBASE_PROJECT_ID":         cfg.FirebaseProjectID,
+		"E2E_FIREBASE_AUTH_EMULATOR_HOST": cfg.FirebaseEmulatorHost,
+		"E2E_TEST_EMAIL":                  cfg.TestEmail,
+		"E2E_TEST_PASSWORD":               cfg.TestPassword,
+		"E2E_SCHEDULER_KEY":               cfg.SchedulerKey,
+	}
+	for key, value := range required {
+		if strings.TrimSpace(value) == "" {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return e2eConfig{}, fmt.Errorf("missing required E2E environment variables: %s", strings.Join(missing, ", "))
+	}
+
+	if err := requireE2EDatabaseName(cfg.DatabaseURL); err != nil {
+		return e2eConfig{}, err
+	}
+
+	return cfg, nil
+}
+
+func requireE2EDatabaseName(databaseURL string) error {
+	parsed, err := url.Parse(databaseURL)
+	if err != nil {
+		return fmt.Errorf("parse E2E_DATABASE_URL: %w", err)
+	}
+
+	dbName := strings.Trim(strings.TrimSpace(parsed.Path), "/")
+	if dbName == "" {
+		return errors.New("E2E_DATABASE_URL must include a database name")
+	}
+
+	normalized := strings.ToLower(dbName)
+	if !strings.Contains(normalized, "e2e") && !strings.Contains(normalized, "test") {
+		return fmt.Errorf("refusing to reset database %q: E2E database name must contain e2e or test", dbName)
+	}
+
+	return nil
+}

--- a/test/e2e/database.go
+++ b/test/e2e/database.go
@@ -1,0 +1,69 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"stds_backend/internal/platform/database"
+	"stds_backend/internal/platform/database/migrate"
+)
+
+const seededUserID = "00000000-0000-0000-0000-0000000000e2"
+
+func resetAndMigrateDatabase(ctx context.Context, databaseURL string) (*sql.DB, error) {
+	db, err := database.Open(ctx, databaseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := db.ExecContext(ctx, `
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+GRANT ALL ON SCHEMA public TO public;
+`); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("reset E2E database schema: %w", err)
+	}
+
+	if err := migrate.NewRunner(db).Up(ctx); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("run E2E migrations: %w", err)
+	}
+
+	return db, nil
+}
+
+func seedAuthenticatedUser(ctx context.Context, db *sql.DB, firebaseUID string, email string) error {
+	_, err := db.ExecContext(ctx, `
+INSERT INTO users (
+	id,
+	firebase_uid,
+	email,
+	name,
+	role,
+	permission_overrides,
+	assigned_property_ids,
+	created_at,
+	updated_at
+) VALUES (
+	$1,
+	$2,
+	$3,
+	'E2E Admin',
+	'admin',
+	'[]'::jsonb,
+	'[]'::jsonb,
+	$4,
+	$4
+)
+`, seededUserID, firebaseUID, email, time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("seed E2E authenticated user: %w", err)
+	}
+
+	return nil
+}

--- a/test/e2e/firebase.go
+++ b/test/e2e/firebase.go
@@ -1,0 +1,96 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const emulatorAPIKey = "fake-api-key"
+
+type emulatorToken struct {
+	IDToken string
+	UID     string
+}
+
+func issueFirebaseEmulatorToken(ctx context.Context, cfg e2eConfig) (emulatorToken, error) {
+	token, err := signUpFirebaseEmulatorUser(ctx, cfg)
+	if err == nil {
+		return token, nil
+	}
+	if !strings.Contains(err.Error(), "EMAIL_EXISTS") {
+		return emulatorToken{}, err
+	}
+
+	return signInFirebaseEmulatorUser(ctx, cfg)
+}
+
+func signUpFirebaseEmulatorUser(ctx context.Context, cfg e2eConfig) (emulatorToken, error) {
+	payload := map[string]any{
+		"email":             cfg.TestEmail,
+		"password":          cfg.TestPassword,
+		"returnSecureToken": true,
+	}
+
+	return callFirebaseEmulatorAuth(ctx, cfg.FirebaseEmulatorHost, "accounts:signUp", payload)
+}
+
+func signInFirebaseEmulatorUser(ctx context.Context, cfg e2eConfig) (emulatorToken, error) {
+	payload := map[string]any{
+		"email":             cfg.TestEmail,
+		"password":          cfg.TestPassword,
+		"returnSecureToken": true,
+	}
+
+	return callFirebaseEmulatorAuth(ctx, cfg.FirebaseEmulatorHost, "accounts:signInWithPassword", payload)
+}
+
+func callFirebaseEmulatorAuth(ctx context.Context, host string, method string, payload map[string]any) (emulatorToken, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return emulatorToken{}, fmt.Errorf("marshal Firebase emulator payload: %w", err)
+	}
+
+	url := fmt.Sprintf("http://%s/identitytoolkit.googleapis.com/v1/%s?key=%s", host, method, emulatorAPIKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return emulatorToken{}, fmt.Errorf("build Firebase emulator request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return emulatorToken{}, fmt.Errorf("call Firebase Auth Emulator: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return emulatorToken{}, fmt.Errorf("read Firebase emulator response: %w", err)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return emulatorToken{}, fmt.Errorf("Firebase emulator auth failed: %s", strings.TrimSpace(string(respBody)))
+	}
+
+	var result struct {
+		IDToken string `json:"idToken"`
+		LocalID string `json:"localId"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return emulatorToken{}, fmt.Errorf("decode Firebase emulator response: %w", err)
+	}
+	if result.IDToken == "" || result.LocalID == "" {
+		return emulatorToken{}, fmt.Errorf("Firebase emulator response missing idToken or localId")
+	}
+
+	return emulatorToken{IDToken: result.IDToken, UID: result.LocalID}, nil
+}

--- a/test/e2e/http.go
+++ b/test/e2e/http.go
@@ -1,0 +1,84 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type apiClient struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+func newAPIClient(baseURL string, token string) apiClient {
+	return apiClient{
+		baseURL: baseURL,
+		token:   token,
+		client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (c apiClient) getJSON(ctx context.Context, path string) (*http.Response, []byte, error) {
+	return c.doJSON(ctx, http.MethodGet, path, nil)
+}
+
+func (c apiClient) doJSON(ctx context.Context, method string, path string, body any) (*http.Response, []byte, error) {
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshal request body: %w", err)
+		}
+		reader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("call API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	return resp, respBody, nil
+}
+
+func requireStatus(t *testing.T, resp *http.Response, body []byte, expected int) {
+	t.Helper()
+
+	if resp.StatusCode != expected {
+		t.Fatalf("expected HTTP %d, got %d: %s", expected, resp.StatusCode, string(body))
+	}
+}
+
+func decodeJSON(t *testing.T, body []byte, target any) {
+	t.Helper()
+
+	if err := json.Unmarshal(body, target); err != nil {
+		t.Fatalf("decode JSON response: %v\nbody: %s", err, string(body))
+	}
+}

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -1,0 +1,87 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestE2EHarnessAuthenticatedSmoke(t *testing.T) {
+	cfg, err := loadE2EConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	db, err := resetAndMigrateDatabase(ctx, cfg.DatabaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	token, err := issueFirebaseEmulatorToken(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := seedAuthenticatedUser(ctx, db, token.UID, cfg.TestEmail); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newAPIClient(cfg.BaseURL, token.IDToken)
+
+	t.Run("health endpoint reaches API and database", func(t *testing.T) {
+		resp, body, err := client.getJSON(ctx, "/healthz")
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireStatus(t, resp, body, http.StatusOK)
+
+		var payload struct {
+			OK bool `json:"ok"`
+			DB bool `json:"db"`
+		}
+		decodeJSON(t, body, &payload)
+		if !payload.OK || !payload.DB {
+			t.Fatalf("expected healthy API and database, got ok=%t db=%t body=%s", payload.OK, payload.DB, string(body))
+		}
+	})
+
+	t.Run("authenticated current user resolves seeded Firebase UID", func(t *testing.T) {
+		resp, body, err := client.getJSON(ctx, "/api/v1/users/me")
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireStatus(t, resp, body, http.StatusOK)
+
+		var payload struct {
+			ID          string `json:"id"`
+			FirebaseID  string `json:"firebase_uid"`
+			Email       string `json:"email"`
+			DisplayName string `json:"name"`
+			Role        string `json:"role"`
+		}
+		decodeJSON(t, body, &payload)
+
+		if payload.ID != seededUserID {
+			t.Fatalf("expected seeded user id %q, got %q", seededUserID, payload.ID)
+		}
+		if payload.FirebaseID != token.UID {
+			t.Fatalf("expected firebase_uid %q, got %q", token.UID, payload.FirebaseID)
+		}
+		if payload.Email != cfg.TestEmail {
+			t.Fatalf("expected email %q, got %q", cfg.TestEmail, payload.Email)
+		}
+		if payload.DisplayName != "E2E Admin" {
+			t.Fatalf("expected name %q, got %q", "E2E Admin", payload.DisplayName)
+		}
+		if payload.Role != "admin" {
+			t.Fatalf("expected role %q, got %q", "admin", payload.Role)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #90.

This PR adds the first Go `testing` based E2E foundation for the P1 first-launch acceptance work tracked under #71. It intentionally keeps the scope to the harness and one smoke/authenticated API check, leaving the larger business-flow coverage for the split follow-up issues.

## What changed

- Added `test/e2e` behind the `e2e` build tag so normal `go test ./...` does not require E2E configuration.
- Added E2E configuration loading through explicit `E2E_*` environment variables.
- Added database reset protection: the harness refuses to reset a database unless the database name contains `e2e` or `test`.
- Added E2E setup that resets the dedicated DB schema, runs embedded migrations, seeds a backend user, signs in through Firebase Auth Emulator, and calls the real HTTP API.
- Added a smoke check for `/healthz` and an authenticated check for `/api/v1/users/me`.
- Added local helper scripts:
  - `./scripts/e2e_api.sh`
  - `./scripts/e2e_test.sh`
- Documented local E2E setup in `README.md`, including the dedicated DB name approach.
- Added a GitHub Actions `E2E harness smoke` job that starts PostgreSQL, Firebase Auth Emulator, the API server, and runs `go test -tags=e2e ./test/e2e`.
- Updated `cicd.md` to describe the opt-in E2E harness as part of PR/dev-test validation.

## Notes

`docker-compose.yml` was not changed. Local development can keep using the existing `stds-postgres` container and create a second database name such as `stds_backend_e2e`; the harness resets only that dedicated DB schema.

## Validation

- `go test ./...`
- `./scripts/e2e_test.sh -run '^$'`
- `go test -tags=e2e ./test/e2e` with local PostgreSQL, Firebase Auth Emulator, and API server running
- `git diff --cached --check`