### PR TITLE
Map legacy rent payment cycles into rent_billing_cadence

### DIFF
--- a/internal/migration/legacy/leases.go
+++ b/internal/migration/legacy/leases.go
@@ -26,6 +26,26 @@ const (
 	depositStatusSettled          = "settled"
 )
 
+var legacyLeaseActiveLikeRoomIDs = map[string]string{
+	"38":  "1",
+	"135": "1",
+	"45":  "6",
+	"51":  "6",
+	"53":  "6",
+	"55":  "6",
+	"56":  "6",
+	"57":  "6",
+	"59":  "6",
+	"62":  "6",
+	"63":  "6",
+	"64":  "6",
+	"67":  "6",
+	"68":  "6",
+	"137": "6",
+	"147": "6",
+	"254": "6",
+}
+
 // MigrateLeasesOptions controls Task 9 execution.
 type MigrateLeasesOptions struct {
 	SourceDir string
@@ -34,30 +54,48 @@ type MigrateLeasesOptions struct {
 
 // LeaseMigrationReport captures Task 9 execution details.
 type LeaseMigrationReport struct {
-	GeneratedAt                     time.Time         `json:"generated_at"`
-	SourcePath                      string            `json:"source_path"`
-	SourceLinkPath                  string            `json:"source_link_path"`
-	ReportPath                      string            `json:"report_path"`
-	TotalSourceRows                 int               `json:"total_source_rows"`
-	EligibleRows                    int               `json:"eligible_rows"`
-	ImportedRows                    int               `json:"imported_rows"`
-	AlreadyMappedRows               int               `json:"already_mapped_rows"`
-	MappingsCreated                 int               `json:"mappings_created"`
-	SkippedRows                     int               `json:"skipped_rows"`
-	InvalidRows                     int               `json:"invalid_rows"`
-	MissingRoomMappings             int               `json:"missing_room_mappings"`
-	MissingTenantMappings           int               `json:"missing_tenant_mappings"`
-	MissingRentAmountRows           int               `json:"missing_rent_amount_rows"`
-	MultiTenantLeaseRows            int               `json:"multi_tenant_lease_rows"`
-	NotesPopulated                  int               `json:"notes_populated"`
-	TerminationReasonsPopulated     int               `json:"termination_reasons_populated"`
-	SettlementDetailsPopulated      int               `json:"settlement_details_populated"`
-	DepositRefundAmountPopulated    int               `json:"deposit_refund_amount_populated"`
-	DepositDeductionAmountPopulated int               `json:"deposit_deduction_amount_populated"`
-	StatusDistribution              map[string]int    `json:"status_distribution"`
-	DepositStatusDistribution       map[string]int    `json:"deposit_status_distribution"`
-	Skipped                         []LeaseSkipRecord `json:"skipped"`
-	Assumptions                     []string          `json:"assumptions"`
+	GeneratedAt                     time.Time                  `json:"generated_at"`
+	SourcePath                      string                     `json:"source_path"`
+	SourceLinkPath                  string                     `json:"source_link_path"`
+	RoomSourcePath                  string                     `json:"room_source_path"`
+	ReportPath                      string                     `json:"report_path"`
+	TotalSourceRows                 int                        `json:"total_source_rows"`
+	EligibleRows                    int                        `json:"eligible_rows"`
+	ImportedRows                    int                        `json:"imported_rows"`
+	AlreadyMappedRows               int                        `json:"already_mapped_rows"`
+	MappingsCreated                 int                        `json:"mappings_created"`
+	SkippedRows                     int                        `json:"skipped_rows"`
+	InvalidRows                     int                        `json:"invalid_rows"`
+	MissingRoomMappings             int                        `json:"missing_room_mappings"`
+	MissingTenantMappings           int                        `json:"missing_tenant_mappings"`
+	MissingRentAmountRows           int                        `json:"missing_rent_amount_rows"`
+	MissingRentCadenceRows          int                        `json:"missing_rent_cadence_rows"`
+	MissingMatchingRentPriceRows    int                        `json:"missing_matching_rent_price_rows"`
+	InvalidRentPriceRows            int                        `json:"invalid_rent_price_rows"`
+	MultiTenantLeaseRows            int                        `json:"multi_tenant_lease_rows"`
+	NotesPopulated                  int                        `json:"notes_populated"`
+	TerminationReasonsPopulated     int                        `json:"termination_reasons_populated"`
+	SettlementDetailsPopulated      int                        `json:"settlement_details_populated"`
+	DepositRefundAmountPopulated    int                        `json:"deposit_refund_amount_populated"`
+	DepositDeductionAmountPopulated int                        `json:"deposit_deduction_amount_populated"`
+	StatusDistribution              map[string]int             `json:"status_distribution"`
+	DepositStatusDistribution       map[string]int             `json:"deposit_status_distribution"`
+	RentBillingCadenceDistribution  map[string]int             `json:"rent_billing_cadence_distribution"`
+	ActiveLikeRoomChecks            []LeaseActiveLikeRoomCheck `json:"active_like_room_checks"`
+	Skipped                         []LeaseSkipRecord          `json:"skipped"`
+	Assumptions                     []string                   `json:"assumptions"`
+}
+
+// LeaseActiveLikeRoomCheck records the explicit active-like room checks required by #107.
+type LeaseActiveLikeRoomCheck struct {
+	LegacyEstateID     string `json:"legacy_estate_id"`
+	LegacyRoomID       string `json:"legacy_room_id"`
+	LegacyRentID       string `json:"legacy_rent_id,omitempty"`
+	PaymentCycle       string `json:"estate_rent_money,omitempty"`
+	RentBillingCadence string `json:"rent_billing_cadence,omitempty"`
+	RentAmount         int    `json:"rent_amount,omitempty"`
+	Migrated           bool   `json:"migrated"`
+	SkipReason         string `json:"skip_reason,omitempty"`
 }
 
 // LeaseSkipRecord captures a skipped lease row and the reason.
@@ -117,9 +155,13 @@ type legacyLeaseTenantResolution struct {
 }
 
 type legacyLeaseRoomResolution struct {
-	RoomID            string
-	PropertyID        string
-	DefaultRentAmount *int
+	RoomID     string
+	PropertyID string
+}
+
+type legacyLeaseRoomPrice struct {
+	LegacyEstateID string
+	Prices         legacyRoomPricePayload
 }
 
 type normalizedLeaseRecord struct {
@@ -130,6 +172,7 @@ type normalizedLeaseRecord struct {
 	PropertyID             string
 	TenantID               string
 	RentAmount             int
+	RentBillingCadence     string
 	StartDate              time.Time
 	EndDate                time.Time
 	Status                 string
@@ -153,6 +196,7 @@ func MigrateLeases(ctx context.Context, db *sql.DB, options MigrateLeasesOptions
 
 	sourcePath := filepath.Join(options.SourceDir, legacyLeaseSourceFileName)
 	linkPath := filepath.Join(options.SourceDir, legacyLeaseUserSourceFileName)
+	roomSourcePath := filepath.Join(options.SourceDir, legacyRoomSourceFileName)
 
 	records, err := loadLegacyLeases(sourcePath)
 	if err != nil {
@@ -162,21 +206,28 @@ func MigrateLeases(ctx context.Context, db *sql.DB, options MigrateLeasesOptions
 	if err != nil {
 		return nil, err
 	}
+	roomPrices, err := loadLegacyLeaseRoomPrices(roomSourcePath)
+	if err != nil {
+		return nil, err
+	}
 
 	tenantResolutions := buildLegacyLeaseTenantResolutions(links)
 
 	report := &LeaseMigrationReport{
-		GeneratedAt:               time.Now().UTC(),
-		SourcePath:                sourcePath,
-		SourceLinkPath:            linkPath,
-		TotalSourceRows:           len(records),
-		StatusDistribution:        make(map[string]int),
-		DepositStatusDistribution: make(map[string]int),
-		Skipped:                   make([]LeaseSkipRecord, 0),
+		GeneratedAt:                    time.Now().UTC(),
+		SourcePath:                     sourcePath,
+		SourceLinkPath:                 linkPath,
+		RoomSourcePath:                 roomSourcePath,
+		TotalSourceRows:                len(records),
+		StatusDistribution:             make(map[string]int),
+		DepositStatusDistribution:      make(map[string]int),
+		RentBillingCadenceDistribution: make(map[string]int),
+		ActiveLikeRoomChecks:           buildInitialLeaseActiveLikeRoomChecks(),
+		Skipped:                        make([]LeaseSkipRecord, 0),
 		Assumptions: []string{
 			"Task 7 room mapping remains authoritative: room_id and property_id are resolved through legacy_room_mappings joined to rooms, never re-derived from lease source text.",
 			"Task 8 tenant mapping remains authoritative: the primary tenant is selected by the minimum legacy tenant id rule from xx_estate_rent_user, then resolved through legacy_tenant_mappings.",
-			"Task 9 rent_amount uses the mapped room's default_rent_amount as the monthly lease amount; legacy payment-cycle labels are preserved only in migration assumptions and settlement detail, not modeled as new lease columns.",
+			"Task 9 rent_billing_cadence is mapped from xx_estate_rent.estate_rent_money and rent_amount is resolved from the matching xx_estate_room.estate_room_price entry.",
 			"Task 1 deposit fallback policy remains authoritative: leases with legacy stop payloads are imported with deposit_status=settled, while written_off is never inferred during this stage.",
 			"Task 9 deposit settlement keeps the detailed legacy stop payload in settlement_detail; lease deposit refund and deduction amounts only partition deposit_amount using positive stop-side charges.",
 		},
@@ -229,10 +280,11 @@ func MigrateLeases(ctx context.Context, db *sql.DB, options MigrateLeasesOptions
 			}
 		}
 
-		normalized, skipReason, err := normalizeLegacyLeaseRecord(record, roomResolution, roomFound, tenantResolution, tenantMappingFound, tenantID)
+		normalized, skipReason, err := normalizeLegacyLeaseRecord(record, roomResolution, roomFound, roomPrices, tenantResolution, tenantMappingFound, tenantID)
 		if err != nil {
 			return nil, err
 		}
+		updateLeaseActiveLikeRoomChecks(report.ActiveLikeRoomChecks, record, normalized, skipReason)
 		if skipReason != "" {
 			report.SkippedRows++
 			report.InvalidRows++
@@ -242,8 +294,15 @@ func MigrateLeases(ctx context.Context, db *sql.DB, options MigrateLeasesOptions
 			if !tenantMappingFound {
 				report.MissingTenantMappings++
 			}
-			if roomFound && roomResolution.DefaultRentAmount == nil {
+			switch {
+			case skipReason == "missing or unsupported estate_rent_money":
+				report.MissingRentCadenceRows++
+			case skipReason == "missing matching estate_room_price for rent cadence":
 				report.MissingRentAmountRows++
+				report.MissingMatchingRentPriceRows++
+			case strings.HasPrefix(skipReason, "invalid matching estate_room_price:"):
+				report.MissingRentAmountRows++
+				report.InvalidRentPriceRows++
 			}
 			report.Skipped = append(report.Skipped, LeaseSkipRecord{
 				LegacyRentID:   legacyRentID,
@@ -268,6 +327,7 @@ func MigrateLeases(ctx context.Context, db *sql.DB, options MigrateLeasesOptions
 		report.MappingsCreated++
 		report.StatusDistribution[normalized.Status]++
 		report.DepositStatusDistribution[normalized.DepositStatus]++
+		report.RentBillingCadenceDistribution[normalized.RentBillingCadence]++
 		if normalized.Notes != "" {
 			report.NotesPopulated++
 		}
@@ -287,6 +347,7 @@ func MigrateLeases(ctx context.Context, db *sql.DB, options MigrateLeasesOptions
 
 	report.StatusDistribution = sortedDistribution(report.StatusDistribution)
 	report.DepositStatusDistribution = sortedDistribution(report.DepositStatusDistribution)
+	report.RentBillingCadenceDistribution = sortedDistribution(report.RentBillingCadenceDistribution)
 
 	if err := tx.Commit(); err != nil {
 		return nil, fmt.Errorf("commit lease migration: %w", err)
@@ -356,6 +417,34 @@ func loadLegacyLeaseTenantLinks(path string) ([]legacyLeaseTenantLink, error) {
 	return source.Links, nil
 }
 
+func loadLegacyLeaseRoomPrices(path string) (map[string]legacyLeaseRoomPrice, error) {
+	rooms, err := loadLegacyRooms(path)
+	if err != nil {
+		return nil, err
+	}
+
+	pricesByRoomID := make(map[string]legacyLeaseRoomPrice, len(rooms))
+	for _, room := range rooms {
+		roomID := strings.TrimSpace(room.RoomID)
+		if roomID == "" {
+			continue
+		}
+
+		price := legacyLeaseRoomPrice{
+			LegacyEstateID: strings.TrimSpace(room.EstateID),
+			Prices:         legacyRoomPricePayload{},
+		}
+		if strings.TrimSpace(room.PriceRaw) != "" {
+			if err := json.Unmarshal([]byte(strings.TrimSpace(room.PriceRaw)), &price.Prices); err != nil {
+				return nil, fmt.Errorf("decode estate_room_price for room %s: %w", roomID, err)
+			}
+		}
+		pricesByRoomID[roomID] = price
+	}
+
+	return pricesByRoomID, nil
+}
+
 func buildLegacyLeaseTenantResolutions(links []legacyLeaseTenantLink) map[string]legacyLeaseTenantResolution {
 	grouped := make(map[string][]string)
 	for _, link := range links {
@@ -387,10 +476,57 @@ func buildLegacyLeaseTenantResolutions(links []legacyLeaseTenantLink) map[string
 	return resolutions
 }
 
+func buildInitialLeaseActiveLikeRoomChecks() []LeaseActiveLikeRoomCheck {
+	roomIDs := make([]string, 0, len(legacyLeaseActiveLikeRoomIDs))
+	for roomID := range legacyLeaseActiveLikeRoomIDs {
+		roomIDs = append(roomIDs, roomID)
+	}
+	sort.Slice(roomIDs, func(i, j int) bool {
+		left, leftErr := strconv.Atoi(roomIDs[i])
+		right, rightErr := strconv.Atoi(roomIDs[j])
+		if leftErr == nil && rightErr == nil {
+			return left < right
+		}
+		return roomIDs[i] < roomIDs[j]
+	})
+
+	checks := make([]LeaseActiveLikeRoomCheck, 0, len(roomIDs))
+	for _, roomID := range roomIDs {
+		checks = append(checks, LeaseActiveLikeRoomCheck{
+			LegacyEstateID: legacyLeaseActiveLikeRoomIDs[roomID],
+			LegacyRoomID:   roomID,
+		})
+	}
+
+	return checks
+}
+
+func updateLeaseActiveLikeRoomChecks(checks []LeaseActiveLikeRoomCheck, record legacyLeaseRecord, normalized normalizedLeaseRecord, skipReason string) {
+	roomID := strings.TrimSpace(record.RoomID)
+	if _, ok := legacyLeaseActiveLikeRoomIDs[roomID]; !ok || strings.TrimSpace(record.Enabled) != "1" {
+		return
+	}
+
+	for index := range checks {
+		if checks[index].LegacyRoomID != roomID {
+			continue
+		}
+
+		checks[index].LegacyRentID = strings.TrimSpace(record.RentID)
+		checks[index].PaymentCycle = strings.TrimSpace(record.PaymentCycle)
+		checks[index].RentBillingCadence = normalized.RentBillingCadence
+		checks[index].RentAmount = normalized.RentAmount
+		checks[index].Migrated = skipReason == ""
+		checks[index].SkipReason = skipReason
+		return
+	}
+}
+
 func normalizeLegacyLeaseRecord(
 	record legacyLeaseRecord,
 	roomResolution legacyLeaseRoomResolution,
 	roomMappingFound bool,
+	roomPrices map[string]legacyLeaseRoomPrice,
 	tenantResolution legacyLeaseTenantResolution,
 	tenantMappingFound bool,
 	tenantID string,
@@ -412,12 +548,22 @@ func normalizeLegacyLeaseRecord(
 		return normalizedLeaseRecord{}, "missing estate_room_id", nil
 	case !roomMappingFound:
 		return normalizedLeaseRecord{}, "missing room mapping for estate_room_id", nil
-	case roomResolution.DefaultRentAmount == nil:
-		return normalizedLeaseRecord{}, "missing default_rent_amount on mapped room", nil
 	case tenantResolution.LegacyTenantID == "":
 		return normalizedLeaseRecord{}, "missing linked tenant in estate_rent_user", nil
 	case !tenantMappingFound:
 		return normalizedLeaseRecord{}, "missing tenant mapping for linked tenant", nil
+	}
+
+	rentCadence, ok := mapLegacyRentBillingCadence(record.PaymentCycle)
+	if !ok {
+		return normalizedLeaseRecord{}, "missing or unsupported estate_rent_money", nil
+	}
+	rentAmount, ok, err := resolveLegacyLeaseRentAmount(normalized.LegacyRoomID, rentCadence, roomPrices)
+	if err != nil {
+		return normalizedLeaseRecord{}, fmt.Sprintf("invalid matching estate_room_price: %v", err), nil
+	}
+	if !ok {
+		return normalizedLeaseRecord{}, "missing matching estate_room_price for rent cadence", nil
 	}
 
 	startDate, err := parseLegacyDate(record.StartDate)
@@ -440,7 +586,8 @@ func normalizeLegacyLeaseRecord(
 	normalized.StartDate = startDate
 	normalized.EndDate = endDate
 	normalized.DepositAmount = depositAmount
-	normalized.RentAmount = *roomResolution.DefaultRentAmount
+	normalized.RentAmount = rentAmount
+	normalized.RentBillingCadence = rentCadence
 	normalized.Status = deriveLegacyLeaseStatus(record)
 	normalized.DepositStatus = deriveLegacyLeaseDepositStatus(record)
 
@@ -465,6 +612,71 @@ func normalizeLegacyLeaseRecord(
 	}
 
 	return normalized, "", nil
+}
+
+func mapLegacyRentBillingCadence(value string) (string, bool) {
+	switch strings.TrimSpace(value) {
+	case "月繳":
+		return "monthly", true
+	case "季繳":
+		return "quarterly", true
+	case "半年", "半年繳":
+		return "semiannual", true
+	case "年繳":
+		return "annual", true
+	default:
+		return "", false
+	}
+}
+
+func resolveLegacyLeaseRentAmount(legacyRoomID string, rentCadence string, roomPrices map[string]legacyLeaseRoomPrice) (int, bool, error) {
+	roomPrice, ok := roomPrices[legacyRoomID]
+	if !ok {
+		return 0, false, nil
+	}
+
+	label, ok := legacyRentPriceLabel(rentCadence)
+	if !ok {
+		return 0, false, nil
+	}
+
+	price, ok := roomPrice.Prices[label]
+	if !ok {
+		return 0, false, nil
+	}
+
+	money := strings.TrimSpace(price.Money)
+	if money == "" {
+		return 0, false, nil
+	}
+
+	parsed, err := strconv.Atoi(money)
+	if err != nil {
+		return 0, false, err
+	}
+	if parsed == 0 {
+		return 0, false, nil
+	}
+	if parsed < 0 {
+		return 0, false, errors.New("must be >= 0")
+	}
+
+	return parsed, true, nil
+}
+
+func legacyRentPriceLabel(rentCadence string) (string, bool) {
+	switch rentCadence {
+	case "monthly":
+		return "月繳", true
+	case "quarterly":
+		return "季繳", true
+	case "semiannual":
+		return "半年", true
+	case "annual":
+		return "年繳", true
+	default:
+		return "", false
+	}
 }
 
 func parseLegacyDate(value string) (time.Time, error) {
@@ -655,7 +867,7 @@ LIMIT 1
 
 func findLeaseRoomResolution(ctx context.Context, tx *sql.Tx, legacyRoomID string) (legacyLeaseRoomResolution, bool, error) {
 	const query = `
-SELECT lrm.room_id, r.property_id, r.default_rent_amount
+SELECT lrm.room_id, r.property_id
 FROM legacy_room_mappings lrm
 JOIN rooms r
   ON r.id = lrm.room_id
@@ -665,17 +877,11 @@ LIMIT 1
 `
 
 	var resolution legacyLeaseRoomResolution
-	var defaultRentAmount sql.NullInt64
-	if err := tx.QueryRowContext(ctx, query, legacyRoomID).Scan(&resolution.RoomID, &resolution.PropertyID, &defaultRentAmount); err != nil {
+	if err := tx.QueryRowContext(ctx, query, legacyRoomID).Scan(&resolution.RoomID, &resolution.PropertyID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return legacyLeaseRoomResolution{}, false, nil
 		}
 		return legacyLeaseRoomResolution{}, false, fmt.Errorf("query room resolution by legacy_room_id: %w", err)
-	}
-
-	if defaultRentAmount.Valid {
-		value := int(defaultRentAmount.Int64)
-		resolution.DefaultRentAmount = &value
 	}
 
 	return resolution, true, nil
@@ -709,6 +915,7 @@ INSERT INTO leases (
 	rent_amount,
 	start_date,
 	end_date,
+	rent_billing_cadence,
 	electricity_billing_cadence,
 	status,
 	deposit_amount,
@@ -718,7 +925,7 @@ INSERT INTO leases (
 	notes,
 	termination_reason,
 	settlement_detail
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::jsonb)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16::jsonb)
 RETURNING id
 `
 
@@ -732,6 +939,7 @@ RETURNING id
 		lease.RentAmount,
 		lease.StartDate,
 		lease.EndDate,
+		lease.RentBillingCadence,
 		"monthly",
 		lease.Status,
 		lease.DepositAmount,

--- a/internal/migration/legacy/leases_test.go
+++ b/internal/migration/legacy/leases_test.go
@@ -28,11 +28,18 @@ func TestNormalizeLegacyLeaseRecord(t *testing.T) {
 	normalized, skipReason, err := normalizeLegacyLeaseRecord(
 		record,
 		legacyLeaseRoomResolution{
-			RoomID:            "room-uuid-35",
-			PropertyID:        "property-uuid-1",
-			DefaultRentAmount: intPtr(5000),
+			RoomID:     "room-uuid-35",
+			PropertyID: "property-uuid-1",
 		},
 		true,
+		map[string]legacyLeaseRoomPrice{
+			"35": {
+				LegacyEstateID: "1",
+				Prices: legacyRoomPricePayload{
+					"月繳": {Money: "5000"},
+				},
+			},
+		},
 		legacyLeaseTenantResolution{
 			LegacyTenantID: "7",
 			CandidateCount: 2,
@@ -55,6 +62,9 @@ func TestNormalizeLegacyLeaseRecord(t *testing.T) {
 	if normalized.RentAmount != 5000 {
 		t.Fatalf("RentAmount = %d, want 5000", normalized.RentAmount)
 	}
+	if normalized.RentBillingCadence != "monthly" {
+		t.Fatalf("RentBillingCadence = %q, want monthly", normalized.RentBillingCadence)
+	}
 	if normalized.Status != leaseStatusTerminated {
 		t.Fatalf("Status = %q, want %q", normalized.Status, leaseStatusTerminated)
 	}
@@ -72,6 +82,106 @@ func TestNormalizeLegacyLeaseRecord(t *testing.T) {
 	}
 	if normalized.SettlementDetailJSON == nil {
 		t.Fatal("SettlementDetailJSON should not be nil")
+	}
+}
+
+func TestNormalizeLegacyLeaseRecordMapsRentCadenceAndAmount(t *testing.T) {
+	tests := []struct {
+		name    string
+		roomID  string
+		cycle   string
+		cadence string
+		amount  int
+		prices  legacyRoomPricePayload
+	}{
+		{
+			name:    "monthly",
+			roomID:  "10",
+			cycle:   "月繳",
+			cadence: "monthly",
+			amount:  1000,
+			prices: legacyRoomPricePayload{
+				"月繳": {Money: "1000"},
+			},
+		},
+		{
+			name:    "quarterly",
+			roomID:  "20",
+			cycle:   "季繳",
+			cadence: "quarterly",
+			amount:  2200,
+			prices: legacyRoomPricePayload{
+				"季繳": {Money: "2200"},
+				"月繳": {Money: ""},
+			},
+		},
+		{
+			name:    "semiannual",
+			roomID:  "30",
+			cycle:   "半年繳",
+			cadence: "semiannual",
+			amount:  3300,
+			prices: legacyRoomPricePayload{
+				"半年": {Money: "3300"},
+				"月繳": {Money: ""},
+			},
+		},
+		{
+			name:    "annual only room 254",
+			roomID:  "254",
+			cycle:   "年繳",
+			cadence: "annual",
+			amount:  1600,
+			prices: legacyRoomPricePayload{
+				"年繳": {Money: "1600"},
+				"月繳": {Money: ""},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized, skipReason, err := normalizeLegacyLeaseRecord(
+				legacyLeaseRecord{
+					RentID:        "1",
+					RoomID:        tt.roomID,
+					StartDate:     "2024-01-01",
+					EndDate:       "2024-12-31",
+					DepositAmount: "1000",
+					PaymentCycle:  tt.cycle,
+					Enabled:       "1",
+				},
+				legacyLeaseRoomResolution{
+					RoomID:     "room-uuid-" + tt.roomID,
+					PropertyID: "property-uuid-1",
+				},
+				true,
+				map[string]legacyLeaseRoomPrice{
+					tt.roomID: {
+						LegacyEstateID: "1",
+						Prices:         tt.prices,
+					},
+				},
+				legacyLeaseTenantResolution{
+					LegacyTenantID: "7",
+					CandidateCount: 1,
+				},
+				true,
+				"tenant-uuid-7",
+			)
+			if err != nil {
+				t.Fatalf("normalizeLegacyLeaseRecord() error = %v", err)
+			}
+			if skipReason != "" {
+				t.Fatalf("normalizeLegacyLeaseRecord() skipReason = %q, want empty", skipReason)
+			}
+			if normalized.RentBillingCadence != tt.cadence {
+				t.Fatalf("RentBillingCadence = %q, want %q", normalized.RentBillingCadence, tt.cadence)
+			}
+			if normalized.RentAmount != tt.amount {
+				t.Fatalf("RentAmount = %d, want %d", normalized.RentAmount, tt.amount)
+			}
+		})
 	}
 }
 
@@ -113,6 +223,13 @@ func TestMigrateLeasesWritesReportWithImportedAndSkippedRows(t *testing.T) {
 		{RentID: "1", TenantID: "161"},
 		{RentID: "2", TenantID: "9"},
 	})
+	writeLegacyLeaseRoomFixture(t, sourceDir, []legacyRoomRecord{
+		{
+			RoomID:   "10",
+			EstateID: "1",
+			PriceRaw: `{"年繳":{"money":"9000"},"月繳":{"money":""}}`,
+		},
+	})
 
 	mock.ExpectBegin()
 	mock.ExpectExec(regexp.QuoteMeta(`
@@ -131,7 +248,7 @@ LIMIT 1
 		WithArgs("1").
 		WillReturnRows(sqlmock.NewRows([]string{"?column?"}))
 	mock.ExpectQuery(regexp.QuoteMeta(`
-SELECT lrm.room_id, r.property_id, r.default_rent_amount
+SELECT lrm.room_id, r.property_id
 FROM legacy_room_mappings lrm
 JOIN rooms r
   ON r.id = lrm.room_id
@@ -140,7 +257,7 @@ WHERE lrm.legacy_room_id = $1
 LIMIT 1
 `)).
 		WithArgs("10").
-		WillReturnRows(sqlmock.NewRows([]string{"room_id", "property_id", "default_rent_amount"}).AddRow("room-uuid-10", "property-uuid-10", 10000))
+		WillReturnRows(sqlmock.NewRows([]string{"room_id", "property_id"}).AddRow("room-uuid-10", "property-uuid-10"))
 	mock.ExpectQuery(regexp.QuoteMeta(`
 SELECT tenant_id
 FROM legacy_tenant_mappings
@@ -157,6 +274,7 @@ INSERT INTO leases (
 	rent_amount,
 	start_date,
 	end_date,
+	rent_billing_cadence,
 	electricity_billing_cadence,
 	status,
 	deposit_amount,
@@ -166,16 +284,17 @@ INSERT INTO leases (
 	notes,
 	termination_reason,
 	settlement_detail
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::jsonb)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16::jsonb)
 RETURNING id
 `)).
 		WithArgs(
 			"tenant-uuid-7",
 			"room-uuid-10",
 			"property-uuid-10",
-			10000,
+			9000,
 			time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 			time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC),
+			"annual",
 			"monthly",
 			leaseStatusTerminated,
 			4000,
@@ -204,7 +323,7 @@ LIMIT 1
 		WithArgs("2").
 		WillReturnRows(sqlmock.NewRows([]string{"?column?"}))
 	mock.ExpectQuery(regexp.QuoteMeta(`
-SELECT lrm.room_id, r.property_id, r.default_rent_amount
+SELECT lrm.room_id, r.property_id
 FROM legacy_room_mappings lrm
 JOIN rooms r
   ON r.id = lrm.room_id
@@ -213,7 +332,7 @@ WHERE lrm.legacy_room_id = $1
 LIMIT 1
 `)).
 		WithArgs("20").
-		WillReturnRows(sqlmock.NewRows([]string{"room_id", "property_id", "default_rent_amount"}))
+		WillReturnRows(sqlmock.NewRows([]string{"room_id", "property_id"}))
 	mock.ExpectQuery(regexp.QuoteMeta(`
 SELECT tenant_id
 FROM legacy_tenant_mappings
@@ -250,6 +369,9 @@ LIMIT 1
 	if report.DepositStatusDistribution[depositStatusSettled] != 1 {
 		t.Fatalf("DepositStatusDistribution[%s] = %d, want 1", depositStatusSettled, report.DepositStatusDistribution[depositStatusSettled])
 	}
+	if report.RentBillingCadenceDistribution["annual"] != 1 {
+		t.Fatalf("RentBillingCadenceDistribution[annual] = %d, want 1", report.RentBillingCadenceDistribution["annual"])
+	}
 	if report.ReportPath == "" {
 		t.Fatal("ReportPath should not be empty")
 	}
@@ -265,6 +387,156 @@ LIMIT 1
 	}
 	if got := len(persisted.Skipped); got != 1 {
 		t.Fatalf("len(persisted.Skipped) = %d, want 1", got)
+	}
+	for _, assumption := range persisted.Assumptions {
+		if assumption == "Task 9 rent_amount uses the mapped room's default_rent_amount as the monthly lease amount; legacy payment-cycle labels are preserved only in migration assumptions and settlement detail, not modeled as new lease columns." {
+			t.Fatal("persisted report still contains the old rent payment-cycle assumption")
+		}
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestMigrateLeasesImportsActiveLikeAnnualOnlyRoom254(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	sourceDir := t.TempDir()
+	reportDir := t.TempDir()
+
+	writeLegacyLeaseFixture(t, sourceDir, []legacyLeaseRecord{
+		{
+			RentID:        "491",
+			RoomID:        "254",
+			StartDate:     "2024-01-01",
+			EndDate:       "2026-12-31",
+			DepositAmount: "1600",
+			PaymentCycle:  "年繳",
+			Enabled:       "1",
+		},
+	})
+	writeLegacyLeaseUserFixture(t, sourceDir, []legacyLeaseTenantLink{
+		{RentID: "491", TenantID: "254"},
+	})
+	writeLegacyLeaseRoomFixture(t, sourceDir, []legacyRoomRecord{
+		{
+			RoomID:   "254",
+			EstateID: "6",
+			Title:    "儲藏室",
+			PriceRaw: `{"年繳":{"money":"1600","month":"12","times":"1"},"半年":{"money":"","month":"","times":"2"},"季繳":{"money":"","month":"","times":"4"},"月繳":{"money":"","month":"","times":"12"}}`,
+		},
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`
+CREATE TABLE IF NOT EXISTS legacy_lease_mappings (
+	legacy_rent_id VARCHAR(50) PRIMARY KEY,
+	lease_id UUID NOT NULL UNIQUE REFERENCES leases(id),
+	created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT 1
+FROM legacy_lease_mappings
+WHERE legacy_rent_id = $1
+LIMIT 1
+`)).
+		WithArgs("491").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT lrm.room_id, r.property_id
+FROM legacy_room_mappings lrm
+JOIN rooms r
+  ON r.id = lrm.room_id
+WHERE lrm.legacy_room_id = $1
+  AND r.deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("254").
+		WillReturnRows(sqlmock.NewRows([]string{"room_id", "property_id"}).AddRow("room-uuid-254", "property-uuid-6"))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT tenant_id
+FROM legacy_tenant_mappings
+WHERE legacy_tenant_id = $1
+LIMIT 1
+`)).
+		WithArgs("254").
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id"}).AddRow("tenant-uuid-254"))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO leases (
+	tenant_id,
+	room_id,
+	property_id,
+	rent_amount,
+	start_date,
+	end_date,
+	rent_billing_cadence,
+	electricity_billing_cadence,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	notes,
+	termination_reason,
+	settlement_detail
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16::jsonb)
+RETURNING id
+`)).
+		WithArgs(
+			"tenant-uuid-254",
+			"room-uuid-254",
+			"property-uuid-6",
+			1600,
+			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+			"annual",
+			"monthly",
+			leaseStatusActive,
+			1600,
+			nil,
+			nil,
+			depositStatusHeld,
+			nil,
+			nil,
+			nil,
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("lease-uuid-491"))
+	mock.ExpectExec(regexp.QuoteMeta(`
+INSERT INTO legacy_lease_mappings (
+	legacy_rent_id,
+	lease_id
+) VALUES ($1, $2)
+`)).
+		WithArgs("491", "lease-uuid-491").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	report, err := MigrateLeases(context.Background(), db, MigrateLeasesOptions{
+		SourceDir: sourceDir,
+		ReportDir: reportDir,
+	})
+	if err != nil {
+		t.Fatalf("MigrateLeases() error = %v", err)
+	}
+
+	if report.ImportedRows != 1 {
+		t.Fatalf("ImportedRows = %d, want 1", report.ImportedRows)
+	}
+	if report.RentBillingCadenceDistribution["annual"] != 1 {
+		t.Fatalf("RentBillingCadenceDistribution[annual] = %d, want 1", report.RentBillingCadenceDistribution["annual"])
+	}
+	check := findActiveLikeRoomCheck(t, report.ActiveLikeRoomChecks, "254")
+	if !check.Migrated {
+		t.Fatalf("room 254 check Migrated = false, skip reason %q", check.SkipReason)
+	}
+	if check.RentBillingCadence != "annual" || check.RentAmount != 1600 {
+		t.Fatalf("room 254 check = %+v, want annual rent 1600", check)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -304,6 +576,30 @@ func writeLegacyLeaseUserFixture(t *testing.T, dir string, records []legacyLease
 	}
 }
 
-func intPtr(value int) *int {
-	return &value
+func writeLegacyLeaseRoomFixture(t *testing.T, dir string, records []legacyRoomRecord) {
+	t.Helper()
+
+	payload, err := json.Marshal(map[string]any{
+		legacyRoomSourceRootKey: records,
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	path := filepath.Join(dir, legacyRoomSourceFileName)
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatalf("os.WriteFile(%s) error = %v", path, err)
+	}
+}
+
+func findActiveLikeRoomCheck(t *testing.T, checks []LeaseActiveLikeRoomCheck, roomID string) LeaseActiveLikeRoomCheck {
+	t.Helper()
+
+	for _, check := range checks {
+		if check.LegacyRoomID == roomID {
+			return check
+		}
+	}
+	t.Fatalf("active-like room check for room %s not found", roomID)
+	return LeaseActiveLikeRoomCheck{}
 }

--- a/internal/migration/legacy/validation.go
+++ b/internal/migration/legacy/validation.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -267,6 +268,10 @@ func loadLeaseStageReportSummary(reportDir string) StageReportSummary {
 		Notes: []string{
 			fmt.Sprintf("multi-tenant source rows=%d", persisted.MultiTenantLeaseRows),
 			fmt.Sprintf("missing rent amount rows=%d", persisted.MissingRentAmountRows),
+			fmt.Sprintf("missing rent cadence rows=%d", persisted.MissingRentCadenceRows),
+			fmt.Sprintf("missing matching rent price rows=%d", persisted.MissingMatchingRentPriceRows),
+			fmt.Sprintf("invalid rent price rows=%d", persisted.InvalidRentPriceRows),
+			fmt.Sprintf("rent cadence distribution=%s", formatDistribution(persisted.RentBillingCadenceDistribution)),
 		},
 	}
 }
@@ -559,6 +564,7 @@ WHERE l.deleted_at IS NULL
     OR l.room_id IS NULL
     OR l.property_id IS NULL
     OR l.rent_amount IS NULL
+    OR l.rent_billing_cadence IS NULL
     OR l.start_date IS NULL
     OR l.end_date IS NULL
     OR l.status IS NULL
@@ -925,6 +931,7 @@ SELECT m.legacy_rent_id,
        l.status,
        l.deposit_status,
        l.rent_amount::text,
+       l.rent_billing_cadence,
        l.room_id,
        l.tenant_id
 FROM legacy_lease_mappings m
@@ -938,7 +945,7 @@ LIMIT 3
 	}
 	sections = append(sections, buildSpotCheckSection("leases", leaseEntries,
 		func(columns []string) string {
-			return fmt.Sprintf("status=%s deposit_status=%s rent_amount=%s room_id=%s tenant_id=%s", columns[2], columns[3], columns[4], columns[5], columns[6])
+			return fmt.Sprintf("status=%s deposit_status=%s rent_amount=%s rent_billing_cadence=%s room_id=%s tenant_id=%s", columns[2], columns[3], columns[4], columns[5], columns[6], columns[7])
 		}))
 
 	return sections, nil
@@ -1008,6 +1015,25 @@ func queryCount(ctx context.Context, db *sql.DB, query string, args ...any) (int
 	}
 
 	return count, nil
+}
+
+func formatDistribution(distribution map[string]int) string {
+	if len(distribution) == 0 {
+		return "none"
+	}
+
+	keys := make([]string, 0, len(distribution))
+	for key := range distribution {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%d", key, distribution[key]))
+	}
+
+	return strings.Join(parts, ",")
 }
 
 func verifyFinalValidationReport(report *FinalValidationReport) error {

--- a/internal/migration/legacy/validation_test.go
+++ b/internal/migration/legacy/validation_test.go
@@ -203,6 +203,7 @@ WHERE l.deleted_at IS NULL
     OR l.room_id IS NULL
     OR l.property_id IS NULL
     OR l.rent_amount IS NULL
+    OR l.rent_billing_cadence IS NULL
     OR l.start_date IS NULL
     OR l.end_date IS NULL
     OR l.status IS NULL
@@ -441,6 +442,7 @@ SELECT m.legacy_rent_id,
        l.status,
        l.deposit_status,
        l.rent_amount::text,
+       l.rent_billing_cadence,
        l.room_id,
        l.tenant_id
 FROM legacy_lease_mappings m
@@ -449,8 +451,8 @@ WHERE l.deleted_at IS NULL
 ORDER BY m.legacy_rent_id
 LIMIT 3
 `)).
-		WillReturnRows(sqlmock.NewRows([]string{"legacy_rent_id", "id", "status", "deposit_status", "rent_amount", "room_id", "tenant_id"}).
-			AddRow("40", "lease-1", "active", "held", "12000", "room-1", "tenant-1"))
+		WillReturnRows(sqlmock.NewRows([]string{"legacy_rent_id", "id", "status", "deposit_status", "rent_amount", "rent_billing_cadence", "room_id", "tenant_id"}).
+			AddRow("40", "lease-1", "active", "held", "12000", "annual", "room-1", "tenant-1"))
 }
 
 func expectCountQuery(mock sqlmock.Sqlmock, query string, count int) {
@@ -487,11 +489,12 @@ func writeTask13StageReports(t *testing.T, reportDir string) {
 		InvalidEmailCount: 1,
 	})
 	writeJSONFixture(t, filepath.Join(reportDir, "task9_leases_report.json"), LeaseMigrationReport{
-		ImportedRows:          2,
-		AlreadyMappedRows:     0,
-		SkippedRows:           0,
-		MultiTenantLeaseRows:  1,
-		MissingRentAmountRows: 0,
+		ImportedRows:                   2,
+		AlreadyMappedRows:              0,
+		SkippedRows:                    0,
+		MultiTenantLeaseRows:           1,
+		MissingRentAmountRows:          0,
+		RentBillingCadenceDistribution: map[string]int{"annual": 1, "monthly": 1},
 	})
 	writeJSONFixture(t, filepath.Join(reportDir, "task10_room_status_report.json"), RoomStatusReconciliationReport{
 		ActiveLeaseRooms:     1,


### PR DESCRIPTION
Closes #107

## Summary

- Map legacy `xx_estate_rent.estate_rent_money` values into `leases.rent_billing_cadence` during lease migration.
- Resolve migrated `leases.rent_amount` from the matching `xx_estate_room.estate_room_price` cadence entry instead of relying on `rooms.default_rent_amount`.
- Extend Task 9 migration reports and final validation output with rent cadence distribution, cadence/price skip reasons, and explicit active-like room checks including room `254`.
- Add focused legacy migration tests for monthly, quarterly, semiannual, annual, active-like missing-default-rent, and room `254` annual-only coverage.

## Validation

- `GOCACHE=/tmp/go-cache go test ./internal/migration/legacy ./cmd/migrate_legacy`
- `GOCACHE=/tmp/go-cache go test ./...`
- `git diff --check`
- Full local legacy migration validation against temporary DB `ci_issue107_legacy`:
  - Task 9 leases: `imported=571`, `skipped=18`
  - rent cadence distribution: `annual=124`, `monthly=338`, `quarterly=40`, `semiannual=69`
  - missing cadence: `0`
  - missing matching rent price: `9`
  - invalid rent price: `0`
  - active-like room checks: `17/17` migrated, room `254` migrated as `annual` with `rent_amount=1600`
  - final validation report generated successfully at `/tmp/issue107_legacy_reports/task13_validation_report.json`

## Notes

- No runtime API, OpenAPI, or domain behavior changes are included.