### PR TITLE
[E2E] Add lease and billing acceptance flows

### DIFF
--- a/test/e2e/billing_payment_report_test.go
+++ b/test/e2e/billing_payment_report_test.go
@@ -1,0 +1,322 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestE2EBillingPaymentAndFinancialReportAcceptance(t *testing.T) {
+	cfg, err := loadE2EConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	db, err := resetAndMigrateDatabase(ctx, cfg.DatabaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	adminToken, err := issueFirebaseEmulatorToken(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seedAuthenticatedUser(ctx, db, adminToken.UID, cfg.TestEmail); err != nil {
+		t.Fatal(err)
+	}
+
+	adminClient := newAPIClient(cfg.BaseURL, adminToken.IDToken)
+	property := createProperty(t, ctx, adminClient, "E2E Billing Property")
+	room := createRoom(t, ctx, adminClient, property.ID, "E2E Billing Room 101")
+	tenant := createTenant(t, ctx, adminClient)
+
+	reportYear, reportMonth, paidAt := billingFlowE2EReportPaymentTime()
+	lease := billingFlowE2ECreateLease(t, ctx, adminClient, tenant.ID, room.ID, reportYear, reportMonth)
+	if lease.PropertyID != property.ID {
+		t.Fatalf("expected lease property_id %q, got %q", property.ID, lease.PropertyID)
+	}
+
+	bills := billingFlowE2EListBills(t, ctx, adminClient, lease.ID)
+	rentBill := billingFlowE2EFindBill(t, bills, "rent")
+	electricityBill := billingFlowE2EFindBill(t, bills, "electricity")
+
+	if rentBill.Amount == nil {
+		t.Fatalf("expected rent bill amount: %+v", rentBill)
+	}
+	if *rentBill.Amount != lease.RentAmount {
+		t.Fatalf("expected rent amount %d, got %d", lease.RentAmount, *rentBill.Amount)
+	}
+	if rentBill.Status != "pending_payment" {
+		t.Fatalf("expected rent bill status pending_payment, got %q", rentBill.Status)
+	}
+	if electricityBill.Status != "pending_meter" {
+		t.Fatalf("expected electricity bill status pending_meter, got %q", electricityBill.Status)
+	}
+
+	electricityBill = billingFlowE2ERecordMeter(t, ctx, adminClient, electricityBill.ID, 120)
+	if electricityBill.Status != "pending_payment" {
+		t.Fatalf("expected electricity bill status pending_payment, got %q", electricityBill.Status)
+	}
+	if electricityBill.Amount == nil || *electricityBill.Amount != 540 {
+		t.Fatalf("expected electricity amount 540, got %+v", electricityBill.Amount)
+	}
+	if electricityBill.MeterPreviousReading == nil || *electricityBill.MeterPreviousReading != 0 {
+		t.Fatalf("expected meter_previous_reading 0, got %+v", electricityBill.MeterPreviousReading)
+	}
+	if electricityBill.MeterCurrentReading == nil || *electricityBill.MeterCurrentReading != 120 {
+		t.Fatalf("expected meter_current_reading 120, got %+v", electricityBill.MeterCurrentReading)
+	}
+	if electricityBill.MeterUnitPrice == nil || *electricityBill.MeterUnitPrice != property.ElectricityUnitPrice {
+		t.Fatalf("expected meter_unit_price %v, got %+v", property.ElectricityUnitPrice, electricityBill.MeterUnitPrice)
+	}
+
+	rentBill = billingFlowE2ERecordPayment(t, ctx, adminClient, rentBill.ID, *rentBill.Amount, paidAt)
+	electricityBill = billingFlowE2ERecordPayment(t, ctx, adminClient, electricityBill.ID, *electricityBill.Amount, paidAt)
+
+	billingFlowE2EAssertPaidBill(t, billingFlowE2EGetBill(t, ctx, adminClient, rentBill.ID), *rentBill.Amount)
+	billingFlowE2EAssertPaidBill(t, billingFlowE2EGetBill(t, ctx, adminClient, electricityBill.ID), *electricityBill.Amount)
+
+	report := billingFlowE2EGetFinancialReport(t, ctx, adminClient, property.ID, reportYear, reportMonth)
+	if report.PropertyID != property.ID {
+		t.Fatalf("expected report property_id %q, got %q", property.ID, report.PropertyID)
+	}
+	if report.Year != reportYear || report.Month != reportMonth {
+		t.Fatalf("expected report period %04d-%02d, got %04d-%02d", reportYear, reportMonth, report.Year, report.Month)
+	}
+	if report.IsFinalized {
+		t.Fatalf("expected live report is_finalized false")
+	}
+
+	expectedIncome := *rentBill.Amount + *electricityBill.Amount
+	if report.TotalIncome < expectedIncome {
+		t.Fatalf("expected total_income at least %d, got %d", expectedIncome, report.TotalIncome)
+	}
+	billingFlowE2ERequireReportEntry(t, report, "rent_payment", *rentBill.Amount)
+	billingFlowE2ERequireReportEntry(t, report, "electricity_payment", *electricityBill.Amount)
+}
+
+type billingFlowE2ELeaseResponse struct {
+	ID                        string `json:"id"`
+	TenantID                  string `json:"tenant_id"`
+	RoomID                    string `json:"room_id"`
+	PropertyID                string `json:"property_id"`
+	RentAmount                int    `json:"rent_amount"`
+	StartDate                 string `json:"start_date"`
+	EndDate                   string `json:"end_date"`
+	ElectricityBillingCadence string `json:"electricity_billing_cadence"`
+	DepositAmount             int    `json:"deposit_amount"`
+	DepositStatus             string `json:"deposit_status"`
+	Status                    string `json:"status"`
+}
+
+type billingFlowE2EBillResponse struct {
+	ID                   string   `json:"id"`
+	LeaseID              string   `json:"lease_id"`
+	TenantID             string   `json:"tenant_id"`
+	RoomID               string   `json:"room_id"`
+	PropertyID           string   `json:"property_id"`
+	Type                 string   `json:"type"`
+	Amount               *int     `json:"amount"`
+	PeriodStart          string   `json:"period_start"`
+	PeriodEnd            string   `json:"period_end"`
+	DueDate              string   `json:"due_date"`
+	Status               string   `json:"status"`
+	PaymentMethod        *string  `json:"payment_method"`
+	PaidAmount           *int     `json:"paid_amount"`
+	MeterPreviousReading *int     `json:"meter_previous_reading"`
+	MeterCurrentReading  *int     `json:"meter_current_reading"`
+	MeterUnitPrice       *float64 `json:"meter_unit_price"`
+}
+
+type billingFlowE2EBillListResponse struct {
+	Data []billingFlowE2EBillResponse `json:"data"`
+}
+
+type billingFlowE2EFinancialReportResponse struct {
+	PropertyID   string                               `json:"property_id"`
+	Year         int                                  `json:"year"`
+	Month        int                                  `json:"month"`
+	TotalIncome  int                                  `json:"total_income"`
+	TotalExpense int                                  `json:"total_expense"`
+	Net          int                                  `json:"net"`
+	IsFinalized  bool                                 `json:"is_finalized"`
+	Entries      []billingFlowE2EFinancialReportEntry `json:"entries"`
+}
+
+type billingFlowE2EFinancialReportEntry struct {
+	Category    string `json:"category"`
+	Description string `json:"description"`
+	Amount      int    `json:"amount"`
+}
+
+func billingFlowE2ECreateLease(t *testing.T, ctx context.Context, client apiClient, tenantID string, roomID string, year int, month int) billingFlowE2ELeaseResponse {
+	t.Helper()
+
+	const rentAmount = 18000
+
+	startDate := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
+	endDate := startDate.AddDate(0, 2, -1)
+	request := map[string]any{
+		"tenant_id":                   tenantID,
+		"room_id":                     roomID,
+		"rent_amount":                 rentAmount,
+		"start_date":                  startDate.Format("2006-01-02"),
+		"end_date":                    endDate.Format("2006-01-02"),
+		"deposit_amount":              36000,
+		"electricity_billing_cadence": "monthly",
+	}
+	resp, body, err := client.postJSON(ctx, "/api/v1/leases", request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusCreated)
+
+	var lease billingFlowE2ELeaseResponse
+	decodeJSON(t, body, &lease)
+	if lease.ID == "" {
+		t.Fatalf("expected lease id in response: %s", string(body))
+	}
+	if lease.TenantID != tenantID {
+		t.Fatalf("expected lease tenant_id %q, got %q", tenantID, lease.TenantID)
+	}
+	if lease.RoomID != roomID {
+		t.Fatalf("expected lease room_id %q, got %q", roomID, lease.RoomID)
+	}
+	if lease.RentAmount != rentAmount {
+		t.Fatalf("expected lease rent_amount %d, got %d", rentAmount, lease.RentAmount)
+	}
+	if lease.Status != "active" {
+		t.Fatalf("expected lease status active, got %q", lease.Status)
+	}
+
+	return lease
+}
+
+func billingFlowE2EListBills(t *testing.T, ctx context.Context, client apiClient, leaseID string) []billingFlowE2EBillResponse {
+	t.Helper()
+
+	resp, body, err := client.getJSON(ctx, "/api/v1/bills?lease_id="+leaseID+"&limit=100")
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var result billingFlowE2EBillListResponse
+	decodeJSON(t, body, &result)
+	return result.Data
+}
+
+func billingFlowE2EFindBill(t *testing.T, bills []billingFlowE2EBillResponse, billType string) billingFlowE2EBillResponse {
+	t.Helper()
+
+	for _, bill := range bills {
+		if bill.Type == billType {
+			return bill
+		}
+	}
+	t.Fatalf("expected %s bill in %+v", billType, bills)
+	return billingFlowE2EBillResponse{}
+}
+
+func billingFlowE2ERecordMeter(t *testing.T, ctx context.Context, client apiClient, billID string, currentReading int) billingFlowE2EBillResponse {
+	t.Helper()
+
+	resp, body, err := client.postJSON(ctx, "/api/v1/bills/"+billID+"/meter", map[string]any{
+		"current_reading": currentReading,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var bill billingFlowE2EBillResponse
+	decodeJSON(t, body, &bill)
+	return bill
+}
+
+func billingFlowE2ERecordPayment(t *testing.T, ctx context.Context, client apiClient, billID string, paidAmount int, paidAt time.Time) billingFlowE2EBillResponse {
+	t.Helper()
+
+	resp, body, err := client.postJSON(ctx, "/api/v1/bills/"+billID+"/payment", map[string]any{
+		"payment_method": "transfer",
+		"paid_amount":    paidAmount,
+		"paid_at":        paidAt.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var bill billingFlowE2EBillResponse
+	decodeJSON(t, body, &bill)
+	return bill
+}
+
+func billingFlowE2EGetBill(t *testing.T, ctx context.Context, client apiClient, billID string) billingFlowE2EBillResponse {
+	t.Helper()
+
+	resp, body, err := client.getJSON(ctx, "/api/v1/bills/"+billID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var bill billingFlowE2EBillResponse
+	decodeJSON(t, body, &bill)
+	return bill
+}
+
+func billingFlowE2EAssertPaidBill(t *testing.T, bill billingFlowE2EBillResponse, expectedAmount int) {
+	t.Helper()
+
+	if bill.Status != "paid" {
+		t.Fatalf("expected bill %s status paid, got %q", bill.ID, bill.Status)
+	}
+	if bill.PaidAmount == nil || *bill.PaidAmount != expectedAmount {
+		t.Fatalf("expected bill %s paid_amount %d, got %+v", bill.ID, expectedAmount, bill.PaidAmount)
+	}
+	if bill.PaymentMethod == nil || *bill.PaymentMethod != "transfer" {
+		t.Fatalf("expected bill %s payment_method transfer, got %+v", bill.ID, bill.PaymentMethod)
+	}
+}
+
+func billingFlowE2EGetFinancialReport(t *testing.T, ctx context.Context, client apiClient, propertyID string, year int, month int) billingFlowE2EFinancialReportResponse {
+	t.Helper()
+
+	path := fmt.Sprintf("/api/v1/properties/%s/financial-report/%d/%d", propertyID, year, month)
+	resp, body, err := client.getJSON(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var report billingFlowE2EFinancialReportResponse
+	decodeJSON(t, body, &report)
+	return report
+}
+
+func billingFlowE2ERequireReportEntry(t *testing.T, report billingFlowE2EFinancialReportResponse, category string, amount int) {
+	t.Helper()
+
+	for _, entry := range report.Entries {
+		if entry.Category == category && entry.Amount == amount {
+			return
+		}
+	}
+	t.Fatalf("expected report entry category %q amount %d in %+v", category, amount, report.Entries)
+}
+
+func billingFlowE2EReportPaymentTime() (int, int, time.Time) {
+	location := time.FixedZone("Asia/Taipei", 8*60*60)
+	now := time.Now().In(location)
+	paidAt := time.Date(now.Year(), now.Month(), now.Day(), 12, 0, 0, 0, location)
+	return paidAt.Year(), int(paidAt.Month()), paidAt
+}

--- a/test/e2e/lease_billing_lifecycle_test.go
+++ b/test/e2e/lease_billing_lifecycle_test.go
@@ -1,0 +1,299 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestE2ELeaseCreationLifecycleAcceptance(t *testing.T) {
+	cfg, err := loadE2EConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	db, err := resetAndMigrateDatabase(ctx, cfg.DatabaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	adminToken, err := issueFirebaseEmulatorToken(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seedAuthenticatedUser(ctx, db, adminToken.UID, cfg.TestEmail); err != nil {
+		t.Fatal(err)
+	}
+
+	adminClient := newAPIClient(cfg.BaseURL, adminToken.IDToken)
+
+	property := createProperty(t, ctx, adminClient, "E2E Lease Lifecycle Property")
+	room := createRoom(t, ctx, adminClient, property.ID, "E2E Lease Lifecycle Room")
+	tenant := createTenant(t, ctx, adminClient)
+
+	lease := leaseLifecycleE2ECreateLease(t, ctx, adminClient, leaseLifecycleE2ECreateLeaseParams{
+		PropertyID: property.ID,
+		RoomID:     room.ID,
+		TenantID:   tenant.ID,
+		StartDate:  "2026-05-01",
+		EndDate:    "2026-06-30",
+		RentAmount: 18000,
+		Deposit:    36000,
+		Cadence:    "monthly",
+	})
+
+	readRoom := getRoom(t, ctx, adminClient, room.ID)
+	if readRoom.Status != "occupied" {
+		t.Fatalf("expected room status %q after lease creation, got %q", "occupied", readRoom.Status)
+	}
+
+	readTenant := getTenant(t, ctx, adminClient, tenant.ID)
+	if readTenant.Status != "active" {
+		t.Fatalf("expected tenant status %q after lease creation, got %q", "active", readTenant.Status)
+	}
+
+	readLease := leaseLifecycleE2EGetLease(t, ctx, adminClient, lease.ID)
+	leaseLifecycleE2ERequireLease(t, readLease, leaseLifecycleE2ECreateLeaseParams{
+		PropertyID: property.ID,
+		RoomID:     room.ID,
+		TenantID:   tenant.ID,
+		StartDate:  "2026-05-01",
+		EndDate:    "2026-06-30",
+		RentAmount: 18000,
+		Deposit:    36000,
+		Cadence:    "monthly",
+	})
+
+	bills := leaseLifecycleE2EListBills(t, ctx, adminClient, lease.ID)
+	leaseLifecycleE2ERequireGeneratedBills(t, bills, leaseLifecycleE2EGeneratedBillExpectation{
+		LeaseID:    lease.ID,
+		PropertyID: property.ID,
+		RoomID:     room.ID,
+		TenantID:   tenant.ID,
+		RentAmount: 18000,
+	})
+}
+
+type leaseLifecycleE2ECreateLeaseParams struct {
+	PropertyID string
+	RoomID     string
+	TenantID   string
+	StartDate  string
+	EndDate    string
+	RentAmount int
+	Deposit    int
+	Cadence    string
+}
+
+type leaseLifecycleE2ELeaseResponse struct {
+	ID                        string  `json:"id"`
+	TenantID                  string  `json:"tenant_id"`
+	RoomID                    string  `json:"room_id"`
+	PropertyID                string  `json:"property_id"`
+	RentAmount                int     `json:"rent_amount"`
+	StartDate                 string  `json:"start_date"`
+	EndDate                   string  `json:"end_date"`
+	ElectricityBillingCadence string  `json:"electricity_billing_cadence"`
+	Status                    string  `json:"status"`
+	DepositAmount             int     `json:"deposit_amount"`
+	DepositStatus             string  `json:"deposit_status"`
+	DepositRefundAmount       *int    `json:"deposit_refund_amount"`
+	DepositDeductionAmount    *int    `json:"deposit_deduction_amount"`
+	DepositDeductionReason    *string `json:"deposit_deduction_reason"`
+	Notes                     *string `json:"notes"`
+	TerminationReason         *string `json:"termination_reason"`
+	Version                   int     `json:"version"`
+}
+
+type leaseLifecycleE2EBillListResponse struct {
+	Data []leaseLifecycleE2EBillResponse `json:"data"`
+}
+
+type leaseLifecycleE2EBillResponse struct {
+	ID            string  `json:"id"`
+	LeaseID       string  `json:"lease_id"`
+	TenantID      string  `json:"tenant_id"`
+	RoomID        string  `json:"room_id"`
+	PropertyID    string  `json:"property_id"`
+	Type          string  `json:"type"`
+	Amount        *int    `json:"amount"`
+	PeriodStart   string  `json:"period_start"`
+	PeriodEnd     string  `json:"period_end"`
+	DueDate       string  `json:"due_date"`
+	Status        string  `json:"status"`
+	PaidAmount    *int    `json:"paid_amount"`
+	PaymentMethod *string `json:"payment_method"`
+	Version       int     `json:"version"`
+}
+
+type leaseLifecycleE2EGeneratedBillExpectation struct {
+	LeaseID    string
+	PropertyID string
+	RoomID     string
+	TenantID   string
+	RentAmount int
+}
+
+func leaseLifecycleE2ECreateLease(t *testing.T, ctx context.Context, client apiClient, params leaseLifecycleE2ECreateLeaseParams) leaseLifecycleE2ELeaseResponse {
+	t.Helper()
+
+	resp, body, err := client.postJSON(ctx, "/api/v1/leases", map[string]any{
+		"tenant_id":                   params.TenantID,
+		"room_id":                     params.RoomID,
+		"rent_amount":                 params.RentAmount,
+		"start_date":                  params.StartDate,
+		"end_date":                    params.EndDate,
+		"deposit_amount":              params.Deposit,
+		"electricity_billing_cadence": params.Cadence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusCreated)
+
+	var lease leaseLifecycleE2ELeaseResponse
+	decodeJSON(t, body, &lease)
+	leaseLifecycleE2ERequireLease(t, lease, params)
+
+	return lease
+}
+
+func leaseLifecycleE2EGetLease(t *testing.T, ctx context.Context, client apiClient, leaseID string) leaseLifecycleE2ELeaseResponse {
+	t.Helper()
+
+	resp, body, err := client.getJSON(ctx, "/api/v1/leases/"+leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var lease leaseLifecycleE2ELeaseResponse
+	decodeJSON(t, body, &lease)
+	return lease
+}
+
+func leaseLifecycleE2EListBills(t *testing.T, ctx context.Context, client apiClient, leaseID string) []leaseLifecycleE2EBillResponse {
+	t.Helper()
+
+	resp, body, err := client.getJSON(ctx, fmt.Sprintf("/api/v1/bills?lease_id=%s&limit=100", url.QueryEscape(leaseID)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var list leaseLifecycleE2EBillListResponse
+	decodeJSON(t, body, &list)
+	return list.Data
+}
+
+func leaseLifecycleE2ERequireLease(t *testing.T, lease leaseLifecycleE2ELeaseResponse, expected leaseLifecycleE2ECreateLeaseParams) {
+	t.Helper()
+
+	if lease.ID == "" {
+		t.Fatal("expected lease id in response")
+	}
+	if lease.PropertyID != expected.PropertyID {
+		t.Fatalf("expected property_id %q, got %q", expected.PropertyID, lease.PropertyID)
+	}
+	if lease.RoomID != expected.RoomID {
+		t.Fatalf("expected room_id %q, got %q", expected.RoomID, lease.RoomID)
+	}
+	if lease.TenantID != expected.TenantID {
+		t.Fatalf("expected tenant_id %q, got %q", expected.TenantID, lease.TenantID)
+	}
+	if lease.Status != "active" {
+		t.Fatalf("expected lease status %q, got %q", "active", lease.Status)
+	}
+	if lease.DepositStatus != "held" {
+		t.Fatalf("expected deposit_status %q, got %q", "held", lease.DepositStatus)
+	}
+	if lease.ElectricityBillingCadence != expected.Cadence {
+		t.Fatalf("expected electricity_billing_cadence %q, got %q", expected.Cadence, lease.ElectricityBillingCadence)
+	}
+	if lease.RentAmount != expected.RentAmount {
+		t.Fatalf("expected rent_amount %d, got %d", expected.RentAmount, lease.RentAmount)
+	}
+	if lease.DepositAmount != expected.Deposit {
+		t.Fatalf("expected deposit_amount %d, got %d", expected.Deposit, lease.DepositAmount)
+	}
+	if lease.StartDate != expected.StartDate {
+		t.Fatalf("expected start_date %q, got %q", expected.StartDate, lease.StartDate)
+	}
+	if lease.EndDate != expected.EndDate {
+		t.Fatalf("expected end_date %q, got %q", expected.EndDate, lease.EndDate)
+	}
+}
+
+func leaseLifecycleE2ERequireGeneratedBills(t *testing.T, bills []leaseLifecycleE2EBillResponse, expected leaseLifecycleE2EGeneratedBillExpectation) {
+	t.Helper()
+
+	if len(bills) == 0 {
+		t.Fatal("expected generated bills for lease")
+	}
+
+	rentBillCount := 0
+	electricityBillCount := 0
+	for _, bill := range bills {
+		leaseLifecycleE2ERequireBillScope(t, bill, expected)
+
+		switch bill.Type {
+		case "rent":
+			if bill.Status != "pending_payment" {
+				t.Fatalf("expected rent bill status %q, got %q for bill %q", "pending_payment", bill.Status, bill.ID)
+			}
+			if bill.Amount == nil {
+				t.Fatalf("expected rent bill amount for bill %q", bill.ID)
+			}
+			if *bill.Amount != expected.RentAmount {
+				t.Fatalf("expected rent bill amount %d, got %d for bill %q", expected.RentAmount, *bill.Amount, bill.ID)
+			}
+			rentBillCount++
+		case "electricity":
+			if bill.Status != "pending_meter" {
+				t.Fatalf("expected electricity bill status %q, got %q for bill %q", "pending_meter", bill.Status, bill.ID)
+			}
+			if bill.Amount != nil {
+				t.Fatalf("expected nil electricity bill amount, got %d for bill %q", *bill.Amount, bill.ID)
+			}
+			electricityBillCount++
+		default:
+			t.Fatalf("unexpected generated bill type %q for bill %q", bill.Type, bill.ID)
+		}
+	}
+
+	if rentBillCount == 0 {
+		t.Fatal("expected at least one generated rent bill")
+	}
+	if electricityBillCount == 0 {
+		t.Fatal("expected at least one generated electricity bill")
+	}
+}
+
+func leaseLifecycleE2ERequireBillScope(t *testing.T, bill leaseLifecycleE2EBillResponse, expected leaseLifecycleE2EGeneratedBillExpectation) {
+	t.Helper()
+
+	if bill.ID == "" {
+		t.Fatal("expected bill id in response")
+	}
+	if bill.LeaseID != expected.LeaseID {
+		t.Fatalf("expected bill lease_id %q, got %q for bill %q", expected.LeaseID, bill.LeaseID, bill.ID)
+	}
+	if bill.PropertyID != expected.PropertyID {
+		t.Fatalf("expected bill property_id %q, got %q for bill %q", expected.PropertyID, bill.PropertyID, bill.ID)
+	}
+	if bill.RoomID != expected.RoomID {
+		t.Fatalf("expected bill room_id %q, got %q for bill %q", expected.RoomID, bill.RoomID, bill.ID)
+	}
+	if bill.TenantID != expected.TenantID {
+		t.Fatalf("expected bill tenant_id %q, got %q for bill %q", expected.TenantID, bill.TenantID, bill.ID)
+	}
+}

--- a/test/e2e/lease_termination_acceptance_test.go
+++ b/test/e2e/lease_termination_acceptance_test.go
@@ -1,0 +1,360 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestE2ELeaseTerminationAcceptance(t *testing.T) {
+	cfg, err := loadE2EConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	db, err := resetAndMigrateDatabase(ctx, cfg.DatabaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	adminToken, err := issueFirebaseEmulatorToken(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seedAuthenticatedUser(ctx, db, adminToken.UID, cfg.TestEmail); err != nil {
+		t.Fatal(err)
+	}
+
+	adminClient := newAPIClient(cfg.BaseURL, adminToken.IDToken)
+
+	t.Run("normal termination rejects active lease with unpaid bills", func(t *testing.T) {
+		fixture := terminationE2ECreateLeaseFixture(t, ctx, adminClient, cfg.TestEmail, "normal-reject")
+		pendingBills := terminationE2EListBills(t, ctx, adminClient, terminationE2EListBillsFilter{
+			LeaseID: fixture.Lease.ID,
+			Status:  "pending_payment",
+			Limit:   100,
+		})
+		if len(pendingBills.Data) == 0 {
+			t.Fatalf("expected generated pending bills for lease %q", fixture.Lease.ID)
+		}
+
+		resp, body, err := adminClient.postJSON(ctx, "/api/v1/leases/"+fixture.Lease.ID+"/terminate", map[string]any{
+			"refund_amount": 36000,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireStatus(t, resp, body, http.StatusUnprocessableEntity)
+		terminationE2ERequireAPIErrorCode(t, body, "LEASE_HAS_UNPAID_BILLS")
+
+		readBack := terminationE2EGetLease(t, ctx, adminClient, fixture.Lease.ID)
+		if readBack.Status != "active" {
+			t.Fatalf("expected lease status %q after rejected termination, got %q", "active", readBack.Status)
+		}
+	})
+
+	t.Run("force termination writes off unpaid bills and releases room", func(t *testing.T) {
+		fixture := terminationE2ECreateLeaseFixture(t, ctx, adminClient, cfg.TestEmail, "force-write-off")
+		generatedBills := terminationE2EListBills(t, ctx, adminClient, terminationE2EListBillsFilter{
+			LeaseID: fixture.Lease.ID,
+			Limit:   100,
+		})
+		unpaidBillIDs := terminationE2ECollectUnpaidBillIDs(generatedBills.Data)
+		if len(unpaidBillIDs) == 0 {
+			t.Fatalf("expected generated unpaid bills for lease %q", fixture.Lease.ID)
+		}
+
+		resp, body, err := adminClient.postJSON(ctx, "/api/v1/leases/"+fixture.Lease.ID+"/force-terminate", map[string]any{
+			"reason":           "E2E forced termination for unpaid bills",
+			"deposit_handling": "write_off",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireStatus(t, resp, body, http.StatusOK)
+
+		var forceTermination terminationE2EForceTerminationResponse
+		decodeJSON(t, body, &forceTermination)
+		if forceTermination.LeaseID != fixture.Lease.ID {
+			t.Fatalf("expected force termination lease_id %q, got %q", fixture.Lease.ID, forceTermination.LeaseID)
+		}
+		if forceTermination.Status != "completed" {
+			t.Fatalf("expected force termination status %q, got %q", "completed", forceTermination.Status)
+		}
+		if forceTermination.DepositHandling != "write_off" {
+			t.Fatalf("expected deposit_handling %q, got %q", "write_off", forceTermination.DepositHandling)
+		}
+		if len(forceTermination.Bills) != len(unpaidBillIDs) {
+			t.Fatalf("expected force termination to track %d unpaid bills, got %d: %s", len(unpaidBillIDs), len(forceTermination.Bills), string(body))
+		}
+		if len(forceTermination.Bills) == 0 {
+			t.Fatalf("expected force termination to track written-off bills: %s", string(body))
+		}
+		trackedBillIDs := make(map[string]bool, len(forceTermination.Bills))
+		for _, bill := range forceTermination.Bills {
+			if bill.Status != "done" {
+				t.Fatalf("expected tracked bill %q status %q, got %q", bill.BillID, "done", bill.Status)
+			}
+			if bill.BillID == "" {
+				t.Fatalf("expected tracked bill id in response: %s", string(body))
+			}
+			if !unpaidBillIDs[bill.BillID] {
+				t.Fatalf("tracked bill %q was not in the original unpaid bill set", bill.BillID)
+			}
+			trackedBillIDs[bill.BillID] = true
+		}
+		for billID := range unpaidBillIDs {
+			if !trackedBillIDs[billID] {
+				t.Fatalf("original unpaid bill %q was not tracked by force termination response", billID)
+			}
+		}
+
+		readBack := terminationE2EGetLease(t, ctx, adminClient, fixture.Lease.ID)
+		if readBack.Status != "force_terminated" {
+			t.Fatalf("expected lease status %q, got %q", "force_terminated", readBack.Status)
+		}
+		if readBack.DepositStatus != "written_off" {
+			t.Fatalf("expected lease deposit_status %q, got %q", "written_off", readBack.DepositStatus)
+		}
+
+		room := getRoom(t, ctx, adminClient, fixture.Room.ID)
+		if room.Status != "vacant" {
+			t.Fatalf("expected room status %q after forced termination, got %q", "vacant", room.Status)
+		}
+
+		writtenOffBills := terminationE2EListBills(t, ctx, adminClient, terminationE2EListBillsFilter{
+			LeaseID: fixture.Lease.ID,
+			Status:  "written_off",
+			Limit:   100,
+		})
+		if len(writtenOffBills.Data) != len(unpaidBillIDs) {
+			t.Fatalf("expected %d written-off bills, got %d", len(unpaidBillIDs), len(writtenOffBills.Data))
+		}
+		for _, bill := range writtenOffBills.Data {
+			if !unpaidBillIDs[bill.ID] {
+				t.Fatalf("written-off bill %q was not in the original unpaid bill set", bill.ID)
+			}
+			if bill.LeaseID != fixture.Lease.ID {
+				t.Fatalf("expected written-off bill lease_id %q, got %q", fixture.Lease.ID, bill.LeaseID)
+			}
+			if bill.Status != "written_off" {
+				t.Fatalf("expected written-off bill status %q, got %q", "written_off", bill.Status)
+			}
+		}
+		remainingBills := terminationE2EListBills(t, ctx, adminClient, terminationE2EListBillsFilter{
+			LeaseID: fixture.Lease.ID,
+			Limit:   100,
+		})
+		for _, bill := range remainingBills.Data {
+			if terminationE2EIsUnpaidStatus(bill.Status) {
+				t.Fatalf("expected no remaining unpaid bill after force termination, got bill %q status %q", bill.ID, bill.Status)
+			}
+		}
+	})
+}
+
+type terminationE2ELeaseFixture struct {
+	Property e2ePropertyResponse
+	Room     e2eRoomResponse
+	Tenant   e2eTenantResponse
+	Lease    terminationE2ELeaseResponse
+}
+
+type terminationE2ELeaseResponse struct {
+	ID                        string `json:"id"`
+	TenantID                  string `json:"tenant_id"`
+	RoomID                    string `json:"room_id"`
+	PropertyID                string `json:"property_id"`
+	RentAmount                int    `json:"rent_amount"`
+	StartDate                 string `json:"start_date"`
+	EndDate                   string `json:"end_date"`
+	ElectricityBillingCadence string `json:"electricity_billing_cadence"`
+	Status                    string `json:"status"`
+	DepositAmount             int    `json:"deposit_amount"`
+	DepositStatus             string `json:"deposit_status"`
+}
+
+type terminationE2EForceTerminationResponse struct {
+	ID              string                         `json:"id"`
+	LeaseID         string                         `json:"lease_id"`
+	Status          string                         `json:"status"`
+	DepositHandling string                         `json:"deposit_handling"`
+	Bills           []terminationE2ETrackedBillRef `json:"bills"`
+}
+
+type terminationE2ETrackedBillRef struct {
+	BillID string `json:"bill_id"`
+	Status string `json:"status"`
+}
+
+type terminationE2EBillListResponse struct {
+	Data []terminationE2EBillResponse `json:"data"`
+}
+
+type terminationE2EBillResponse struct {
+	ID      string `json:"id"`
+	LeaseID string `json:"lease_id"`
+	Status  string `json:"status"`
+}
+
+type terminationE2EListBillsFilter struct {
+	LeaseID string
+	Status  string
+	Limit   int
+}
+
+func terminationE2ECreateLeaseFixture(t *testing.T, ctx context.Context, client apiClient, baseEmail string, suffix string) terminationE2ELeaseFixture {
+	t.Helper()
+
+	property := createProperty(t, ctx, client, "E2E Termination Property "+suffix)
+	room := createRoom(t, ctx, client, property.ID, "E2E Termination Room "+suffix)
+	tenant := terminationE2ECreateTenant(t, ctx, client, baseEmail, suffix)
+	lease := terminationE2ECreateLease(t, ctx, client, tenant.ID, room.ID)
+
+	return terminationE2ELeaseFixture{
+		Property: property,
+		Room:     room,
+		Tenant:   tenant,
+		Lease:    lease,
+	}
+}
+
+func terminationE2ECreateTenant(t *testing.T, ctx context.Context, client apiClient, baseEmail string, suffix string) e2eTenantResponse {
+	t.Helper()
+
+	request := map[string]any{
+		"name":  "E2E Termination Tenant " + suffix,
+		"email": e2eEmail(baseEmail, "termination-"+suffix),
+		"phone": "0912-345-678",
+	}
+	resp, body, err := client.postJSON(ctx, "/api/v1/tenants", request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusCreated)
+
+	var tenant e2eTenantResponse
+	decodeJSON(t, body, &tenant)
+	if tenant.ID == "" {
+		t.Fatalf("expected tenant id in response: %s", string(body))
+	}
+	if tenant.Email != request["email"] {
+		t.Fatalf("expected tenant email %q, got %q", request["email"], tenant.Email)
+	}
+
+	return tenant
+}
+
+func terminationE2ECreateLease(t *testing.T, ctx context.Context, client apiClient, tenantID string, roomID string) terminationE2ELeaseResponse {
+	t.Helper()
+
+	request := map[string]any{
+		"tenant_id":                   tenantID,
+		"room_id":                     roomID,
+		"rent_amount":                 18000,
+		"start_date":                  "2026-06-01",
+		"end_date":                    "2026-08-31",
+		"deposit_amount":              36000,
+		"electricity_billing_cadence": "monthly",
+	}
+	resp, body, err := client.postJSON(ctx, "/api/v1/leases", request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusCreated)
+
+	var lease terminationE2ELeaseResponse
+	decodeJSON(t, body, &lease)
+	if lease.ID == "" {
+		t.Fatalf("expected lease id in response: %s", string(body))
+	}
+	if lease.TenantID != tenantID {
+		t.Fatalf("expected lease tenant_id %q, got %q", tenantID, lease.TenantID)
+	}
+	if lease.RoomID != roomID {
+		t.Fatalf("expected lease room_id %q, got %q", roomID, lease.RoomID)
+	}
+	if lease.Status != "active" {
+		t.Fatalf("expected lease status %q, got %q", "active", lease.Status)
+	}
+
+	return lease
+}
+
+func terminationE2EGetLease(t *testing.T, ctx context.Context, client apiClient, leaseID string) terminationE2ELeaseResponse {
+	t.Helper()
+
+	resp, body, err := client.getJSON(ctx, "/api/v1/leases/"+leaseID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var lease terminationE2ELeaseResponse
+	decodeJSON(t, body, &lease)
+	return lease
+}
+
+func terminationE2EListBills(t *testing.T, ctx context.Context, client apiClient, filter terminationE2EListBillsFilter) terminationE2EBillListResponse {
+	t.Helper()
+
+	query := url.Values{}
+	if filter.LeaseID != "" {
+		query.Set("lease_id", filter.LeaseID)
+	}
+	if filter.Status != "" {
+		query.Set("status", filter.Status)
+	}
+	if filter.Limit > 0 {
+		query.Set("limit", "100")
+	}
+
+	resp, body, err := client.getJSON(ctx, "/api/v1/bills?"+query.Encode())
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var bills terminationE2EBillListResponse
+	decodeJSON(t, body, &bills)
+	return bills
+}
+
+func terminationE2ECollectUnpaidBillIDs(bills []terminationE2EBillResponse) map[string]bool {
+	unpaidBillIDs := make(map[string]bool)
+	for _, bill := range bills {
+		if terminationE2EIsUnpaidStatus(bill.Status) {
+			unpaidBillIDs[bill.ID] = true
+		}
+	}
+	return unpaidBillIDs
+}
+
+func terminationE2EIsUnpaidStatus(status string) bool {
+	switch status {
+	case "pending_meter", "pending_payment", "overdue":
+		return true
+	default:
+		return false
+	}
+}
+
+func terminationE2ERequireAPIErrorCode(t *testing.T, body []byte, expectedCode string) {
+	t.Helper()
+
+	var payload struct {
+		ErrorCode string `json:"error_code"`
+	}
+	decodeJSON(t, body, &payload)
+	if payload.ErrorCode != expectedCode {
+		t.Fatalf("expected error_code %q, got %q: %s", expectedCode, payload.ErrorCode, string(body))
+	}
+}


### PR DESCRIPTION
## Summary

Closes #92.

Parent umbrella: #71.

This PR adds first-launch E2E acceptance coverage for the lease and billing flow slice. The tests run behind the existing `e2e` build tag and use the Go E2E harness from #90/#91: real HTTP API, real middleware, real PostgreSQL E2E database reset/migration, Firebase Auth Emulator tokens, and API-visible assertions.

## What changed

- Added `TestE2ELeaseCreationLifecycleAcceptance`.
  - Creates property, room, tenant, and lease through the real API.
  - Verifies lease creation response and read-back state.
  - Verifies lease-created side effects through API reads:
    - room becomes `occupied`
    - tenant lifecycle-visible state is `active`
    - generated rent and electricity bills exist for the lease
  - Asserts rent bills are `pending_payment` with expected rent amount and electricity bills are `pending_meter` with nil amount.

- Added `TestE2EBillingPaymentAndFinancialReportAcceptance`.
  - Creates a lease and reads generated bills through `GET /api/v1/bills`.
  - Records electricity meter usage through `POST /api/v1/bills/{id}/meter`.
  - Records rent and electricity payments through `POST /api/v1/bills/{id}/payment`.
  - Reads bill detail back to verify paid state, paid amount, and payment method.
  - Reads the live property financial report and verifies income plus `rent_payment` and `electricity_payment` entries.

- Added `TestE2ELeaseTerminationAcceptance`.
  - Verifies normal termination rejects active leases with unpaid bills using `LEASE_HAS_UNPAID_BILLS`.
  - Verifies force termination with `deposit_handling: write_off` completes successfully.
  - Captures all original unpaid bills (`pending_meter`, `pending_payment`, `overdue`) before force termination.
  - Verifies all original unpaid bills are tracked by the force termination response, become `written_off`, and no unpaid bills remain.
  - Verifies lease status becomes `force_terminated`, deposit status becomes `written_off`, and room is released to `vacant`.

## Validation

- `gofmt`
- `git diff --cached --check`
- `go test -tags=e2e ./test/e2e -run '^$' -count=1`
- `go test ./...`
- `./scripts/e2e_test.sh -run 'TestE2E(LeaseCreationLifecycleAcceptance|LeaseTerminationAcceptance)' -count=1`
- `./scripts/e2e_test.sh -run 'TestE2E(LeaseCreationLifecycleAcceptance|BillingPaymentAndFinancialReportAcceptance|LeaseTerminationAcceptance)' -count=1`
- `./scripts/e2e_test.sh`

## Notes

The umbrella issue #71 remains open as the P1 E2E tracker. This PR closes only the focused lease/billing implementation issue #92.