### PR TITLE
Add legacy migrated E2E read checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,51 @@ Run the E2E suite:
 The harness refuses to reset a database unless the database name contains `e2e` or `test`.
 The local scripts provide defaults for E2E environment variables and still allow overrides, for example `APP_PORT=8081 E2E_BASE_URL=http://127.0.0.1:8081 ./scripts/e2e_test.sh`.
 
+## Legacy migrated E2E sign-off
+
+Legacy migrated data checks are separate from the normal seed-based E2E suite.
+They are intended for one-time legacy migration sign-off and are not wired into
+required PR CI.
+
+Use a separate database name for this mode, for example
+`stds_backend_legacy_e2e`. The legacy E2E tests do not reset the database or
+seed business data. They only seed the backend admin user row needed for the
+Firebase Auth Emulator token, then discover representative migrated records
+through legacy mapping tables.
+
+Prepare the legacy E2E database:
+
+```bash
+docker compose up -d postgres
+docker exec stds-postgres psql -U stds -d postgres -c "CREATE DATABASE stds_backend_legacy_e2e"
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate up
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy properties
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy rooms
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy tenants
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy leases
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy room-status
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy bills
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy journal
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy validate
+```
+
+Before sign-off, review the generated validation report and source/target
+reconciliation. By default, `scripts/legacy_e2e_test.sh` requires
+`artifacts/legacy_migration/task13_validation_report.json` to exist.
+
+Start dependencies and the API:
+
+```bash
+firebase emulators:start --only auth
+./scripts/legacy_e2e_api.sh
+```
+
+Run the legacy read checks:
+
+```bash
+./scripts/legacy_e2e_test.sh
+```
+
 ## Email notifications
 
 `POST /api/v1/users` now creates the Firebase Auth user, generates a Firebase password reset URL, and sends the onboarding email through Resend.

--- a/scripts/legacy_e2e_api.sh
+++ b/scripts/legacy_e2e_api.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export APP_ENV="${APP_ENV:-e2e}"
+export APP_HOST="${APP_HOST:-127.0.0.1}"
+export APP_PORT="${APP_PORT:-8080}"
+export APP_SCHEDULER_KEY="${APP_SCHEDULER_KEY:-legacy-e2e-scheduler-key}"
+export DATABASE_URL="${DATABASE_URL:-postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable}"
+export FIREBASE_PROJECT_ID="${FIREBASE_PROJECT_ID:-demo-stds-backend}"
+export FIREBASE_AUTH_EMULATOR_HOST="${FIREBASE_AUTH_EMULATOR_HOST:-127.0.0.1:9099}"
+export GCS_BUCKET_NAME="${GCS_BUCKET_NAME:-stds-legacy-e2e}"
+export ATTACHMENT_STORAGE_MODE="${ATTACHMENT_STORAGE_MODE:-fake-metadata}"
+export RESEND_API_KEY="${RESEND_API_KEY:-legacy-e2e-resend-key}"
+export RESEND_FROM_EMAIL="${RESEND_FROM_EMAIL:-legacy-e2e@example.com}"
+
+go run ./cmd/api

--- a/scripts/legacy_e2e_test.sh
+++ b/scripts/legacy_e2e_test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export LEGACY_E2E_BASE_URL="${LEGACY_E2E_BASE_URL:-http://127.0.0.1:8080}"
+export LEGACY_E2E_DATABASE_URL="${LEGACY_E2E_DATABASE_URL:-postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable}"
+export LEGACY_E2E_FIREBASE_PROJECT_ID="${LEGACY_E2E_FIREBASE_PROJECT_ID:-demo-stds-backend}"
+export LEGACY_E2E_FIREBASE_AUTH_EMULATOR_HOST="${LEGACY_E2E_FIREBASE_AUTH_EMULATOR_HOST:-127.0.0.1:9099}"
+export LEGACY_E2E_TEST_EMAIL="${LEGACY_E2E_TEST_EMAIL:-legacy-e2e-admin@example.com}"
+export LEGACY_E2E_TEST_PASSWORD="${LEGACY_E2E_TEST_PASSWORD:-Test123!}"
+export LEGACY_E2E_VALIDATION_REPORT_PATH="${LEGACY_E2E_VALIDATION_REPORT_PATH:-artifacts/legacy_migration/task13_validation_report.json}"
+
+if [[ "$LEGACY_E2E_VALIDATION_REPORT_PATH" != /* ]]; then
+  export LEGACY_E2E_VALIDATION_REPORT_PATH="$PWD/$LEGACY_E2E_VALIDATION_REPORT_PATH"
+fi
+
+go test -tags=legacye2e ./test/legacye2e "$@"

--- a/test/legacye2e/config.go
+++ b/test/legacye2e/config.go
@@ -1,0 +1,81 @@
+//go:build legacye2e
+
+package legacye2e
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"sort"
+	"strings"
+)
+
+type legacyE2EConfig struct {
+	BaseURL              string
+	DatabaseURL          string
+	FirebaseProjectID    string
+	FirebaseEmulatorHost string
+	TestEmail            string
+	TestPassword         string
+	ValidationReportPath string
+}
+
+func loadLegacyE2EConfig() (legacyE2EConfig, error) {
+	cfg := legacyE2EConfig{
+		BaseURL:              strings.TrimRight(os.Getenv("LEGACY_E2E_BASE_URL"), "/"),
+		DatabaseURL:          os.Getenv("LEGACY_E2E_DATABASE_URL"),
+		FirebaseProjectID:    os.Getenv("LEGACY_E2E_FIREBASE_PROJECT_ID"),
+		FirebaseEmulatorHost: os.Getenv("LEGACY_E2E_FIREBASE_AUTH_EMULATOR_HOST"),
+		TestEmail:            os.Getenv("LEGACY_E2E_TEST_EMAIL"),
+		TestPassword:         os.Getenv("LEGACY_E2E_TEST_PASSWORD"),
+		ValidationReportPath: os.Getenv("LEGACY_E2E_VALIDATION_REPORT_PATH"),
+	}
+
+	missing := make([]string, 0)
+	required := map[string]string{
+		"LEGACY_E2E_BASE_URL":                    cfg.BaseURL,
+		"LEGACY_E2E_DATABASE_URL":                cfg.DatabaseURL,
+		"LEGACY_E2E_FIREBASE_PROJECT_ID":         cfg.FirebaseProjectID,
+		"LEGACY_E2E_FIREBASE_AUTH_EMULATOR_HOST": cfg.FirebaseEmulatorHost,
+		"LEGACY_E2E_TEST_EMAIL":                  cfg.TestEmail,
+		"LEGACY_E2E_TEST_PASSWORD":               cfg.TestPassword,
+	}
+	for key, value := range required {
+		if strings.TrimSpace(value) == "" {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return legacyE2EConfig{}, fmt.Errorf("missing required legacy E2E environment variables: %s", strings.Join(missing, ", "))
+	}
+
+	if err := requireLegacyE2EDatabaseName(cfg.DatabaseURL); err != nil {
+		return legacyE2EConfig{}, err
+	}
+
+	return cfg, nil
+}
+
+func requireLegacyE2EDatabaseName(databaseURL string) error {
+	parsed, err := url.Parse(databaseURL)
+	if err != nil {
+		return fmt.Errorf("parse LEGACY_E2E_DATABASE_URL: %w", err)
+	}
+
+	dbName := strings.Trim(strings.TrimSpace(parsed.Path), "/")
+	if dbName == "" {
+		return errors.New("LEGACY_E2E_DATABASE_URL must include a database name")
+	}
+
+	normalized := strings.ToLower(dbName)
+	if !strings.Contains(normalized, "legacy") {
+		return fmt.Errorf("refusing legacy E2E database %q: database name must contain legacy", dbName)
+	}
+	if !strings.Contains(normalized, "e2e") && !strings.Contains(normalized, "test") && !strings.Contains(normalized, "staging") {
+		return fmt.Errorf("refusing legacy E2E database %q: database name must contain e2e, test, or staging", dbName)
+	}
+
+	return nil
+}

--- a/test/legacye2e/database.go
+++ b/test/legacye2e/database.go
@@ -1,0 +1,58 @@
+//go:build legacye2e
+
+package legacye2e
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+const legacyE2EAdminUserID = "00000000-0000-0000-0000-0000000097e2"
+
+func seedLegacyE2EAdminUser(ctx context.Context, db *sql.DB, firebaseUID string, email string) error {
+	assignedPropertyIDs, err := json.Marshal([]string{})
+	if err != nil {
+		return fmt.Errorf("marshal legacy E2E assigned properties: %w", err)
+	}
+
+	_, err = db.ExecContext(ctx, `
+INSERT INTO users (
+	id,
+	firebase_uid,
+	email,
+	name,
+	role,
+	permission_overrides,
+	assigned_property_ids,
+	created_at,
+	updated_at
+) VALUES (
+	$1,
+	$2,
+	$3,
+	$4,
+	'admin',
+	'[]'::jsonb,
+	$5::jsonb,
+	$6,
+	$6
+)
+ON CONFLICT (id) DO UPDATE SET
+	firebase_uid = EXCLUDED.firebase_uid,
+	email = EXCLUDED.email,
+	name = EXCLUDED.name,
+	role = EXCLUDED.role,
+	permission_overrides = EXCLUDED.permission_overrides,
+	assigned_property_ids = EXCLUDED.assigned_property_ids,
+	deleted_at = NULL,
+	updated_at = EXCLUDED.updated_at
+`, legacyE2EAdminUserID, firebaseUID, email, "Legacy E2E Admin", string(assignedPropertyIDs), time.Now().UTC())
+	if err != nil {
+		return fmt.Errorf("seed legacy E2E authenticated user: %w", err)
+	}
+
+	return nil
+}

--- a/test/legacye2e/firebase.go
+++ b/test/legacye2e/firebase.go
@@ -1,0 +1,96 @@
+//go:build legacye2e
+
+package legacye2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const legacyEmulatorAPIKey = "fake-api-key"
+
+type legacyEmulatorToken struct {
+	IDToken string
+	UID     string
+}
+
+func issueLegacyFirebaseEmulatorToken(ctx context.Context, cfg legacyE2EConfig) (legacyEmulatorToken, error) {
+	token, err := signUpLegacyFirebaseEmulatorUser(ctx, cfg)
+	if err == nil {
+		return token, nil
+	}
+	if !strings.Contains(err.Error(), "EMAIL_EXISTS") {
+		return legacyEmulatorToken{}, err
+	}
+
+	return signInLegacyFirebaseEmulatorUser(ctx, cfg)
+}
+
+func signUpLegacyFirebaseEmulatorUser(ctx context.Context, cfg legacyE2EConfig) (legacyEmulatorToken, error) {
+	payload := map[string]any{
+		"email":             cfg.TestEmail,
+		"password":          cfg.TestPassword,
+		"returnSecureToken": true,
+	}
+
+	return callLegacyFirebaseEmulatorAuth(ctx, cfg.FirebaseEmulatorHost, "accounts:signUp", payload)
+}
+
+func signInLegacyFirebaseEmulatorUser(ctx context.Context, cfg legacyE2EConfig) (legacyEmulatorToken, error) {
+	payload := map[string]any{
+		"email":             cfg.TestEmail,
+		"password":          cfg.TestPassword,
+		"returnSecureToken": true,
+	}
+
+	return callLegacyFirebaseEmulatorAuth(ctx, cfg.FirebaseEmulatorHost, "accounts:signInWithPassword", payload)
+}
+
+func callLegacyFirebaseEmulatorAuth(ctx context.Context, host string, method string, payload map[string]any) (legacyEmulatorToken, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return legacyEmulatorToken{}, fmt.Errorf("marshal Firebase emulator payload: %w", err)
+	}
+
+	url := fmt.Sprintf("http://%s/identitytoolkit.googleapis.com/v1/%s?key=%s", host, method, legacyEmulatorAPIKey)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return legacyEmulatorToken{}, fmt.Errorf("build Firebase emulator request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return legacyEmulatorToken{}, fmt.Errorf("call Firebase Auth Emulator: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return legacyEmulatorToken{}, fmt.Errorf("read Firebase emulator response: %w", err)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return legacyEmulatorToken{}, fmt.Errorf("Firebase emulator auth failed: %s", strings.TrimSpace(string(respBody)))
+	}
+
+	var result struct {
+		IDToken string `json:"idToken"`
+		LocalID string `json:"localId"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return legacyEmulatorToken{}, fmt.Errorf("decode Firebase emulator response: %w", err)
+	}
+	if result.IDToken == "" || result.LocalID == "" {
+		return legacyEmulatorToken{}, fmt.Errorf("Firebase emulator response missing idToken or localId")
+	}
+
+	return legacyEmulatorToken{IDToken: result.IDToken, UID: result.LocalID}, nil
+}

--- a/test/legacye2e/http.go
+++ b/test/legacye2e/http.go
@@ -1,0 +1,84 @@
+//go:build legacye2e
+
+package legacye2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type legacyAPIClient struct {
+	baseURL string
+	token   string
+	client  *http.Client
+}
+
+func newLegacyAPIClient(baseURL string, token string) legacyAPIClient {
+	return legacyAPIClient{
+		baseURL: baseURL,
+		token:   token,
+		client:  &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (c legacyAPIClient) getJSON(ctx context.Context, path string) (*http.Response, []byte, error) {
+	return c.doJSON(ctx, http.MethodGet, path, nil)
+}
+
+func (c legacyAPIClient) doJSON(ctx context.Context, method string, path string, body any) (*http.Response, []byte, error) {
+	var reader io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("marshal request body: %w", err)
+		}
+		reader = bytes.NewReader(payload)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("call API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	return resp, respBody, nil
+}
+
+func requireStatus(t *testing.T, resp *http.Response, body []byte, expected int) {
+	t.Helper()
+
+	if resp.StatusCode != expected {
+		t.Fatalf("expected HTTP %d, got %d: %s", expected, resp.StatusCode, string(body))
+	}
+}
+
+func decodeJSON(t *testing.T, body []byte, target any) {
+	t.Helper()
+
+	if err := json.Unmarshal(body, target); err != nil {
+		t.Fatalf("decode JSON response: %v\nbody: %s", err, string(body))
+	}
+}

--- a/test/legacye2e/legacy_read_test.go
+++ b/test/legacye2e/legacy_read_test.go
@@ -1,0 +1,491 @@
+//go:build legacye2e
+
+package legacye2e
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"stds_backend/internal/platform/database"
+)
+
+func TestLegacyE2EMigratedDataReadChecks(t *testing.T) {
+	cfg, err := loadLegacyE2EConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.ValidationReportPath != "" {
+		if _, err := os.Stat(cfg.ValidationReportPath); err != nil {
+			t.Fatalf("legacy validation report is required before legacy E2E sign-off: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	db, err := database.Open(ctx, cfg.DatabaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	token, err := issueLegacyFirebaseEmulatorToken(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seedLegacyE2EAdminUser(ctx, db, token.UID, cfg.TestEmail); err != nil {
+		t.Fatal(err)
+	}
+
+	client := newLegacyAPIClient(cfg.BaseURL, token.IDToken)
+	targets := discoverLegacyReadTargets(t, ctx, db)
+
+	t.Run("health endpoint reaches migrated database", func(t *testing.T) {
+		resp, body, err := client.getJSON(ctx, "/healthz")
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireStatus(t, resp, body, http.StatusOK)
+
+		var payload struct {
+			OK bool `json:"ok"`
+			DB bool `json:"db"`
+		}
+		decodeJSON(t, body, &payload)
+		if !payload.OK || !payload.DB {
+			t.Fatalf("expected healthy API and database, got ok=%t db=%t body=%s", payload.OK, payload.DB, string(body))
+		}
+	})
+
+	t.Run("property read path returns mapped legacy property", func(t *testing.T) {
+		var property struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			OwnerID string `json:"owner_id"`
+		}
+		getLegacyJSON(t, ctx, client, "/api/v1/properties/"+targets.PropertyID, &property)
+		if property.ID != targets.PropertyID {
+			t.Fatalf("expected property id %q, got %q", targets.PropertyID, property.ID)
+		}
+		if property.Name == "" {
+			t.Fatalf("expected property name in response")
+		}
+		if property.OwnerID == "" {
+			t.Fatalf("expected property owner_id in response")
+		}
+	})
+
+	t.Run("room read path returns mapped legacy room relationship", func(t *testing.T) {
+		var room struct {
+			ID         string `json:"id"`
+			PropertyID string `json:"property_id"`
+			Name       string `json:"name"`
+			Status     string `json:"status"`
+		}
+		getLegacyJSON(t, ctx, client, "/api/v1/rooms/"+targets.RoomID, &room)
+		if room.ID != targets.RoomID {
+			t.Fatalf("expected room id %q, got %q", targets.RoomID, room.ID)
+		}
+		if room.PropertyID != targets.RoomPropertyID {
+			t.Fatalf("expected room property_id %q, got %q", targets.RoomPropertyID, room.PropertyID)
+		}
+		if room.Name == "" || room.Status == "" {
+			t.Fatalf("expected room name and status in response")
+		}
+	})
+
+	t.Run("tenant read path returns mapped legacy tenant", func(t *testing.T) {
+		var tenant struct {
+			ID       string `json:"id"`
+			Name     string `json:"name"`
+			Status   string `json:"status"`
+			Contacts []any  `json:"contacts"`
+		}
+		getLegacyJSON(t, ctx, client, "/api/v1/tenants/"+targets.TenantID, &tenant)
+		if tenant.ID != targets.TenantID {
+			t.Fatalf("expected tenant id %q, got %q", targets.TenantID, tenant.ID)
+		}
+		if tenant.Name == "" || tenant.Status == "" {
+			t.Fatalf("expected tenant name and status in response")
+		}
+		if tenant.Contacts == nil {
+			t.Fatalf("expected tenant contacts array in response")
+		}
+	})
+
+	t.Run("lease read path returns mapped legacy lease relationships", func(t *testing.T) {
+		var lease struct {
+			ID                        string `json:"id"`
+			TenantID                  string `json:"tenant_id"`
+			RoomID                    string `json:"room_id"`
+			Status                    string `json:"status"`
+			RentBillingCadence        string `json:"rent_billing_cadence"`
+			ElectricityBillingCadence string `json:"electricity_billing_cadence"`
+		}
+		getLegacyJSON(t, ctx, client, "/api/v1/leases/"+targets.LeaseID, &lease)
+		if lease.ID != targets.LeaseID {
+			t.Fatalf("expected lease id %q, got %q", targets.LeaseID, lease.ID)
+		}
+		if lease.TenantID != targets.LeaseTenantID {
+			t.Fatalf("expected lease tenant_id %q, got %q", targets.LeaseTenantID, lease.TenantID)
+		}
+		if lease.RoomID != targets.LeaseRoomID {
+			t.Fatalf("expected lease room_id %q, got %q", targets.LeaseRoomID, lease.RoomID)
+		}
+		if lease.Status == "" || lease.RentBillingCadence == "" || lease.ElectricityBillingCadence == "" {
+			t.Fatalf("expected lease status and cadence fields in response")
+		}
+	})
+
+	t.Run("bill read path returns mapped legacy bill scope", func(t *testing.T) {
+		var bill struct {
+			ID         string `json:"id"`
+			LeaseID    string `json:"lease_id"`
+			TenantID   string `json:"tenant_id"`
+			RoomID     string `json:"room_id"`
+			PropertyID string `json:"property_id"`
+			Type       string `json:"type"`
+			Status     string `json:"status"`
+		}
+		getLegacyJSON(t, ctx, client, "/api/v1/bills/"+targets.BillID, &bill)
+		if bill.ID != targets.BillID {
+			t.Fatalf("expected bill id %q, got %q", targets.BillID, bill.ID)
+		}
+		if bill.LeaseID != targets.BillLeaseID || bill.TenantID != targets.BillTenantID || bill.RoomID != targets.BillRoomID || bill.PropertyID != targets.BillPropertyID {
+			t.Fatalf("unexpected bill scope: %+v", bill)
+		}
+		if bill.Type == "" || bill.Status == "" {
+			t.Fatalf("expected bill type and status in response")
+		}
+	})
+
+	t.Run("financial report read path returns migrated snapshot when available", func(t *testing.T) {
+		if targets.FinancialReport == nil {
+			t.Skip("no finalized monthly snapshot was found for mapped legacy properties")
+		}
+
+		reportTarget := targets.FinancialReport
+		var report struct {
+			PropertyID  string `json:"property_id"`
+			Year        int    `json:"year"`
+			Month       int    `json:"month"`
+			IsFinalized bool   `json:"is_finalized"`
+			Entries     []any  `json:"entries"`
+		}
+		path := fmt.Sprintf("/api/v1/properties/%s/financial-report/%d/%d", reportTarget.PropertyID, reportTarget.Year, reportTarget.Month)
+		getLegacyJSON(t, ctx, client, path, &report)
+		if report.PropertyID != reportTarget.PropertyID || report.Year != reportTarget.Year || report.Month != reportTarget.Month {
+			t.Fatalf("unexpected financial report identity: %+v", report)
+		}
+		if !report.IsFinalized {
+			t.Fatalf("expected finalized migrated financial report")
+		}
+		if report.Entries == nil {
+			t.Fatalf("expected financial report entries array in response")
+		}
+	})
+
+	t.Run("journal read path returns mapped legacy journal log", func(t *testing.T) {
+		var journal struct {
+			ID         string `json:"id"`
+			PropertyID string `json:"property_id"`
+			AuthorID   string `json:"author_id"`
+			Content    string `json:"content"`
+		}
+		getLegacyJSON(t, ctx, client, "/api/v1/journal-logs/"+targets.JournalLogID, &journal)
+		if journal.ID != targets.JournalLogID {
+			t.Fatalf("expected journal id %q, got %q", targets.JournalLogID, journal.ID)
+		}
+		if journal.PropertyID == "" || journal.AuthorID == "" || journal.Content == "" {
+			t.Fatalf("expected journal scope and content in response")
+		}
+	})
+
+	t.Run("repair read path returns mapped legacy repair request", func(t *testing.T) {
+		var repair struct {
+			ID          string `json:"id"`
+			PropertyID  string `json:"property_id"`
+			RoomID      string `json:"room_id"`
+			Title       string `json:"title"`
+			Description string `json:"description"`
+			Status      string `json:"status"`
+		}
+		getLegacyJSON(t, ctx, client, "/api/v1/repair-requests/"+targets.RepairRequestID, &repair)
+		if repair.ID != targets.RepairRequestID {
+			t.Fatalf("expected repair request id %q, got %q", targets.RepairRequestID, repair.ID)
+		}
+		if repair.PropertyID == "" || repair.RoomID == "" || repair.Title == "" || repair.Description == "" || repair.Status == "" {
+			t.Fatalf("expected repair scope, text, and status in response")
+		}
+	})
+
+	t.Run("attachment metadata read path returns mapped resource attachment when available", func(t *testing.T) {
+		if targets.Attachment == nil {
+			t.Skip("no attachment metadata was found for mapped legacy resources")
+		}
+
+		var list struct {
+			Data []struct {
+				ID       string `json:"id"`
+				FileName string `json:"file_name"`
+			} `json:"data"`
+		}
+		getLegacyJSON(t, ctx, client, targets.Attachment.ListPath, &list)
+		for _, attachment := range list.Data {
+			if attachment.ID == targets.Attachment.ID {
+				if attachment.FileName == "" {
+					t.Fatalf("expected attachment file_name in response")
+				}
+				return
+			}
+		}
+		t.Fatalf("expected attachment %q in %s response", targets.Attachment.ID, targets.Attachment.ListPath)
+	})
+}
+
+type legacyReadTargets struct {
+	PropertyID      string
+	RoomID          string
+	RoomPropertyID  string
+	TenantID        string
+	LeaseID         string
+	LeaseTenantID   string
+	LeaseRoomID     string
+	BillID          string
+	BillLeaseID     string
+	BillTenantID    string
+	BillRoomID      string
+	BillPropertyID  string
+	JournalLogID    string
+	RepairRequestID string
+	FinancialReport *legacyFinancialReportTarget
+	Attachment      *legacyAttachmentTarget
+}
+
+type legacyFinancialReportTarget struct {
+	PropertyID string
+	Year       int
+	Month      int
+}
+
+type legacyAttachmentTarget struct {
+	ID       string
+	ListPath string
+}
+
+func discoverLegacyReadTargets(t *testing.T, ctx context.Context, db *sql.DB) legacyReadTargets {
+	t.Helper()
+
+	targets := legacyReadTargets{
+		PropertyID:      requireLegacyString(t, ctx, db, "mapped legacy property", mappedLegacyPropertyQuery),
+		TenantID:        requireLegacyString(t, ctx, db, "mapped legacy tenant", mappedLegacyTenantQuery),
+		JournalLogID:    requireLegacyString(t, ctx, db, "mapped legacy journal log", mappedLegacyJournalLogQuery),
+		RepairRequestID: requireLegacyString(t, ctx, db, "mapped legacy repair request", mappedLegacyRepairRequestQuery),
+	}
+
+	requireLegacyRow(t, ctx, db, "mapped legacy room", mappedLegacyRoomQuery, &targets.RoomID, &targets.RoomPropertyID)
+	requireLegacyRow(t, ctx, db, "mapped legacy lease", mappedLegacyLeaseQuery, &targets.LeaseID, &targets.LeaseTenantID, &targets.LeaseRoomID)
+	requireLegacyRow(t, ctx, db, "mapped legacy bill", mappedLegacyBillQuery, &targets.BillID, &targets.BillLeaseID, &targets.BillTenantID, &targets.BillRoomID, &targets.BillPropertyID)
+
+	var report legacyFinancialReportTarget
+	if err := queryOptionalLegacyRow(ctx, db, mappedLegacyFinancialReportQuery, &report.PropertyID, &report.Year, &report.Month); err != nil {
+		t.Fatalf("discover mapped legacy financial report: %v", err)
+	}
+	if report.PropertyID != "" {
+		targets.FinancialReport = &report
+	}
+
+	var attachment legacyAttachmentTarget
+	if err := queryOptionalLegacyRow(ctx, db, mappedLegacyAttachmentQuery, &attachment.ID, &attachment.ListPath); err != nil {
+		t.Fatalf("discover mapped legacy attachment metadata: %v", err)
+	}
+	if attachment.ID != "" {
+		targets.Attachment = &attachment
+	}
+
+	return targets
+}
+
+func getLegacyJSON(t *testing.T, ctx context.Context, client legacyAPIClient, path string, target any) {
+	t.Helper()
+
+	resp, body, err := client.getJSON(ctx, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+	decodeJSON(t, body, target)
+}
+
+func requireLegacyString(t *testing.T, ctx context.Context, db *sql.DB, name string, query string) string {
+	t.Helper()
+
+	var value string
+	requireLegacyRow(t, ctx, db, name, query, &value)
+	return value
+}
+
+func requireLegacyRow(t *testing.T, ctx context.Context, db *sql.DB, name string, query string, destinations ...any) {
+	t.Helper()
+
+	err := db.QueryRowContext(ctx, query).Scan(destinations...)
+	if err == nil {
+		return
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("missing required %s; prepare the legacy E2E database with full legacy import and validation first", name)
+	}
+	t.Fatalf("discover %s: %v", name, err)
+}
+
+func queryOptionalLegacyRow(ctx context.Context, db *sql.DB, query string, destinations ...any) error {
+	err := db.QueryRowContext(ctx, query).Scan(destinations...)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	return err
+}
+
+const mappedLegacyPropertyQuery = `
+SELECT p.id::text
+FROM legacy_property_mappings m
+JOIN properties p ON p.id = m.property_id
+WHERE p.deleted_at IS NULL
+ORDER BY m.legacy_estate_id
+LIMIT 1
+`
+
+const mappedLegacyRoomQuery = `
+SELECT r.id::text, r.property_id::text
+FROM legacy_room_mappings m
+JOIN rooms r ON r.id = m.room_id
+JOIN properties p ON p.id = r.property_id AND p.deleted_at IS NULL
+WHERE r.deleted_at IS NULL
+ORDER BY m.legacy_room_id
+LIMIT 1
+`
+
+const mappedLegacyTenantQuery = `
+SELECT t.id::text
+FROM legacy_tenant_mappings m
+JOIN tenants t ON t.id = m.tenant_id
+WHERE t.deleted_at IS NULL
+ORDER BY m.legacy_tenant_id
+LIMIT 1
+`
+
+const mappedLegacyLeaseQuery = `
+SELECT l.id::text, l.tenant_id::text, l.room_id::text
+FROM legacy_lease_mappings m
+JOIN leases l ON l.id = m.lease_id
+JOIN tenants t ON t.id = l.tenant_id AND t.deleted_at IS NULL
+JOIN rooms r ON r.id = l.room_id AND r.deleted_at IS NULL
+JOIN properties p ON p.id = l.property_id AND p.deleted_at IS NULL
+WHERE l.deleted_at IS NULL
+ORDER BY m.legacy_rent_id
+LIMIT 1
+`
+
+const mappedLegacyBillQuery = `
+SELECT b.id::text, b.lease_id::text, b.tenant_id::text, b.room_id::text, b.property_id::text
+FROM legacy_bill_mappings m
+JOIN bills b ON b.id = m.bill_id
+JOIN leases l ON l.id = b.lease_id AND l.deleted_at IS NULL
+JOIN tenants t ON t.id = b.tenant_id AND t.deleted_at IS NULL
+JOIN rooms r ON r.id = b.room_id AND r.deleted_at IS NULL
+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL
+WHERE b.deleted_at IS NULL
+ORDER BY m.legacy_bill_key
+LIMIT 1
+`
+
+const mappedLegacyFinancialReportQuery = `
+SELECT ms.property_id::text, ms.year::int, ms.month::int
+FROM monthly_snapshots ms
+JOIN legacy_property_mappings m ON m.property_id = ms.property_id
+JOIN properties p ON p.id = ms.property_id AND p.deleted_at IS NULL
+ORDER BY ms.year DESC, ms.month DESC
+LIMIT 1
+`
+
+const mappedLegacyJournalLogQuery = `
+SELECT jl.id::text
+FROM legacy_schedule_mappings m
+JOIN journal_logs jl ON m.target_table = 'journal_logs' AND jl.id = m.target_id
+JOIN properties p ON p.id = jl.property_id AND p.deleted_at IS NULL
+WHERE jl.deleted_at IS NULL
+ORDER BY m.legacy_schedule_id
+LIMIT 1
+`
+
+const mappedLegacyRepairRequestQuery = `
+SELECT rr.id::text
+FROM legacy_schedule_mappings m
+JOIN repair_requests rr ON m.target_table = 'repair_requests' AND rr.id = m.target_id
+JOIN properties p ON p.id = rr.property_id AND p.deleted_at IS NULL
+JOIN rooms r ON r.id = rr.room_id AND r.deleted_at IS NULL
+WHERE rr.deleted_at IS NULL
+ORDER BY m.legacy_schedule_id
+LIMIT 1
+`
+
+const mappedLegacyAttachmentQuery = `
+SELECT id, list_path
+FROM (
+	SELECT pa.id::text AS id, '/api/v1/properties/' || pa.property_id::text || '/attachments' AS list_path
+	FROM property_attachments pa
+	JOIN legacy_property_mappings m ON m.property_id = pa.property_id
+	WHERE pa.deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT ra.id::text AS id, '/api/v1/rooms/' || ra.room_id::text || '/attachments' AS list_path
+	FROM room_attachments ra
+	JOIN legacy_room_mappings m ON m.room_id = ra.room_id
+	WHERE ra.deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT ta.id::text AS id, '/api/v1/tenants/' || ta.tenant_id::text || '/attachments' AS list_path
+	FROM tenant_attachments ta
+	JOIN legacy_tenant_mappings m ON m.tenant_id = ta.tenant_id
+	WHERE ta.deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT la.id::text AS id, '/api/v1/leases/' || la.lease_id::text || '/attachments' AS list_path
+	FROM lease_attachments la
+	JOIN legacy_lease_mappings m ON m.lease_id = la.lease_id
+	WHERE la.deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT ba.id::text AS id, '/api/v1/bills/' || ba.bill_id::text || '/attachments' AS list_path
+	FROM bill_attachments ba
+	JOIN legacy_bill_mappings m ON m.bill_id = ba.bill_id
+	WHERE ba.deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT jla.id::text AS id, '/api/v1/journal-logs/' || jla.journal_log_id::text || '/attachments' AS list_path
+	FROM journal_log_attachments jla
+	JOIN legacy_schedule_mappings m ON m.target_table = 'journal_logs' AND m.target_id = jla.journal_log_id
+	WHERE jla.deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT rra.id::text AS id, '/api/v1/repair-requests/' || rra.repair_request_id::text || '/attachments' AS list_path
+	FROM repair_request_attachments rra
+	JOIN legacy_schedule_mappings m ON m.target_table = 'repair_requests' AND m.target_id = rra.repair_request_id
+	WHERE rra.deleted_at IS NULL
+) mapped_attachments
+ORDER BY id
+LIMIT 1
+`


### PR DESCRIPTION
## Summary

Closes #97

- Add a separate `legacye2e` test mode for legacy migrated data API read checks.
- Add dedicated `scripts/legacy_e2e_api.sh` and `scripts/legacy_e2e_test.sh` wrappers.
- Discover representative migrated records from legacy mapping tables instead of hard-coded legacy IDs.
- Document local legacy migration sign-off setup and keep these checks out of required PR CI.

## Scope Notes

This intentionally stays separate from the normal seed-based E2E suite. The legacy E2E test does not reset the migrated database and only seeds the backend admin user row required for the Firebase Auth Emulator token.

The runtime checks cover mapped migrated properties, rooms, tenants, leases, bills, journal logs, and repair requests. Financial snapshots and attachment metadata are checked when representative migrated rows exist, and skipped otherwise.

## Validation

- `./scripts/legacy_e2e_test.sh -run '^$'`
- `GOCACHE=/tmp/go-cache go test ./...`
- `git diff --check`
- Full local legacy runtime sign-off:

```bash
LEGACY_E2E_VALIDATION_REPORT_PATH=artifacts/legacy_e2e_migration/task13_validation_report.json \
LEGACY_E2E_DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable \
./scripts/legacy_e2e_test.sh -count=1 -v
```

Full runtime result: PASS.

Passed read checks: health, property, room, tenant, lease, bill, journal log, repair request.

Skipped due to no representative rows in the prepared migrated DB: finalized monthly snapshot, attachment metadata.