### PR TITLE
[Reports] Preserve monthly report display fields

### DIFF
--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -190,13 +190,14 @@ Lease 於建立時也決定 `electricityBillingCadence`（`monthly | bimonthly`�
   - 來源：Bill payment command 直接寫入；Journal expense command 直接寫入並保留 `JournalExpenseRecorded` 作 trace/reserved event；DepositRefunded / DepositDeducted 由押金處理 command 直接寫入
   - `category: rent_payment | electricity_payment | deposit_refund | deposit_deduction | journal_expense`（財報分類用）
   - `accounting_title_id` / `accounting_title_code` / `accounting_title_name`：穩定會計科目維度；`accounting_titles` 是 runtime master data，`category` 仍是既有財報 total classification，不以 `accounting_titles.kind` 取代收入/支出計算
+  - `source_date` / `room_label` / `tenant_label` / `period_label` / `display_note`：報表列顯示事實；`source_date` 是顯示日期，不是新的 occurred-at domain model；labels/notes 由建立分錄當下保存
 - **寫入邊界**：只載入當月資料，不載入歷史分錄
-- **月結快照**：每月月底排程執行，將當月 AccountingEntry 封存為 `monthly_snapshot_entries`，一併保存 `accounting_title_id` 與 code/name copy，清空 Aggregate 內當月暫存資料
+- **月結快照**：每月月底排程執行，將當月 AccountingEntry 封存為 `monthly_snapshot_entries`，一併保存 `accounting_title_id`、code/name copy 與 display fields，清空 Aggregate 內當月暫存資料
 - **初始化**：物業建立時由 property creation command direct orchestration 自動建立，生命週期與物業綁定
 - **刪除策略**：物業軟刪除時 PropertyAccount 封存，MonthlySnapshot 永久保留
 - **讀取策略**：
   - 當月：讀取 PropertyAccount 當月 AccountingEntry
-  - 歷史：讀取 `monthly_snapshot_entries`（直接 SQL，不走 Aggregate）
+  - 歷史：讀取 `monthly_snapshot_entries`（直接 SQL，不走 Aggregate），finalized report 使用 snapshot-preserved display fields，不回查 mutable bills/rooms/tenants/leases 重建顯示文字
   - 財報：組合當月 + 歷史，依 category 分組顯示
 
 ### JournalLog Aggregate（Journal BC）
@@ -511,8 +512,8 @@ PropertyOwnerView
 | accounting_titles table | 欄位：`id, code, name, kind: income \| expense, legacy_kind, is_active, created_at, updated_at`；runtime master data；`kind` 不取代 `category` 的財報 total classification |
 | legacy_accounting_title_mappings table | 欄位：`legacy_accounting_id, legacy_accounting_title_id, accounting_title_id, legacy_accounting_kind, legacy_accounting_title, source_table, created_at`；保存 legacy `xx_accounting_title` 對 canonical title 的 mapping |
 | monthly_snapshots table（summary） | 欄位：`id, property_id, year, month, total_income, total_expense, net`；Index：`(property_id, year, month)` |
-| accounting_entries table（當月暫存） | 欄位：`id, property_account_id, category, accounting_title_id, accounting_title_code, accounting_title_name, description, amount, source_ref, year, month`；`category` 供財報 totals，accounting title 供報表科目顯示與 P&L 聚合 |
-| monthly_snapshot_entries table（明細） | 欄位：`id, snapshot_id, category, accounting_title_id, accounting_title_code, accounting_title_name, description, amount, source_ref`；Index：`(snapshot_id, category)`；code/name copy 保護 finalized historical report 不受 title rename 影響 |
+| accounting_entries table（當月暫存） | 欄位：`id, property_account_id, category, accounting_title_id, accounting_title_code, accounting_title_name, source_date, room_label, tenant_label, period_label, display_note, description, amount, source_ref, year, month`；`category` 供財報 totals，accounting title 供報表科目顯示與 P&L 聚合，display fields 供報表列日期/標籤/備註穩定顯示 |
+| monthly_snapshot_entries table（明細） | 欄位：`id, snapshot_id, category, accounting_title_id, accounting_title_code, accounting_title_name, source_date, room_label, tenant_label, period_label, display_note, description, amount, source_ref`；Index：`(snapshot_id, category)`；code/name copy 保護 finalized historical report 不受 title rename 影響，display fields 保護 finalized report 不需回查 mutable source tables |
 | MonthlySnapshot 排程 | 排除軟刪除物業：加 `AND deleted_at IS NULL` filter |
 | force_termination_bills table | 欄位：`id, force_termination_id, bill_id, status: pending \| done`；Index：`(force_termination_id, status)`；同步完成後所有追蹤帳單應為 `done` |
 | voided / written_off 帳單 | 狀態轉換（非軟刪除），查詢加 `AND status NOT IN ('voided', 'written_off')` |

--- a/docs/spec/schema.sql
+++ b/docs/spec/schema.sql
@@ -342,6 +342,12 @@ CREATE TABLE accounting_entries (
     accounting_title_id   UUID        REFERENCES accounting_titles(id),
     accounting_title_code VARCHAR(20),
     accounting_title_name VARCHAR(100),
+    -- display fields：報表列穩定顯示事實；source_date 為顯示日期，label/note 不在月結後回查 mutable source tables
+    source_date         DATE,
+    room_label          TEXT,
+    tenant_label        TEXT,
+    period_label        TEXT,
+    display_note        TEXT,
     amount              INTEGER      NOT NULL,
     description         TEXT,
     -- source_ref：來源事件與 ID（BillPaid / JournalExpenseRecorded / DepositRefunded / DepositDeducted）
@@ -397,6 +403,12 @@ CREATE TABLE monthly_snapshot_entries (
     accounting_title_id   UUID        REFERENCES accounting_titles(id),
     accounting_title_code VARCHAR(20),
     accounting_title_name VARCHAR(100),
+    -- snapshot copy 保護 finalized historical report 的日期、標籤與備註不受來源資料異動影響
+    source_date     DATE,
+    room_label      TEXT,
+    tenant_label    TEXT,
+    period_label    TEXT,
+    display_note    TEXT,
     description     TEXT,
     amount          INTEGER      NOT NULL,
     source_ref      JSONB,

--- a/internal/application/billing/record_commands_test.go
+++ b/internal/application/billing/record_commands_test.go
@@ -340,6 +340,18 @@ func TestRecordPaymentServiceRecordsPaymentAndPublishesEventAfterCommit(t *testi
 	if accountingRepo.entry.SourceRef["type"] != "BillPaid" || accountingRepo.entry.SourceRef["bill_id"] != testBillID {
 		t.Fatalf("unexpected source ref: %+v", accountingRepo.entry.SourceRef)
 	}
+	if accountingRepo.entry.SourceDate == nil {
+		t.Fatal("expected accounting source date")
+	}
+	if accountingRepo.entry.RoomLabel != nil || accountingRepo.entry.TenantLabel != nil {
+		t.Fatalf("unexpected unavailable labels: room=%v tenant=%v", accountingRepo.entry.RoomLabel, accountingRepo.entry.TenantLabel)
+	}
+	if accountingRepo.entry.PeriodLabel == nil || *accountingRepo.entry.PeriodLabel != "2026-03-15 至 2026-04-14" {
+		t.Fatalf("period label = %v, want 2026-03-15 至 2026-04-14", accountingRepo.entry.PeriodLabel)
+	}
+	if accountingRepo.entry.DisplayNote == nil || *accountingRepo.entry.DisplayNote != "租金：2026-03-15 至 2026-04-14" {
+		t.Fatalf("display note = %v, want rent period note", accountingRepo.entry.DisplayNote)
+	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
@@ -374,6 +386,16 @@ func TestRecordPaymentServiceAllowsOverdueBill(t *testing.T) {
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestAccountingSourceDateUsesTaiwanReportDate(t *testing.T) {
+	sourceDate := accountingSourceDate(time.Date(2026, 4, 30, 16, 30, 0, 0, time.UTC))
+	if sourceDate.Year() != 2026 || sourceDate.Month() != time.May || sourceDate.Day() != 1 {
+		t.Fatalf("source date = %s, want 2026-05-01 in Taiwan", sourceDate)
+	}
+	if sourceDate.Location().String() != taiwanReportLocation.String() {
+		t.Fatalf("source date location = %s, want %s", sourceDate.Location(), taiwanReportLocation)
 	}
 }
 
@@ -507,6 +529,9 @@ func TestRecordPaymentServiceRollsBackWhenAccountingEntryFails(t *testing.T) {
 	}
 	if accountingRepo.entry.Category != AccountingCategoryElectricityPayment || accountingRepo.entry.AccountingTitleCode != AccountingTitleCodeElectricityPayment || accountingRepo.entry.Amount != 585 {
 		t.Fatalf("unexpected accounting entry: %+v", accountingRepo.entry)
+	}
+	if accountingRepo.entry.DisplayNote == nil || *accountingRepo.entry.DisplayNote != "電費：2026-03-15 至 2026-04-14" {
+		t.Fatalf("display note = %v, want electricity period note", accountingRepo.entry.DisplayNote)
 	}
 	if len(publisher.events) != 0 {
 		t.Fatalf("expected no committed events, got %d", len(publisher.events))

--- a/internal/application/billing/record_commands_test.go
+++ b/internal/application/billing/record_commands_test.go
@@ -343,6 +343,10 @@ func TestRecordPaymentServiceRecordsPaymentAndPublishesEventAfterCommit(t *testi
 	if accountingRepo.entry.SourceDate == nil {
 		t.Fatal("expected accounting source date")
 	}
+	wantSourceDate := accountingSourceDate(paidAt)
+	if !accountingRepo.entry.SourceDate.Equal(wantSourceDate) {
+		t.Fatalf("accounting source date = %s, want %s", accountingRepo.entry.SourceDate, wantSourceDate)
+	}
 	if accountingRepo.entry.RoomLabel != nil || accountingRepo.entry.TenantLabel != nil {
 		t.Fatalf("unexpected unavailable labels: room=%v tenant=%v", accountingRepo.entry.RoomLabel, accountingRepo.entry.TenantLabel)
 	}

--- a/internal/application/billing/record_payment.go
+++ b/internal/application/billing/record_payment.go
@@ -92,6 +92,9 @@ func (s *RecordPaymentService) Execute(ctx context.Context, input RecordPaymentI
 		if err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)
 		}
+		sourceDate := accountingSourceDate(time.Now())
+		periodLabel := formatAccountingPeriodLabel(updatedBill.PeriodStart, updatedBill.PeriodEnd)
+		displayNote := formatBillAccountingDisplayNote(updatedBill.Type, periodLabel)
 		if err := s.accountingRepo.CreateAccountingEntry(ctx, tx, AccountingEntryParams{
 			PropertyID:          updatedBill.PropertyID,
 			Category:            category,
@@ -101,8 +104,11 @@ func (s *RecordPaymentService) Execute(ctx context.Context, input RecordPaymentI
 				"type":    "BillPaid",
 				"bill_id": updatedBill.ID,
 			},
-			Year:  state.PaidAt.Year(),
-			Month: int(state.PaidAt.Month()),
+			Year:        state.PaidAt.Year(),
+			Month:       int(state.PaidAt.Month()),
+			SourceDate:  &sourceDate,
+			PeriodLabel: &periodLabel,
+			DisplayNote: &displayNote,
 		}); err != nil {
 			return mapAccountingRepositoryError(err)
 		}
@@ -128,4 +134,19 @@ func (s *RecordPaymentService) Execute(ctx context.Context, input RecordPaymentI
 	}
 
 	return updated, nil
+}
+
+func formatAccountingPeriodLabel(start time.Time, end time.Time) string {
+	return start.Format("2006-01-02") + " 至 " + end.Format("2006-01-02")
+}
+
+func accountingSourceDate(value time.Time) time.Time {
+	return value.In(taiwanReportLocation)
+}
+
+func formatBillAccountingDisplayNote(billType string, periodLabel string) string {
+	if billType == domainbilling.TypeElectricity {
+		return "電費：" + periodLabel
+	}
+	return "租金：" + periodLabel
 }

--- a/internal/application/billing/record_payment.go
+++ b/internal/application/billing/record_payment.go
@@ -92,7 +92,7 @@ func (s *RecordPaymentService) Execute(ctx context.Context, input RecordPaymentI
 		if err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)
 		}
-		sourceDate := accountingSourceDate(time.Now())
+		sourceDate := accountingSourceDate(*state.PaidAt)
 		periodLabel := formatAccountingPeriodLabel(updatedBill.PeriodStart, updatedBill.PeriodEnd)
 		displayNote := formatBillAccountingDisplayNote(updatedBill.Type, periodLabel)
 		if err := s.accountingRepo.CreateAccountingEntry(ctx, tx, AccountingEntryParams{

--- a/internal/application/billing/reports.go
+++ b/internal/application/billing/reports.go
@@ -202,6 +202,11 @@ type MonthlyCashflowEntry struct {
 	AccountingTitleID   *string
 	AccountingTitleCode *string
 	AccountingTitleName *string
+	SourceDate          *time.Time
+	RoomLabel           *string
+	TenantLabel         *string
+	PeriodLabel         *string
+	DisplayNote         *string
 	Description         *string
 	Amount              int
 	SourceRef           json.RawMessage
@@ -1445,7 +1450,7 @@ func newMonthlyCashflowView(cashflow MonthlyCashflow, openingBalance int) monthl
 		totalIncome += income
 		totalExpense += expense
 		view.Rows = append(view.Rows, monthlyCashflowViewRow{
-			DateLabel:    row.CreatedAt.In(taiwanReportLocation).Format("01/02"),
+			DateLabel:    cashflowDateLabel(row),
 			SubjectLabel: cashflowSubjectLabel(row),
 			IncomeLabel:  optionalMoneyLabel(income),
 			ExpenseLabel: optionalMoneyLabel(expense),
@@ -1508,7 +1513,17 @@ func cashflowCategoryLabel(category string) string {
 	}
 }
 
+func cashflowDateLabel(row MonthlyCashflowEntry) string {
+	if row.SourceDate != nil {
+		return row.SourceDate.In(taiwanReportLocation).Format("01/02")
+	}
+	return row.CreatedAt.In(taiwanReportLocation).Format("01/02")
+}
+
 func cashflowNote(row MonthlyCashflowEntry) string {
+	if displayNote := stringValue(row.DisplayNote); displayNote != "" {
+		return displayNote
+	}
 	if description := stringValue(row.Description); description != "" {
 		return description
 	}

--- a/internal/application/billing/reports_test.go
+++ b/internal/application/billing/reports_test.go
@@ -621,6 +621,8 @@ func TestExportBillReceiptRendererFailureMapsInternalError(t *testing.T) {
 
 func TestExportMonthlyCashflowUsesCurrentMonthLiveRowsAndRunningBalance(t *testing.T) {
 	description := "101 2026-05 rent"
+	sourceDate := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	displayNote := "101 王小明 2026-05 租金"
 	repo := &reportRepositoryStub{
 		liveCashflow: &MonthlyCashflow{
 			PropertyID:   testPropertyID,
@@ -633,6 +635,8 @@ func TestExportMonthlyCashflowUsesCurrentMonthLiveRowsAndRunningBalance(t *testi
 					AccountingTitleCode: stringPtr("4603"),
 					AccountingTitleName: stringPtr("租金收入"),
 					Description:         &description,
+					SourceDate:          &sourceDate,
+					DisplayNote:         &displayNote,
 					Amount:              18000,
 					SourceRef:           []byte(`{"bill_id":"bill-1"}`),
 					CreatedAt:           time.Date(2026, 5, 3, 10, 0, 0, 0, time.UTC),
@@ -686,7 +690,7 @@ func TestExportMonthlyCashflowUsesCurrentMonthLiveRowsAndRunningBalance(t *testi
 	if len(view.Rows) != 2 || view.Rows[0].BalanceLabel != "NT$ 19,000" || view.Rows[1].BalanceLabel != "NT$ 16,500" {
 		t.Fatalf("unexpected rows: %+v", view.Rows)
 	}
-	if view.Rows[0].SubjectLabel != "租金收入" || view.Rows[0].Note != "101 2026-05 rent" {
+	if view.Rows[0].DateLabel != "05/02" || view.Rows[0].SubjectLabel != "租金收入" || view.Rows[0].Note != "101 王小明 2026-05 租金" {
 		t.Fatalf("unexpected first row: %+v", view.Rows[0])
 	}
 	if view.Rows[1].SubjectLabel != "其他支出" {
@@ -734,6 +738,60 @@ func TestExportMonthlyCashflowFallsBackToCategorySubjectForOldRows(t *testing.T)
 	}
 	if len(view.Rows) != 1 || view.Rows[0].SubjectLabel != "押金退還" {
 		t.Fatalf("unexpected fallback row: %+v", view.Rows)
+	}
+	if view.Rows[0].DateLabel != "05/06" {
+		t.Fatalf("fallback date = %q, want created_at date", view.Rows[0].DateLabel)
+	}
+}
+
+func TestExportMonthlyCashflowFallsBackFromDisplayNoteToDescriptionThenSourceRefReason(t *testing.T) {
+	description := "journal description"
+	repo := &reportRepositoryStub{
+		liveCashflow: &MonthlyCashflow{
+			PropertyID:   testPropertyID,
+			PropertyName: "Demo Property",
+			Year:         2026,
+			Month:        5,
+			Rows: []MonthlyCashflowEntry{
+				{
+					Category:    "journal_expense",
+					Description: &description,
+					Amount:      -1000,
+					CreatedAt:   time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC),
+				},
+				{
+					Category:  "deposit_refund",
+					Amount:    -2000,
+					SourceRef: []byte(`{"reason":"押金退還原因"}`),
+					CreatedAt: time.Date(2026, 5, 7, 10, 0, 0, 0, time.UTC),
+				},
+			},
+		},
+	}
+	renderer := &recordingReportRenderer{html: []byte("<html>cashflow</html>")}
+	service := NewExportMonthlyCashflowService(repo, renderer, fixedClock{now: time.Date(2026, 5, 8, 16, 0, 0, 0, time.UTC)})
+
+	_, err := service.Execute(context.Background(), ExportMonthlyCashflowInput{
+		ActorRole:  "staff",
+		PropertyID: testPropertyID,
+		Year:       2026,
+		Month:      5,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	view, ok := renderer.data.(monthlyCashflowView)
+	if !ok {
+		t.Fatalf("renderer data = %T, want monthlyCashflowView", renderer.data)
+	}
+	if len(view.Rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(view.Rows))
+	}
+	if view.Rows[0].Note != "journal description" {
+		t.Fatalf("first row note = %q, want description fallback", view.Rows[0].Note)
+	}
+	if view.Rows[1].Note != "押金退還原因" {
+		t.Fatalf("second row note = %q, want source_ref.reason fallback", view.Rows[1].Note)
 	}
 }
 

--- a/internal/application/billing/repository.go
+++ b/internal/application/billing/repository.go
@@ -111,6 +111,11 @@ type AccountingEntryParams struct {
 	SourceRef           map[string]interface{}
 	Year                int
 	Month               int
+	SourceDate          *time.Time
+	RoomLabel           *string
+	TenantLabel         *string
+	PeriodLabel         *string
+	DisplayNote         *string
 }
 
 // AccountingRepository defines persistence required to complete bill payment.

--- a/internal/application/journal/create.go
+++ b/internal/application/journal/create.go
@@ -108,6 +108,7 @@ func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*Journa
 
 		if journalLog.ExpenseAmount != nil {
 			year, month := journalAccountingPeriod(journalLog.CreatedAt)
+			sourceDate := journalLog.CreatedAt.In(journalAccountingLocation)
 			if err := s.accountingRepo.CreateExpenseAccountingEntry(ctx, tx, ExpenseAccountingEntryParams{
 				PropertyID:          journalLog.PropertyID,
 				Category:            accountingCategoryJournalExpense,
@@ -117,6 +118,8 @@ func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*Journa
 				SourceRef:           map[string]interface{}{"type": "JournalExpenseRecorded", "journal_log_id": journalLog.ID},
 				Year:                year,
 				Month:               month,
+				SourceDate:          &sourceDate,
+				DisplayNote:         journalLog.ExpenseDescription,
 			}); err != nil {
 				return mapAccountingRepositoryError(err)
 			}

--- a/internal/application/journal/create_test.go
+++ b/internal/application/journal/create_test.go
@@ -76,6 +76,13 @@ func TestCreateServiceCreatesAccountingEntryAndPublishesEventWhenExpensePresent(
 	if accountingRepo.entry.SourceRef["type"] != "JournalExpenseRecorded" || accountingRepo.entry.SourceRef["journal_log_id"] != testJournalID {
 		t.Fatalf("accounting SourceRef = %#v", accountingRepo.entry.SourceRef)
 	}
+	wantSourceDate := createdAt.In(journalAccountingLocation)
+	if accountingRepo.entry.SourceDate == nil || !accountingRepo.entry.SourceDate.Equal(wantSourceDate) {
+		t.Fatalf("accounting SourceDate = %v, want %s", accountingRepo.entry.SourceDate, wantSourceDate)
+	}
+	if accountingRepo.entry.DisplayNote == nil || *accountingRepo.entry.DisplayNote != description {
+		t.Fatalf("accounting DisplayNote = %v, want %s", accountingRepo.entry.DisplayNote, description)
+	}
 	if len(publisher.events) != 1 {
 		t.Fatalf("published events = %d, want 1", len(publisher.events))
 	}
@@ -334,6 +341,13 @@ func TestUpdateServiceUpdatesMutableFields(t *testing.T) {
 	}
 	if accountingRepo.syncedEntry.Year != 2026 || accountingRepo.syncedEntry.Month != 5 {
 		t.Fatalf("syncedEntry Year/Month = %d/%d, want 2026/5", accountingRepo.syncedEntry.Year, accountingRepo.syncedEntry.Month)
+	}
+	wantSourceDate := repo.current.CreatedAt.In(journalAccountingLocation)
+	if accountingRepo.syncedEntry.SourceDate == nil || !accountingRepo.syncedEntry.SourceDate.Equal(wantSourceDate) {
+		t.Fatalf("syncedEntry SourceDate = %v, want %s", accountingRepo.syncedEntry.SourceDate, wantSourceDate)
+	}
+	if accountingRepo.syncedEntry.DisplayNote == nil || *accountingRepo.syncedEntry.DisplayNote != description {
+		t.Fatalf("syncedEntry DisplayNote = %v, want %s", accountingRepo.syncedEntry.DisplayNote, description)
 	}
 }
 

--- a/internal/application/journal/repository.go
+++ b/internal/application/journal/repository.go
@@ -72,6 +72,8 @@ type ExpenseAccountingEntryParams struct {
 	SourceRef           map[string]interface{}
 	Year                int
 	Month               int
+	SourceDate          *time.Time
+	DisplayNote         *string
 }
 
 // UpdateParams contains mutable journal log fields.

--- a/internal/application/journal/update.go
+++ b/internal/application/journal/update.go
@@ -78,6 +78,7 @@ func (s *UpdateService) Execute(ctx context.Context, input UpdateInput) (*Journa
 			var entry *ExpenseAccountingEntryParams
 			if journalLog.ExpenseAmount != nil {
 				year, month := journalAccountingPeriod(journalLog.CreatedAt)
+				sourceDate := journalLog.CreatedAt.In(journalAccountingLocation)
 				entry = &ExpenseAccountingEntryParams{
 					PropertyID:          journalLog.PropertyID,
 					Category:            accountingCategoryJournalExpense,
@@ -87,6 +88,8 @@ func (s *UpdateService) Execute(ctx context.Context, input UpdateInput) (*Journa
 					SourceRef:           map[string]interface{}{"type": "JournalExpenseRecorded", "journal_log_id": journalLog.ID},
 					Year:                year,
 					Month:               month,
+					SourceDate:          &sourceDate,
+					DisplayNote:         journalLog.ExpenseDescription,
 				}
 			}
 			if err := s.accountingRepo.SyncExpenseAccountingEntry(ctx, tx, journalLog.ID, entry); err != nil {

--- a/internal/application/lease/repository.go
+++ b/internal/application/lease/repository.go
@@ -134,6 +134,9 @@ type DepositAccountingEntryParams struct {
 	SourceRef           map[string]interface{}
 	Year                int
 	Month               int
+	SourceDate          *time.Time
+	TenantLabel         *string
+	DisplayNote         *string
 }
 
 // TerminateLeaseParams contains fields for predecessor termination.

--- a/internal/application/lease/update_deposit.go
+++ b/internal/application/lease/update_deposit.go
@@ -22,6 +22,8 @@ const (
 	depositAccountingTitleCodeDeduction = "4601"
 )
 
+var depositAccountingLocation = time.FixedZone("Asia/Taipei", 8*60*60)
+
 // UpdateDepositInput is the command payload for deposit settlement.
 type UpdateDepositInput struct {
 	ActorRole           string
@@ -170,7 +172,9 @@ func recordDepositAccountingEntries(ctx context.Context, tx *sql.Tx, repo Deposi
 		return apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "deposit_accounting"})
 	}
 
+	sourceDate := depositAccountingSourceDate(occurredAt)
 	if refundAmount > 0 {
+		displayNote := "押金退款"
 		if err := repo.CreateDepositAccountingEntry(ctx, tx, DepositAccountingEntryParams{
 			PropertyID:          lease.PropertyID,
 			Category:            depositAccountingCategoryRefund,
@@ -180,8 +184,10 @@ func recordDepositAccountingEntries(ctx context.Context, tx *sql.Tx, repo Deposi
 				"type":     "DepositRefunded",
 				"lease_id": lease.ID,
 			},
-			Year:  occurredAt.Year(),
-			Month: int(occurredAt.Month()),
+			Year:        sourceDate.Year(),
+			Month:       int(sourceDate.Month()),
+			SourceDate:  &sourceDate,
+			DisplayNote: &displayNote,
 		}); err != nil {
 			return mapDepositAccountingError(err)
 		}
@@ -200,14 +206,20 @@ func recordDepositAccountingEntries(ctx context.Context, tx *sql.Tx, repo Deposi
 				"lease_id": lease.ID,
 				"reason":   deductionReason,
 			},
-			Year:  occurredAt.Year(),
-			Month: int(occurredAt.Month()),
+			Year:        sourceDate.Year(),
+			Month:       int(sourceDate.Month()),
+			SourceDate:  &sourceDate,
+			DisplayNote: &description,
 		}); err != nil {
 			return mapDepositAccountingError(err)
 		}
 	}
 
 	return nil
+}
+
+func depositAccountingSourceDate(value time.Time) time.Time {
+	return value.In(depositAccountingLocation)
 }
 
 func mapDepositAccountingError(err error) error {

--- a/internal/application/lease/update_lease_test.go
+++ b/internal/application/lease/update_lease_test.go
@@ -463,6 +463,15 @@ func TestUpdateDepositServiceCreatesRefundAccountingEntry(t *testing.T) {
 	if entry.Category != depositAccountingCategoryRefund || entry.AccountingTitleCode != depositAccountingTitleCodeRefund || entry.Amount != -refundAmount {
 		t.Fatalf("accounting entry = %+v", entry)
 	}
+	if entry.SourceDate == nil {
+		t.Fatal("expected source date")
+	}
+	if entry.TenantLabel != nil {
+		t.Fatalf("tenant label = %v, want nil because only tenant ID is available", entry.TenantLabel)
+	}
+	if entry.DisplayNote == nil || *entry.DisplayNote != "押金退款" {
+		t.Fatalf("display note = %v, want 押金退款", entry.DisplayNote)
+	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
@@ -519,9 +528,47 @@ func TestUpdateDepositServiceCreatesDeductionAccountingEntry(t *testing.T) {
 	if entry.Description == nil || *entry.Description != reason {
 		t.Fatalf("description = %v, want %q", entry.Description, reason)
 	}
+	if entry.SourceDate == nil {
+		t.Fatal("expected source date")
+	}
+	if entry.TenantLabel != nil {
+		t.Fatalf("tenant label = %v, want nil because only tenant ID is available", entry.TenantLabel)
+	}
+	if entry.DisplayNote == nil || *entry.DisplayNote != reason {
+		t.Fatalf("display note = %v, want %q", entry.DisplayNote, reason)
+	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestRecordDepositAccountingEntriesUsesTaiwanSourceDate(t *testing.T) {
+	accountingRepo := &depositAccountingRepositoryStub{}
+	occurredAt := time.Date(2026, 4, 30, 16, 30, 0, 0, time.UTC)
+
+	err := recordDepositAccountingEntries(context.Background(), nil, accountingRepo, &Lease{
+		ID:         updateLeaseTestLeaseID,
+		PropertyID: "property-1",
+	}, 36000, 0, "", occurredAt)
+	if err != nil {
+		t.Fatalf("recordDepositAccountingEntries: %v", err)
+	}
+	if len(accountingRepo.entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(accountingRepo.entries))
+	}
+	sourceDate := accountingRepo.entries[0].SourceDate
+	if sourceDate == nil {
+		t.Fatal("expected source date")
+	}
+	if sourceDate.Year() != 2026 || sourceDate.Month() != time.May || sourceDate.Day() != 1 {
+		t.Fatalf("source date = %s, want 2026-05-01 in Taiwan", sourceDate)
+	}
+	if sourceDate.Location().String() != depositAccountingLocation.String() {
+		t.Fatalf("source date location = %s, want %s", sourceDate.Location(), depositAccountingLocation)
+	}
+	if accountingRepo.entries[0].Year != 2026 || accountingRepo.entries[0].Month != 5 {
+		t.Fatalf("accounting period = %d/%d, want 2026/5", accountingRepo.entries[0].Year, accountingRepo.entries[0].Month)
 	}
 }
 

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -2755,5 +2755,5 @@ func nullableDate(value *time.Time) any {
 	if value == nil {
 		return nil
 	}
-	return *value
+	return value.Format("2006-01-02")
 }

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -100,6 +100,11 @@ type CreateAccountingEntryParams struct {
 	SourceRef           map[string]any
 	Year                int
 	Month               int
+	SourceDate          *time.Time
+	RoomLabel           *string
+	TenantLabel         *string
+	PeriodLabel         *string
+	DisplayNote         *string
 }
 
 // FinancialReportSummary is one monthly financial report summary row.
@@ -151,6 +156,11 @@ type MonthlyCashflowEntry struct {
 	AccountingTitleID   *string
 	AccountingTitleCode *string
 	AccountingTitleName *string
+	SourceDate          *time.Time
+	RoomLabel           *string
+	TenantLabel         *string
+	PeriodLabel         *string
+	DisplayNote         *string
 	Description         *string
 	Amount              int
 	SourceRef           json.RawMessage
@@ -535,6 +545,11 @@ INSERT INTO monthly_snapshot_entries (
 	accounting_title_id,
 	accounting_title_code,
 	accounting_title_name,
+	source_date,
+	room_label,
+	tenant_label,
+	period_label,
+	display_note,
 	description,
 	amount,
 	source_ref,
@@ -546,6 +561,11 @@ SELECT
 	ae.accounting_title_id,
 	ae.accounting_title_code,
 	ae.accounting_title_name,
+	ae.source_date,
+	ae.room_label,
+	ae.tenant_label,
+	ae.period_label,
+	ae.display_note,
 	ae.description,
 	ae.amount,
 	ae.source_ref,
@@ -1071,7 +1091,12 @@ INSERT INTO accounting_entries (
 	description,
 	source_ref,
 	year,
-	month
+	month,
+	source_date,
+	room_label,
+	tenant_label,
+	period_label,
+	display_note
 )
 SELECT
 	$1,
@@ -1083,7 +1108,12 @@ SELECT
 	$4,
 	$5::jsonb,
 	$6,
-	$7
+	$7,
+	$9::date,
+	$10,
+	$11,
+	$12,
+	$13
 FROM accounting_titles at
 WHERE at.code = $8
   AND at.is_active = true
@@ -1098,6 +1128,11 @@ WHERE at.code = $8
 		params.Year,
 		params.Month,
 		params.AccountingTitleCode,
+		nullableDate(params.SourceDate),
+		nullableString(params.RoomLabel),
+		nullableString(params.TenantLabel),
+		nullableString(params.PeriodLabel),
+		nullableString(params.DisplayNote),
 	)
 	if err != nil {
 		return fmt.Errorf("insert accounting entry: %w", err)
@@ -1812,6 +1847,11 @@ SELECT
 	mse.accounting_title_id,
 	mse.accounting_title_code,
 	mse.accounting_title_name,
+	mse.source_date,
+	mse.room_label,
+	mse.tenant_label,
+	mse.period_label,
+	mse.display_note,
 	mse.description,
 	mse.amount,
 	mse.source_ref,
@@ -1876,6 +1916,11 @@ SELECT
 	ae.accounting_title_id,
 	ae.accounting_title_code,
 	ae.accounting_title_name,
+	ae.source_date,
+	ae.room_label,
+	ae.tenant_label,
+	ae.period_label,
+	ae.display_note,
 	ae.description,
 	ae.amount,
 	ae.source_ref,
@@ -2504,6 +2549,11 @@ func scanMonthlyCashflowRow(row rowScanner) (MonthlyCashflowEntry, bool, *Monthl
 	var accountingTitleID sql.NullString
 	var accountingTitleCode sql.NullString
 	var accountingTitleName sql.NullString
+	var sourceDate sql.NullTime
+	var roomLabel sql.NullString
+	var tenantLabel sql.NullString
+	var periodLabel sql.NullString
+	var displayNote sql.NullString
 	var description sql.NullString
 	var amount sql.NullInt64
 	var sourceRef sql.NullString
@@ -2519,6 +2569,11 @@ func scanMonthlyCashflowRow(row rowScanner) (MonthlyCashflowEntry, bool, *Monthl
 		&accountingTitleID,
 		&accountingTitleCode,
 		&accountingTitleName,
+		&sourceDate,
+		&roomLabel,
+		&tenantLabel,
+		&periodLabel,
+		&displayNote,
 		&description,
 		&amount,
 		&sourceRef,
@@ -2541,6 +2596,21 @@ func scanMonthlyCashflowRow(row rowScanner) (MonthlyCashflowEntry, bool, *Monthl
 	}
 	if accountingTitleName.Valid {
 		entry.AccountingTitleName = &accountingTitleName.String
+	}
+	if sourceDate.Valid {
+		entry.SourceDate = &sourceDate.Time
+	}
+	if roomLabel.Valid {
+		entry.RoomLabel = &roomLabel.String
+	}
+	if tenantLabel.Valid {
+		entry.TenantLabel = &tenantLabel.String
+	}
+	if periodLabel.Valid {
+		entry.PeriodLabel = &periodLabel.String
+	}
+	if displayNote.Valid {
+		entry.DisplayNote = &displayNote.String
 	}
 	if description.Valid {
 		entry.Description = &description.String
@@ -2675,6 +2745,13 @@ func ensureUpdated(result sql.Result) error {
 }
 
 func nullableString(value *string) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func nullableDate(value *time.Time) any {
 	if value == nil {
 		return nil
 	}

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -571,7 +571,7 @@ func TestInsertAccountingEntryWritesTitleLinkage(t *testing.T) {
 	periodLabel := "2026-04-01 至 2026-04-30"
 	displayNote := "租金：2026-04-01 至 2026-04-30"
 	mock.ExpectExec(`(?s)INSERT INTO accounting_entries \(\s+property_account_id,\s+category,\s+accounting_title_id,\s+accounting_title_code,\s+accounting_title_name,\s+amount,\s+description,\s+source_ref,\s+year,\s+month,\s+source_date,\s+room_label,\s+tenant_label,\s+period_label,\s+display_note\s+\).*FROM accounting_titles at\s+WHERE at.code = \$8\s+AND at.is_active = true`).
-		WithArgs("account-1", "rent_payment", 12000, description, `{"bill_id":"bill-1"}`, 2026, 4, "4603", sourceDate, nil, nil, periodLabel, displayNote).
+		WithArgs("account-1", "rent_payment", 12000, description, `{"bill_id":"bill-1"}`, 2026, 4, "4603", "2026-04-24", nil, nil, periodLabel, displayNote).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
@@ -611,7 +611,7 @@ func TestReplaceJournalExpenseAccountingEntryDeletesExistingAndInsertsReplacemen
 		WithArgs("journal-1").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectExec(`(?s)INSERT INTO accounting_entries \(\s+property_account_id,\s+category,\s+accounting_title_id,\s+accounting_title_code,\s+accounting_title_name,\s+amount,\s+description,\s+source_ref,\s+year,\s+month,\s+source_date,\s+room_label,\s+tenant_label,\s+period_label,\s+display_note\s+\).*FROM accounting_titles at\s+WHERE at.code = \$8\s+AND at.is_active = true`).
-		WithArgs("account-1", "journal_expense", 4200, description, `{"journal_log_id":"journal-1","type":"JournalExpenseRecorded"}`, 2026, 5, "6681", sourceDate, nil, nil, nil, description).
+		WithArgs("account-1", "journal_expense", 4200, description, `{"journal_log_id":"journal-1","type":"JournalExpenseRecorded"}`, 2026, 5, "6681", "2026-05-02", nil, nil, nil, description).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -567,8 +567,11 @@ func TestInsertAccountingEntryWritesTitleLinkage(t *testing.T) {
 
 	tx := beginBillingTx(t, db, mock)
 	description := "bill payment"
-	mock.ExpectExec(`(?s)INSERT INTO accounting_entries \(\s+property_account_id,\s+category,\s+accounting_title_id,\s+accounting_title_code,\s+accounting_title_name,\s+amount,\s+description,\s+source_ref,\s+year,\s+month\s+\).*FROM accounting_titles at\s+WHERE at.code = \$8\s+AND at.is_active = true`).
-		WithArgs("account-1", "rent_payment", 12000, description, `{"bill_id":"bill-1"}`, 2026, 4, "4603").
+	sourceDate := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	periodLabel := "2026-04-01 至 2026-04-30"
+	displayNote := "租金：2026-04-01 至 2026-04-30"
+	mock.ExpectExec(`(?s)INSERT INTO accounting_entries \(\s+property_account_id,\s+category,\s+accounting_title_id,\s+accounting_title_code,\s+accounting_title_name,\s+amount,\s+description,\s+source_ref,\s+year,\s+month,\s+source_date,\s+room_label,\s+tenant_label,\s+period_label,\s+display_note\s+\).*FROM accounting_titles at\s+WHERE at.code = \$8\s+AND at.is_active = true`).
+		WithArgs("account-1", "rent_payment", 12000, description, `{"bill_id":"bill-1"}`, 2026, 4, "4603", sourceDate, nil, nil, periodLabel, displayNote).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
@@ -581,6 +584,9 @@ func TestInsertAccountingEntryWritesTitleLinkage(t *testing.T) {
 		SourceRef:           map[string]any{"bill_id": "bill-1"},
 		Year:                2026,
 		Month:               4,
+		SourceDate:          &sourceDate,
+		PeriodLabel:         &periodLabel,
+		DisplayNote:         &displayNote,
 	})
 	if err != nil {
 		t.Fatalf("InsertAccountingEntry: %v", err)
@@ -600,11 +606,12 @@ func TestReplaceJournalExpenseAccountingEntryDeletesExistingAndInsertsReplacemen
 
 	tx := beginBillingTx(t, db, mock)
 	description := "updated repair expense"
+	sourceDate := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
 	mock.ExpectExec(`(?s)DELETE FROM accounting_entries\s+WHERE category = 'journal_expense'\s+AND source_ref->>'journal_log_id' = \$1`).
 		WithArgs("journal-1").
 		WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(`(?s)INSERT INTO accounting_entries \(\s+property_account_id,\s+category,\s+accounting_title_id,\s+accounting_title_code,\s+accounting_title_name,\s+amount,\s+description,\s+source_ref,\s+year,\s+month\s+\).*FROM accounting_titles at\s+WHERE at.code = \$8\s+AND at.is_active = true`).
-		WithArgs("account-1", "journal_expense", 4200, description, `{"journal_log_id":"journal-1","type":"JournalExpenseRecorded"}`, 2026, 5, "6681").
+	mock.ExpectExec(`(?s)INSERT INTO accounting_entries \(\s+property_account_id,\s+category,\s+accounting_title_id,\s+accounting_title_code,\s+accounting_title_name,\s+amount,\s+description,\s+source_ref,\s+year,\s+month,\s+source_date,\s+room_label,\s+tenant_label,\s+period_label,\s+display_note\s+\).*FROM accounting_titles at\s+WHERE at.code = \$8\s+AND at.is_active = true`).
+		WithArgs("account-1", "journal_expense", 4200, description, `{"journal_log_id":"journal-1","type":"JournalExpenseRecorded"}`, 2026, 5, "6681", sourceDate, nil, nil, nil, description).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit()
 
@@ -617,6 +624,8 @@ func TestReplaceJournalExpenseAccountingEntryDeletesExistingAndInsertsReplacemen
 		SourceRef:           map[string]any{"type": "JournalExpenseRecorded", "journal_log_id": "journal-1"},
 		Year:                2026,
 		Month:               5,
+		SourceDate:          &sourceDate,
+		DisplayNote:         &description,
 	})
 	if err != nil {
 		t.Fatalf("ReplaceJournalExpenseAccountingEntry: %v", err)
@@ -793,11 +802,12 @@ func TestGetMonthlyCashflowFinalizedMapsSnapshotRows(t *testing.T) {
 	defer closeBillingDB(t, db)
 
 	createdAt := time.Date(2026, 4, 30, 23, 0, 0, 0, time.UTC)
+	sourceDate := time.Date(2026, 4, 29, 0, 0, 0, 0, time.UTC)
 	mock.ExpectQuery(`(?s)FROM monthly_snapshots ms\s+JOIN properties p ON p.id = ms.property_id AND p.deleted_at IS NULL\s+LEFT JOIN monthly_snapshot_entries mse ON mse.snapshot_id = ms.id\s+WHERE ms.property_id = \$1\s+AND ms.year = \$2\s+AND ms.month = \$3`).
 		WithArgs("property-1", 2026, 4).
 		WillReturnRows(monthlyCashflowRows().
-			AddRow("property-1", "Demo Property", 2026, 4, "entry-1", "rent_payment", "title-4603", "4603", "租金收入", "rent", 12000, []byte(`{"bill_id":"bill-1"}`), createdAt).
-			AddRow("property-1", "Demo Property", 2026, 4, "entry-2", "journal_expense", "title-6681", "6681", "其他支出", nil, -1500, []byte(`{"journal_log_id":"journal-1"}`), createdAt))
+			AddRow("property-1", "Demo Property", 2026, 4, "entry-1", "rent_payment", "title-4603", "4603", "租金收入", sourceDate, "101", "王小明", "2026-04", "101 王小明 2026-04 rent", "rent", 12000, []byte(`{"bill_id":"bill-1"}`), createdAt).
+			AddRow("property-1", "Demo Property", 2026, 4, "entry-2", "journal_expense", "title-6681", "6681", "其他支出", nil, nil, nil, nil, "水電修繕", nil, -1500, []byte(`{"journal_log_id":"journal-1"}`), createdAt))
 
 	cashflow, err := repo.GetMonthlyCashflow(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 4, false)
 	if err != nil {
@@ -815,8 +825,14 @@ func TestGetMonthlyCashflowFinalizedMapsSnapshotRows(t *testing.T) {
 	if cashflow.Rows[0].AccountingTitleCode == nil || *cashflow.Rows[0].AccountingTitleCode != "4603" || cashflow.Rows[0].AccountingTitleName == nil || *cashflow.Rows[0].AccountingTitleName != "租金收入" {
 		t.Fatalf("first row title = %+v/%+v, want 4603 租金收入", cashflow.Rows[0].AccountingTitleCode, cashflow.Rows[0].AccountingTitleName)
 	}
+	if cashflow.Rows[0].SourceDate == nil || !cashflow.Rows[0].SourceDate.Equal(sourceDate) || cashflow.Rows[0].RoomLabel == nil || *cashflow.Rows[0].RoomLabel != "101" || cashflow.Rows[0].TenantLabel == nil || *cashflow.Rows[0].TenantLabel != "王小明" || cashflow.Rows[0].PeriodLabel == nil || *cashflow.Rows[0].PeriodLabel != "2026-04" || cashflow.Rows[0].DisplayNote == nil || *cashflow.Rows[0].DisplayNote != "101 王小明 2026-04 rent" {
+		t.Fatalf("first row display fields = %+v", cashflow.Rows[0])
+	}
 	if cashflow.Rows[1].AccountingTitleCode == nil || *cashflow.Rows[1].AccountingTitleCode != "6681" || cashflow.Rows[1].AccountingTitleName == nil || *cashflow.Rows[1].AccountingTitleName != "其他支出" {
 		t.Fatalf("second row title = %+v/%+v, want 6681 其他支出", cashflow.Rows[1].AccountingTitleCode, cashflow.Rows[1].AccountingTitleName)
+	}
+	if cashflow.Rows[1].DisplayNote == nil || *cashflow.Rows[1].DisplayNote != "水電修繕" {
+		t.Fatalf("second row display note = %+v, want 水電修繕", cashflow.Rows[1].DisplayNote)
 	}
 	if string(cashflow.Rows[1].SourceRef) != `{"journal_log_id":"journal-1"}` {
 		t.Fatalf("source_ref = %s", cashflow.Rows[1].SourceRef)
@@ -832,10 +848,11 @@ func TestGetMonthlyCashflowLiveMapsAccountingRows(t *testing.T) {
 	defer closeBillingDB(t, db)
 
 	createdAt := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	sourceDate := time.Date(2026, 5, 4, 0, 0, 0, 0, time.UTC)
 	mock.ExpectQuery(`(?s)FROM property_accounts pa\s+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL\s+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id\s+AND ae.year = \$2\s+AND ae.month = \$3\s+WHERE pa.property_id = \$1\s+AND pa.deleted_at IS NULL`).
 		WithArgs("property-1", 2026, 5).
 		WillReturnRows(monthlyCashflowRows().
-			AddRow("property-1", "Demo Property", 2026, 5, "entry-1", "electricity_payment", "title-4605", "4605", "房客電費收入", nil, 860, []byte(`{"bill_id":"bill-2"}`), createdAt))
+			AddRow("property-1", "Demo Property", 2026, 5, "entry-1", "electricity_payment", "title-4605", "4605", "房客電費收入", sourceDate, "102", "李小華", "2026-05", "102 李小華 2026-05 electricity", nil, 860, []byte(`{"bill_id":"bill-2"}`), createdAt))
 
 	cashflow, err := repo.GetMonthlyCashflow(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 5, true)
 	if err != nil {
@@ -849,6 +866,9 @@ func TestGetMonthlyCashflowLiveMapsAccountingRows(t *testing.T) {
 	}
 	if cashflow.Rows[0].AccountingTitleCode == nil || *cashflow.Rows[0].AccountingTitleCode != "4605" || cashflow.Rows[0].AccountingTitleName == nil || *cashflow.Rows[0].AccountingTitleName != "房客電費收入" {
 		t.Fatalf("row title = %+v/%+v, want 4605 房客電費收入", cashflow.Rows[0].AccountingTitleCode, cashflow.Rows[0].AccountingTitleName)
+	}
+	if cashflow.Rows[0].SourceDate == nil || !cashflow.Rows[0].SourceDate.Equal(sourceDate) || cashflow.Rows[0].DisplayNote == nil || *cashflow.Rows[0].DisplayNote != "102 李小華 2026-05 electricity" {
+		t.Fatalf("row display fields = %+v", cashflow.Rows[0])
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -1226,6 +1246,11 @@ func TestCreateMonthlySnapshotCopiesTitleLinkageAndEntryCreatedAt(t *testing.T) 
 	accounting_title_id,
 	accounting_title_code,
 	accounting_title_name,
+	source_date,
+	room_label,
+	tenant_label,
+	period_label,
+	display_note,
 	description,
 	amount,
 	source_ref,
@@ -1237,6 +1262,11 @@ SELECT
 	ae.accounting_title_id,
 	ae.accounting_title_code,
 	ae.accounting_title_name,
+	ae.source_date,
+	ae.room_label,
+	ae.tenant_label,
+	ae.period_label,
+	ae.display_note,
 	ae.description,
 	ae.amount,
 	ae.source_ref,
@@ -1382,6 +1412,11 @@ func monthlyCashflowRows() *sqlmock.Rows {
 		"accounting_title_id",
 		"accounting_title_code",
 		"accounting_title_name",
+		"source_date",
+		"room_label",
+		"tenant_label",
+		"period_label",
+		"display_note",
 		"description",
 		"amount",
 		"source_ref",

--- a/internal/platform/database/migrate/migrations/000017_add_accounting_entry_display_fields.down.sql
+++ b/internal/platform/database/migrate/migrations/000017_add_accounting_entry_display_fields.down.sql
@@ -1,0 +1,13 @@
+ALTER TABLE monthly_snapshot_entries
+    DROP COLUMN IF EXISTS display_note,
+    DROP COLUMN IF EXISTS period_label,
+    DROP COLUMN IF EXISTS tenant_label,
+    DROP COLUMN IF EXISTS room_label,
+    DROP COLUMN IF EXISTS source_date;
+
+ALTER TABLE accounting_entries
+    DROP COLUMN IF EXISTS display_note,
+    DROP COLUMN IF EXISTS period_label,
+    DROP COLUMN IF EXISTS tenant_label,
+    DROP COLUMN IF EXISTS room_label,
+    DROP COLUMN IF EXISTS source_date;

--- a/internal/platform/database/migrate/migrations/000017_add_accounting_entry_display_fields.up.sql
+++ b/internal/platform/database/migrate/migrations/000017_add_accounting_entry_display_fields.up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE accounting_entries
+    ADD COLUMN IF NOT EXISTS source_date DATE,
+    ADD COLUMN IF NOT EXISTS room_label TEXT,
+    ADD COLUMN IF NOT EXISTS tenant_label TEXT,
+    ADD COLUMN IF NOT EXISTS period_label TEXT,
+    ADD COLUMN IF NOT EXISTS display_note TEXT;
+
+ALTER TABLE monthly_snapshot_entries
+    ADD COLUMN IF NOT EXISTS source_date DATE,
+    ADD COLUMN IF NOT EXISTS room_label TEXT,
+    ADD COLUMN IF NOT EXISTS tenant_label TEXT,
+    ADD COLUMN IF NOT EXISTS period_label TEXT,
+    ADD COLUMN IF NOT EXISTS display_note TEXT;

--- a/internal/platform/database/migrate/runner_test.go
+++ b/internal/platform/database/migrate/runner_test.go
@@ -32,6 +32,7 @@ var expectedMigrationVersions = []string{
 	"000014",
 	"000015",
 	"000016",
+	"000017",
 }
 
 func TestRunnerUpAppliesMigrationsAndRecordsVersions(t *testing.T) {
@@ -77,8 +78,8 @@ func TestRunnerDownRollsBackAppliedMigrationsInDescendingOrder(t *testing.T) {
 	defer db.Close()
 
 	migrations := migrationsByVersion(t, "down")
-	appliedVersions := []string{"000012", "000013", "000014", "000015", "000016"}
-	expectedRollbackOrder := []string{"000016", "000015", "000014", "000013", "000012"}
+	appliedVersions := []string{"000012", "000013", "000014", "000015", "000016", "000017"}
+	expectedRollbackOrder := []string{"000017", "000016", "000015", "000014", "000013", "000012"}
 
 	expectSchemaMigrationsQuery(mock, appliedVersions)
 	for _, version := range expectedRollbackOrder {
@@ -143,6 +144,41 @@ func TestAccountingTitleMigrationSeedsRuntimeTitlesAndBackfillsCategories(t *tes
 	for _, snippet := range requiredSnippets {
 		if !strings.Contains(sql, snippet) {
 			t.Fatalf("000016 migration missing %q", snippet)
+		}
+	}
+}
+
+func TestAccountingEntryDisplayFieldsMigrationAddsNullableFields(t *testing.T) {
+	migrations := migrationsByVersion(t, "up")
+	sql := migrations["000017"].SQL
+
+	requiredSnippets := []string{
+		"ALTER TABLE accounting_entries",
+		"ADD COLUMN IF NOT EXISTS source_date DATE",
+		"ADD COLUMN IF NOT EXISTS room_label TEXT",
+		"ADD COLUMN IF NOT EXISTS tenant_label TEXT",
+		"ADD COLUMN IF NOT EXISTS period_label TEXT",
+		"ADD COLUMN IF NOT EXISTS display_note TEXT",
+		"ALTER TABLE monthly_snapshot_entries",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(sql, snippet) {
+			t.Fatalf("000017 migration missing %q", snippet)
+		}
+	}
+
+	downSQL := migrationsByVersion(t, "down")["000017"].SQL
+	for _, snippet := range []string{
+		"ALTER TABLE monthly_snapshot_entries",
+		"DROP COLUMN IF EXISTS display_note",
+		"DROP COLUMN IF EXISTS period_label",
+		"DROP COLUMN IF EXISTS tenant_label",
+		"DROP COLUMN IF EXISTS room_label",
+		"DROP COLUMN IF EXISTS source_date",
+		"ALTER TABLE accounting_entries",
+	} {
+		if !strings.Contains(downSQL, snippet) {
+			t.Fatalf("000017 down migration missing %q", snippet)
 		}
 	}
 }

--- a/internal/platform/database/migrate/runner_test.go
+++ b/internal/platform/database/migrate/runner_test.go
@@ -168,15 +168,20 @@ func TestAccountingEntryDisplayFieldsMigrationAddsNullableFields(t *testing.T) {
 	}
 
 	downSQL := migrationsByVersion(t, "down")["000017"].SQL
-	for _, snippet := range []string{
+	requiredDownSnippets := []string{
 		"ALTER TABLE monthly_snapshot_entries",
 		"DROP COLUMN IF EXISTS display_note",
 		"DROP COLUMN IF EXISTS period_label",
 		"DROP COLUMN IF EXISTS tenant_label",
 		"DROP COLUMN IF EXISTS room_label",
 		"DROP COLUMN IF EXISTS source_date",
-		"ALTER TABLE accounting_entries",
-	} {
+		"ALTER TABLE accounting_entries\n    DROP COLUMN IF EXISTS display_note",
+		"ALTER TABLE accounting_entries\n    DROP COLUMN IF EXISTS display_note,\n    DROP COLUMN IF EXISTS period_label",
+		"ALTER TABLE accounting_entries\n    DROP COLUMN IF EXISTS display_note,\n    DROP COLUMN IF EXISTS period_label,\n    DROP COLUMN IF EXISTS tenant_label",
+		"ALTER TABLE accounting_entries\n    DROP COLUMN IF EXISTS display_note,\n    DROP COLUMN IF EXISTS period_label,\n    DROP COLUMN IF EXISTS tenant_label,\n    DROP COLUMN IF EXISTS room_label",
+		"ALTER TABLE accounting_entries\n    DROP COLUMN IF EXISTS display_note,\n    DROP COLUMN IF EXISTS period_label,\n    DROP COLUMN IF EXISTS tenant_label,\n    DROP COLUMN IF EXISTS room_label,\n    DROP COLUMN IF EXISTS source_date",
+	}
+	for _, snippet := range requiredDownSnippets {
 		if !strings.Contains(downSQL, snippet) {
 			t.Fatalf("000017 down migration missing %q", snippet)
 		}

--- a/internal/server/billing_adapters.go
+++ b/internal/server/billing_adapters.go
@@ -618,6 +618,11 @@ func (a billingAccountingRepositoryAdapter) CreateAccountingEntry(ctx context.Co
 		SourceRef:           params.SourceRef,
 		Year:                params.Year,
 		Month:               params.Month,
+		SourceDate:          params.SourceDate,
+		RoomLabel:           params.RoomLabel,
+		TenantLabel:         params.TenantLabel,
+		PeriodLabel:         params.PeriodLabel,
+		DisplayNote:         params.DisplayNote,
 	})
 }
 
@@ -845,6 +850,11 @@ func toAppMonthlyCashflow(cashflow *dbbilling.MonthlyCashflow) *appbilling.Month
 			AccountingTitleID:   cashflow.Rows[i].AccountingTitleID,
 			AccountingTitleCode: cashflow.Rows[i].AccountingTitleCode,
 			AccountingTitleName: cashflow.Rows[i].AccountingTitleName,
+			SourceDate:          cashflow.Rows[i].SourceDate,
+			RoomLabel:           cashflow.Rows[i].RoomLabel,
+			TenantLabel:         cashflow.Rows[i].TenantLabel,
+			PeriodLabel:         cashflow.Rows[i].PeriodLabel,
+			DisplayNote:         cashflow.Rows[i].DisplayNote,
 			Description:         cashflow.Rows[i].Description,
 			Amount:              cashflow.Rows[i].Amount,
 			SourceRef:           cashflow.Rows[i].SourceRef,

--- a/internal/server/journal_adapters.go
+++ b/internal/server/journal_adapters.go
@@ -32,6 +32,8 @@ func (a journalExpenseAccountingAdapter) CreateExpenseAccountingEntry(ctx contex
 		SourceRef:           params.SourceRef,
 		Year:                params.Year,
 		Month:               params.Month,
+		SourceDate:          params.SourceDate,
+		DisplayNote:         params.DisplayNote,
 	})
 }
 
@@ -58,5 +60,7 @@ func (a journalExpenseAccountingAdapter) SyncExpenseAccountingEntry(ctx context.
 		SourceRef:           params.SourceRef,
 		Year:                params.Year,
 		Month:               params.Month,
+		SourceDate:          params.SourceDate,
+		DisplayNote:         params.DisplayNote,
 	})
 }

--- a/internal/server/lease_adapters.go
+++ b/internal/server/lease_adapters.go
@@ -38,6 +38,9 @@ func (a leaseDepositAccountingAdapter) CreateDepositAccountingEntry(ctx context.
 		SourceRef:           params.SourceRef,
 		Year:                params.Year,
 		Month:               params.Month,
+		SourceDate:          params.SourceDate,
+		TenantLabel:         params.TenantLabel,
+		DisplayNote:         params.DisplayNote,
 	})
 }
 


### PR DESCRIPTION
Closes #123
Refs #126

## Summary

- add nullable display fields to live accounting entries and monthly snapshot entries
- copy display fields into finalized monthly snapshot entries during month close
- preserve source date, period label, and display note on billing, journal expense, and deposit accounting write paths
- update monthly cashflow read/render fallback behavior to prefer preserved source date and display note while keeping #126 accounting title subject behavior unchanged

## Validation

- `git diff --check`
- `GOCACHE=/tmp/go-cache go test -count=1 ./internal/application/billing ./internal/application/journal ./internal/application/lease`
- `GOCACHE=/tmp/go-cache go test -count=1 ./internal/platform/database/billing`
- `GOCACHE=/tmp/go-cache go test -count=1 ./internal/platform/database/migrate`
- `GOCACHE=/tmp/go-cache go test -count=1 ./internal/server`
- `GOCACHE=/tmp/go-cache go test -count=1 ./...`