### PR TITLE
[Dashboard] Add backend-owned occupancy read models

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -686,6 +686,84 @@ paths:
                   value:
                     error_code: USER_NOT_FOUND
                     message: User not found.
+  /dashboard:
+    get:
+      operationId: getDashboard
+      summary: Home dashboard summary read model
+      description: |
+        Backend-owned cross-property dashboard read model for frontend home cards and lists.
+        The response is scoped by role and property authorization so frontend does not aggregate
+        rooms, bills, or journals across child endpoints.
+      tags:
+        - Property
+      x-required-role:
+        - admin
+        - organizer
+        - staff
+        - owner
+      x-ownership-required: true
+      responses:
+        '200':
+          description: Home dashboard summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HomeDashboardResponse'
+              examples:
+                success:
+                  value:
+                    portfolio_summary:
+                      total_rooms: 10
+                      occupied_rooms: 7
+                      vacant_rooms: 2
+                      maintenance_rooms: 1
+                      occupancy_rate: 0.7
+                    monthly_billing_summary:
+                      expected_rent: 120000
+                      collected_rent: 90000
+                      overdue_bill_count: 3
+                    property_summaries:
+                      - property_id: 10000000-0000-0000-0000-000000000001
+                        property_name: 台北大安物業
+                        occupancy_summary:
+                          total_rooms: 10
+                          occupied_rooms: 7
+                          vacant_rooms: 2
+                          maintenance_rooms: 1
+                          occupancy_rate: 0.7
+                        monthly_billing_summary:
+                          expected_rent: 120000
+                          collected_rent: 90000
+                          overdue_bill_count: 3
+                    recent_journals:
+                      - id: 60000000-0000-0000-0000-000000000001
+                        property_id: 10000000-0000-0000-0000-000000000001
+                        property_name: 台北大安物業
+                        type: journal_log
+                        content: 更換大廳燈泡
+                        created_at: '2026-04-10T09:00:00Z'
+        '401':
+          description: 未認證
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error_code: UNAUTHORIZED
+                    message: Unauthorized.
+        '403':
+          description: 權限不足
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                forbidden:
+                  value:
+                    error_code: FORBIDDEN
+                    message: Forbidden.
   /properties:
     get:
       operationId: listProperties
@@ -719,6 +797,12 @@ paths:
                         address: 台北市大安區復興南路一段100號
                         electricity_unit_price: 4.5
                         default_electricity_billing_cadence: monthly
+                        occupancy_summary:
+                          total_rooms: 10
+                          occupied_rooms: 7
+                          vacant_rooms: 2
+                          maintenance_rooms: 1
+                          occupancy_rate: 0.7
         '401':
           description: 未認證
           content:
@@ -1775,6 +1859,12 @@ paths:
                       expected_rent: 50000
                       collected_rent: 40000
                       overdue_bill_count: 2
+                    occupancy_summary:
+                      total_rooms: 2
+                      occupied_rooms: 1
+                      vacant_rooms: 1
+                      maintenance_rooms: 0
+                      occupancy_rate: 0.5
                     recent_journals:
                       - id: 60000000-0000-0000-0000-000000000001
                         type: journal_log
@@ -6751,6 +6841,76 @@ components:
           items:
             type: string
             format: uuid
+    OccupancySummary:
+      type: object
+      properties:
+        total_rooms:
+          type: integer
+        occupied_rooms:
+          type: integer
+        vacant_rooms:
+          type: integer
+        maintenance_rooms:
+          type: integer
+        occupancy_rate:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 1
+    HomeDashboardBillingSummary:
+      type: object
+      properties:
+        expected_rent:
+          type: integer
+        collected_rent:
+          type: integer
+        overdue_bill_count:
+          type: integer
+    HomeDashboardPropertySummary:
+      type: object
+      properties:
+        property_id:
+          type: string
+          format: uuid
+        property_name:
+          type: string
+        occupancy_summary:
+          $ref: '#/components/schemas/OccupancySummary'
+        monthly_billing_summary:
+          $ref: '#/components/schemas/HomeDashboardBillingSummary'
+    HomeDashboardRecentJournalItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        property_id:
+          type: string
+          format: uuid
+        property_name:
+          type: string
+        type:
+          type: string
+        content:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+    HomeDashboardResponse:
+      type: object
+      properties:
+        portfolio_summary:
+          $ref: '#/components/schemas/OccupancySummary'
+        monthly_billing_summary:
+          $ref: '#/components/schemas/HomeDashboardBillingSummary'
+        property_summaries:
+          type: array
+          items:
+            $ref: '#/components/schemas/HomeDashboardPropertySummary'
+        recent_journals:
+          type: array
+          items:
+            $ref: '#/components/schemas/HomeDashboardRecentJournalItem'
     PropertyResponse:
       type: object
       properties:
@@ -6793,6 +6953,8 @@ components:
           type: array
           items: {}
           nullable: true
+        occupancy_summary:
+          $ref: '#/components/schemas/OccupancySummary'
         created_at:
           type: string
           format: date-time
@@ -7082,6 +7244,8 @@ components:
             $ref: '#/components/schemas/DashboardRoomItem'
         monthly_summary:
           $ref: '#/components/schemas/DashboardMonthlySummary'
+        occupancy_summary:
+          $ref: '#/components/schemas/OccupancySummary'
         recent_journals:
           type: array
           items:

--- a/docs/spec/src/components/schemas/property/DashboardResponse.yaml
+++ b/docs/spec/src/components/schemas/property/DashboardResponse.yaml
@@ -9,6 +9,8 @@ properties:
       $ref: ./DashboardRoomItem.yaml
   monthly_summary:
     $ref: ./DashboardMonthlySummary.yaml
+  occupancy_summary:
+    $ref: ./OccupancySummary.yaml
   recent_journals:
     type: array
     items:

--- a/docs/spec/src/components/schemas/property/HomeDashboardBillingSummary.yaml
+++ b/docs/spec/src/components/schemas/property/HomeDashboardBillingSummary.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  expected_rent:
+    type: integer
+  collected_rent:
+    type: integer
+  overdue_bill_count:
+    type: integer

--- a/docs/spec/src/components/schemas/property/HomeDashboardPropertySummary.yaml
+++ b/docs/spec/src/components/schemas/property/HomeDashboardPropertySummary.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  property_id:
+    type: string
+    format: uuid
+  property_name:
+    type: string
+  occupancy_summary:
+    $ref: ./OccupancySummary.yaml
+  monthly_billing_summary:
+    $ref: ./HomeDashboardBillingSummary.yaml

--- a/docs/spec/src/components/schemas/property/HomeDashboardRecentJournalItem.yaml
+++ b/docs/spec/src/components/schemas/property/HomeDashboardRecentJournalItem.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+  property_id:
+    type: string
+    format: uuid
+  property_name:
+    type: string
+  type:
+    type: string
+  content:
+    type: string
+  created_at:
+    type: string
+    format: date-time

--- a/docs/spec/src/components/schemas/property/HomeDashboardResponse.yaml
+++ b/docs/spec/src/components/schemas/property/HomeDashboardResponse.yaml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  portfolio_summary:
+    $ref: ./OccupancySummary.yaml
+  monthly_billing_summary:
+    $ref: ./HomeDashboardBillingSummary.yaml
+  property_summaries:
+    type: array
+    items:
+      $ref: ./HomeDashboardPropertySummary.yaml
+  recent_journals:
+    type: array
+    items:
+      $ref: ./HomeDashboardRecentJournalItem.yaml

--- a/docs/spec/src/components/schemas/property/OccupancySummary.yaml
+++ b/docs/spec/src/components/schemas/property/OccupancySummary.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  total_rooms:
+    type: integer
+  occupied_rooms:
+    type: integer
+  vacant_rooms:
+    type: integer
+  maintenance_rooms:
+    type: integer
+  occupancy_rate:
+    type: number
+    format: double
+    minimum: 0
+    maximum: 1

--- a/docs/spec/src/components/schemas/property/PropertyResponse.yaml
+++ b/docs/spec/src/components/schemas/property/PropertyResponse.yaml
@@ -39,6 +39,8 @@ properties:
     type: array
     items: {}
     nullable: true
+  occupancy_summary:
+    $ref: ./OccupancySummary.yaml
   created_at:
     type: string
     format: date-time

--- a/docs/spec/src/openapi.yaml
+++ b/docs/spec/src/openapi.yaml
@@ -87,6 +87,8 @@ paths:
     $ref: paths/iam/users_{id}_property-assignments.yaml
   /users/{id}/password-reset:
     $ref: paths/iam/users_{id}_password-reset.yaml
+  /dashboard:
+    $ref: paths/property/dashboard.yaml
   /properties:
     $ref: paths/property/properties.yaml
   /properties/{id}:

--- a/docs/spec/src/paths/property/dashboard.yaml
+++ b/docs/spec/src/paths/property/dashboard.yaml
@@ -1,0 +1,77 @@
+get:
+  operationId: getDashboard
+  summary: Home dashboard summary read model
+  description: |
+    Backend-owned cross-property dashboard read model for frontend home cards and lists.
+    The response is scoped by role and property authorization so frontend does not aggregate
+    rooms, bills, or journals across child endpoints.
+  tags:
+    - Property
+  x-required-role:
+    - admin
+    - organizer
+    - staff
+    - owner
+  x-ownership-required: true
+  responses:
+    '200':
+      description: Home dashboard summary
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/property/HomeDashboardResponse.yaml
+          examples:
+            success:
+              value:
+                portfolio_summary:
+                  total_rooms: 10
+                  occupied_rooms: 7
+                  vacant_rooms: 2
+                  maintenance_rooms: 1
+                  occupancy_rate: 0.7
+                monthly_billing_summary:
+                  expected_rent: 120000
+                  collected_rent: 90000
+                  overdue_bill_count: 3
+                property_summaries:
+                  - property_id: 10000000-0000-0000-0000-000000000001
+                    property_name: 台北大安物業
+                    occupancy_summary:
+                      total_rooms: 10
+                      occupied_rooms: 7
+                      vacant_rooms: 2
+                      maintenance_rooms: 1
+                      occupancy_rate: 0.7
+                    monthly_billing_summary:
+                      expected_rent: 120000
+                      collected_rent: 90000
+                      overdue_bill_count: 3
+                recent_journals:
+                  - id: 60000000-0000-0000-0000-000000000001
+                    property_id: 10000000-0000-0000-0000-000000000001
+                    property_name: 台北大安物業
+                    type: journal_log
+                    content: 更換大廳燈泡
+                    created_at: '2026-04-10T09:00:00Z'
+    '401':
+      description: 未認證
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+          examples:
+            unauthorized:
+              value:
+                error_code: UNAUTHORIZED
+                message: Unauthorized.
+    '403':
+      description: 權限不足
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+          examples:
+            forbidden:
+              value:
+                error_code: FORBIDDEN
+                message: Forbidden.

--- a/docs/spec/src/paths/property/properties.yaml
+++ b/docs/spec/src/paths/property/properties.yaml
@@ -30,6 +30,12 @@ get:
                     address: 台北市大安區復興南路一段100號
                     electricity_unit_price: 4.5
                     default_electricity_billing_cadence: monthly
+                    occupancy_summary:
+                      total_rooms: 10
+                      occupied_rooms: 7
+                      vacant_rooms: 2
+                      maintenance_rooms: 1
+                      occupancy_rate: 0.7
     '401':
       description: 未認證
       content:

--- a/docs/spec/src/paths/property/properties_{id}_dashboard.yaml
+++ b/docs/spec/src/paths/property/properties_{id}_dashboard.yaml
@@ -40,6 +40,12 @@ get:
                   expected_rent: 50000
                   collected_rent: 40000
                   overdue_bill_count: 2
+                occupancy_summary:
+                  total_rooms: 2
+                  occupied_rooms: 1
+                  vacant_rooms: 1
+                  maintenance_rooms: 0
+                  occupancy_rate: 0.5
                 recent_journals:
                   - id: 60000000-0000-0000-0000-000000000001
                     type: journal_log

--- a/internal/application/property/dashboard.go
+++ b/internal/application/property/dashboard.go
@@ -16,6 +16,13 @@ type DashboardInput struct {
 	PropertyID string
 }
 
+// HomeDashboardInput is the query payload for retrieving the home dashboard.
+type HomeDashboardInput struct {
+	ActorRole           string
+	ActorUserID         string
+	AssignedPropertyIDs []string
+}
+
 // DashboardService retrieves the property dashboard read model.
 type DashboardService struct {
 	repo DashboardRepository
@@ -60,6 +67,30 @@ func (s *DashboardService) Execute(ctx context.Context, input DashboardInput) (*
 		default:
 			return nil, apperr.ErrInternalServerError.WithCause(err)
 		}
+	}
+
+	return dashboard, nil
+}
+
+// ExecuteHome validates scope and returns the role-scoped home dashboard.
+func (s *DashboardService) ExecuteHome(ctx context.Context, input HomeDashboardInput) (*HomeDashboard, error) {
+	role := strings.TrimSpace(input.ActorRole)
+	userID := strings.TrimSpace(input.ActorUserID)
+	if role == "" {
+		return nil, apperr.ErrUnauthorized
+	}
+	if role == "owner" && userID == "" {
+		return nil, apperr.ErrUnauthorized
+	}
+
+	current := s.now().In(taiwanDashboardLocation)
+	dashboard, err := s.repo.GetHomeDashboard(ctx, DashboardScope{
+		Role:                role,
+		UserID:              userID,
+		AssignedPropertyIDs: input.AssignedPropertyIDs,
+	}, current.Year(), int(current.Month()))
+	if err != nil {
+		return nil, apperr.ErrInternalServerError.WithCause(err)
 	}
 
 	return dashboard, nil

--- a/internal/application/property/dashboard_test.go
+++ b/internal/application/property/dashboard_test.go
@@ -75,11 +75,52 @@ func TestDashboardServiceRejectsInvalidPropertyID(t *testing.T) {
 	}
 }
 
+func TestDashboardServiceExecuteHomePreservesScopeAndTaiwanMonth(t *testing.T) {
+	repo := &dashboardRepositoryStub{
+		home: &HomeDashboard{
+			PortfolioSummary: OccupancySummary{TotalRooms: 2},
+		},
+	}
+	service := NewDashboardService(repo)
+	service.now = func() time.Time {
+		return time.Date(2026, 3, 31, 16, 30, 0, 0, time.UTC)
+	}
+
+	dashboard, err := service.ExecuteHome(context.Background(), HomeDashboardInput{
+		ActorRole:           "staff",
+		ActorUserID:         "90000000-0000-0000-0000-000000000001",
+		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000001"},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteHome: %v", err)
+	}
+	if dashboard.PortfolioSummary.TotalRooms != 2 {
+		t.Fatalf("unexpected dashboard: %+v", dashboard)
+	}
+	if repo.scope.Role != "staff" || repo.scope.UserID != "90000000-0000-0000-0000-000000000001" || len(repo.scope.AssignedPropertyIDs) != 1 {
+		t.Fatalf("unexpected scope: %+v", repo.scope)
+	}
+	if repo.year != 2026 || repo.month != 4 {
+		t.Fatalf("unexpected repository period: year=%d month=%d", repo.year, repo.month)
+	}
+}
+
+func TestDashboardServiceExecuteHomeRequiresRole(t *testing.T) {
+	service := NewDashboardService(&dashboardRepositoryStub{})
+
+	_, err := service.ExecuteHome(context.Background(), HomeDashboardInput{})
+	if !errors.Is(err, apperr.ErrUnauthorized) {
+		t.Fatalf("expected unauthorized, got %v", err)
+	}
+}
+
 type dashboardRepositoryStub struct {
 	propertyID string
 	year       int
 	month      int
+	scope      DashboardScope
 	dashboard  *Dashboard
+	home       *HomeDashboard
 	err        error
 }
 
@@ -92,4 +133,15 @@ func (r *dashboardRepositoryStub) GetDashboard(_ context.Context, propertyID str
 	}
 
 	return r.dashboard, nil
+}
+
+func (r *dashboardRepositoryStub) GetHomeDashboard(_ context.Context, scope DashboardScope, year int, month int) (*HomeDashboard, error) {
+	r.scope = scope
+	r.year = year
+	r.month = month
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return r.home, nil
 }

--- a/internal/application/property/repository.go
+++ b/internal/application/property/repository.go
@@ -55,7 +55,43 @@ type Dashboard struct {
 	PropertyID     string
 	Rooms          []DashboardRoom
 	MonthlySummary DashboardMonthlySummary
+	Occupancy      OccupancySummary
 	RecentJournals []DashboardRecentJournal
+}
+
+// HomeDashboard contains the role-scoped dashboard read model for the home page.
+type HomeDashboard struct {
+	PortfolioSummary      OccupancySummary
+	MonthlyBillingSummary DashboardMonthlySummary
+	PropertySummaries     []HomeDashboardPropertySummary
+	RecentJournals        []HomeDashboardRecentJournal
+}
+
+// HomeDashboardPropertySummary contains one property's home dashboard row.
+type HomeDashboardPropertySummary struct {
+	PropertyID     string
+	PropertyName   string
+	Occupancy      OccupancySummary
+	MonthlySummary DashboardMonthlySummary
+}
+
+// HomeDashboardRecentJournal contains one recent activity item for the home dashboard.
+type HomeDashboardRecentJournal struct {
+	ID           string
+	PropertyID   string
+	PropertyName string
+	Type         string
+	Content      string
+	CreatedAt    time.Time
+}
+
+// OccupancySummary contains room status totals and occupied ratio.
+type OccupancySummary struct {
+	TotalRooms       int
+	OccupiedRooms    int
+	VacantRooms      int
+	MaintenanceRooms int
+	OccupancyRate    float64
 }
 
 // DashboardRoom contains one room row in the dashboard.
@@ -153,4 +189,12 @@ type PropertyAccountRepository interface {
 // DashboardRepository defines the read model needed by the property dashboard.
 type DashboardRepository interface {
 	GetDashboard(ctx context.Context, propertyID string, year int, month int) (*Dashboard, error)
+	GetHomeDashboard(ctx context.Context, scope DashboardScope, year int, month int) (*HomeDashboard, error)
+}
+
+// DashboardScope defines role and property visibility for dashboard reads.
+type DashboardScope struct {
+	Role                string
+	UserID              string
+	AssignedPropertyIDs []string
 }

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -707,10 +707,11 @@ type DashboardRecentJournalItem struct {
 
 // DashboardResponse defines model for DashboardResponse.
 type DashboardResponse struct {
-	MonthlySummary *DashboardMonthlySummary      `json:"monthly_summary,omitempty"`
-	PropertyId     *openapi_types.UUID           `json:"property_id,omitempty"`
-	RecentJournals *[]DashboardRecentJournalItem `json:"recent_journals,omitempty"`
-	Rooms          *[]DashboardRoomItem          `json:"rooms,omitempty"`
+	MonthlySummary   *DashboardMonthlySummary      `json:"monthly_summary,omitempty"`
+	OccupancySummary *OccupancySummary             `json:"occupancy_summary,omitempty"`
+	PropertyId       *openapi_types.UUID           `json:"property_id,omitempty"`
+	RecentJournals   *[]DashboardRecentJournalItem `json:"recent_journals,omitempty"`
+	Rooms            *[]DashboardRoomItem          `json:"rooms,omitempty"`
 }
 
 // DashboardRoomItem defines model for DashboardRoomItem.
@@ -802,6 +803,39 @@ type ForceTerminationResponseDepositHandling string
 
 // ForceTerminationResponseStatus defines model for ForceTerminationResponse.Status.
 type ForceTerminationResponseStatus string
+
+// HomeDashboardBillingSummary defines model for HomeDashboardBillingSummary.
+type HomeDashboardBillingSummary struct {
+	CollectedRent    *int `json:"collected_rent,omitempty"`
+	ExpectedRent     *int `json:"expected_rent,omitempty"`
+	OverdueBillCount *int `json:"overdue_bill_count,omitempty"`
+}
+
+// HomeDashboardPropertySummary defines model for HomeDashboardPropertySummary.
+type HomeDashboardPropertySummary struct {
+	MonthlyBillingSummary *HomeDashboardBillingSummary `json:"monthly_billing_summary,omitempty"`
+	OccupancySummary      *OccupancySummary            `json:"occupancy_summary,omitempty"`
+	PropertyId            *openapi_types.UUID          `json:"property_id,omitempty"`
+	PropertyName          *string                      `json:"property_name,omitempty"`
+}
+
+// HomeDashboardRecentJournalItem defines model for HomeDashboardRecentJournalItem.
+type HomeDashboardRecentJournalItem struct {
+	Content      *string             `json:"content,omitempty"`
+	CreatedAt    *time.Time          `json:"created_at,omitempty"`
+	Id           *openapi_types.UUID `json:"id,omitempty"`
+	PropertyId   *openapi_types.UUID `json:"property_id,omitempty"`
+	PropertyName *string             `json:"property_name,omitempty"`
+	Type         *string             `json:"type,omitempty"`
+}
+
+// HomeDashboardResponse defines model for HomeDashboardResponse.
+type HomeDashboardResponse struct {
+	MonthlyBillingSummary *HomeDashboardBillingSummary      `json:"monthly_billing_summary,omitempty"`
+	PortfolioSummary      *OccupancySummary                 `json:"portfolio_summary,omitempty"`
+	PropertySummaries     *[]HomeDashboardPropertySummary   `json:"property_summaries,omitempty"`
+	RecentJournals        *[]HomeDashboardRecentJournalItem `json:"recent_journals,omitempty"`
+}
 
 // JournalLogListResponse defines model for JournalLogListResponse.
 type JournalLogListResponse struct {
@@ -905,6 +939,15 @@ type LeaseResponseRentBillingCadence string
 // LeaseResponseStatus defines model for LeaseResponse.Status.
 type LeaseResponseStatus string
 
+// OccupancySummary defines model for OccupancySummary.
+type OccupancySummary struct {
+	MaintenanceRooms *int     `json:"maintenance_rooms,omitempty"`
+	OccupancyRate    *float64 `json:"occupancy_rate,omitempty"`
+	OccupiedRooms    *int     `json:"occupied_rooms,omitempty"`
+	TotalRooms       *int     `json:"total_rooms,omitempty"`
+	VacantRooms      *int     `json:"vacant_rooms,omitempty"`
+}
+
 // PropertyAssignmentRequest defines model for PropertyAssignmentRequest.
 type PropertyAssignmentRequest struct {
 	PropertyIds []openapi_types.UUID `json:"property_ids"`
@@ -929,6 +972,7 @@ type PropertyResponse struct {
 	Id                   *openapi_types.UUID `json:"id,omitempty"`
 	Name                 *string             `json:"name,omitempty"`
 	Notes                *string             `json:"notes"`
+	OccupancySummary     *OccupancySummary   `json:"occupancy_summary,omitempty"`
 	OwnerId              *openapi_types.UUID `json:"owner_id,omitempty"`
 	Subtitle             *string             `json:"subtitle"`
 	UpdatedAt            *time.Time          `json:"updated_at,omitempty"`
@@ -1533,6 +1577,9 @@ type ServerInterface interface {
 	// Export bill receipt as HTML
 	// (GET /bills/{id}/receipt)
 	ExportBillReceipt(c *gin.Context, id string, params ExportBillReceiptParams)
+	// Home dashboard summary read model
+	// (GET /dashboard)
+	GetDashboard(c *gin.Context)
 	// 查詢強制終止進度
 	// (GET /force-terminations/{id})
 	GetForceTermination(c *gin.Context, id openapi_types.UUID)
@@ -2078,6 +2125,21 @@ func (siw *ServerInterfaceWrapper) ExportBillReceipt(c *gin.Context) {
 	}
 
 	siw.Handler.ExportBillReceipt(c, id, params)
+}
+
+// GetDashboard operation middleware
+func (siw *ServerInterfaceWrapper) GetDashboard(c *gin.Context) {
+
+	c.Set(BearerAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetDashboard(c)
 }
 
 // GetForceTermination operation middleware
@@ -4536,6 +4598,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/bills/:id/meter", wrapper.SubmitBillMeter)
 	router.POST(options.BaseURL+"/bills/:id/payment", wrapper.RecordBillPayment)
 	router.GET(options.BaseURL+"/bills/:id/receipt", wrapper.ExportBillReceipt)
+	router.GET(options.BaseURL+"/dashboard", wrapper.GetDashboard)
 	router.GET(options.BaseURL+"/force-terminations/:id", wrapper.GetForceTermination)
 	router.POST(options.BaseURL+"/internal/jobs/force-terminations/compensate", wrapper.RunForceTerminationCompensationJob)
 	router.POST(options.BaseURL+"/internal/jobs/leases/expire", wrapper.RunLeaseExpiryJob)

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -1365,6 +1365,27 @@ func (s *APIServer) ListProperties(c *gin.Context) {
 	c.JSON(http.StatusOK, api.PropertyListResponse{Data: &items})
 }
 
+// GetDashboard handles home dashboard retrieval.
+func (s *APIServer) GetDashboard(c *gin.Context) {
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+
+	dashboard, err := s.propertyDashboard.ExecuteHome(c.Request.Context(), appproperty.HomeDashboardInput{
+		ActorRole:           principal.Role,
+		ActorUserID:         principal.UserID,
+		AssignedPropertyIDs: principal.AssignedPropertyIDs,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toHomeDashboardResponse(dashboard))
+}
+
 // CreateProperty handles property creation.
 func (s *APIServer) CreateProperty(c *gin.Context) {
 	var request api.CreatePropertyRequest
@@ -2923,14 +2944,106 @@ func toDashboardResponse(dashboard *appproperty.Dashboard) api.DashboardResponse
 			CollectedRent:    &collectedRent,
 			OverdueBillCount: &overdueBillCount,
 		},
-		RecentJournals: &recentJournals,
-		Rooms:          &rooms,
+		OccupancySummary: toOccupancySummaryResponse(dashboard.Occupancy),
+		RecentJournals:   &recentJournals,
+		Rooms:            &rooms,
 	}
 	if propertyOK {
 		response.PropertyId = &propertyID
 	}
 
 	return response
+}
+
+func toHomeDashboardResponse(dashboard *appproperty.HomeDashboard) api.HomeDashboardResponse {
+	propertySummaries := make([]api.HomeDashboardPropertySummary, 0, len(dashboard.PropertySummaries))
+	for i := range dashboard.PropertySummaries {
+		propertySummaries = append(propertySummaries, toHomeDashboardPropertySummary(dashboard.PropertySummaries[i]))
+	}
+	recentJournals := make([]api.HomeDashboardRecentJournalItem, 0, len(dashboard.RecentJournals))
+	for i := range dashboard.RecentJournals {
+		recentJournals = append(recentJournals, toHomeDashboardRecentJournalItem(dashboard.RecentJournals[i]))
+	}
+
+	return api.HomeDashboardResponse{
+		PortfolioSummary:      toOccupancySummaryResponse(dashboard.PortfolioSummary),
+		MonthlyBillingSummary: toHomeDashboardBillingSummary(dashboard.MonthlyBillingSummary),
+		PropertySummaries:     &propertySummaries,
+		RecentJournals:        &recentJournals,
+	}
+}
+
+func toHomeDashboardPropertySummary(summary appproperty.HomeDashboardPropertySummary) api.HomeDashboardPropertySummary {
+	propertyID, propertyOK := parseUUID(summary.PropertyID)
+	propertyName := summary.PropertyName
+	response := api.HomeDashboardPropertySummary{
+		MonthlyBillingSummary: toHomeDashboardBillingSummary(summary.MonthlySummary),
+		OccupancySummary:      toOccupancySummaryResponse(summary.Occupancy),
+		PropertyName:          &propertyName,
+	}
+	if propertyOK {
+		response.PropertyId = &propertyID
+	}
+	return response
+}
+
+func toHomeDashboardBillingSummary(summary appproperty.DashboardMonthlySummary) *api.HomeDashboardBillingSummary {
+	expectedRent := summary.ExpectedRent
+	collectedRent := summary.CollectedRent
+	overdueBillCount := summary.OverdueBillCount
+	return &api.HomeDashboardBillingSummary{
+		ExpectedRent:     &expectedRent,
+		CollectedRent:    &collectedRent,
+		OverdueBillCount: &overdueBillCount,
+	}
+}
+
+func toHomeDashboardRecentJournalItem(journal appproperty.HomeDashboardRecentJournal) api.HomeDashboardRecentJournalItem {
+	id, idOK := parseUUID(journal.ID)
+	propertyID, propertyOK := parseUUID(journal.PropertyID)
+	propertyName := journal.PropertyName
+	content := journal.Content
+	createdAt := journal.CreatedAt
+	itemType := journal.Type
+
+	response := api.HomeDashboardRecentJournalItem{
+		Content:      &content,
+		CreatedAt:    &createdAt,
+		PropertyName: &propertyName,
+		Type:         &itemType,
+	}
+	if idOK {
+		response.Id = &id
+	}
+	if propertyOK {
+		response.PropertyId = &propertyID
+	}
+	return response
+}
+
+func toOccupancySummaryResponse(summary appproperty.OccupancySummary) *api.OccupancySummary {
+	totalRooms := summary.TotalRooms
+	occupiedRooms := summary.OccupiedRooms
+	vacantRooms := summary.VacantRooms
+	maintenanceRooms := summary.MaintenanceRooms
+	occupancyRate := summary.OccupancyRate
+	return &api.OccupancySummary{
+		TotalRooms:       &totalRooms,
+		OccupiedRooms:    &occupiedRooms,
+		VacantRooms:      &vacantRooms,
+		MaintenanceRooms: &maintenanceRooms,
+		OccupancyRate:    &occupancyRate,
+	}
+}
+
+func toDBPropertyOccupancySummaryResponse(summary dbpropertyquery.OccupancySummary) *api.OccupancySummary {
+	return toOccupancySummaryResponse(appproperty.OccupancySummary{
+		TotalRooms:       summary.TotalRooms,
+		OccupiedRooms:    summary.OccupiedRooms,
+		VacantRooms:      summary.VacantRooms,
+		MaintenanceRooms: summary.MaintenanceRooms,
+		OccupancyRate:    summary.OccupancyRate,
+	})
 }
 
 func toDashboardRoomItem(room appproperty.DashboardRoom) api.DashboardRoomItem {
@@ -3030,11 +3143,12 @@ func toPropertyResponse(property *dbpropertyquery.Property) api.PropertyResponse
 	version := property.Version
 
 	response := api.PropertyResponse{
-		Address:   &address,
-		CreatedAt: &createdAt,
-		Name:      &name,
-		UpdatedAt: &updatedAt,
-		Version:   &version,
+		Address:          &address,
+		CreatedAt:        &createdAt,
+		Name:             &name,
+		OccupancySummary: toDBPropertyOccupancySummaryResponse(property.Occupancy),
+		UpdatedAt:        &updatedAt,
+		Version:          &version,
 	}
 	if property.DefaultElectricityBillingCadence != "" {
 		cadence := api.PropertyResponseDefaultElectricityBillingCadence(property.DefaultElectricityBillingCadence)

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -109,6 +109,13 @@ func TestGetPropertyDashboardReturnsDashboardResponse(t *testing.T) {
 				CollectedRent:    40000,
 				OverdueBillCount: 2,
 			},
+			Occupancy: appproperty.OccupancySummary{
+				TotalRooms:       2,
+				OccupiedRooms:    1,
+				VacantRooms:      1,
+				MaintenanceRooms: 0,
+				OccupancyRate:    0.5,
+			},
 			RecentJournals: []appproperty.DashboardRecentJournal{
 				{ID: "60000000-0000-0000-0000-000000000001", Type: "journal_log", Content: "Changed lobby light", CreatedAt: createdAt},
 			},
@@ -138,10 +145,90 @@ func TestGetPropertyDashboardReturnsDashboardResponse(t *testing.T) {
 	if response.MonthlySummary == nil || response.MonthlySummary.ExpectedRent == nil || *response.MonthlySummary.ExpectedRent != 50000 {
 		t.Fatalf("unexpected monthly summary: %+v", response.MonthlySummary)
 	}
+	if response.OccupancySummary == nil || response.OccupancySummary.OccupancyRate == nil || *response.OccupancySummary.OccupancyRate != 0.5 {
+		t.Fatalf("unexpected occupancy summary: %+v", response.OccupancySummary)
+	}
 	if response.Rooms == nil || len(*response.Rooms) != 1 || (*response.Rooms)[0].Status == nil || string(*(*response.Rooms)[0].Status) != "occupied" {
 		t.Fatalf("unexpected rooms: %+v", response.Rooms)
 	}
 	if response.RecentJournals == nil || len(*response.RecentJournals) != 1 || (*response.RecentJournals)[0].Type == nil || *(*response.RecentJournals)[0].Type != "journal_log" {
+		t.Fatalf("unexpected recent journals: %+v", response.RecentJournals)
+	}
+}
+
+func TestGetDashboardReturnsHomeDashboardResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	propertyID := "10000000-0000-0000-0000-000000000001"
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	repo := &recordingDashboardRepository{
+		home: &appproperty.HomeDashboard{
+			PortfolioSummary: appproperty.OccupancySummary{
+				TotalRooms:    2,
+				OccupiedRooms: 1,
+				VacantRooms:   1,
+				OccupancyRate: 0.5,
+			},
+			MonthlyBillingSummary: appproperty.DashboardMonthlySummary{
+				ExpectedRent:     50000,
+				CollectedRent:    40000,
+				OverdueBillCount: 2,
+			},
+			PropertySummaries: []appproperty.HomeDashboardPropertySummary{
+				{
+					PropertyID:   propertyID,
+					PropertyName: "Demo Property",
+					Occupancy: appproperty.OccupancySummary{
+						TotalRooms:    2,
+						OccupiedRooms: 1,
+						VacantRooms:   1,
+						OccupancyRate: 0.5,
+					},
+					MonthlySummary: appproperty.DashboardMonthlySummary{
+						ExpectedRent:     50000,
+						CollectedRent:    40000,
+						OverdueBillCount: 2,
+					},
+				},
+			},
+			RecentJournals: []appproperty.HomeDashboardRecentJournal{
+				{ID: "60000000-0000-0000-0000-000000000001", PropertyID: propertyID, PropertyName: "Demo Property", Type: "journal_log", Content: "Changed lobby light", CreatedAt: createdAt},
+			},
+		},
+	}
+	server := &APIServer{propertyDashboard: appproperty.NewDashboardService(repo)}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/dashboard", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		Role:                "staff",
+		UserID:              "90000000-0000-0000-0000-000000000001",
+		AssignedPropertyIDs: []string{propertyID},
+	})
+
+	server.GetDashboard(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if repo.scope.Role != "staff" || len(repo.scope.AssignedPropertyIDs) != 1 || repo.scope.AssignedPropertyIDs[0] != propertyID {
+		t.Fatalf("unexpected dashboard scope: %+v", repo.scope)
+	}
+
+	var response api.HomeDashboardResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.PortfolioSummary == nil || response.PortfolioSummary.TotalRooms == nil || *response.PortfolioSummary.TotalRooms != 2 {
+		t.Fatalf("unexpected portfolio summary: %+v", response.PortfolioSummary)
+	}
+	if response.MonthlyBillingSummary == nil || response.MonthlyBillingSummary.ExpectedRent == nil || *response.MonthlyBillingSummary.ExpectedRent != 50000 {
+		t.Fatalf("unexpected billing summary: %+v", response.MonthlyBillingSummary)
+	}
+	if response.PropertySummaries == nil || len(*response.PropertySummaries) != 1 || (*response.PropertySummaries)[0].PropertyName == nil || *(*response.PropertySummaries)[0].PropertyName != "Demo Property" {
+		t.Fatalf("unexpected property summaries: %+v", response.PropertySummaries)
+	}
+	if response.RecentJournals == nil || len(*response.RecentJournals) != 1 || (*response.RecentJournals)[0].PropertyName == nil || *(*response.RecentJournals)[0].PropertyName != "Demo Property" {
 		t.Fatalf("unexpected recent journals: %+v", response.RecentJournals)
 	}
 }
@@ -1150,7 +1237,9 @@ type recordingDashboardRepository struct {
 	propertyID string
 	year       int
 	month      int
+	scope      appproperty.DashboardScope
 	dashboard  *appproperty.Dashboard
+	home       *appproperty.HomeDashboard
 	err        error
 }
 
@@ -1163,6 +1252,17 @@ func (r *recordingDashboardRepository) GetDashboard(_ context.Context, propertyI
 	}
 
 	return r.dashboard, nil
+}
+
+func (r *recordingDashboardRepository) GetHomeDashboard(_ context.Context, scope appproperty.DashboardScope, year int, month int) (*appproperty.HomeDashboard, error) {
+	r.scope = scope
+	r.year = year
+	r.month = month
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	return r.home, nil
 }
 
 type recordingRepairQueryRepo struct {

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -198,6 +198,7 @@ func routePolicies(authzRepos AuthorizationRepositories) []routePolicy {
 		{method: "POST", path: "/api/v1/leases/:id/checkout-settlement/finalize", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByLeaseID, apperr.ErrLeaseNotFound)},
 		{method: "GET", path: "/api/v1/leases/:id/checkout-settlement/export", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByLeaseID, apperr.ErrLeaseNotFound)},
 
+		{method: "GET", path: "/api/v1/dashboard", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}},
 		{method: "GET", path: "/api/v1/properties", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}},
 		{method: "POST", path: "/api/v1/properties", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "GET", path: "/api/v1/properties/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}, propertyResolver: middleware.ParamPropertyID("id")},

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -3362,6 +3362,70 @@ func TestGetPropertyDashboardReturnsAccessibleDashboard(t *testing.T) {
 	}
 }
 
+func TestGetDashboardReturnsScopedHomeDashboard(t *testing.T) {
+	dashboardRepo := &fakeDashboardRepository{
+		homeDashboard: &appproperty.HomeDashboard{
+			PortfolioSummary: appproperty.OccupancySummary{
+				TotalRooms:    2,
+				OccupiedRooms: 1,
+				VacantRooms:   1,
+				OccupancyRate: 0.5,
+			},
+			MonthlyBillingSummary: appproperty.DashboardMonthlySummary{
+				ExpectedRent:     50000,
+				CollectedRent:    40000,
+				OverdueBillCount: 2,
+			},
+			PropertySummaries: []appproperty.HomeDashboardPropertySummary{
+				{
+					PropertyID:   testPropertyID1,
+					PropertyName: "Demo Property",
+					Occupancy: appproperty.OccupancySummary{
+						TotalRooms:    2,
+						OccupiedRooms: 1,
+						VacantRooms:   1,
+						OccupancyRate: 0.5,
+					},
+					MonthlySummary: appproperty.DashboardMonthlySummary{
+						ExpectedRent:     50000,
+						CollectedRent:    40000,
+						OverdueBillCount: 2,
+					},
+				},
+			},
+		},
+	}
+	engine := newTestEngineWithPropertyDashboard(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		appproperty.NewDashboardService(dashboardRepo),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dashboard", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if dashboardRepo.scope.Role != "organizer" || len(dashboardRepo.scope.AssignedPropertyIDs) != 1 || dashboardRepo.scope.AssignedPropertyIDs[0] != testPropertyID1 {
+		t.Fatalf("unexpected dashboard scope: %+v", dashboardRepo.scope)
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["portfolio_summary"] == nil || payload["property_summaries"] == nil {
+		t.Fatalf("expected dashboard summaries, got %v", payload)
+	}
+}
+
 func TestGetPropertyDashboardRejectsUnassignedProperty(t *testing.T) {
 	engine := newTestEngineWithPropertyDashboard(
 		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}},
@@ -4181,11 +4245,13 @@ type fakePropertyQueryRepo struct {
 }
 
 type fakeDashboardRepository struct {
-	propertyID string
-	year       int
-	month      int
-	dashboard  *appproperty.Dashboard
-	err        error
+	propertyID    string
+	year          int
+	month         int
+	scope         appproperty.DashboardScope
+	dashboard     *appproperty.Dashboard
+	homeDashboard *appproperty.HomeDashboard
+	err           error
 }
 
 func (r *fakeDashboardRepository) GetDashboard(_ context.Context, propertyID string, year int, month int) (*appproperty.Dashboard, error) {
@@ -4200,6 +4266,20 @@ func (r *fakeDashboardRepository) GetDashboard(_ context.Context, propertyID str
 	}
 
 	return r.dashboard, nil
+}
+
+func (r *fakeDashboardRepository) GetHomeDashboard(_ context.Context, scope appproperty.DashboardScope, year int, month int) (*appproperty.HomeDashboard, error) {
+	r.scope = scope
+	r.year = year
+	r.month = month
+	if r.err != nil {
+		return nil, r.err
+	}
+	if r.homeDashboard == nil {
+		return &appproperty.HomeDashboard{}, nil
+	}
+
+	return r.homeDashboard, nil
 }
 
 type fakeTenantRepo struct {

--- a/internal/platform/database/propertydashboard/repository.go
+++ b/internal/platform/database/propertydashboard/repository.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	appproperty "stds_backend/internal/application/property"
@@ -26,6 +27,10 @@ func (r *SQLRepository) GetDashboard(ctx context.Context, propertyID string, yea
 		return nil, err
 	}
 
+	occupancy, err := r.getOccupancySummary(ctx, propertyID)
+	if err != nil {
+		return nil, err
+	}
 	rooms, err := r.listRooms(ctx, propertyID)
 	if err != nil {
 		return nil, err
@@ -43,8 +48,40 @@ func (r *SQLRepository) GetDashboard(ctx context.Context, propertyID string, yea
 		PropertyID:     propertyID,
 		Rooms:          rooms,
 		MonthlySummary: summary,
+		Occupancy:      occupancy,
 		RecentJournals: journals,
 	}, nil
+}
+
+// GetHomeDashboard returns cross-property dashboard summaries for the caller's scope.
+func (r *SQLRepository) GetHomeDashboard(ctx context.Context, scope appproperty.DashboardScope, year int, month int) (*appproperty.HomeDashboard, error) {
+	summaries, err := r.listHomePropertySummaries(ctx, scope, year, month)
+	if err != nil {
+		return nil, err
+	}
+	journals, err := r.listHomeRecentJournals(ctx, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	dashboard := appproperty.HomeDashboard{
+		PropertySummaries: summaries,
+		RecentJournals:    journals,
+	}
+	for i := range summaries {
+		dashboard.PortfolioSummary.TotalRooms += summaries[i].Occupancy.TotalRooms
+		dashboard.PortfolioSummary.OccupiedRooms += summaries[i].Occupancy.OccupiedRooms
+		dashboard.PortfolioSummary.VacantRooms += summaries[i].Occupancy.VacantRooms
+		dashboard.PortfolioSummary.MaintenanceRooms += summaries[i].Occupancy.MaintenanceRooms
+		dashboard.MonthlyBillingSummary.ExpectedRent += summaries[i].MonthlySummary.ExpectedRent
+		dashboard.MonthlyBillingSummary.CollectedRent += summaries[i].MonthlySummary.CollectedRent
+		dashboard.MonthlyBillingSummary.OverdueBillCount += summaries[i].MonthlySummary.OverdueBillCount
+	}
+	if dashboard.PortfolioSummary.TotalRooms > 0 {
+		dashboard.PortfolioSummary.OccupancyRate = float64(dashboard.PortfolioSummary.OccupiedRooms) / float64(dashboard.PortfolioSummary.TotalRooms)
+	}
+
+	return &dashboard, nil
 }
 
 func (r *SQLRepository) ensurePropertyExists(ctx context.Context, propertyID string) error {
@@ -93,6 +130,32 @@ ORDER BY created_at DESC, id DESC
 	}
 
 	return rooms, nil
+}
+
+func (r *SQLRepository) getOccupancySummary(ctx context.Context, propertyID string) (appproperty.OccupancySummary, error) {
+	const query = `
+SELECT
+	COUNT(*)::int AS total_rooms,
+	COUNT(*) FILTER (WHERE status = 'occupied')::int AS occupied_rooms,
+	COUNT(*) FILTER (WHERE status = 'vacant')::int AS vacant_rooms,
+	COUNT(*) FILTER (WHERE status = 'maintenance')::int AS maintenance_rooms,
+	CASE WHEN COUNT(*) = 0 THEN 0 ELSE COUNT(*) FILTER (WHERE status = 'occupied')::float / COUNT(*)::float END AS occupancy_rate
+FROM rooms
+WHERE property_id = $1
+  AND deleted_at IS NULL
+`
+	var summary appproperty.OccupancySummary
+	if err := r.db.QueryRowContext(ctx, query, propertyID).Scan(
+		&summary.TotalRooms,
+		&summary.OccupiedRooms,
+		&summary.VacantRooms,
+		&summary.MaintenanceRooms,
+		&summary.OccupancyRate,
+	); err != nil {
+		return appproperty.OccupancySummary{}, fmt.Errorf("query dashboard occupancy summary: %w", err)
+	}
+
+	return summary, nil
 }
 
 func (r *SQLRepository) getMonthlySummary(ctx context.Context, propertyID string, year int, month int) (appproperty.DashboardMonthlySummary, error) {
@@ -156,4 +219,159 @@ LIMIT 5
 	}
 
 	return journals, nil
+}
+
+func (r *SQLRepository) listHomePropertySummaries(ctx context.Context, scope appproperty.DashboardScope, year int, month int) ([]appproperty.HomeDashboardPropertySummary, error) {
+	periodStart := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := periodStart.AddDate(0, 1, 0)
+	args := []any{periodStart, periodEnd}
+	scopeClause, args, ok := appendDashboardScope("p", scope, args)
+	if !ok {
+		return []appproperty.HomeDashboardPropertySummary{}, nil
+	}
+
+	query := `
+WITH room_summary AS (
+	SELECT
+		property_id,
+		COUNT(*)::int AS total_rooms,
+		COUNT(*) FILTER (WHERE status = 'occupied')::int AS occupied_rooms,
+		COUNT(*) FILTER (WHERE status = 'vacant')::int AS vacant_rooms,
+		COUNT(*) FILTER (WHERE status = 'maintenance')::int AS maintenance_rooms
+	FROM rooms
+	WHERE deleted_at IS NULL
+	GROUP BY property_id
+),
+bill_summary AS (
+	SELECT
+		property_id,
+		COALESCE(SUM(CASE WHEN type = 'rent' AND status NOT IN ('voided', 'written_off') AND period_start >= $1 AND period_start < $2 THEN amount ELSE 0 END), 0)::int AS expected_rent,
+		COALESCE(SUM(CASE WHEN type = 'rent' AND status = 'paid' AND period_start >= $1 AND period_start < $2 THEN paid_amount ELSE 0 END), 0)::int AS collected_rent,
+		COUNT(*) FILTER (WHERE status = 'overdue' AND period_start >= $1 AND period_start < $2)::int AS overdue_bill_count
+	FROM bills
+	WHERE deleted_at IS NULL
+	GROUP BY property_id
+)
+SELECT
+	p.id,
+	p.name,
+	COALESCE(room_summary.total_rooms, 0) AS total_rooms,
+	COALESCE(room_summary.occupied_rooms, 0) AS occupied_rooms,
+	COALESCE(room_summary.vacant_rooms, 0) AS vacant_rooms,
+	COALESCE(room_summary.maintenance_rooms, 0) AS maintenance_rooms,
+	CASE WHEN COALESCE(room_summary.total_rooms, 0) = 0 THEN 0 ELSE room_summary.occupied_rooms::float / room_summary.total_rooms::float END AS occupancy_rate,
+	COALESCE(bill_summary.expected_rent, 0) AS expected_rent,
+	COALESCE(bill_summary.collected_rent, 0) AS collected_rent,
+	COALESCE(bill_summary.overdue_bill_count, 0) AS overdue_bill_count
+FROM properties p
+LEFT JOIN room_summary ON room_summary.property_id = p.id
+LEFT JOIN bill_summary ON bill_summary.property_id = p.id
+WHERE p.deleted_at IS NULL
+` + scopeClause + `
+ORDER BY p.created_at DESC, p.id DESC
+`
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list home dashboard property summaries: %w", err)
+	}
+	defer rows.Close()
+
+	summaries := make([]appproperty.HomeDashboardPropertySummary, 0)
+	for rows.Next() {
+		var summary appproperty.HomeDashboardPropertySummary
+		if err := rows.Scan(
+			&summary.PropertyID,
+			&summary.PropertyName,
+			&summary.Occupancy.TotalRooms,
+			&summary.Occupancy.OccupiedRooms,
+			&summary.Occupancy.VacantRooms,
+			&summary.Occupancy.MaintenanceRooms,
+			&summary.Occupancy.OccupancyRate,
+			&summary.MonthlySummary.ExpectedRent,
+			&summary.MonthlySummary.CollectedRent,
+			&summary.MonthlySummary.OverdueBillCount,
+		); err != nil {
+			return nil, fmt.Errorf("scan home dashboard property summary: %w", err)
+		}
+		summaries = append(summaries, summary)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate home dashboard property summaries: %w", err)
+	}
+
+	return summaries, nil
+}
+
+func (r *SQLRepository) listHomeRecentJournals(ctx context.Context, scope appproperty.DashboardScope) ([]appproperty.HomeDashboardRecentJournal, error) {
+	args := []any{}
+	journalScopeClause, args, ok := appendDashboardScope("p", scope, args)
+	if !ok {
+		return []appproperty.HomeDashboardRecentJournal{}, nil
+	}
+	repairScopeClause := strings.ReplaceAll(journalScopeClause, "p.", "rp.")
+
+	query := `
+SELECT id, property_id, property_name, type, content, created_at
+FROM (
+	SELECT jl.id, jl.property_id, p.name AS property_name, 'journal_log' AS type, jl.content, jl.created_at
+	FROM journal_logs jl
+	JOIN properties p ON p.id = jl.property_id AND p.deleted_at IS NULL
+	WHERE jl.deleted_at IS NULL
+` + journalScopeClause + `
+	UNION ALL
+	SELECT rr.id, rr.property_id, rp.name AS property_name, 'repair_request' AS type, rr.title AS content, rr.created_at
+	FROM repair_requests rr
+	JOIN properties rp ON rp.id = rr.property_id AND rp.deleted_at IS NULL
+	WHERE rr.deleted_at IS NULL
+` + repairScopeClause + `
+) recent_activity
+ORDER BY created_at DESC, id DESC
+LIMIT 5
+`
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list home dashboard recent journals: %w", err)
+	}
+	defer rows.Close()
+
+	journals := make([]appproperty.HomeDashboardRecentJournal, 0)
+	for rows.Next() {
+		var journal appproperty.HomeDashboardRecentJournal
+		if err := rows.Scan(
+			&journal.ID,
+			&journal.PropertyID,
+			&journal.PropertyName,
+			&journal.Type,
+			&journal.Content,
+			&journal.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan home dashboard recent journal: %w", err)
+		}
+		journals = append(journals, journal)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate home dashboard recent journals: %w", err)
+	}
+
+	return journals, nil
+}
+
+func appendDashboardScope(alias string, scope appproperty.DashboardScope, args []any) (string, []any, bool) {
+	switch scope.Role {
+	case "owner":
+		args = append(args, scope.UserID)
+		return fmt.Sprintf(" AND %s.owner_id = $%d", alias, len(args)), args, true
+	case "organizer", "staff":
+		if len(scope.AssignedPropertyIDs) == 0 {
+			return "", args, false
+		}
+		placeholders := make([]string, 0, len(scope.AssignedPropertyIDs))
+		for _, propertyID := range scope.AssignedPropertyIDs {
+			args = append(args, propertyID)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		return fmt.Sprintf(" AND %s.id IN (%s)", alias, strings.Join(placeholders, ", ")), args, true
+	default:
+		return "", args, true
+	}
 }

--- a/internal/platform/database/propertydashboard/repository_test.go
+++ b/internal/platform/database/propertydashboard/repository_test.go
@@ -26,6 +26,10 @@ func TestGetDashboardReturnsPropertyDashboard(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT 1\nFROM properties")).
 		WithArgs(propertyID).
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(1))
+	mock.ExpectQuery("(?s)COUNT\\(\\*\\)::int AS total_rooms.*occupancy_rate.*FROM rooms").
+		WithArgs(propertyID).
+		WillReturnRows(sqlmock.NewRows([]string{"total_rooms", "occupied_rooms", "vacant_rooms", "maintenance_rooms", "occupancy_rate"}).
+			AddRow(2, 1, 1, 0, 0.5))
 	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, status\nFROM rooms")).
 		WithArgs(propertyID).
 		WillReturnRows(sqlmock.NewRows([]string{"id", "name", "status"}).
@@ -54,6 +58,9 @@ func TestGetDashboardReturnsPropertyDashboard(t *testing.T) {
 	if len(dashboard.Rooms) != 1 || dashboard.Rooms[0].Status != "occupied" {
 		t.Fatalf("unexpected rooms: %+v", dashboard.Rooms)
 	}
+	if dashboard.Occupancy.TotalRooms != 2 || dashboard.Occupancy.OccupancyRate != 0.5 {
+		t.Fatalf("unexpected occupancy summary: %+v", dashboard.Occupancy)
+	}
 	if dashboard.MonthlySummary.ExpectedRent != 50000 || dashboard.MonthlySummary.CollectedRent != 40000 || dashboard.MonthlySummary.OverdueBillCount != 2 {
 		t.Fatalf("unexpected monthly summary: %+v", dashboard.MonthlySummary)
 	}
@@ -65,6 +72,56 @@ func TestGetDashboardReturnsPropertyDashboard(t *testing.T) {
 	}
 	if dashboard.RecentJournals[1].Type != "journal_log" || dashboard.RecentJournals[1].Content != "Changed lobby light" {
 		t.Fatalf("expected journal log second, got %+v", dashboard.RecentJournals[1])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestGetHomeDashboardReturnsScopedSummaries(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	propertyID := "10000000-0000-0000-0000-000000000001"
+	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(`(?s)WITH room_summary AS.*bill_summary AS.*AND p.id IN \(\$3\).*ORDER BY p.created_at DESC, p.id DESC`).
+		WithArgs(
+			time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+			time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			propertyID,
+		).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"property_id", "property_name", "total_rooms", "occupied_rooms", "vacant_rooms", "maintenance_rooms", "occupancy_rate", "expected_rent", "collected_rent", "overdue_bill_count",
+		}).AddRow(propertyID, "Demo Property", 4, 2, 1, 1, 0.5, 50000, 40000, 2))
+	mock.ExpectQuery(`(?s)FROM journal_logs jl.*AND p.id IN \(\$1\).*UNION ALL.*FROM repair_requests rr.*AND rp.id IN \(\$1\).*LIMIT 5`).
+		WithArgs(propertyID).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "property_id", "property_name", "type", "content", "created_at"}).
+			AddRow("60000000-0000-0000-0000-000000000001", propertyID, "Demo Property", "journal_log", "Changed lobby light", createdAt))
+
+	dashboard, err := repo.GetHomeDashboard(context.Background(), appproperty.DashboardScope{
+		Role:                "staff",
+		AssignedPropertyIDs: []string{propertyID},
+	}, 2026, 4)
+	if err != nil {
+		t.Fatalf("GetHomeDashboard: %v", err)
+	}
+	if dashboard.PortfolioSummary.TotalRooms != 4 || dashboard.PortfolioSummary.OccupancyRate != 0.5 {
+		t.Fatalf("unexpected portfolio summary: %+v", dashboard.PortfolioSummary)
+	}
+	if dashboard.MonthlyBillingSummary.ExpectedRent != 50000 || dashboard.MonthlyBillingSummary.OverdueBillCount != 2 {
+		t.Fatalf("unexpected billing summary: %+v", dashboard.MonthlyBillingSummary)
+	}
+	if len(dashboard.PropertySummaries) != 1 || dashboard.PropertySummaries[0].PropertyName != "Demo Property" {
+		t.Fatalf("unexpected property summaries: %+v", dashboard.PropertySummaries)
+	}
+	if len(dashboard.RecentJournals) != 1 || dashboard.RecentJournals[0].PropertyName != "Demo Property" {
+		t.Fatalf("unexpected recent journals: %+v", dashboard.RecentJournals)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/platform/database/propertyquery/repository.go
+++ b/internal/platform/database/propertyquery/repository.go
@@ -23,9 +23,19 @@ type Property struct {
 	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+	Occupancy                        OccupancySummary
 	CreatedAt                        time.Time
 	UpdatedAt                        time.Time
 	Version                          int
+}
+
+// OccupancySummary contains room status totals for one property.
+type OccupancySummary struct {
+	TotalRooms       int
+	OccupiedRooms    int
+	VacantRooms      int
+	MaintenanceRooms int
+	OccupancyRate    float64
 }
 
 // Room is the read model returned by room queries.
@@ -66,10 +76,26 @@ func NewRepository(db *sql.DB) *SQLRepository {
 // FindByID returns a single active property.
 func (r *SQLRepository) FindByID(ctx context.Context, propertyID string) (*Property, error) {
 	const query = `
-SELECT id, name, address, electricity_unit_price, default_electricity_billing_cadence, owner_id, created_at, updated_at, version
-FROM properties
-WHERE id = $1
-  AND deleted_at IS NULL
+SELECT
+	p.id,
+	p.name,
+	p.address,
+	p.electricity_unit_price,
+	p.default_electricity_billing_cadence,
+	p.owner_id,
+	COUNT(rooms.id)::int AS total_rooms,
+	COUNT(rooms.id) FILTER (WHERE rooms.status = 'occupied')::int AS occupied_rooms,
+	COUNT(rooms.id) FILTER (WHERE rooms.status = 'vacant')::int AS vacant_rooms,
+	COUNT(rooms.id) FILTER (WHERE rooms.status = 'maintenance')::int AS maintenance_rooms,
+	CASE WHEN COUNT(rooms.id) = 0 THEN 0 ELSE COUNT(rooms.id) FILTER (WHERE rooms.status = 'occupied')::float / COUNT(rooms.id)::float END AS occupancy_rate,
+	p.created_at,
+	p.updated_at,
+	p.version
+FROM properties p
+LEFT JOIN rooms ON rooms.property_id = p.id AND rooms.deleted_at IS NULL
+WHERE p.id = $1
+  AND p.deleted_at IS NULL
+GROUP BY p.id
 LIMIT 1
 `
 
@@ -87,15 +113,30 @@ LIMIT 1
 // ListAccessible returns properties visible to the authenticated principal.
 func (r *SQLRepository) ListAccessible(ctx context.Context, role string, userID string, assignedPropertyIDs []string) ([]Property, error) {
 	base := `
-SELECT id, name, address, electricity_unit_price, default_electricity_billing_cadence, owner_id, created_at, updated_at, version
-FROM properties
-WHERE deleted_at IS NULL
+SELECT
+	p.id,
+	p.name,
+	p.address,
+	p.electricity_unit_price,
+	p.default_electricity_billing_cadence,
+	p.owner_id,
+	COUNT(rooms.id)::int AS total_rooms,
+	COUNT(rooms.id) FILTER (WHERE rooms.status = 'occupied')::int AS occupied_rooms,
+	COUNT(rooms.id) FILTER (WHERE rooms.status = 'vacant')::int AS vacant_rooms,
+	COUNT(rooms.id) FILTER (WHERE rooms.status = 'maintenance')::int AS maintenance_rooms,
+	CASE WHEN COUNT(rooms.id) = 0 THEN 0 ELSE COUNT(rooms.id) FILTER (WHERE rooms.status = 'occupied')::float / COUNT(rooms.id)::float END AS occupancy_rate,
+	p.created_at,
+	p.updated_at,
+	p.version
+FROM properties p
+LEFT JOIN rooms ON rooms.property_id = p.id AND rooms.deleted_at IS NULL
+WHERE p.deleted_at IS NULL
 `
 	args := []any{}
 
 	switch role {
 	case "owner":
-		base += " AND owner_id = $1"
+		base += " AND p.owner_id = $1"
 		args = append(args, userID)
 	case "organizer", "staff":
 		if len(assignedPropertyIDs) == 0 {
@@ -106,10 +147,10 @@ WHERE deleted_at IS NULL
 			args = append(args, propertyID)
 			placeholders = append(placeholders, fmt.Sprintf("$%d", i+1))
 		}
-		base += " AND id IN (" + strings.Join(placeholders, ", ") + ")"
+		base += " AND p.id IN (" + strings.Join(placeholders, ", ") + ")"
 	}
 
-	base += " ORDER BY created_at DESC"
+	base += " GROUP BY p.id ORDER BY p.created_at DESC"
 	rows, err := r.db.QueryContext(ctx, base, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list accessible properties: %w", err)
@@ -207,6 +248,11 @@ func scanProperty(row rowScanner) (*Property, error) {
 		&electricityUnitPrice,
 		&property.DefaultElectricityBillingCadence,
 		&property.OwnerID,
+		&property.Occupancy.TotalRooms,
+		&property.Occupancy.OccupiedRooms,
+		&property.Occupancy.VacantRooms,
+		&property.Occupancy.MaintenanceRooms,
+		&property.Occupancy.OccupancyRate,
 		&property.CreatedAt,
 		&property.UpdatedAt,
 		&property.Version,

--- a/internal/platform/database/propertyquery/repository_test.go
+++ b/internal/platform/database/propertyquery/repository_test.go
@@ -12,6 +12,54 @@ import (
 	"stds_backend/internal/shared/apperr"
 )
 
+func TestListAccessibleReturnsOccupancySummary(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(`(?s)LEFT JOIN rooms ON rooms.property_id = p.id AND rooms.deleted_at IS NULL\s+WHERE p.deleted_at IS NULL\s+GROUP BY p.id ORDER BY p.created_at DESC`).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "name", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id",
+			"total_rooms", "occupied_rooms", "vacant_rooms", "maintenance_rooms", "occupancy_rate",
+			"created_at", "updated_at", "version",
+		}).AddRow(
+			"10000000-0000-0000-0000-000000000001",
+			"Demo Property",
+			"Demo Address",
+			4.5,
+			"monthly",
+			"90000000-0000-0000-0000-000000000001",
+			4,
+			2,
+			1,
+			1,
+			0.5,
+			now,
+			now,
+			3,
+		))
+
+	properties, err := repo.ListAccessible(context.Background(), "admin", "", nil)
+	if err != nil {
+		t.Fatalf("ListAccessible: %v", err)
+	}
+	if len(properties) != 1 {
+		t.Fatalf("expected 1 property, got %d", len(properties))
+	}
+	if properties[0].Occupancy.TotalRooms != 4 || properties[0].Occupancy.OccupancyRate != 0.5 {
+		t.Fatalf("unexpected occupancy summary: %+v", properties[0].Occupancy)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func TestListRoomsByPropertyReturnsActiveRoomsWithStatusFilterAndPagination(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/test/e2e/auth_master_data_test.go
+++ b/test/e2e/auth_master_data_test.go
@@ -116,12 +116,13 @@ func TestE2EAuthAndMasterDataAcceptance(t *testing.T) {
 }
 
 type e2ePropertyResponse struct {
-	ID                               string  `json:"id"`
-	Name                             string  `json:"name"`
-	Address                          string  `json:"address"`
-	ElectricityUnitPrice             float64 `json:"electricity_unit_price"`
-	DefaultElectricityBillingCadence string  `json:"default_electricity_billing_cadence"`
-	OwnerID                          string  `json:"owner_id"`
+	ID                               string              `json:"id"`
+	Name                             string              `json:"name"`
+	Address                          string              `json:"address"`
+	ElectricityUnitPrice             float64             `json:"electricity_unit_price"`
+	DefaultElectricityBillingCadence string              `json:"default_electricity_billing_cadence"`
+	OwnerID                          string              `json:"owner_id"`
+	OccupancySummary                 e2eOccupancySummary `json:"occupancy_summary"`
 }
 
 type e2eRoomResponse struct {

--- a/test/e2e/dashboard_read_model_test.go
+++ b/test/e2e/dashboard_read_model_test.go
@@ -1,0 +1,189 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestE2EDashboardReadModelsAcceptance(t *testing.T) {
+	cfg, err := loadE2EConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	db, err := resetAndMigrateDatabase(ctx, cfg.DatabaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	adminToken, err := issueFirebaseEmulatorToken(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seedAuthenticatedUser(ctx, db, adminToken.UID, cfg.TestEmail); err != nil {
+		t.Fatal(err)
+	}
+
+	adminClient := newAPIClient(cfg.BaseURL, adminToken.IDToken)
+	assignedProperty := createProperty(t, ctx, adminClient, "E2E Dashboard Assigned Property")
+	unassignedProperty := createProperty(t, ctx, adminClient, "E2E Dashboard Unassigned Property")
+	occupiedRoom := createRoom(t, ctx, adminClient, assignedProperty.ID, "E2E Dashboard Occupied Room")
+	createRoom(t, ctx, adminClient, assignedProperty.ID, "E2E Dashboard Vacant Room")
+	createRoom(t, ctx, adminClient, unassignedProperty.ID, "E2E Dashboard Unassigned Room")
+	tenant := createTenant(t, ctx, adminClient)
+	leaseLifecycleE2ECreateLease(t, ctx, adminClient, leaseLifecycleE2ECreateLeaseParams{
+		PropertyID: assignedProperty.ID,
+		RoomID:     occupiedRoom.ID,
+		TenantID:   tenant.ID,
+		StartDate:  "2026-05-01",
+		EndDate:    "2026-06-30",
+		RentAmount: 18000,
+		Deposit:    36000,
+		Cadence:    "monthly",
+	})
+
+	scopedEmail := e2eEmail(cfg.TestEmail, "dashboard")
+	scopedToken, err := issueFirebaseEmulatorTokenForCredentials(ctx, cfg, scopedEmail, cfg.TestPassword)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seedBackendUser(ctx, db, seedBackendUserParams{
+		ID:                  seededScopedUserID,
+		FirebaseUID:         scopedToken.UID,
+		Email:               scopedEmail,
+		Name:                "E2E Dashboard Organizer",
+		Role:                "organizer",
+		AssignedPropertyIDs: []string{assignedProperty.ID},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	scopedClient := newAPIClient(cfg.BaseURL, scopedToken.IDToken)
+
+	t.Run("property list includes backend-owned occupancy summary", func(t *testing.T) {
+		resp, body, err := scopedClient.getJSON(ctx, "/api/v1/properties")
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireStatus(t, resp, body, http.StatusOK)
+
+		var list e2ePropertyListResponse
+		decodeJSON(t, body, &list)
+		if len(list.Data) != 1 {
+			t.Fatalf("expected scoped property list length 1, got %d: %+v", len(list.Data), list.Data)
+		}
+		if list.Data[0].ID != assignedProperty.ID {
+			t.Fatalf("expected assigned property %q, got %q", assignedProperty.ID, list.Data[0].ID)
+		}
+		requireE2EOccupancySummary(t, list.Data[0].OccupancySummary, e2eOccupancySummary{
+			TotalRooms:    2,
+			OccupiedRooms: 1,
+			VacantRooms:   1,
+			OccupancyRate: 0.5,
+		})
+	})
+
+	t.Run("property dashboard includes occupancy summary", func(t *testing.T) {
+		resp, body, err := scopedClient.getJSON(ctx, "/api/v1/properties/"+assignedProperty.ID+"/dashboard")
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireStatus(t, resp, body, http.StatusOK)
+
+		var dashboard e2ePropertyDashboardResponse
+		decodeJSON(t, body, &dashboard)
+		requireE2EOccupancySummary(t, dashboard.OccupancySummary, e2eOccupancySummary{
+			TotalRooms:    2,
+			OccupiedRooms: 1,
+			VacantRooms:   1,
+			OccupancyRate: 0.5,
+		})
+	})
+
+	t.Run("home dashboard is scoped and aggregates backend summaries", func(t *testing.T) {
+		resp, body, err := scopedClient.getJSON(ctx, "/api/v1/dashboard")
+		if err != nil {
+			t.Fatal(err)
+		}
+		requireStatus(t, resp, body, http.StatusOK)
+
+		var dashboard e2eHomeDashboardResponse
+		decodeJSON(t, body, &dashboard)
+		requireE2EOccupancySummary(t, dashboard.PortfolioSummary, e2eOccupancySummary{
+			TotalRooms:    2,
+			OccupiedRooms: 1,
+			VacantRooms:   1,
+			OccupancyRate: 0.5,
+		})
+		if len(dashboard.PropertySummaries) != 1 {
+			t.Fatalf("expected 1 scoped property summary, got %d: %+v", len(dashboard.PropertySummaries), dashboard.PropertySummaries)
+		}
+		if dashboard.PropertySummaries[0].PropertyID != assignedProperty.ID {
+			t.Fatalf("expected assigned property summary %q, got %q", assignedProperty.ID, dashboard.PropertySummaries[0].PropertyID)
+		}
+		if dashboard.MonthlyBillingSummary.ExpectedRent == 0 {
+			t.Fatalf("expected backend monthly billing summary to include generated rent: %+v", dashboard.MonthlyBillingSummary)
+		}
+	})
+}
+
+type e2ePropertyListResponse struct {
+	Data []e2ePropertyResponse `json:"data"`
+}
+
+type e2eOccupancySummary struct {
+	TotalRooms       int     `json:"total_rooms"`
+	OccupiedRooms    int     `json:"occupied_rooms"`
+	VacantRooms      int     `json:"vacant_rooms"`
+	MaintenanceRooms int     `json:"maintenance_rooms"`
+	OccupancyRate    float64 `json:"occupancy_rate"`
+}
+
+type e2ePropertyDashboardResponse struct {
+	OccupancySummary e2eOccupancySummary `json:"occupancy_summary"`
+}
+
+type e2eHomeDashboardBillingSummary struct {
+	ExpectedRent     int `json:"expected_rent"`
+	CollectedRent    int `json:"collected_rent"`
+	OverdueBillCount int `json:"overdue_bill_count"`
+}
+
+type e2eHomeDashboardPropertySummary struct {
+	PropertyID       string              `json:"property_id"`
+	PropertyName     string              `json:"property_name"`
+	OccupancySummary e2eOccupancySummary `json:"occupancy_summary"`
+}
+
+type e2eHomeDashboardResponse struct {
+	PortfolioSummary      e2eOccupancySummary               `json:"portfolio_summary"`
+	MonthlyBillingSummary e2eHomeDashboardBillingSummary    `json:"monthly_billing_summary"`
+	PropertySummaries     []e2eHomeDashboardPropertySummary `json:"property_summaries"`
+}
+
+func requireE2EOccupancySummary(t *testing.T, got e2eOccupancySummary, want e2eOccupancySummary) {
+	t.Helper()
+
+	if got.TotalRooms != want.TotalRooms {
+		t.Fatalf("expected total_rooms %d, got %d: %+v", want.TotalRooms, got.TotalRooms, got)
+	}
+	if got.OccupiedRooms != want.OccupiedRooms {
+		t.Fatalf("expected occupied_rooms %d, got %d: %+v", want.OccupiedRooms, got.OccupiedRooms, got)
+	}
+	if got.VacantRooms != want.VacantRooms {
+		t.Fatalf("expected vacant_rooms %d, got %d: %+v", want.VacantRooms, got.VacantRooms, got)
+	}
+	if got.MaintenanceRooms != want.MaintenanceRooms {
+		t.Fatalf("expected maintenance_rooms %d, got %d: %+v", want.MaintenanceRooms, got.MaintenanceRooms, got)
+	}
+	if got.OccupancyRate != want.OccupancyRate {
+		t.Fatalf("expected occupancy_rate %v, got %v: %+v", want.OccupancyRate, got.OccupancyRate, got)
+	}
+}


### PR DESCRIPTION
Closes #137

## Summary

Adds backend-owned dashboard summary read models so frontend v1.0 can render property and home dashboard data without cross-endpoint aggregation.

## Changes

- Add `GET /dashboard` for role-scoped cross-property dashboard summaries.
- Add shared `occupancy_summary` to `GET /properties` and `GET /properties/{id}/dashboard`.
- Aggregate portfolio occupancy, monthly billing summary, per-property summaries, and recent activity in backend SQL/read models.
- Regenerate OpenAPI bundle and generated Go API bindings.
- Add focused application, handler/router, SQL repository, and E2E coverage.

## Validation

- `npm run openapi:generate`
- `npm run openapi:lint`
- `GOCACHE=/tmp/go-cache go test ./internal/application/property ./internal/http/handler ./internal/http/router ./internal/platform/database/propertyquery ./internal/platform/database/propertydashboard`
- `GOCACHE=/tmp/go-cache go test ./...`
- `GOCACHE=/tmp/go-cache go test -tags=e2e ./test/e2e -run '^TestE2EDashboardReadModelsAcceptance$' -count=0`
- `GOCACHE=/tmp/go-cache E2E_BASE_URL=http://127.0.0.1:8081 ./scripts/e2e_test.sh -run '^TestE2EDashboardReadModelsAcceptance$' -count=1`
- `git diff --check`