### PR TITLE
[E2E] Add journal acceptance flow

### DIFF
--- a/internal/application/journal/create.go
+++ b/internal/application/journal/create.go
@@ -104,19 +104,20 @@ func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*Journa
 		}
 
 		if journalLog.ExpenseAmount != nil {
-			occurredAt := journalLog.CreatedAt.UTC()
+			year, month := journalAccountingPeriod(journalLog.CreatedAt)
 			if err := s.accountingRepo.CreateExpenseAccountingEntry(ctx, tx, ExpenseAccountingEntryParams{
 				PropertyID:  journalLog.PropertyID,
 				Category:    accountingCategoryJournalExpense,
 				Amount:      *journalLog.ExpenseAmount,
 				Description: journalLog.ExpenseDescription,
 				SourceRef:   map[string]interface{}{"type": "JournalExpenseRecorded", "journal_log_id": journalLog.ID},
-				Year:        occurredAt.Year(),
-				Month:       int(occurredAt.Month()),
+				Year:        year,
+				Month:       month,
 			}); err != nil {
 				return mapAccountingRepositoryError(err)
 			}
 
+			occurredAt := journalLog.CreatedAt.UTC()
 			recorder.Record(domainevents.JournalExpenseRecorded{
 				JournalLogID: journalLog.ID,
 				PropertyID:   journalLog.PropertyID,

--- a/internal/application/journal/create_test.go
+++ b/internal/application/journal/create_test.go
@@ -24,7 +24,7 @@ const (
 func TestCreateServiceCreatesAccountingEntryAndPublishesEventWhenExpensePresent(t *testing.T) {
 	amount := 3500
 	description := "Pipe repair"
-	createdAt := time.Date(2026, 4, 15, 11, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2026, 4, 30, 16, 30, 0, 0, time.UTC)
 	repo := &journalRepositoryStub{
 		propertyExists: true,
 		room:           &Room{ID: testRoomID, PropertyID: testPropertyID},
@@ -70,8 +70,8 @@ func TestCreateServiceCreatesAccountingEntryAndPublishesEventWhenExpensePresent(
 	if accountingRepo.entry.Description == nil || *accountingRepo.entry.Description != description {
 		t.Fatalf("accounting description = %v, want %s", accountingRepo.entry.Description, description)
 	}
-	if accountingRepo.entry.Year != 2026 || accountingRepo.entry.Month != 4 {
-		t.Fatalf("accounting Year/Month = %d/%d, want 2026/4", accountingRepo.entry.Year, accountingRepo.entry.Month)
+	if accountingRepo.entry.Year != 2026 || accountingRepo.entry.Month != 5 {
+		t.Fatalf("accounting Year/Month = %d/%d, want 2026/5", accountingRepo.entry.Year, accountingRepo.entry.Month)
 	}
 	if accountingRepo.entry.SourceRef["type"] != "JournalExpenseRecorded" || accountingRepo.entry.SourceRef["journal_log_id"] != testJournalID {
 		t.Fatalf("accounting SourceRef = %#v", accountingRepo.entry.SourceRef)
@@ -292,13 +292,14 @@ func TestUpdateServiceUpdatesMutableFields(t *testing.T) {
 			AuthorID:           testActorID,
 			Content:            "Original",
 			ExpenseDescription: stringPtr("Old"),
-			CreatedAt:          time.Now(),
+			CreatedAt:          time.Date(2026, 4, 30, 16, 30, 0, 0, time.UTC),
 			UpdatedAt:          time.Now(),
 		},
 	}
 	runner, _, cleanup := newJournalTxRunner(t)
 	defer cleanup()
-	service := NewUpdateService(repo, runner)
+	accountingRepo := &expenseAccountingRepositoryStub{}
+	service := NewUpdateService(repo, accountingRepo, runner)
 	content := " Updated journal "
 
 	updated, err := service.Execute(context.Background(), UpdateInput{
@@ -319,6 +320,18 @@ func TestUpdateServiceUpdatesMutableFields(t *testing.T) {
 	if updated.ExpenseDescription == nil || *updated.ExpenseDescription != description {
 		t.Fatalf("ExpenseDescription = %v, want %s", updated.ExpenseDescription, description)
 	}
+	if accountingRepo.syncCalls != 1 {
+		t.Fatalf("SyncExpenseAccountingEntry calls = %d, want 1", accountingRepo.syncCalls)
+	}
+	if accountingRepo.syncedJournalLogID != testJournalID {
+		t.Fatalf("syncedJournalLogID = %s, want %s", accountingRepo.syncedJournalLogID, testJournalID)
+	}
+	if accountingRepo.syncedEntry == nil || accountingRepo.syncedEntry.Amount != amount {
+		t.Fatalf("syncedEntry = %+v, want amount %d", accountingRepo.syncedEntry, amount)
+	}
+	if accountingRepo.syncedEntry.Year != 2026 || accountingRepo.syncedEntry.Month != 5 {
+		t.Fatalf("syncedEntry Year/Month = %d/%d, want 2026/5", accountingRepo.syncedEntry.Year, accountingRepo.syncedEntry.Month)
+	}
 }
 
 func TestUpdateServiceRejectsEmptyContent(t *testing.T) {
@@ -334,7 +347,7 @@ func TestUpdateServiceRejectsEmptyContent(t *testing.T) {
 	}
 	runner, _, cleanup := newJournalTxRunnerExpectRollback(t)
 	defer cleanup()
-	service := NewUpdateService(repo, runner)
+	service := NewUpdateService(repo, &expenseAccountingRepositoryStub{}, runner)
 	content := " "
 
 	_, err := service.Execute(context.Background(), UpdateInput{
@@ -370,14 +383,24 @@ func (s *journalPublisherStub) Publish(_ context.Context, event any) error {
 }
 
 type expenseAccountingRepositoryStub struct {
-	entry       ExpenseAccountingEntryParams
-	err         error
-	createCalls int
+	entry              ExpenseAccountingEntryParams
+	syncedEntry        *ExpenseAccountingEntryParams
+	syncedJournalLogID string
+	err                error
+	createCalls        int
+	syncCalls          int
 }
 
 func (s *expenseAccountingRepositoryStub) CreateExpenseAccountingEntry(_ context.Context, _ *sql.Tx, params ExpenseAccountingEntryParams) error {
 	s.createCalls++
 	s.entry = params
+	return s.err
+}
+
+func (s *expenseAccountingRepositoryStub) SyncExpenseAccountingEntry(_ context.Context, _ *sql.Tx, journalLogID string, params *ExpenseAccountingEntryParams) error {
+	s.syncCalls++
+	s.syncedJournalLogID = journalLogID
+	s.syncedEntry = params
 	return s.err
 }
 

--- a/internal/application/journal/helpers.go
+++ b/internal/application/journal/helpers.go
@@ -2,11 +2,14 @@ package journal
 
 import (
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
 	"stds_backend/internal/shared/apperr"
 )
+
+var journalAccountingLocation = time.FixedZone("Asia/Taipei", 8*60*60)
 
 func normalizeWriteRole(role string) (string, error) {
 	normalized := strings.ToLower(strings.TrimSpace(role))
@@ -69,4 +72,9 @@ func requirePropertyAccess(role string, assignedPropertyIDs []string, propertyID
 	default:
 		return apperr.ErrForbidden
 	}
+}
+
+func journalAccountingPeriod(value time.Time) (int, int) {
+	occurredAt := value.In(journalAccountingLocation)
+	return occurredAt.Year(), int(occurredAt.Month())
 }

--- a/internal/application/journal/repository.go
+++ b/internal/application/journal/repository.go
@@ -96,4 +96,5 @@ type Repository interface {
 // ExpenseAccountingRepository defines persistence required for journal expense accounting.
 type ExpenseAccountingRepository interface {
 	CreateExpenseAccountingEntry(ctx context.Context, tx *sql.Tx, params ExpenseAccountingEntryParams) error
+	SyncExpenseAccountingEntry(ctx context.Context, tx *sql.Tx, journalLogID string, params *ExpenseAccountingEntryParams) error
 }

--- a/internal/application/journal/update.go
+++ b/internal/application/journal/update.go
@@ -19,13 +19,14 @@ type UpdateInput struct {
 
 // UpdateService updates journal logs.
 type UpdateService struct {
-	repo     Repository
-	txRunner TransactionRunner
+	repo           Repository
+	accountingRepo ExpenseAccountingRepository
+	txRunner       TransactionRunner
 }
 
 // NewUpdateService returns an UpdateService.
-func NewUpdateService(repo Repository, txRunner TransactionRunner) *UpdateService {
-	return &UpdateService{repo: repo, txRunner: txRunner}
+func NewUpdateService(repo Repository, accountingRepo ExpenseAccountingRepository, txRunner TransactionRunner) *UpdateService {
+	return &UpdateService{repo: repo, accountingRepo: accountingRepo, txRunner: txRunner}
 }
 
 // Execute updates mutable journal log fields.
@@ -68,6 +69,28 @@ func (s *UpdateService) Execute(ctx context.Context, input UpdateInput) (*Journa
 		})
 		if err != nil {
 			return mapRepositoryError(err)
+		}
+
+		if current.ExpenseAmount != nil || journalLog.ExpenseAmount != nil {
+			if s.accountingRepo == nil {
+				return apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "journal_accounting"})
+			}
+			var entry *ExpenseAccountingEntryParams
+			if journalLog.ExpenseAmount != nil {
+				year, month := journalAccountingPeriod(journalLog.CreatedAt)
+				entry = &ExpenseAccountingEntryParams{
+					PropertyID:  journalLog.PropertyID,
+					Category:    accountingCategoryJournalExpense,
+					Amount:      *journalLog.ExpenseAmount,
+					Description: journalLog.ExpenseDescription,
+					SourceRef:   map[string]interface{}{"type": "JournalExpenseRecorded", "journal_log_id": journalLog.ID},
+					Year:        year,
+					Month:       month,
+				}
+			}
+			if err := s.accountingRepo.SyncExpenseAccountingEntry(ctx, tx, journalLog.ID, entry); err != nil {
+				return mapAccountingRepositoryError(err)
+			}
 		}
 
 		updated = journalLog

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -5072,7 +5072,7 @@ func defaultAPIServerDeps(userRepo *fakeUserRepo, authenticator fakeAuthenticato
 			List:   appjournal.NewListService(nil),
 			Get:    appjournal.NewGetService(nil),
 			Create: appjournal.NewCreateService(nil, nil, nil),
-			Update: appjournal.NewUpdateService(nil, nil),
+			Update: appjournal.NewUpdateService(nil, nil, nil),
 			Delete: appjournal.NewDeleteService(nil, nil),
 		},
 		Repair: handler.RepairServices{

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -980,6 +980,29 @@ INSERT INTO accounting_entries (
 	return nil
 }
 
+// DeleteJournalExpenseAccountingEntry removes the accounting entry tied to one journal log.
+func (r *SQLRepository) DeleteJournalExpenseAccountingEntry(ctx context.Context, tx *sql.Tx, journalLogID string) error {
+	const query = `
+DELETE FROM accounting_entries
+WHERE category = 'journal_expense'
+  AND source_ref->>'journal_log_id' = $1
+`
+	if _, err := tx.ExecContext(ctx, query, journalLogID); err != nil {
+		return fmt.Errorf("delete journal expense accounting entry: %w", err)
+	}
+
+	return nil
+}
+
+// ReplaceJournalExpenseAccountingEntry replaces the accounting entry tied to one journal log.
+func (r *SQLRepository) ReplaceJournalExpenseAccountingEntry(ctx context.Context, tx *sql.Tx, journalLogID string, params CreateAccountingEntryParams) error {
+	if err := r.DeleteJournalExpenseAccountingEntry(ctx, tx, journalLogID); err != nil {
+		return err
+	}
+
+	return r.InsertAccountingEntry(ctx, tx, params)
+}
+
 // ListFinancialReportSummaries returns finalized summaries and the requested current live summary.
 func (r *SQLRepository) ListFinancialReportSummaries(ctx context.Context, scope Scope, propertyID string, year *int, currentYear int, currentMonth int) ([]FinancialReportSummary, error) {
 	finalized, err := r.listFinalizedFinancialReportSummaries(ctx, scope, propertyID, year)

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -435,6 +435,41 @@ func TestInsertAccountingEntryWritesCategoryAmountSourceRefYearAndMonth(t *testi
 	}
 }
 
+func TestReplaceJournalExpenseAccountingEntryDeletesExistingAndInsertsReplacement(t *testing.T) {
+	db, mock, repo := newBillingRepoTest(t)
+	defer closeBillingDB(t, db)
+
+	tx := beginBillingTx(t, db, mock)
+	description := "updated repair expense"
+	mock.ExpectExec(`(?s)DELETE FROM accounting_entries\s+WHERE category = 'journal_expense'\s+AND source_ref->>'journal_log_id' = \$1`).
+		WithArgs("journal-1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`(?s)INSERT INTO accounting_entries \(\s+property_account_id,\s+category,\s+amount,\s+description,\s+source_ref,\s+year,\s+month\s+\) VALUES \(\$1, \$2, \$3, \$4, \$5::jsonb, \$6, \$7\)`).
+		WithArgs("account-1", "journal_expense", 4200, description, `{"journal_log_id":"journal-1","type":"JournalExpenseRecorded"}`, 2026, 5).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	err := repo.ReplaceJournalExpenseAccountingEntry(context.Background(), tx, "journal-1", CreateAccountingEntryParams{
+		PropertyAccountID: "account-1",
+		Category:          "journal_expense",
+		Amount:            4200,
+		Description:       &description,
+		SourceRef:         map[string]any{"type": "JournalExpenseRecorded", "journal_log_id": "journal-1"},
+		Year:              2026,
+		Month:             5,
+	})
+	if err != nil {
+		t.Fatalf("ReplaceJournalExpenseAccountingEntry: %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func TestCreatePropertyAccountInsertsPropertyAccount(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)

--- a/internal/server/journal_adapters.go
+++ b/internal/server/journal_adapters.go
@@ -33,3 +33,28 @@ func (a journalExpenseAccountingAdapter) CreateExpenseAccountingEntry(ctx contex
 		Month:             params.Month,
 	})
 }
+
+func (a journalExpenseAccountingAdapter) SyncExpenseAccountingEntry(ctx context.Context, tx *sql.Tx, journalLogID string, params *appjournal.ExpenseAccountingEntryParams) error {
+	if params == nil {
+		return a.repo.DeleteJournalExpenseAccountingEntry(ctx, tx, journalLogID)
+	}
+
+	account, err := a.repo.FindPropertyAccountByPropertyID(ctx, tx, params.PropertyID)
+	if err != nil {
+		if errors.Is(err, dbbilling.ErrNotFound) {
+			return appjournal.ErrPropertyAccountNotFound
+		}
+
+		return err
+	}
+
+	return a.repo.ReplaceJournalExpenseAccountingEntry(ctx, tx, journalLogID, dbbilling.CreateAccountingEntryParams{
+		PropertyAccountID: account.ID,
+		Category:          params.Category,
+		Amount:            params.Amount,
+		Description:       params.Description,
+		SourceRef:         params.SourceRef,
+		Year:              params.Year,
+		Month:             params.Month,
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,7 +147,7 @@ func New(cfg *config.Config) (*Server, error) {
 		List:   appjournal.NewListService(journalRepo),
 		Get:    appjournal.NewGetService(journalRepo),
 		Create: appjournal.NewCreateService(journalRepo, journalAccounting, txRunner),
-		Update: appjournal.NewUpdateService(journalRepo, txRunner),
+		Update: appjournal.NewUpdateService(journalRepo, journalAccounting, txRunner),
 		Delete: appjournal.NewDeleteService(journalRepo, txRunner),
 	}
 	jobTriggerService := appjobs.NewTriggerService(jobRunStoreAdapter{repo: jobRunsRepo}, newJobRunners(db, txRunner, notificationService), cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)

--- a/test/e2e/http.go
+++ b/test/e2e/http.go
@@ -35,6 +35,10 @@ func (c apiClient) postJSON(ctx context.Context, path string, body any) (*http.R
 	return c.doJSON(ctx, http.MethodPost, path, body)
 }
 
+func (c apiClient) patchJSON(ctx context.Context, path string, body any) (*http.Response, []byte, error) {
+	return c.doJSON(ctx, http.MethodPatch, path, body)
+}
+
 func (c apiClient) doJSON(ctx context.Context, method string, path string, body any) (*http.Response, []byte, error) {
 	var reader io.Reader
 	if body != nil {

--- a/test/e2e/journal_acceptance_test.go
+++ b/test/e2e/journal_acceptance_test.go
@@ -1,0 +1,318 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestE2EJournalAcceptance(t *testing.T) {
+	cfg, err := loadE2EConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	db, err := resetAndMigrateDatabase(ctx, cfg.DatabaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	adminToken, err := issueFirebaseEmulatorToken(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seedAuthenticatedUser(ctx, db, adminToken.UID, cfg.TestEmail); err != nil {
+		t.Fatal(err)
+	}
+
+	adminClient := newAPIClient(cfg.BaseURL, adminToken.IDToken)
+	assignedProperty := createProperty(t, ctx, adminClient, "E2E Journal Assigned Property")
+	unassignedProperty := createProperty(t, ctx, adminClient, "E2E Journal Unassigned Property")
+	room := createRoom(t, ctx, adminClient, assignedProperty.ID, "E2E Journal Room")
+
+	scopedEmail := e2eEmail(cfg.TestEmail, "journal-scoped")
+	scopedToken, err := issueFirebaseEmulatorTokenForCredentials(ctx, cfg, scopedEmail, cfg.TestPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seedBackendUser(ctx, db, seedBackendUserParams{
+		ID:                  seededScopedUserID,
+		FirebaseUID:         scopedToken.UID,
+		Email:               scopedEmail,
+		Name:                "E2E Journal Organizer",
+		Role:                "organizer",
+		AssignedPropertyIDs: []string{assignedProperty.ID},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	scopedClient := newAPIClient(cfg.BaseURL, scopedToken.IDToken)
+
+	t.Run("create list detail update and report expense", func(t *testing.T) {
+		plain := journalE2ECreateLog(t, ctx, scopedClient, journalE2ECreateRequest{
+			PropertyID: assignedProperty.ID,
+			Content:    "E2E property inspection",
+		})
+		if plain.ExpenseAmount != nil {
+			t.Fatalf("expected plain journal expense_amount nil, got %+v", plain.ExpenseAmount)
+		}
+
+		expense := 3500
+		description := "Pipe repair"
+		withExpense := journalE2ECreateLog(t, ctx, scopedClient, journalE2ECreateRequest{
+			PropertyID:         assignedProperty.ID,
+			RoomID:             &room.ID,
+			Content:            "E2E bathroom repair",
+			ExpenseAmount:      &expense,
+			ExpenseDescription: &description,
+		})
+		journalE2ERequireLog(t, withExpense, journalE2EExpectation{
+			PropertyID:         assignedProperty.ID,
+			RoomID:             &room.ID,
+			Content:            "E2E bathroom repair",
+			ExpenseAmount:      &expense,
+			ExpenseDescription: &description,
+		})
+
+		list := journalE2EListLogs(t, ctx, scopedClient, assignedProperty.ID)
+		journalE2ERequireListContains(t, list, plain.ID)
+		journalE2ERequireListContains(t, list, withExpense.ID)
+
+		detail := journalE2EGetLog(t, ctx, scopedClient, withExpense.ID)
+		journalE2ERequireLog(t, detail, journalE2EExpectation{
+			PropertyID:         assignedProperty.ID,
+			RoomID:             &room.ID,
+			Content:            "E2E bathroom repair",
+			ExpenseAmount:      &expense,
+			ExpenseDescription: &description,
+		})
+
+		updatedExpense := 4200
+		updatedDescription := "Pipe repair and cleanup"
+		updated := journalE2EUpdateLog(t, ctx, scopedClient, withExpense.ID, map[string]any{
+			"content":             "E2E bathroom repair updated",
+			"expense_amount":      updatedExpense,
+			"expense_description": updatedDescription,
+		})
+		journalE2ERequireLog(t, updated, journalE2EExpectation{
+			PropertyID:         assignedProperty.ID,
+			RoomID:             &room.ID,
+			Content:            "E2E bathroom repair updated",
+			ExpenseAmount:      &updatedExpense,
+			ExpenseDescription: &updatedDescription,
+		})
+
+		year, month := journalE2ECurrentReportPeriod()
+		report := billingFlowE2EGetFinancialReport(t, ctx, scopedClient, assignedProperty.ID, year, month)
+		if report.TotalExpense != updatedExpense {
+			t.Fatalf("expected total_expense %d, got %d", updatedExpense, report.TotalExpense)
+		}
+		if report.Net != -updatedExpense {
+			t.Fatalf("expected net %d, got %d", -updatedExpense, report.Net)
+		}
+		journalE2ERequireSingleReportEntry(t, report, "journal_expense", updatedExpense)
+	})
+
+	t.Run("unassigned property access is rejected", func(t *testing.T) {
+		unassignedLog := journalE2ECreateLog(t, ctx, adminClient, journalE2ECreateRequest{
+			PropertyID: unassignedProperty.ID,
+			Content:    "E2E unassigned journal",
+		})
+
+		resp, body, err := scopedClient.getJSON(ctx, "/api/v1/journal-logs/"+unassignedLog.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireStatus(t, resp, body, http.StatusForbidden)
+		requireAPIError(t, body, "FORBIDDEN", "Forbidden.")
+
+		resp, body, err = scopedClient.postJSON(ctx, "/api/v1/journal-logs", map[string]any{
+			"property_id": unassignedProperty.ID,
+			"content":     "E2E forbidden journal create",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireStatus(t, resp, body, http.StatusForbidden)
+		requireAPIError(t, body, "FORBIDDEN", "Forbidden.")
+	})
+}
+
+type journalE2ECreateRequest struct {
+	PropertyID         string
+	RoomID             *string
+	Content            string
+	ExpenseAmount      *int
+	ExpenseDescription *string
+}
+
+type journalE2EExpectation struct {
+	PropertyID         string
+	RoomID             *string
+	Content            string
+	ExpenseAmount      *int
+	ExpenseDescription *string
+}
+
+type journalE2ELogResponse struct {
+	ID                 string  `json:"id"`
+	PropertyID         string  `json:"property_id"`
+	RoomID             *string `json:"room_id"`
+	AuthorID           string  `json:"author_id"`
+	Content            string  `json:"content"`
+	ExpenseAmount      *int    `json:"expense_amount"`
+	ExpenseDescription *string `json:"expense_description"`
+	CreatedAt          string  `json:"created_at"`
+	UpdatedAt          string  `json:"updated_at"`
+}
+
+type journalE2EListResponse struct {
+	Data []journalE2ELogResponse `json:"data"`
+}
+
+func journalE2ECreateLog(t *testing.T, ctx context.Context, client apiClient, request journalE2ECreateRequest) journalE2ELogResponse {
+	t.Helper()
+
+	body := map[string]any{
+		"property_id": request.PropertyID,
+		"content":     request.Content,
+	}
+	if request.RoomID != nil {
+		body["room_id"] = *request.RoomID
+	}
+	if request.ExpenseAmount != nil {
+		body["expense_amount"] = *request.ExpenseAmount
+	}
+	if request.ExpenseDescription != nil {
+		body["expense_description"] = *request.ExpenseDescription
+	}
+
+	resp, respBody, err := client.postJSON(ctx, "/api/v1/journal-logs", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, respBody, http.StatusCreated)
+
+	var log journalE2ELogResponse
+	decodeJSON(t, respBody, &log)
+	if log.ID == "" {
+		t.Fatalf("expected journal id in response: %s", string(respBody))
+	}
+	return log
+}
+
+func journalE2EUpdateLog(t *testing.T, ctx context.Context, client apiClient, journalLogID string, request map[string]any) journalE2ELogResponse {
+	t.Helper()
+
+	resp, body, err := client.patchJSON(ctx, "/api/v1/journal-logs/"+journalLogID, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var log journalE2ELogResponse
+	decodeJSON(t, body, &log)
+	return log
+}
+
+func journalE2EGetLog(t *testing.T, ctx context.Context, client apiClient, journalLogID string) journalE2ELogResponse {
+	t.Helper()
+
+	resp, body, err := client.getJSON(ctx, "/api/v1/journal-logs/"+journalLogID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var log journalE2ELogResponse
+	decodeJSON(t, body, &log)
+	return log
+}
+
+func journalE2EListLogs(t *testing.T, ctx context.Context, client apiClient, propertyID string) []journalE2ELogResponse {
+	t.Helper()
+
+	path := fmt.Sprintf("/api/v1/journal-logs?property_id=%s&limit=100", url.QueryEscape(propertyID))
+	resp, body, err := client.getJSON(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var list journalE2EListResponse
+	decodeJSON(t, body, &list)
+	return list.Data
+}
+
+func journalE2ERequireLog(t *testing.T, log journalE2ELogResponse, expected journalE2EExpectation) {
+	t.Helper()
+
+	if log.PropertyID != expected.PropertyID {
+		t.Fatalf("expected property_id %q, got %q", expected.PropertyID, log.PropertyID)
+	}
+	if !stringPtrEqual(log.RoomID, expected.RoomID) {
+		t.Fatalf("expected room_id %+v, got %+v", expected.RoomID, log.RoomID)
+	}
+	if log.Content != expected.Content {
+		t.Fatalf("expected content %q, got %q", expected.Content, log.Content)
+	}
+	if !intPtrEqual(log.ExpenseAmount, expected.ExpenseAmount) {
+		t.Fatalf("expected expense_amount %+v, got %+v", expected.ExpenseAmount, log.ExpenseAmount)
+	}
+	if !stringPtrEqual(log.ExpenseDescription, expected.ExpenseDescription) {
+		t.Fatalf("expected expense_description %+v, got %+v", expected.ExpenseDescription, log.ExpenseDescription)
+	}
+}
+
+func journalE2ERequireListContains(t *testing.T, logs []journalE2ELogResponse, journalLogID string) {
+	t.Helper()
+
+	for _, log := range logs {
+		if log.ID == journalLogID {
+			return
+		}
+	}
+	t.Fatalf("expected journal log %q in list: %+v", journalLogID, logs)
+}
+
+func journalE2ERequireSingleReportEntry(t *testing.T, report billingFlowE2EFinancialReportResponse, category string, amount int) {
+	t.Helper()
+
+	count := 0
+	for _, entry := range report.Entries {
+		if entry.Category == category && entry.Amount == amount {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected one report entry category %q amount %d, got %d in %+v", category, amount, count, report.Entries)
+	}
+}
+
+func journalE2ECurrentReportPeriod() (int, int) {
+	location := time.FixedZone("Asia/Taipei", 8*60*60)
+	now := time.Now().In(location)
+	return now.Year(), int(now.Month())
+}
+
+func stringPtrEqual(left *string, right *string) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func intPtrEqual(left *int, right *int) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}


### PR DESCRIPTION
## Summary

Closes #93.

Parent umbrella: #71.

This PR adds first-launch E2E acceptance coverage for the journal flow. The scenario runs through the existing Go E2E harness with real HTTP API calls, real middleware/authz, real PostgreSQL reset/migration, Firebase Auth Emulator tokens, and API-visible assertions.

## What changed

- Added `TestE2EJournalAcceptance`.
  - Creates a normal journal log through `POST /api/v1/journal-logs` and verifies list/detail readback.
  - Creates a room-scoped journal log with `expense_amount` and verifies response, list, and detail state.
  - Updates the journal content and expense fields through `PATCH /api/v1/journal-logs/{id}`.
  - Reads the live property financial report and verifies the updated `journal_expense`, `total_expense`, and `net` values through the API.
  - Verifies an organizer scoped to one property is rejected when reading or creating journal logs for an unassigned property.

- Added E2E HTTP `PATCH` support for update flows.

- Updated journal expense accounting sync behavior.
  - Journal create and update now derive accounting report periods using the same Asia/Taipei month boundary as financial report reads.
  - Journal update replaces or removes the matching `journal_expense` accounting entry when expense fields change, so financial reports do not retain stale journal expense amounts.

## Validation

- `git diff --check`
- `go test ./internal/application/journal ./internal/platform/database/billing ./internal/server ./internal/http/router`
- `go test -tags=e2e ./test/e2e -run '^$' -count=1`
- `go test ./...`
- `./scripts/e2e_test.sh -run 'TestE2EJournalAcceptance' -count=1`
- `./scripts/e2e_test.sh`

## Notes

`delete journal` is intentionally not included in this first-launch acceptance PR. The scoped first-launch path covers create/read, update/report sync, and property authorization. Delete has a separate destructive-flow/report-reversal contract and should be handled in a focused follow-up if launch UI requires it.