### PR TITLE
test: strengthen legacy migration rerun safety coverage

### DIFF
--- a/internal/migration/legacy/bills_test.go
+++ b/internal/migration/legacy/bills_test.go
@@ -3,9 +3,11 @@ package legacy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -236,8 +238,19 @@ LIMIT 1
 	if err := json.Unmarshal(content, &persisted); err != nil {
 		t.Fatalf("json.Unmarshal(report) error = %v", err)
 	}
+	if persisted.ImportedRows != report.ImportedRows ||
+		persisted.SkippedRows != report.SkippedRows ||
+		persisted.FirstReadingSkipped != report.FirstReadingSkipped ||
+		persisted.VacancyPeriodSkipped != report.VacancyPeriodSkipped ||
+		persisted.MissingLeaseMappings != report.MissingLeaseMappings ||
+		persisted.RoundedReadingRows != report.RoundedReadingRows {
+		t.Fatalf("persisted report counts = %+v, want returned counts %+v", persisted, report)
+	}
 	if got := len(persisted.Skipped); got != 2 {
 		t.Fatalf("len(persisted.Skipped) = %d, want 2", got)
+	}
+	if persisted.StatusDistribution[billStatusPaid] != report.StatusDistribution[billStatusPaid] {
+		t.Fatalf("persisted.StatusDistribution[%s] = %d, want %d", billStatusPaid, persisted.StatusDistribution[billStatusPaid], report.StatusDistribution[billStatusPaid])
 	}
 
 	if report.ImportedRows != 1 || paidAt.IsZero() {
@@ -363,6 +376,212 @@ LIMIT 1
 	}
 	if report.SkippedRows != 4 {
 		t.Fatalf("SkippedRows = %d, want 4", report.SkippedRows)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestMigrateBillsSkipsAlreadyMappedRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	sourceDir := t.TempDir()
+	reportDir := t.TempDir()
+
+	writeLegacyBillFixture(t, sourceDir, []legacyElectricRecord{
+		{RoomID: "10", Degrees: "100", Year: "2020", Month: "1", UpdatedAt: "2020-01-31 10:00:00"},
+		{RoomID: "10", Degrees: "120", Year: "2020", Month: "2", UpdatedAt: "2020-02-29 10:00:00"},
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`
+CREATE TABLE IF NOT EXISTS legacy_bill_mappings (
+	legacy_bill_key VARCHAR(100) PRIMARY KEY,
+	bill_id UUID NOT NULL UNIQUE REFERENCES bills(id),
+	created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT 1
+FROM legacy_bill_mappings
+WHERE legacy_bill_key = $1
+LIMIT 1
+`)).
+		WithArgs("10:2020-02").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
+	mock.ExpectCommit()
+
+	report, err := MigrateBills(context.Background(), db, MigrateBillsOptions{
+		SourceDir: sourceDir,
+		ReportDir: reportDir,
+	})
+	if err != nil {
+		t.Fatalf("MigrateBills() error = %v", err)
+	}
+
+	if report.AlreadyMappedRows != 1 {
+		t.Fatalf("AlreadyMappedRows = %d, want 1", report.AlreadyMappedRows)
+	}
+	if report.ImportedRows != 0 {
+		t.Fatalf("ImportedRows = %d, want 0", report.ImportedRows)
+	}
+	if report.MappingsCreated != 0 {
+		t.Fatalf("MappingsCreated = %d, want 0", report.MappingsCreated)
+	}
+	if report.FirstReadingSkipped != 1 {
+		t.Fatalf("FirstReadingSkipped = %d, want 1", report.FirstReadingSkipped)
+	}
+
+	content, err := os.ReadFile(report.ReportPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(report.ReportPath) error = %v", err)
+	}
+
+	var persisted BillMigrationReport
+	if err := json.Unmarshal(content, &persisted); err != nil {
+		t.Fatalf("json.Unmarshal(report) error = %v", err)
+	}
+	if persisted.AlreadyMappedRows != report.AlreadyMappedRows || persisted.ImportedRows != report.ImportedRows || persisted.MappingsCreated != report.MappingsCreated {
+		t.Fatalf("persisted report counts = %+v, want returned counts %+v", persisted, report)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestMigrateBillsRollsBackWhenMappingInsertFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	sourceDir := t.TempDir()
+	reportDir := t.TempDir()
+
+	writeLegacyBillFixture(t, sourceDir, []legacyElectricRecord{
+		{RoomID: "10", Degrees: "100.4", Year: "2020", Month: "1", UpdatedAt: "2020-01-31 10:00:00"},
+		{RoomID: "10", Degrees: "130.6", Year: "2020", Month: "2", UpdatedAt: "2020-02-29 10:00:00"},
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`
+CREATE TABLE IF NOT EXISTS legacy_bill_mappings (
+	legacy_bill_key VARCHAR(100) PRIMARY KEY,
+	bill_id UUID NOT NULL UNIQUE REFERENCES bills(id),
+	created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT 1
+FROM legacy_bill_mappings
+WHERE legacy_bill_key = $1
+LIMIT 1
+`)).
+		WithArgs("10:2020-02").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT lrm.room_id, r.property_id, p.electricity_unit_price
+FROM legacy_room_mappings lrm
+JOIN rooms r
+  ON r.id = lrm.room_id
+JOIN properties p
+  ON p.id = r.property_id
+WHERE lrm.legacy_room_id = $1
+  AND r.deleted_at IS NULL
+  AND p.deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("10").
+		WillReturnRows(sqlmock.NewRows([]string{"room_id", "property_id", "electricity_unit_price"}).AddRow("room-uuid-10", "property-uuid-10", 4.5))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, tenant_id, property_id, start_date
+FROM leases
+WHERE room_id = $1
+  AND start_date <= $2
+  AND end_date >= $3
+  AND deleted_at IS NULL
+ORDER BY start_date DESC, created_at DESC
+LIMIT 1
+`)).
+		WithArgs(
+			"room-uuid-10",
+			time.Date(2020, 2, 29, 0, 0, 0, 0, time.UTC),
+			time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC),
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "tenant_id", "property_id", "start_date"}).AddRow(
+			"lease-uuid-10",
+			"tenant-uuid-10",
+			"property-uuid-10",
+			time.Date(2020, 1, 31, 0, 0, 0, 0, time.UTC),
+		))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO bills (
+	lease_id,
+	tenant_id,
+	room_id,
+	property_id,
+	type,
+	amount,
+	period_start,
+	period_end,
+	due_date,
+	status,
+	paid_at,
+	paid_amount,
+	meter_previous_reading,
+	meter_current_reading,
+	meter_unit_price,
+	meter_recorded_at,
+	source_ref
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb)
+RETURNING id
+`)).
+		WithArgs(
+			"lease-uuid-10",
+			"tenant-uuid-10",
+			"room-uuid-10",
+			"property-uuid-10",
+			billTypeElectricity,
+			136,
+			time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2020, 2, 29, 0, 0, 0, 0, time.UTC),
+			time.Date(2020, 2, 29, 0, 0, 0, 0, time.UTC),
+			billStatusPaid,
+			sqlmock.AnyArg(),
+			136,
+			100,
+			131,
+			4.5,
+			sqlmock.AnyArg(),
+			sqlmock.AnyArg(),
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("bill-uuid-10"))
+	mock.ExpectExec(regexp.QuoteMeta(`
+INSERT INTO legacy_bill_mappings (
+	legacy_bill_key,
+	bill_id
+) VALUES ($1, $2)
+`)).
+		WithArgs("10:2020-02", "bill-uuid-10").
+		WillReturnError(errors.New("mapping insert failed"))
+	mock.ExpectRollback()
+
+	_, err = MigrateBills(context.Background(), db, MigrateBillsOptions{
+		SourceDir: sourceDir,
+		ReportDir: reportDir,
+	})
+	if err == nil {
+		t.Fatal("MigrateBills() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "insert legacy bill mapping") {
+		t.Fatalf("MigrateBills() error = %v, want mapping insert context", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/migration/legacy/bills_test.go
+++ b/internal/migration/legacy/bills_test.go
@@ -446,7 +446,10 @@ LIMIT 1
 	if err := json.Unmarshal(content, &persisted); err != nil {
 		t.Fatalf("json.Unmarshal(report) error = %v", err)
 	}
-	if persisted.AlreadyMappedRows != report.AlreadyMappedRows || persisted.ImportedRows != report.ImportedRows || persisted.MappingsCreated != report.MappingsCreated {
+	if persisted.AlreadyMappedRows != report.AlreadyMappedRows ||
+		persisted.ImportedRows != report.ImportedRows ||
+		persisted.MappingsCreated != report.MappingsCreated ||
+		persisted.FirstReadingSkipped != report.FirstReadingSkipped {
 		t.Fatalf("persisted report counts = %+v, want returned counts %+v", persisted, report)
 	}
 

--- a/internal/migration/legacy/leases_test.go
+++ b/internal/migration/legacy/leases_test.go
@@ -598,7 +598,10 @@ LIMIT 1
 	if err := json.Unmarshal(content, &persisted); err != nil {
 		t.Fatalf("json.Unmarshal(report) error = %v", err)
 	}
-	if persisted.AlreadyMappedRows != report.AlreadyMappedRows || persisted.ImportedRows != report.ImportedRows || persisted.MappingsCreated != report.MappingsCreated {
+	if persisted.AlreadyMappedRows != report.AlreadyMappedRows ||
+		persisted.ImportedRows != report.ImportedRows ||
+		persisted.MappingsCreated != report.MappingsCreated ||
+		persisted.SkippedRows != report.SkippedRows {
 		t.Fatalf("persisted report counts = %+v, want returned counts %+v", persisted, report)
 	}
 

--- a/internal/migration/legacy/leases_test.go
+++ b/internal/migration/legacy/leases_test.go
@@ -3,9 +3,11 @@ package legacy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -385,6 +387,9 @@ LIMIT 1
 	if err := json.Unmarshal(content, &persisted); err != nil {
 		t.Fatalf("json.Unmarshal(report) error = %v", err)
 	}
+	if persisted.ImportedRows != report.ImportedRows || persisted.SkippedRows != report.SkippedRows || persisted.MissingRoomMappings != report.MissingRoomMappings {
+		t.Fatalf("persisted report counts = %+v, want returned counts %+v", persisted, report)
+	}
 	if got := len(persisted.Skipped); got != 1 {
 		t.Fatalf("len(persisted.Skipped) = %d, want 1", got)
 	}
@@ -392,6 +397,334 @@ LIMIT 1
 		if assumption == "Task 9 rent_amount uses the mapped room's default_rent_amount as the monthly lease amount; legacy payment-cycle labels are preserved only in migration assumptions and settlement detail, not modeled as new lease columns." {
 			t.Fatal("persisted report still contains the old rent payment-cycle assumption")
 		}
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestMigrateLeasesReportsMissingTenantMapping(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	sourceDir := t.TempDir()
+	reportDir := t.TempDir()
+
+	writeLegacyLeaseFixture(t, sourceDir, []legacyLeaseRecord{
+		{
+			RentID:        "1",
+			RoomID:        "10",
+			StartDate:     "2020-01-01",
+			EndDate:       "2020-12-31",
+			DepositAmount: "4000",
+			PaymentCycle:  "月繳",
+			Enabled:       "1",
+		},
+	})
+	writeLegacyLeaseUserFixture(t, sourceDir, []legacyLeaseTenantLink{
+		{RentID: "1", TenantID: "7"},
+	})
+	writeLegacyLeaseRoomFixture(t, sourceDir, []legacyRoomRecord{
+		{
+			RoomID:   "10",
+			EstateID: "1",
+			PriceRaw: `{"月繳":{"money":"5000"}}`,
+		},
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`
+CREATE TABLE IF NOT EXISTS legacy_lease_mappings (
+	legacy_rent_id VARCHAR(50) PRIMARY KEY,
+	lease_id UUID NOT NULL UNIQUE REFERENCES leases(id),
+	created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT 1
+FROM legacy_lease_mappings
+WHERE legacy_rent_id = $1
+LIMIT 1
+`)).
+		WithArgs("1").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT lrm.room_id, r.property_id
+FROM legacy_room_mappings lrm
+JOIN rooms r
+  ON r.id = lrm.room_id
+WHERE lrm.legacy_room_id = $1
+  AND r.deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("10").
+		WillReturnRows(sqlmock.NewRows([]string{"room_id", "property_id"}).AddRow("room-uuid-10", "property-uuid-10"))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT tenant_id
+FROM legacy_tenant_mappings
+WHERE legacy_tenant_id = $1
+LIMIT 1
+`)).
+		WithArgs("7").
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id"}))
+	mock.ExpectCommit()
+
+	report, err := MigrateLeases(context.Background(), db, MigrateLeasesOptions{
+		SourceDir: sourceDir,
+		ReportDir: reportDir,
+	})
+	if err != nil {
+		t.Fatalf("MigrateLeases() error = %v", err)
+	}
+
+	if report.ImportedRows != 0 {
+		t.Fatalf("ImportedRows = %d, want 0", report.ImportedRows)
+	}
+	if report.SkippedRows != 1 {
+		t.Fatalf("SkippedRows = %d, want 1", report.SkippedRows)
+	}
+	if report.MissingTenantMappings != 1 {
+		t.Fatalf("MissingTenantMappings = %d, want 1", report.MissingTenantMappings)
+	}
+	if got := len(report.Skipped); got != 1 {
+		t.Fatalf("len(report.Skipped) = %d, want 1", got)
+	}
+	if report.Skipped[0].Reason != "missing tenant mapping for linked tenant" {
+		t.Fatalf("Skipped[0].Reason = %q, want missing tenant mapping", report.Skipped[0].Reason)
+	}
+
+	content, err := os.ReadFile(report.ReportPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(report.ReportPath) error = %v", err)
+	}
+
+	var persisted LeaseMigrationReport
+	if err := json.Unmarshal(content, &persisted); err != nil {
+		t.Fatalf("json.Unmarshal(report) error = %v", err)
+	}
+	if persisted.SkippedRows != report.SkippedRows || persisted.MissingTenantMappings != report.MissingTenantMappings {
+		t.Fatalf("persisted report counts = %+v, want returned counts %+v", persisted, report)
+	}
+	if len(persisted.Skipped) != len(report.Skipped) || persisted.Skipped[0].Reason != report.Skipped[0].Reason {
+		t.Fatalf("persisted skipped = %+v, want %+v", persisted.Skipped, report.Skipped)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestMigrateLeasesSkipsAlreadyMappedRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	sourceDir := t.TempDir()
+	reportDir := t.TempDir()
+
+	writeLegacyLeaseFixture(t, sourceDir, []legacyLeaseRecord{
+		{
+			RentID:        "1",
+			RoomID:        "10",
+			StartDate:     "2020-01-01",
+			EndDate:       "2020-12-31",
+			DepositAmount: "4000",
+			PaymentCycle:  "月繳",
+			Enabled:       "1",
+		},
+	})
+	writeLegacyLeaseUserFixture(t, sourceDir, []legacyLeaseTenantLink{
+		{RentID: "1", TenantID: "7"},
+	})
+	writeLegacyLeaseRoomFixture(t, sourceDir, []legacyRoomRecord{
+		{
+			RoomID:   "10",
+			EstateID: "1",
+			PriceRaw: `{"月繳":{"money":"5000"}}`,
+		},
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`
+CREATE TABLE IF NOT EXISTS legacy_lease_mappings (
+	legacy_rent_id VARCHAR(50) PRIMARY KEY,
+	lease_id UUID NOT NULL UNIQUE REFERENCES leases(id),
+	created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT 1
+FROM legacy_lease_mappings
+WHERE legacy_rent_id = $1
+LIMIT 1
+`)).
+		WithArgs("1").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
+	mock.ExpectCommit()
+
+	report, err := MigrateLeases(context.Background(), db, MigrateLeasesOptions{
+		SourceDir: sourceDir,
+		ReportDir: reportDir,
+	})
+	if err != nil {
+		t.Fatalf("MigrateLeases() error = %v", err)
+	}
+
+	if report.AlreadyMappedRows != 1 {
+		t.Fatalf("AlreadyMappedRows = %d, want 1", report.AlreadyMappedRows)
+	}
+	if report.ImportedRows != 0 {
+		t.Fatalf("ImportedRows = %d, want 0", report.ImportedRows)
+	}
+	if report.MappingsCreated != 0 {
+		t.Fatalf("MappingsCreated = %d, want 0", report.MappingsCreated)
+	}
+	if report.SkippedRows != 0 {
+		t.Fatalf("SkippedRows = %d, want 0", report.SkippedRows)
+	}
+
+	content, err := os.ReadFile(report.ReportPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(report.ReportPath) error = %v", err)
+	}
+
+	var persisted LeaseMigrationReport
+	if err := json.Unmarshal(content, &persisted); err != nil {
+		t.Fatalf("json.Unmarshal(report) error = %v", err)
+	}
+	if persisted.AlreadyMappedRows != report.AlreadyMappedRows || persisted.ImportedRows != report.ImportedRows || persisted.MappingsCreated != report.MappingsCreated {
+		t.Fatalf("persisted report counts = %+v, want returned counts %+v", persisted, report)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestMigrateLeasesRollsBackWhenTargetInsertFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	sourceDir := t.TempDir()
+	reportDir := t.TempDir()
+
+	writeLegacyLeaseFixture(t, sourceDir, []legacyLeaseRecord{
+		{
+			RentID:        "1",
+			RoomID:        "10",
+			StartDate:     "2020-01-01",
+			EndDate:       "2020-12-31",
+			DepositAmount: "4000",
+			PaymentCycle:  "月繳",
+			Enabled:       "1",
+		},
+	})
+	writeLegacyLeaseUserFixture(t, sourceDir, []legacyLeaseTenantLink{
+		{RentID: "1", TenantID: "7"},
+	})
+	writeLegacyLeaseRoomFixture(t, sourceDir, []legacyRoomRecord{
+		{
+			RoomID:   "10",
+			EstateID: "1",
+			PriceRaw: `{"月繳":{"money":"5000"}}`,
+		},
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`
+CREATE TABLE IF NOT EXISTS legacy_lease_mappings (
+	legacy_rent_id VARCHAR(50) PRIMARY KEY,
+	lease_id UUID NOT NULL UNIQUE REFERENCES leases(id),
+	created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT 1
+FROM legacy_lease_mappings
+WHERE legacy_rent_id = $1
+LIMIT 1
+`)).
+		WithArgs("1").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT lrm.room_id, r.property_id
+FROM legacy_room_mappings lrm
+JOIN rooms r
+  ON r.id = lrm.room_id
+WHERE lrm.legacy_room_id = $1
+  AND r.deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("10").
+		WillReturnRows(sqlmock.NewRows([]string{"room_id", "property_id"}).AddRow("room-uuid-10", "property-uuid-10"))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT tenant_id
+FROM legacy_tenant_mappings
+WHERE legacy_tenant_id = $1
+LIMIT 1
+`)).
+		WithArgs("7").
+		WillReturnRows(sqlmock.NewRows([]string{"tenant_id"}).AddRow("tenant-uuid-7"))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO leases (
+	tenant_id,
+	room_id,
+	property_id,
+	rent_amount,
+	start_date,
+	end_date,
+	rent_billing_cadence,
+	electricity_billing_cadence,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	notes,
+	termination_reason,
+	settlement_detail
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16::jsonb)
+RETURNING id
+`)).
+		WithArgs(
+			"tenant-uuid-7",
+			"room-uuid-10",
+			"property-uuid-10",
+			5000,
+			time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2020, 12, 31, 0, 0, 0, 0, time.UTC),
+			"monthly",
+			"monthly",
+			leaseStatusActive,
+			4000,
+			nil,
+			nil,
+			depositStatusHeld,
+			nil,
+			nil,
+			nil,
+		).
+		WillReturnError(errors.New("lease insert failed"))
+	mock.ExpectRollback()
+
+	_, err = MigrateLeases(context.Background(), db, MigrateLeasesOptions{
+		SourceDir: sourceDir,
+		ReportDir: reportDir,
+	})
+	if err == nil {
+		t.Fatal("MigrateLeases() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "insert lease for legacy rent 1") {
+		t.Fatalf("MigrateLeases() error = %v, want lease insert context", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/migration/legacy/properties_test.go
+++ b/internal/migration/legacy/properties_test.go
@@ -266,7 +266,10 @@ LIMIT 1
 	if err := json.Unmarshal(content, &persisted); err != nil {
 		t.Fatalf("json.Unmarshal(report) error = %v", err)
 	}
-	if persisted.AlreadyMappedRows != report.AlreadyMappedRows || persisted.ImportedRows != report.ImportedRows || persisted.MappingsCreated != report.MappingsCreated {
+	if persisted.EligibleRows != report.EligibleRows ||
+		persisted.AlreadyMappedRows != report.AlreadyMappedRows ||
+		persisted.ImportedRows != report.ImportedRows ||
+		persisted.MappingsCreated != report.MappingsCreated {
 		t.Fatalf("persisted report counts = %+v, want returned counts %+v", persisted, report)
 	}
 

--- a/internal/migration/legacy/properties_test.go
+++ b/internal/migration/legacy/properties_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -190,6 +192,191 @@ INSERT INTO legacy_property_mappings (
 	}
 	if got := len(persisted.Skipped); got != 1 {
 		t.Fatalf("len(persisted.Skipped) = %d, want 1", got)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestMigratePropertiesSkipsAlreadyMappedRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	sourceDir := t.TempDir()
+	reportDir := t.TempDir()
+
+	writeLegacyPropertyFixture(t, sourceDir, []legacyPropertyRecord{
+		{
+			EstateID:      "1",
+			Title:         "第一雅築",
+			OwnerLegacyID: "2287",
+			Address:       "台南市永康區中華路619巷22弄29號",
+		},
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`
+CREATE TABLE IF NOT EXISTS legacy_property_mappings (
+	legacy_estate_id VARCHAR(50) PRIMARY KEY,
+	property_id UUID NOT NULL UNIQUE REFERENCES properties(id),
+	created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT 1
+FROM legacy_property_mappings
+WHERE legacy_estate_id = $1
+LIMIT 1
+`)).
+		WithArgs("1").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}).AddRow(1))
+	mock.ExpectCommit()
+
+	report, err := MigrateProperties(context.Background(), db, MigratePropertiesOptions{
+		SourceDir: sourceDir,
+		ReportDir: reportDir,
+	})
+	if err != nil {
+		t.Fatalf("MigrateProperties() error = %v", err)
+	}
+
+	if report.EligibleRows != 1 {
+		t.Fatalf("EligibleRows = %d, want 1", report.EligibleRows)
+	}
+	if report.AlreadyMappedRows != 1 {
+		t.Fatalf("AlreadyMappedRows = %d, want 1", report.AlreadyMappedRows)
+	}
+	if report.ImportedRows != 0 {
+		t.Fatalf("ImportedRows = %d, want 0", report.ImportedRows)
+	}
+	if report.MappingsCreated != 0 {
+		t.Fatalf("MappingsCreated = %d, want 0", report.MappingsCreated)
+	}
+
+	content, err := os.ReadFile(report.ReportPath)
+	if err != nil {
+		t.Fatalf("os.ReadFile(report.ReportPath) error = %v", err)
+	}
+
+	var persisted PropertyMigrationReport
+	if err := json.Unmarshal(content, &persisted); err != nil {
+		t.Fatalf("json.Unmarshal(report) error = %v", err)
+	}
+	if persisted.AlreadyMappedRows != report.AlreadyMappedRows || persisted.ImportedRows != report.ImportedRows || persisted.MappingsCreated != report.MappingsCreated {
+		t.Fatalf("persisted report counts = %+v, want returned counts %+v", persisted, report)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet() error = %v", err)
+	}
+}
+
+func TestMigratePropertiesRollsBackWhenMappingInsertFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New() error = %v", err)
+	}
+	defer db.Close()
+
+	sourceDir := t.TempDir()
+	reportDir := t.TempDir()
+
+	writeLegacyPropertyFixture(t, sourceDir, []legacyPropertyRecord{
+		{
+			EstateID:      "1",
+			Title:         "第一雅築",
+			OwnerLegacyID: "2287",
+			Address:       "台南市永康區中華路619巷22弄29號",
+		},
+	})
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`
+CREATE TABLE IF NOT EXISTS legacy_property_mappings (
+	legacy_estate_id VARCHAR(50) PRIMARY KEY,
+	property_id UUID NOT NULL UNIQUE REFERENCES properties(id),
+	created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+)
+`)).WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT 1
+FROM legacy_property_mappings
+WHERE legacy_estate_id = $1
+LIMIT 1
+`)).
+		WithArgs("1").
+		WillReturnRows(sqlmock.NewRows([]string{"?column?"}))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id
+FROM users
+WHERE firebase_uid = $1
+  AND deleted_at IS NULL
+LIMIT 1
+`)).
+		WithArgs("legacy-owner:2287").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO users (
+	firebase_uid,
+	email,
+	name,
+	role
+) VALUES ($1, $2, $3, 'owner')
+RETURNING id
+`)).
+		WithArgs("legacy-owner:2287", "legacy-owner-2287@migration.local", "Legacy Owner 2287").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("owner-uuid-1"))
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO properties (
+	name,
+	subtitle,
+	address,
+	contact_phone,
+	contact_email,
+	notes,
+	facilities,
+	electricity_unit_price,
+	default_electricity_billing_cadence,
+	owner_id
+) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10)
+RETURNING id
+`)).
+		WithArgs(
+			"第一雅築",
+			nil,
+			"台南市永康區中華路619巷22弄29號",
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			"monthly",
+			"owner-uuid-1",
+		).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("property-uuid-1"))
+	mock.ExpectExec(regexp.QuoteMeta(`
+INSERT INTO legacy_property_mappings (
+	legacy_estate_id,
+	property_id
+) VALUES ($1, $2)
+`)).
+		WithArgs("1", "property-uuid-1").
+		WillReturnError(errors.New("mapping insert failed"))
+	mock.ExpectRollback()
+
+	_, err = MigrateProperties(context.Background(), db, MigratePropertiesOptions{
+		SourceDir: sourceDir,
+		ReportDir: reportDir,
+	})
+	if err == nil {
+		t.Fatal("MigrateProperties() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "insert legacy property mapping") {
+		t.Fatalf("MigrateProperties() error = %v, want mapping insert context", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
## Summary

Closes #76

- Add already-mapped rerun coverage for representative legacy migration stages: properties, leases, and bills.
- Add rollback coverage for property mapping insert failure and downstream lease target insert failure.
- Add missing prerequisite mapping coverage for lease tenant mappings.
- Tighten returned report vs persisted JSON consistency assertions for properties, leases, and bills.

## Scope Notes

- This intentionally stays in `internal/migration/legacy` sqlmock/unit coverage.
- No PostgreSQL integration smoke is added here; real SQL interaction is expected to be covered by E2E scope.
- No production migration behavior was changed.

## Validation

- `go test ./internal/migration/legacy`
- `GOCACHE=/tmp/go-cache go test ./...`
- `git diff --check`