### PR TITLE
Implement bill type filter and list pagination metadata

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -3595,6 +3595,14 @@ paths:
               - overdue
               - voided
               - written_off
+        - name: type
+          in: query
+          schema:
+            type: string
+            enum:
+              - rent
+              - electricity
+          description: 依帳單類型篩選，租金或電費
         - name: month
           in: query
           schema:
@@ -3636,6 +3644,12 @@ paths:
                         amount: null
                         due_date: '2026-05-01'
                         status: pending_meter
+                    pagination:
+                      page: 1
+                      limit: 20
+                      total: 2
+                      total_pages: 1
+                      has_next: false
         '401':
           description: 未認證
           content:
@@ -6784,6 +6798,29 @@ components:
         details:
           type: object
           nullable: true
+    PaginationResponse:
+      type: object
+      properties:
+        page:
+          type: integer
+          description: Current 1-based page number.
+          example: 1
+        limit:
+          type: integer
+          description: Page size used for this response.
+          example: 20
+        total:
+          type: integer
+          description: Total number of rows matching the same filters and access scope.
+          example: 42
+        total_pages:
+          type: integer
+          description: Total page count based on total and limit.
+          example: 3
+        has_next:
+          type: boolean
+          description: Whether another page exists after the current page.
+          example: true
     UserListResponse:
       type: object
       properties:
@@ -6791,6 +6828,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/UserResponse'
+        pagination:
+          $ref: '#/components/schemas/PaginationResponse'
     CreateUserRequest:
       type: object
       required:
@@ -7114,6 +7153,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RoomResponse'
+        pagination:
+          $ref: '#/components/schemas/PaginationResponse'
     CreateRoomRequest:
       type: object
       required:
@@ -7302,6 +7343,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TenantResponse'
+        pagination:
+          $ref: '#/components/schemas/PaginationResponse'
     CreateTenantRequest:
       type: object
       required:
@@ -7417,6 +7460,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LeaseResponse'
+        pagination:
+          $ref: '#/components/schemas/PaginationResponse'
     CreateLeaseRequest:
       type: object
       required:
@@ -7930,6 +7975,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BillResponse'
+        pagination:
+          $ref: '#/components/schemas/PaginationResponse'
     RecordMeterRequest:
       type: object
       required:
@@ -8053,6 +8100,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/JournalLogResponse'
+        pagination:
+          $ref: '#/components/schemas/PaginationResponse'
     CreateJournalLogRequest:
       type: object
       required:
@@ -8090,6 +8139,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RepairRequestResponse'
+        pagination:
+          $ref: '#/components/schemas/PaginationResponse'
     CreateRepairRequestRequest:
       type: object
       required:

--- a/docs/spec/src/components/schemas/billing/BillListResponse.yaml
+++ b/docs/spec/src/components/schemas/billing/BillListResponse.yaml
@@ -4,3 +4,5 @@ properties:
     type: array
     items:
       $ref: ./BillResponse.yaml
+  pagination:
+    $ref: ../shared/PaginationResponse.yaml

--- a/docs/spec/src/components/schemas/iam/UserListResponse.yaml
+++ b/docs/spec/src/components/schemas/iam/UserListResponse.yaml
@@ -4,3 +4,5 @@ properties:
     type: array
     items:
       $ref: ./UserResponse.yaml
+  pagination:
+    $ref: ../shared/PaginationResponse.yaml

--- a/docs/spec/src/components/schemas/journal/JournalLogListResponse.yaml
+++ b/docs/spec/src/components/schemas/journal/JournalLogListResponse.yaml
@@ -4,3 +4,5 @@ properties:
     type: array
     items:
       $ref: ./JournalLogResponse.yaml
+  pagination:
+    $ref: ../shared/PaginationResponse.yaml

--- a/docs/spec/src/components/schemas/property/RoomListResponse.yaml
+++ b/docs/spec/src/components/schemas/property/RoomListResponse.yaml
@@ -4,3 +4,5 @@ properties:
     type: array
     items:
       $ref: ./RoomResponse.yaml
+  pagination:
+    $ref: ../shared/PaginationResponse.yaml

--- a/docs/spec/src/components/schemas/repair/RepairRequestListResponse.yaml
+++ b/docs/spec/src/components/schemas/repair/RepairRequestListResponse.yaml
@@ -4,3 +4,5 @@ properties:
     type: array
     items:
       $ref: ./RepairRequestResponse.yaml
+  pagination:
+    $ref: ../shared/PaginationResponse.yaml

--- a/docs/spec/src/components/schemas/shared/PaginationResponse.yaml
+++ b/docs/spec/src/components/schemas/shared/PaginationResponse.yaml
@@ -1,0 +1,22 @@
+type: object
+properties:
+  page:
+    type: integer
+    description: Current 1-based page number.
+    example: 1
+  limit:
+    type: integer
+    description: Page size used for this response.
+    example: 20
+  total:
+    type: integer
+    description: Total number of rows matching the same filters and access scope.
+    example: 42
+  total_pages:
+    type: integer
+    description: Total page count based on total and limit.
+    example: 3
+  has_next:
+    type: boolean
+    description: Whether another page exists after the current page.
+    example: true

--- a/docs/spec/src/components/schemas/tenancy/LeaseListResponse.yaml
+++ b/docs/spec/src/components/schemas/tenancy/LeaseListResponse.yaml
@@ -4,3 +4,5 @@ properties:
     type: array
     items:
       $ref: ./LeaseResponse.yaml
+  pagination:
+    $ref: ../shared/PaginationResponse.yaml

--- a/docs/spec/src/components/schemas/tenancy/TenantListResponse.yaml
+++ b/docs/spec/src/components/schemas/tenancy/TenantListResponse.yaml
@@ -4,3 +4,5 @@ properties:
     type: array
     items:
       $ref: ./TenantResponse.yaml
+  pagination:
+    $ref: ../shared/PaginationResponse.yaml

--- a/docs/spec/src/paths/billing/bills.yaml
+++ b/docs/spec/src/paths/billing/bills.yaml
@@ -38,6 +38,14 @@ get:
           - overdue
           - voided
           - written_off
+    - name: type
+      in: query
+      schema:
+        type: string
+        enum:
+          - rent
+          - electricity
+      description: 依帳單類型篩選，租金或電費
     - name: month
       in: query
       schema:
@@ -79,6 +87,12 @@ get:
                     amount: null
                     due_date: '2026-05-01'
                     status: pending_meter
+                pagination:
+                  page: 1
+                  limit: 20
+                  total: 2
+                  total_pages: 1
+                  has_next: false
     '401':
       description: 未認證
       content:

--- a/internal/application/billing/list_bills.go
+++ b/internal/application/billing/list_bills.go
@@ -20,6 +20,7 @@ type ListBillsInput struct {
 	PropertyID          *string
 	LeaseID             *string
 	TenantID            *string
+	Type                *string
 	Status              *string
 	Month               *string
 	Limit               int
@@ -37,63 +38,68 @@ func NewListBillsService(repo Repository) *ListBillsService {
 }
 
 // Execute validates filters and delegates role scoping to the repository query contract.
-func (s *ListBillsService) Execute(ctx context.Context, input ListBillsInput) ([]Bill, error) {
+func (s *ListBillsService) Execute(ctx context.Context, input ListBillsInput) (ListBillsResult, error) {
 	actorRole, err := normalizeReadRole(input.ActorRole)
 	if err != nil {
-		return nil, err
+		return ListBillsResult{}, err
 	}
 
 	propertyID, err := normalizeOptionalUUID(input.PropertyID, "property_id")
 	if err != nil {
-		return nil, err
+		return ListBillsResult{}, err
 	}
 	leaseID, err := normalizeOptionalUUID(input.LeaseID, "lease_id")
 	if err != nil {
-		return nil, err
+		return ListBillsResult{}, err
 	}
 	tenantID, err := normalizeOptionalUUID(input.TenantID, "tenant_id")
 	if err != nil {
-		return nil, err
+		return ListBillsResult{}, err
+	}
+	billType, err := normalizeOptionalBillType(input.Type)
+	if err != nil {
+		return ListBillsResult{}, err
 	}
 	status, err := normalizeOptionalStatus(input.Status)
 	if err != nil {
-		return nil, err
+		return ListBillsResult{}, err
 	}
 	month, err := normalizeOptionalMonth(input.Month)
 	if err != nil {
-		return nil, err
+		return ListBillsResult{}, err
 	}
 
 	if input.Limit < 1 || input.Limit > maxListBillsLimit {
-		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+		return ListBillsResult{}, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
 			"field":  "limit",
 			"reason": "must be between 1 and 100",
 		})
 	}
 	if input.Offset < 0 {
-		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+		return ListBillsResult{}, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
 			"field":  "offset",
 			"reason": "must be greater than or equal to 0",
 		})
 	}
 
-	bills, err := s.repo.ListBills(ctx, ListBillsQuery{
+	result, err := s.repo.ListBills(ctx, ListBillsQuery{
 		ActorRole:           actorRole,
 		ActorUserID:         strings.TrimSpace(input.ActorUserID),
 		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
 		PropertyID:          propertyID,
 		LeaseID:             leaseID,
 		TenantID:            tenantID,
+		Type:                billType,
 		Status:              status,
 		Month:               month,
 		Limit:               input.Limit,
 		Offset:              input.Offset,
 	})
 	if err != nil {
-		return nil, mapRepositoryError(err)
+		return ListBillsResult{}, mapRepositoryError(err)
 	}
 
-	return bills, nil
+	return result, nil
 }
 
 func normalizeReadRole(role string) (string, error) {
@@ -143,6 +149,20 @@ func normalizeOptionalStatus(value *string) (*string, error) {
 		return &status, nil
 	default:
 		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "status"})
+	}
+}
+
+func normalizeOptionalBillType(value *string) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	billType := strings.TrimSpace(*value)
+	switch billType {
+	case "rent", "electricity":
+		return &billType, nil
+	default:
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "type"})
 	}
 }
 

--- a/internal/application/billing/record_commands_test.go
+++ b/internal/application/billing/record_commands_test.go
@@ -88,12 +88,34 @@ func TestListBillsServiceRejectsInvalidPagination(t *testing.T) {
 	}
 }
 
-func TestListBillsServiceForwardsValidatedPagination(t *testing.T) {
+func TestListBillsServiceRejectsInvalidType(t *testing.T) {
 	repo := &billingRepositoryStub{}
 	service := NewListBillsService(repo)
+	billType := "deposit"
 
 	_, err := service.Execute(context.Background(), ListBillsInput{
 		ActorRole: "staff",
+		Type:      &billType,
+		Limit:     10,
+	})
+	assertAppErrorCode(t, err, apperr.CodeBadRequest)
+	assertAppErrorDetails(t, err, map[string]any{"field": "type"})
+	if repo.listBillsQuery != nil {
+		t.Fatalf("unexpected ListBills call: %+v", repo.listBillsQuery)
+	}
+}
+
+func TestListBillsServiceForwardsValidatedPagination(t *testing.T) {
+	repo := &billingRepositoryStub{listBillsResult: ListBillsResult{
+		Items: []Bill{{ID: testBillID}},
+		Total: 3,
+	}}
+	service := NewListBillsService(repo)
+	billType := " electricity "
+
+	result, err := service.Execute(context.Background(), ListBillsInput{
+		ActorRole: "staff",
+		Type:      &billType,
 		Limit:     25,
 		Offset:    50,
 	})
@@ -105,6 +127,12 @@ func TestListBillsServiceForwardsValidatedPagination(t *testing.T) {
 	}
 	if repo.listBillsQuery.Limit != 25 || repo.listBillsQuery.Offset != 50 {
 		t.Fatalf("pagination = limit %d offset %d, want 25/50", repo.listBillsQuery.Limit, repo.listBillsQuery.Offset)
+	}
+	if repo.listBillsQuery.Type == nil || *repo.listBillsQuery.Type != "electricity" {
+		t.Fatalf("type = %v, want electricity", repo.listBillsQuery.Type)
+	}
+	if len(result.Items) != 1 || result.Items[0].ID != testBillID || result.Total != 3 {
+		t.Fatalf("unexpected result: %+v", result)
 	}
 }
 
@@ -548,6 +576,7 @@ func TestRecordPaymentServiceRollsBackWhenAccountingEntryFails(t *testing.T) {
 
 type billingRepositoryStub struct {
 	bills                           []Bill
+	listBillsResult                 ListBillsResult
 	listBillsQuery                  *ListBillsQuery
 	bill                            *Bill
 	getBillQuery                    *GetBillQuery
@@ -569,9 +598,12 @@ type billingRepositoryStub struct {
 	updatePaymentErr                error
 }
 
-func (s *billingRepositoryStub) ListBills(_ context.Context, query ListBillsQuery) ([]Bill, error) {
+func (s *billingRepositoryStub) ListBills(_ context.Context, query ListBillsQuery) (ListBillsResult, error) {
 	s.listBillsQuery = &query
-	return s.bills, nil
+	if s.listBillsResult.Items != nil || s.listBillsResult.Total != 0 {
+		return s.listBillsResult, nil
+	}
+	return ListBillsResult{Items: s.bills, Total: len(s.bills)}, nil
 }
 
 func (s *billingRepositoryStub) FindBillByID(_ context.Context, query GetBillQuery) (*Bill, error) {

--- a/internal/application/billing/repository.go
+++ b/internal/application/billing/repository.go
@@ -56,10 +56,17 @@ type ListBillsQuery struct {
 	PropertyID          *string
 	LeaseID             *string
 	TenantID            *string
+	Type                *string
 	Status              *string
 	Month               *time.Time
 	Limit               int
 	Offset              int
+}
+
+// ListBillsResult contains paginated bill rows and the total matching count.
+type ListBillsResult struct {
+	Items []Bill
+	Total int
 }
 
 // GetBillQuery defines role scoping for bill detail retrieval.
@@ -92,7 +99,7 @@ type UpdatePaymentParams struct {
 
 // Repository defines database operations required by billing use cases.
 type Repository interface {
-	ListBills(ctx context.Context, query ListBillsQuery) ([]Bill, error)
+	ListBills(ctx context.Context, query ListBillsQuery) (ListBillsResult, error)
 	FindBillByID(ctx context.Context, query GetBillQuery) (*Bill, error)
 	FindBillByIDForUpdate(ctx context.Context, tx *sql.Tx, billID string) (*Bill, error)
 	FindPreviousElectricityReading(ctx context.Context, tx *sql.Tx, roomID string, beforePeriodStart time.Time) (int, error)

--- a/internal/application/journal/create_test.go
+++ b/internal/application/journal/create_test.go
@@ -239,6 +239,34 @@ func TestCreateServiceMapsMissingPropertyToNotFound(t *testing.T) {
 	}
 }
 
+func TestListServiceReturnsRepositoryResult(t *testing.T) {
+	repo := &journalRepositoryStub{
+		listResult: ListResult{
+			Items: []JournalLog{{ID: testJournalID, PropertyID: testPropertyID}},
+			Total: 12,
+		},
+	}
+	service := NewListService(repo)
+
+	result, err := service.Execute(context.Background(), ListInput{
+		ActorRole: " admin ",
+		Limit:     20,
+		Offset:    40,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result.Total != 12 {
+		t.Fatalf("Total = %d, want 12", result.Total)
+	}
+	if len(result.Items) != 1 || result.Items[0].ID != testJournalID {
+		t.Fatalf("Items = %+v, want journal %s", result.Items, testJournalID)
+	}
+	if repo.listQuery.ActorRole != "admin" {
+		t.Fatalf("ActorRole = %q, want admin", repo.listQuery.ActorRole)
+	}
+}
+
 func TestListServiceRejectsInvalidInputBeforeRepository(t *testing.T) {
 	t.Run("invalid property id", func(t *testing.T) {
 		repo := &journalRepositoryStub{}
@@ -462,13 +490,16 @@ type journalRepositoryStub struct {
 	room           *Room
 	created        *JournalLog
 	current        *JournalLog
+	listResult     ListResult
+	listQuery      ListQuery
 	deletedID      string
 	listCalls      int
 }
 
-func (s *journalRepositoryStub) List(context.Context, ListQuery) ([]JournalLog, error) {
+func (s *journalRepositoryStub) List(_ context.Context, query ListQuery) (ListResult, error) {
 	s.listCalls++
-	return nil, nil
+	s.listQuery = query
+	return s.listResult, nil
 }
 
 func (s *journalRepositoryStub) FindByID(context.Context, string) (*JournalLog, error) {

--- a/internal/application/journal/list.go
+++ b/internal/application/journal/list.go
@@ -35,35 +35,35 @@ func NewListService(repo Repository) *ListService {
 }
 
 // Execute returns active journal logs visible to the actor.
-func (s *ListService) Execute(ctx context.Context, input ListInput) ([]JournalLog, error) {
+func (s *ListService) Execute(ctx context.Context, input ListInput) (ListResult, error) {
 	role := strings.ToLower(strings.TrimSpace(input.ActorRole))
 	switch role {
 	case "admin", "organizer", "staff":
 	default:
-		return nil, apperr.ErrForbidden
+		return ListResult{}, apperr.ErrForbidden
 	}
 	propertyID, err := normalizeOptionalFilterUUID(input.PropertyID, "property_id")
 	if err != nil {
-		return nil, err
+		return ListResult{}, err
 	}
 	roomID, err := normalizeOptionalFilterUUID(input.RoomID, "room_id")
 	if err != nil {
-		return nil, err
+		return ListResult{}, err
 	}
 	if input.Limit < 1 || input.Limit > maxListJournalLogsLimit {
-		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+		return ListResult{}, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
 			"field":  "limit",
 			"reason": "must be between 1 and 100",
 		})
 	}
 	if input.Offset < 0 {
-		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+		return ListResult{}, apperr.ErrBadRequest.WithDetails(map[string]interface{}{
 			"field":  "offset",
 			"reason": "must be greater than or equal to 0",
 		})
 	}
 
-	items, err := s.repo.List(ctx, ListQuery{
+	result, err := s.repo.List(ctx, ListQuery{
 		ActorRole:           role,
 		AssignedPropertyIDs: cloneStrings(input.AssignedPropertyIDs),
 		PropertyID:          propertyID,
@@ -74,10 +74,10 @@ func (s *ListService) Execute(ctx context.Context, input ListInput) ([]JournalLo
 		Offset:              input.Offset,
 	})
 	if err != nil {
-		return nil, mapRepositoryError(err)
+		return ListResult{}, mapRepositoryError(err)
 	}
 
-	return items, nil
+	return result, nil
 }
 
 func normalizeOptionalFilterUUID(value *string, field string) (*string, error) {

--- a/internal/application/journal/repository.go
+++ b/internal/application/journal/repository.go
@@ -52,6 +52,12 @@ type ListQuery struct {
 	Offset              int
 }
 
+// ListResult contains journal logs and the total matching rows before pagination.
+type ListResult struct {
+	Items []JournalLog
+	Total int
+}
+
 // CreateParams contains fields for journal log creation.
 type CreateParams struct {
 	PropertyID         string
@@ -86,7 +92,7 @@ type UpdateParams struct {
 
 // Repository defines persistence required by journal use cases.
 type Repository interface {
-	List(ctx context.Context, query ListQuery) ([]JournalLog, error)
+	List(ctx context.Context, query ListQuery) (ListResult, error)
 	FindByID(ctx context.Context, id string) (*JournalLog, error)
 	FindByIDForUpdate(ctx context.Context, tx *sql.Tx, id string) (*JournalLog, error)
 	EnsurePropertyExists(ctx context.Context, tx *sql.Tx, id string) error

--- a/internal/application/repair/repository.go
+++ b/internal/application/repair/repository.go
@@ -63,6 +63,12 @@ type ListQuery struct {
 	Offset              int
 }
 
+// ListResult contains repair requests and the total matching rows before pagination.
+type ListResult struct {
+	Items []RepairRequest
+	Total int
+}
+
 // CreateParams contains fields for repair request creation.
 type CreateParams struct {
 	PropertyID  string
@@ -100,7 +106,7 @@ type CancelParams struct {
 
 // Repository defines persistence required by repair use cases.
 type Repository interface {
-	List(ctx context.Context, query ListQuery) ([]RepairRequest, error)
+	List(ctx context.Context, query ListQuery) (ListResult, error)
 	FindByID(ctx context.Context, id string) (*RepairRequest, error)
 	FindByIDForUpdate(ctx context.Context, tx *sql.Tx, id string) (*RepairRequest, error)
 	FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*Room, error)

--- a/internal/application/repair/workflow_test.go
+++ b/internal/application/repair/workflow_test.go
@@ -611,8 +611,8 @@ type workflowRepoStub struct {
 	restoreErr     error
 }
 
-func (r *workflowRepoStub) List(context.Context, ListQuery) ([]RepairRequest, error) {
-	return nil, nil
+func (r *workflowRepoStub) List(context.Context, ListQuery) (ListResult, error) {
+	return ListResult{}, nil
 }
 
 func (r *workflowRepoStub) FindByID(context.Context, string) (*RepairRequest, error) {

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -63,8 +63,8 @@ const (
 
 // Defines values for BillResponseType.
 const (
-	Electricity BillResponseType = "electricity"
-	Rent        BillResponseType = "rent"
+	BillResponseTypeElectricity BillResponseType = "electricity"
+	BillResponseTypeRent        BillResponseType = "rent"
 )
 
 // Defines values for CheckoutSettlementBlockerCode.
@@ -324,6 +324,12 @@ const (
 	ListBillsParamsStatusWrittenOff     ListBillsParamsStatus = "written_off"
 )
 
+// Defines values for ListBillsParamsType.
+const (
+	ListBillsParamsTypeElectricity ListBillsParamsType = "electricity"
+	ListBillsParamsTypeRent        ListBillsParamsType = "rent"
+)
+
 // Defines values for ExportBillReceiptParamsFormat.
 const (
 	ExportBillReceiptParamsFormatHtml ExportBillReceiptParamsFormat = "html"
@@ -451,7 +457,8 @@ type AttachmentUploadURLResponse struct {
 
 // BillListResponse defines model for BillListResponse.
 type BillListResponse struct {
-	Data *[]BillResponse `json:"data,omitempty"`
+	Data       *[]BillResponse     `json:"data,omitempty"`
+	Pagination *PaginationResponse `json:"pagination,omitempty"`
 }
 
 // BillResponse defines model for BillResponse.
@@ -839,7 +846,8 @@ type HomeDashboardResponse struct {
 
 // JournalLogListResponse defines model for JournalLogListResponse.
 type JournalLogListResponse struct {
-	Data *[]JournalLogResponse `json:"data,omitempty"`
+	Data       *[]JournalLogResponse `json:"data,omitempty"`
+	Pagination *PaginationResponse   `json:"pagination,omitempty"`
 }
 
 // JournalLogResponse defines model for JournalLogResponse.
@@ -857,7 +865,8 @@ type JournalLogResponse struct {
 
 // LeaseListResponse defines model for LeaseListResponse.
 type LeaseListResponse struct {
-	Data *[]LeaseResponse `json:"data,omitempty"`
+	Data       *[]LeaseResponse    `json:"data,omitempty"`
+	Pagination *PaginationResponse `json:"pagination,omitempty"`
 }
 
 // LeaseReplaceRequest defines model for LeaseReplaceRequest.
@@ -948,6 +957,24 @@ type OccupancySummary struct {
 	VacantRooms      *int     `json:"vacant_rooms,omitempty"`
 }
 
+// PaginationResponse defines model for PaginationResponse.
+type PaginationResponse struct {
+	// HasNext Whether another page exists after the current page.
+	HasNext *bool `json:"has_next,omitempty"`
+
+	// Limit Page size used for this response.
+	Limit *int `json:"limit,omitempty"`
+
+	// Page Current 1-based page number.
+	Page *int `json:"page,omitempty"`
+
+	// Total Total number of rows matching the same filters and access scope.
+	Total *int `json:"total,omitempty"`
+
+	// TotalPages Total page count based on total and limit.
+	TotalPages *int `json:"total_pages,omitempty"`
+}
+
 // PropertyAssignmentRequest defines model for PropertyAssignmentRequest.
 type PropertyAssignmentRequest struct {
 	PropertyIds []openapi_types.UUID `json:"property_ids"`
@@ -1020,7 +1047,8 @@ type RegisterRepairRequestAttachmentRequestPhotoStage string
 
 // RepairRequestListResponse defines model for RepairRequestListResponse.
 type RepairRequestListResponse struct {
-	Data *[]RepairRequestResponse `json:"data,omitempty"`
+	Data       *[]RepairRequestResponse `json:"data,omitempty"`
+	Pagination *PaginationResponse      `json:"pagination,omitempty"`
 }
 
 // RepairRequestResponse defines model for RepairRequestResponse.
@@ -1045,7 +1073,8 @@ type RepairRequestResponseStatus string
 
 // RoomListResponse defines model for RoomListResponse.
 type RoomListResponse struct {
-	Data *[]RoomResponse `json:"data,omitempty"`
+	Data       *[]RoomResponse     `json:"data,omitempty"`
+	Pagination *PaginationResponse `json:"pagination,omitempty"`
 }
 
 // RoomResponse defines model for RoomResponse.
@@ -1106,7 +1135,8 @@ type SetMaintenanceResponse struct {
 
 // TenantListResponse defines model for TenantListResponse.
 type TenantListResponse struct {
-	Data *[]TenantResponse `json:"data,omitempty"`
+	Data       *[]TenantResponse   `json:"data,omitempty"`
+	Pagination *PaginationResponse `json:"pagination,omitempty"`
 }
 
 // TenantResponse defines model for TenantResponse.
@@ -1220,7 +1250,8 @@ type UpdateUserRequestRole string
 
 // UserListResponse defines model for UserListResponse.
 type UserListResponse struct {
-	Data *[]UserResponse `json:"data,omitempty"`
+	Data       *[]UserResponse     `json:"data,omitempty"`
+	Pagination *PaginationResponse `json:"pagination,omitempty"`
 }
 
 // UserResponse defines model for UserResponse.
@@ -1248,13 +1279,19 @@ type ListBillsParams struct {
 	// TenantId 依租客 ID 篩選帳單
 	TenantId *openapi_types.UUID    `form:"tenant_id,omitempty" json:"tenant_id,omitempty"`
 	Status   *ListBillsParamsStatus `form:"status,omitempty" json:"status,omitempty"`
-	Month    *string                `form:"month,omitempty" json:"month,omitempty"`
-	Page     *int                   `form:"page,omitempty" json:"page,omitempty"`
-	Limit    *int                   `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Type 依帳單類型篩選，租金或電費
+	Type  *ListBillsParamsType `form:"type,omitempty" json:"type,omitempty"`
+	Month *string              `form:"month,omitempty" json:"month,omitempty"`
+	Page  *int                 `form:"page,omitempty" json:"page,omitempty"`
+	Limit *int                 `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
 // ListBillsParamsStatus defines parameters for ListBills.
 type ListBillsParamsStatus string
+
+// ListBillsParamsType defines parameters for ListBills.
+type ListBillsParamsType string
 
 // ExportBillReceiptParams defines parameters for ExportBillReceipt.
 type ExportBillReceiptParams struct {
@@ -1923,6 +1960,14 @@ func (siw *ServerInterfaceWrapper) ListBills(c *gin.Context) {
 	err = runtime.BindQueryParameter("form", true, false, "status", c.Request.URL.Query(), &params.Status)
 	if err != nil {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter status: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "type" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "type", c.Request.URL.Query(), &params.Type)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter type: %w", err), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -150,12 +150,12 @@ type RepairServices struct {
 
 // RepairQueryRepository serves repair request read endpoints.
 type RepairQueryRepository interface {
-	List(ctx context.Context, query apprepair.ListQuery) ([]apprepair.RepairRequest, error)
+	List(ctx context.Context, query apprepair.ListQuery) (apprepair.ListResult, error)
 	FindByID(ctx context.Context, id string) (*apprepair.RepairRequest, error)
 }
 
 type BillingQueryService interface {
-	ListBills(ctx context.Context, input BillingListInput) ([]BillingBill, error)
+	ListBills(ctx context.Context, input BillingListInput) (BillingListResult, error)
 	GetBill(ctx context.Context, input BillingGetInput) (*BillingBill, error)
 }
 
@@ -194,10 +194,16 @@ type BillingListInput struct {
 	PropertyID          *string
 	LeaseID             *string
 	TenantID            *string
+	Type                string
 	Status              string
 	Month               *string
 	Limit               int
 	Offset              int
+}
+
+type BillingListResult struct {
+	Items []BillingBill
+	Total int
 }
 
 type BillingGetInput struct {
@@ -596,6 +602,10 @@ func (s *APIServer) ListBills(c *gin.Context, params api.ListBillsParams) {
 	if params.Status != nil {
 		status = string(*params.Status)
 	}
+	billType := ""
+	if params.Type != nil {
+		billType = string(*params.Type)
+	}
 
 	var tenantID *string
 	if params.TenantId != nil {
@@ -603,13 +613,14 @@ func (s *APIServer) ListBills(c *gin.Context, params api.ListBillsParams) {
 		tenantID = &value
 	}
 
-	bills, err := s.billing.Query.ListBills(c.Request.Context(), BillingListInput{
+	result, err := s.billing.Query.ListBills(c.Request.Context(), BillingListInput{
 		ActorRole:           principal.Role,
 		ActorUserID:         principal.UserID,
 		AssignedPropertyIDs: principal.AssignedPropertyIDs,
 		PropertyID:          params.PropertyId,
 		LeaseID:             params.LeaseId,
 		TenantID:            tenantID,
+		Type:                billType,
 		Status:              status,
 		Month:               params.Month,
 		Limit:               pagination.Limit,
@@ -620,12 +631,12 @@ func (s *APIServer) ListBills(c *gin.Context, params api.ListBillsParams) {
 		return
 	}
 
-	items := make([]api.BillResponse, 0, len(bills))
-	for i := range bills {
-		items = append(items, toBillResponse(&bills[i]))
+	items := make([]api.BillResponse, 0, len(result.Items))
+	for i := range result.Items {
+		items = append(items, toBillResponse(&result.Items[i]))
 	}
 
-	c.JSON(http.StatusOK, api.BillListResponse{Data: &items})
+	c.JSON(http.StatusOK, api.BillListResponse{Data: &items, Pagination: toPaginationResponse(pagination, result.Total)})
 }
 
 // CreateAttachmentUploadURL handles attachment upload URL creation.
@@ -852,7 +863,7 @@ func (s *APIServer) ListJournalLogs(c *gin.Context, params api.ListJournalLogsPa
 		dateTo = &value
 	}
 
-	items, err := s.journal.List.Execute(c.Request.Context(), appjournal.ListInput{
+	result, err := s.journal.List.Execute(c.Request.Context(), appjournal.ListInput{
 		ActorRole:           principal.Role,
 		AssignedPropertyIDs: principal.AssignedPropertyIDs,
 		PropertyID:          propertyID,
@@ -867,11 +878,11 @@ func (s *APIServer) ListJournalLogs(c *gin.Context, params api.ListJournalLogsPa
 		return
 	}
 
-	responses := make([]api.JournalLogResponse, 0, len(items))
-	for i := range items {
-		responses = append(responses, toJournalLogResponse(&items[i]))
+	responses := make([]api.JournalLogResponse, 0, len(result.Items))
+	for i := range result.Items {
+		responses = append(responses, toJournalLogResponse(&result.Items[i]))
 	}
-	c.JSON(http.StatusOK, api.JournalLogListResponse{Data: &responses})
+	c.JSON(http.StatusOK, api.JournalLogListResponse{Data: &responses, Pagination: toPaginationResponse(pagination, result.Total)})
 }
 
 // CreateJournalLog handles journal log creation.
@@ -982,7 +993,7 @@ func (s *APIServer) ListLeases(c *gin.Context, params api.ListLeasesParams) {
 		status = string(*params.Status)
 	}
 
-	leases, err := s.leaseQueryRepo.ListAccessible(c.Request.Context(), principal.Role, principal.AssignedPropertyIDs, dbleasequery.ListParams{
+	result, err := s.leaseQueryRepo.ListAccessible(c.Request.Context(), principal.Role, principal.AssignedPropertyIDs, dbleasequery.ListParams{
 		PropertyID: params.PropertyId,
 		RoomID:     params.RoomId,
 		TenantID:   params.TenantId,
@@ -995,12 +1006,12 @@ func (s *APIServer) ListLeases(c *gin.Context, params api.ListLeasesParams) {
 		return
 	}
 
-	items := make([]api.LeaseResponse, 0, len(leases))
-	for _, lease := range leases {
+	items := make([]api.LeaseResponse, 0, len(result.Items))
+	for _, lease := range result.Items {
 		items = append(items, toLeaseResponse(&lease))
 	}
 
-	c.JSON(http.StatusOK, api.LeaseListResponse{Data: &items})
+	c.JSON(http.StatusOK, api.LeaseListResponse{Data: &items, Pagination: toPaginationResponse(pagination, result.Total)})
 }
 
 // CreateLease handles lease creation.
@@ -1849,13 +1860,13 @@ func (s *APIServer) ListPropertyRooms(c *gin.Context, id string, params api.List
 		return
 	}
 
-	rooms, err := s.propertyQueryRepo.ListRoomsByProperty(c.Request.Context(), id, status, pagination.Limit, pagination.Offset)
+	result, err := s.propertyQueryRepo.ListRoomsByProperty(c.Request.Context(), id, status, pagination.Limit, pagination.Offset)
 	if err != nil {
 		c.Error(apperr.ErrInternalServerError.WithCause(err))
 		return
 	}
 
-	if len(rooms) == 0 {
+	if len(result.Items) == 0 {
 		_, err := s.propertyQueryRepo.FindByID(c.Request.Context(), id)
 		if err != nil {
 			switch err {
@@ -1868,12 +1879,12 @@ func (s *APIServer) ListPropertyRooms(c *gin.Context, id string, params api.List
 		}
 	}
 
-	items := make([]api.RoomResponse, 0, len(rooms))
-	for i := range rooms {
-		items = append(items, toRoomResponse(&rooms[i]))
+	items := make([]api.RoomResponse, 0, len(result.Items))
+	for i := range result.Items {
+		items = append(items, toRoomResponse(&result.Items[i]))
 	}
 
-	c.JSON(http.StatusOK, api.RoomListResponse{Data: &items})
+	c.JSON(http.StatusOK, api.RoomListResponse{Data: &items, Pagination: toPaginationResponse(pagination, result.Total)})
 }
 
 // CreatePropertyRoom handles room creation within a property.
@@ -1932,7 +1943,7 @@ func (s *APIServer) ListRepairRequests(c *gin.Context, params api.ListRepairRequ
 		return
 	}
 
-	items, err := s.repairQueryRepo.List(c.Request.Context(), apprepair.ListQuery{
+	result, err := s.repairQueryRepo.List(c.Request.Context(), apprepair.ListQuery{
 		ActorRole:           principal.Role,
 		AssignedPropertyIDs: principal.AssignedPropertyIDs,
 		PropertyID:          propertyID,
@@ -1947,11 +1958,11 @@ func (s *APIServer) ListRepairRequests(c *gin.Context, params api.ListRepairRequ
 		return
 	}
 
-	responses := make([]api.RepairRequestResponse, 0, len(items))
-	for _, item := range items {
+	responses := make([]api.RepairRequestResponse, 0, len(result.Items))
+	for _, item := range result.Items {
 		responses = append(responses, toApplicationRepairRequestResponse(&item))
 	}
-	c.JSON(http.StatusOK, api.RepairRequestListResponse{Data: &responses})
+	c.JSON(http.StatusOK, api.RepairRequestListResponse{Data: &responses, Pagination: toPaginationResponse(pagination, result.Total)})
 }
 
 // CreateRepairRequest handles repair request creation.
@@ -2285,18 +2296,18 @@ func (s *APIServer) ListTenants(c *gin.Context, params api.ListTenantsParams) {
 		status = string(*params.Status)
 	}
 
-	tenants, err := s.tenantQueryRepo.ListAccessible(c.Request.Context(), principal.Role, principal.AssignedPropertyIDs, params.PropertyId, status, pagination.Limit, pagination.Offset)
+	result, err := s.tenantQueryRepo.ListAccessible(c.Request.Context(), principal.Role, principal.AssignedPropertyIDs, params.PropertyId, status, pagination.Limit, pagination.Offset)
 	if err != nil {
 		c.Error(apperr.ErrInternalServerError.WithCause(err))
 		return
 	}
 
-	items := make([]api.TenantResponse, 0, len(tenants))
-	for _, tenant := range tenants {
+	items := make([]api.TenantResponse, 0, len(result.Items))
+	for _, tenant := range result.Items {
 		items = append(items, toTenantResponse(&tenant))
 	}
 
-	c.JSON(http.StatusOK, api.TenantListResponse{Data: &items})
+	c.JSON(http.StatusOK, api.TenantListResponse{Data: &items, Pagination: toPaginationResponse(pagination, result.Total)})
 }
 
 // CreateTenant handles tenant creation.
@@ -2433,7 +2444,7 @@ func (s *APIServer) ListUsers(c *gin.Context, params api.ListUsersParams) {
 		return
 	}
 
-	items, err := s.userRepo.List(c.Request.Context(), users.ListParams{
+	result, err := s.userRepo.List(c.Request.Context(), users.ListParams{
 		Role:   role,
 		Limit:  pagination.Limit,
 		Offset: pagination.Offset,
@@ -2443,12 +2454,12 @@ func (s *APIServer) ListUsers(c *gin.Context, params api.ListUsersParams) {
 		return
 	}
 
-	responseItems := make([]api.UserResponse, 0, len(items))
-	for _, user := range items {
+	responseItems := make([]api.UserResponse, 0, len(result.Items))
+	for _, user := range result.Items {
 		responseItems = append(responseItems, toUserResponse(&user))
 	}
 
-	c.JSON(http.StatusOK, api.UserListResponse{Data: &responseItems})
+	c.JSON(http.StatusOK, api.UserListResponse{Data: &responseItems, Pagination: toPaginationResponse(pagination, result.Total)})
 }
 
 // CreateUser handles user creation.
@@ -2770,6 +2781,23 @@ func toBillListResponse(bills []BillingBill) api.BillListResponse {
 	}
 
 	return api.BillListResponse{Data: &items}
+}
+
+func toPaginationResponse(pagination queryparams.Pagination, total int) *api.PaginationResponse {
+	totalPages := 0
+	if total > 0 {
+		totalPages = (total + pagination.Limit - 1) / pagination.Limit
+	}
+	hasNext := pagination.Page < totalPages
+	page := pagination.Page
+	limit := pagination.Limit
+	return &api.PaginationResponse{
+		Page:       &page,
+		Limit:      &limit,
+		Total:      &total,
+		TotalPages: &totalPages,
+		HasNext:    &hasNext,
+	}
 }
 
 func toBillResponse(bill *BillingBill) api.BillResponse {

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -238,6 +238,7 @@ func TestListBillsForwardsFiltersAndPagination(t *testing.T) {
 
 	query := &recordingBillingQuery{
 		bills: []BillingBill{testBillingBill()},
+		total: 21,
 	}
 	server := &APIServer{billing: BillingServices{Query: query}}
 	recorder := httptest.NewRecorder()
@@ -253,6 +254,7 @@ func TestListBillsForwardsFiltersAndPagination(t *testing.T) {
 	leaseID := "40000000-0000-0000-0000-000000000001"
 	tenantID := openapi_types.UUID([16]byte{0x50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	status := api.ListBillsParamsStatusPaid
+	billType := api.ListBillsParamsTypeRent
 	month := "2026-04"
 	page := 2
 	limit := 10
@@ -262,6 +264,7 @@ func TestListBillsForwardsFiltersAndPagination(t *testing.T) {
 		LeaseId:    &leaseID,
 		TenantId:   &tenantID,
 		Status:     &status,
+		Type:       &billType,
 		Month:      &month,
 		Page:       &page,
 		Limit:      &limit,
@@ -282,7 +285,7 @@ func TestListBillsForwardsFiltersAndPagination(t *testing.T) {
 	if query.input.TenantID == nil || *query.input.TenantID != tenantID.String() {
 		t.Fatalf("TenantID = %v, want %s", query.input.TenantID, tenantID.String())
 	}
-	if query.input.Status != "paid" || query.input.Month == nil || *query.input.Month != month {
+	if query.input.Type != "rent" || query.input.Status != "paid" || query.input.Month == nil || *query.input.Month != month {
 		t.Fatalf("unexpected filters: %+v", query.input)
 	}
 	if query.input.Limit != 10 || query.input.Offset != 10 {
@@ -298,6 +301,12 @@ func TestListBillsForwardsFiltersAndPagination(t *testing.T) {
 	}
 	if (*response.Data)[0].Amount == nil || *(*response.Data)[0].Amount != 12000 {
 		t.Fatalf("unexpected bill response: %+v", (*response.Data)[0])
+	}
+	if response.Pagination == nil || response.Pagination.Total == nil || *response.Pagination.Total != 21 {
+		t.Fatalf("unexpected pagination: %+v", response.Pagination)
+	}
+	if response.Pagination.TotalPages == nil || *response.Pagination.TotalPages != 3 || response.Pagination.HasNext == nil || !*response.Pagination.HasNext {
+		t.Fatalf("unexpected pagination derived fields: %+v", response.Pagination)
 	}
 }
 
@@ -1091,12 +1100,13 @@ type recordingBillingQuery struct {
 	input    BillingListInput
 	getInput BillingGetInput
 	bills    []BillingBill
+	total    int
 	getBill  BillingBill
 }
 
-func (q *recordingBillingQuery) ListBills(_ context.Context, input BillingListInput) ([]BillingBill, error) {
+func (q *recordingBillingQuery) ListBills(_ context.Context, input BillingListInput) (BillingListResult, error) {
 	q.input = input
-	return q.bills, nil
+	return BillingListResult{Items: q.bills, Total: q.total}, nil
 }
 
 func (q *recordingBillingQuery) GetBill(_ context.Context, input BillingGetInput) (*BillingBill, error) {
@@ -1271,9 +1281,9 @@ type recordingRepairQueryRepo struct {
 	err   error
 }
 
-func (r *recordingRepairQueryRepo) List(_ context.Context, query apprepair.ListQuery) ([]apprepair.RepairRequest, error) {
+func (r *recordingRepairQueryRepo) List(_ context.Context, query apprepair.ListQuery) (apprepair.ListResult, error) {
 	r.query = query
-	return r.items, r.err
+	return apprepair.ListResult{Items: r.items, Total: len(r.items)}, r.err
 }
 
 func (r *recordingRepairQueryRepo) FindByID(context.Context, string) (*apprepair.RepairRequest, error) {
@@ -1360,8 +1370,8 @@ type handlerRepairRepositoryStub struct {
 	repairRequest *apprepair.RepairRequest
 }
 
-func (r *handlerRepairRepositoryStub) List(context.Context, apprepair.ListQuery) ([]apprepair.RepairRequest, error) {
-	return nil, nil
+func (r *handlerRepairRepositoryStub) List(context.Context, apprepair.ListQuery) (apprepair.ListResult, error) {
+	return apprepair.ListResult{}, nil
 }
 
 func (r *handlerRepairRepositoryStub) FindByID(context.Context, string) (*apprepair.RepairRequest, error) {

--- a/internal/http/middleware/middleware_test.go
+++ b/internal/http/middleware/middleware_test.go
@@ -675,8 +675,8 @@ func (fakeUserRepo) FindByID(_ context.Context, id string) (*users.User, error) 
 	}, nil
 }
 
-func (fakeUserRepo) List(_ context.Context, _ users.ListParams) ([]users.User, error) {
-	return []users.User{}, nil
+func (fakeUserRepo) List(_ context.Context, _ users.ListParams) (users.UserListResult, error) {
+	return users.UserListResult{Items: []users.User{}}, nil
 }
 
 func (fakeUserRepo) Create(_ context.Context, params users.CreateUserParams) (*users.User, error) {

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -4400,8 +4400,8 @@ type customClaimsCall struct {
 
 type fakeBillingQuery struct{}
 
-func (fakeBillingQuery) ListBills(_ context.Context, _ handler.BillingListInput) ([]handler.BillingBill, error) {
-	return nil, nil
+func (fakeBillingQuery) ListBills(_ context.Context, _ handler.BillingListInput) (handler.BillingListResult, error) {
+	return handler.BillingListResult{}, nil
 }
 
 func (fakeBillingQuery) GetBill(_ context.Context, _ handler.BillingGetInput) (*handler.BillingBill, error) {
@@ -4721,18 +4721,18 @@ func (f fakeUserRepo) FindByID(_ context.Context, id string) (*users.User, error
 	}, nil
 }
 
-func (f *fakeUserRepo) List(_ context.Context, params users.ListParams) ([]users.User, error) {
+func (f *fakeUserRepo) List(_ context.Context, params users.ListParams) (users.UserListResult, error) {
 	if f.listParamsSink != nil {
 		*f.listParamsSink = params
 	}
 	if f.listErr != nil {
-		return nil, f.listErr
+		return users.UserListResult{}, f.listErr
 	}
 	if f.listUsers != nil {
-		return f.listUsers, nil
+		return users.UserListResult{Items: f.listUsers, Total: len(f.listUsers)}, nil
 	}
 
-	return []users.User{
+	items := []users.User{
 		{
 			ID:                  "user-1",
 			FirebaseUID:         "uid-1",
@@ -4745,7 +4745,8 @@ func (f *fakeUserRepo) List(_ context.Context, params users.ListParams) ([]users
 			UpdatedAt:           time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 			Version:             1,
 		},
-	}, nil
+	}
+	return users.UserListResult{Items: items, Total: len(items)}, nil
 }
 
 func (f fakeUserRepo) Create(_ context.Context, params users.CreateUserParams) (*users.User, error) {
@@ -5196,7 +5197,7 @@ func (f fakePropertyQueryRepo) ListAccessible(_ context.Context, _ string, _ str
 	}, nil
 }
 
-func (f fakePropertyQueryRepo) ListRoomsByProperty(_ context.Context, propertyID string, status string, limit int, offset int) ([]dbpropertyquery.Room, error) {
+func (f fakePropertyQueryRepo) ListRoomsByProperty(_ context.Context, propertyID string, status string, limit int, offset int) (dbpropertyquery.RoomListResult, error) {
 	if f.listRoomsCall != nil {
 		f.listRoomsCall.propertyID = propertyID
 		f.listRoomsCall.status = status
@@ -5204,10 +5205,10 @@ func (f fakePropertyQueryRepo) ListRoomsByProperty(_ context.Context, propertyID
 		f.listRoomsCall.offset = offset
 	}
 	if f.roomErr != nil {
-		return nil, f.roomErr
+		return dbpropertyquery.RoomListResult{}, f.roomErr
 	}
 	if f.rooms != nil {
-		return f.rooms, nil
+		return dbpropertyquery.RoomListResult{Items: f.rooms, Total: len(f.rooms)}, nil
 	}
 
 	size := 10.5
@@ -5218,7 +5219,7 @@ func (f fakePropertyQueryRepo) ListRoomsByProperty(_ context.Context, propertyID
 	zone := "A"
 	facilities := map[string]interface{}{"ac": true}
 
-	return []dbpropertyquery.Room{
+	rooms := []dbpropertyquery.Room{
 		{
 			ID:                testRoomID1,
 			PropertyID:        propertyID,
@@ -5234,7 +5235,8 @@ func (f fakePropertyQueryRepo) ListRoomsByProperty(_ context.Context, propertyID
 			CreatedAt:         time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 			UpdatedAt:         time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 		},
-	}, nil
+	}
+	return dbpropertyquery.RoomListResult{Items: rooms, Total: len(rooms)}, nil
 }
 
 func (f fakePropertyQueryRepo) FindRoomByID(_ context.Context, roomID string) (*dbpropertyquery.Room, error) {
@@ -5586,7 +5588,7 @@ func (f fakeLeaseRepo) DeactivateTenantIfNoActiveLeases(_ context.Context, _ *sq
 	return nil
 }
 
-func (f fakeTenantQueryRepo) ListAccessible(_ context.Context, role string, assignedPropertyIDs []string, propertyID *string, status string, limit int, offset int) ([]dbtenantquery.Tenant, error) {
+func (f fakeTenantQueryRepo) ListAccessible(_ context.Context, role string, assignedPropertyIDs []string, propertyID *string, status string, limit int, offset int) (dbtenantquery.TenantListResult, error) {
 	if f.listCall != nil {
 		f.listCall.role = role
 		f.listCall.assignedPropertyIDs = assignedPropertyIDs
@@ -5596,13 +5598,13 @@ func (f fakeTenantQueryRepo) ListAccessible(_ context.Context, role string, assi
 		f.listCall.offset = offset
 	}
 	if f.tenantErr != nil {
-		return nil, f.tenantErr
+		return dbtenantquery.TenantListResult{}, f.tenantErr
 	}
 	if f.tenants != nil {
-		return f.tenants, nil
+		return dbtenantquery.TenantListResult{Items: f.tenants, Total: len(f.tenants)}, nil
 	}
 
-	return []dbtenantquery.Tenant{}, nil
+	return dbtenantquery.TenantListResult{Items: []dbtenantquery.Tenant{}}, nil
 }
 
 func (f fakeTenantQueryRepo) FindByIDAccessible(_ context.Context, _ string, _ string, _ []string) (*dbtenantquery.Tenant, error) {
@@ -5641,20 +5643,20 @@ func (f fakeTenantQueryRepo) ListLeasesByTenantAccessible(_ context.Context, ten
 	return []dbtenantquery.Lease{}, nil
 }
 
-func (f fakeLeaseQueryRepo) ListAccessible(_ context.Context, role string, assignedPropertyIDs []string, params dbleasequery.ListParams) ([]dbleasequery.Lease, error) {
+func (f fakeLeaseQueryRepo) ListAccessible(_ context.Context, role string, assignedPropertyIDs []string, params dbleasequery.ListParams) (dbleasequery.LeaseListResult, error) {
 	if f.listCall != nil {
 		f.listCall.role = role
 		f.listCall.assignedPropertyIDs = assignedPropertyIDs
 		f.listCall.params = params
 	}
 	if f.leaseErr != nil {
-		return nil, f.leaseErr
+		return dbleasequery.LeaseListResult{}, f.leaseErr
 	}
 	if f.leases != nil {
-		return f.leases, nil
+		return dbleasequery.LeaseListResult{Items: f.leases, Total: len(f.leases)}, nil
 	}
 
-	return []dbleasequery.Lease{}, nil
+	return dbleasequery.LeaseListResult{Items: []dbleasequery.Lease{}}, nil
 }
 
 func (f fakeLeaseQueryRepo) FindByIDAccessible(_ context.Context, id string, role string, assignedPropertyIDs []string) (*dbleasequery.Lease, error) {
@@ -5689,8 +5691,8 @@ func (f fakeLeaseQueryRepo) FindByIDAccessible(_ context.Context, id string, rol
 	}, nil
 }
 
-func (fakeRepairQueryRepo) List(context.Context, apprepair.ListQuery) ([]apprepair.RepairRequest, error) {
-	return []apprepair.RepairRequest{}, nil
+func (fakeRepairQueryRepo) List(context.Context, apprepair.ListQuery) (apprepair.ListResult, error) {
+	return apprepair.ListResult{Items: []apprepair.RepairRequest{}}, nil
 }
 
 func (fakeRepairQueryRepo) FindByID(context.Context, string) (*apprepair.RepairRequest, error) {

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -30,10 +30,17 @@ type BillFilter struct {
 	PropertyID *string
 	LeaseID    *string
 	TenantID   *string
+	Type       *string
 	Status     *string
 	Month      *string
 	Limit      int
 	Offset     int
+}
+
+// BillListResult contains paginated bill rows and the total matching count.
+type BillListResult struct {
+	Items []Bill
+	Total int
 }
 
 // Bill is the billing read and mutation model persisted in PostgreSQL.
@@ -599,15 +606,23 @@ WHERE pa.id = ae.property_account_id
 }
 
 // ListAccessible returns active bills visible to the provided scope.
-func (r *SQLRepository) ListAccessible(ctx context.Context, scope Scope, filter BillFilter) (bills []Bill, err error) {
+func (r *SQLRepository) ListAccessible(ctx context.Context, scope Scope, filter BillFilter) (result BillListResult, err error) {
 	query, args, ok := buildAccessibleBillQuery(scope, filter, false, nil)
 	if !ok {
-		return []Bill{}, nil
+		return BillListResult{Items: []Bill{}}, nil
+	}
+	countQuery, countArgs, ok := buildAccessibleBillCountQuery(scope, filter)
+	if !ok {
+		return BillListResult{Items: []Bill{}}, nil
+	}
+
+	if err := r.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&result.Total); err != nil {
+		return BillListResult{}, fmt.Errorf("count accessible bills: %w", err)
 	}
 
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("list accessible bills: %w", err)
+		return BillListResult{}, fmt.Errorf("list accessible bills: %w", err)
 	}
 	defer func() {
 		if cerr := rows.Close(); cerr != nil && err == nil {
@@ -615,19 +630,19 @@ func (r *SQLRepository) ListAccessible(ctx context.Context, scope Scope, filter 
 		}
 	}()
 
-	bills = make([]Bill, 0)
+	result.Items = make([]Bill, 0)
 	for rows.Next() {
 		bill, err := scanBill(rows)
 		if err != nil {
-			return nil, fmt.Errorf("scan bill row: %w", err)
+			return BillListResult{}, fmt.Errorf("scan bill row: %w", err)
 		}
-		bills = append(bills, *bill)
+		result.Items = append(result.Items, *bill)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate bill rows: %w", err)
+		return BillListResult{}, fmt.Errorf("iterate bill rows: %w", err)
 	}
 
-	return bills, nil
+	return result, nil
 }
 
 // FindByIDAccessible returns one visible bill. Pending electricity bills with a NULL
@@ -2186,6 +2201,34 @@ func profitLossSignedAmountSQL(categoryExpr string, amountExpr string) string {
 }
 
 func buildAccessibleBillQuery(scope Scope, filter BillFilter, single bool, billID *string) (string, []any, bool) {
+	base, args, ok := buildAccessibleBillQueryBase(scope, filter, billID)
+	if !ok {
+		return "", nil, false
+	}
+	if single {
+		base += "\nLIMIT 1"
+		return base, args, true
+	}
+
+	args = append(args, filter.Limit, filter.Offset)
+	base += fmt.Sprintf("\nORDER BY b.due_date DESC, b.created_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
+	return base, args, true
+}
+
+func buildAccessibleBillCountQuery(scope Scope, filter BillFilter) (string, []any, bool) {
+	base, args, ok := buildAccessibleBillQueryBase(scope, filter, nil)
+	if !ok {
+		return "", nil, false
+	}
+	fromIndex := strings.Index(base, "FROM bills b")
+	if fromIndex < 0 {
+		return "", nil, false
+	}
+
+	return "SELECT COUNT(*)\n" + base[fromIndex:], args, true
+}
+
+func buildAccessibleBillQueryBase(scope Scope, filter BillFilter, billID *string) (string, []any, bool) {
 	base := `
 SELECT
 	b.id,
@@ -2253,6 +2296,10 @@ FROM bills b
 		args = append(args, strings.TrimSpace(*filter.TenantID))
 		conditions = append(conditions, fmt.Sprintf("b.tenant_id = $%d", len(args)))
 	}
+	if filter.Type != nil && strings.TrimSpace(*filter.Type) != "" {
+		args = append(args, strings.TrimSpace(*filter.Type))
+		conditions = append(conditions, fmt.Sprintf("b.type = $%d", len(args)))
+	}
 	if filter.Status != nil && strings.TrimSpace(*filter.Status) != "" {
 		args = append(args, strings.TrimSpace(*filter.Status))
 		conditions = append(conditions, fmt.Sprintf("b.status = $%d", len(args)))
@@ -2267,13 +2314,6 @@ FROM bills b
 		base += strings.Join(joins, "\n") + "\n"
 	}
 	base += "WHERE " + strings.Join(conditions, "\n  AND ")
-	if single {
-		base += "\nLIMIT 1"
-		return base, args, true
-	}
-
-	args = append(args, filter.Limit, filter.Offset)
-	base += fmt.Sprintf("\nORDER BY b.due_date DESC, b.created_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
 	return base, args, true
 }
 

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -16,6 +16,9 @@ func TestListAccessibleOwnerScopeReturnsOwnedBills(t *testing.T) {
 	defer closeBillingDB(t, db)
 
 	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\)\s+FROM bills b\s+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL\s+WHERE b.deleted_at IS NULL\s+AND p.owner_id = \$1`).
+		WithArgs("user-1").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 	mock.ExpectQuery(`(?s)FROM bills b\s+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL\s+WHERE b.deleted_at IS NULL\s+AND p.owner_id = \$1\s+ORDER BY b.due_date DESC, b.created_at DESC LIMIT \$2 OFFSET \$3`).
 		WithArgs("user-1", 10, 0).
 		WillReturnRows(billRows().AddRow(
@@ -23,15 +26,18 @@ func TestListAccessibleOwnerScopeReturnsOwnedBills(t *testing.T) {
 			now, now, now, "pending_payment", nil, nil, nil, nil, nil, nil, nil, nil, 0, now, now, 1,
 		))
 
-	bills, err := repo.ListAccessible(context.Background(), Scope{Role: "owner", UserID: "user-1"}, BillFilter{Limit: 10})
+	result, err := repo.ListAccessible(context.Background(), Scope{Role: "owner", UserID: "user-1"}, BillFilter{Limit: 10})
 	if err != nil {
 		t.Fatalf("ListAccessible: %v", err)
 	}
-	if len(bills) != 1 {
-		t.Fatalf("expected 1 bill, got %d", len(bills))
+	if len(result.Items) != 1 {
+		t.Fatalf("expected 1 bill, got %d", len(result.Items))
 	}
-	if bills[0].PropertyID != "property-owned" {
-		t.Fatalf("PropertyID = %q, want property-owned", bills[0].PropertyID)
+	if result.Items[0].PropertyID != "property-owned" {
+		t.Fatalf("PropertyID = %q, want property-owned", result.Items[0].PropertyID)
+	}
+	if result.Total != 1 {
+		t.Fatalf("Total = %d, want 1", result.Total)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -201,12 +207,15 @@ func TestListAccessibleOrganizerWithNoAssignedPropertiesReturnsEmpty(t *testing.
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)
 
-	bills, err := repo.ListAccessible(context.Background(), Scope{Role: "organizer"}, BillFilter{Limit: 10})
+	result, err := repo.ListAccessible(context.Background(), Scope{Role: "organizer"}, BillFilter{Limit: 10})
 	if err != nil {
 		t.Fatalf("ListAccessible: %v", err)
 	}
-	if len(bills) != 0 {
-		t.Fatalf("expected no bills, got %d", len(bills))
+	if len(result.Items) != 0 {
+		t.Fatalf("expected no bills, got %d", len(result.Items))
+	}
+	if result.Total != 0 {
+		t.Fatalf("Total = %d, want 0", result.Total)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
@@ -220,20 +229,25 @@ func TestListAccessibleAppliesFiltersAndPagination(t *testing.T) {
 	propertyID := "property-1"
 	leaseID := "lease-1"
 	tenantID := "tenant-1"
+	billType := "electricity"
 	status := "pending_payment"
 	month := "2026-04"
 
-	mock.ExpectQuery(`(?s)b.property_id IN \(\$1\).*b.property_id = \$2.*b.lease_id = \$3.*b.tenant_id = \$4.*b.status = \$5.*b.due_date >= to_date\(\$6, 'YYYY-MM'\).*b.due_date < to_date\(\$6, 'YYYY-MM'\) \+ INTERVAL '1 month'.*LIMIT \$7 OFFSET \$8`).
-		WithArgs("property-1", propertyID, leaseID, tenantID, status, month, 25, 50).
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\).*b.property_id IN \(\$1\).*b.property_id = \$2.*b.lease_id = \$3.*b.tenant_id = \$4.*b.type = \$5.*b.status = \$6.*b.due_date >= to_date\(\$7, 'YYYY-MM'\).*b.due_date < to_date\(\$7, 'YYYY-MM'\) \+ INTERVAL '1 month'`).
+		WithArgs("property-1", propertyID, leaseID, tenantID, billType, status, month).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+	mock.ExpectQuery(`(?s)b.property_id IN \(\$1\).*b.property_id = \$2.*b.lease_id = \$3.*b.tenant_id = \$4.*b.type = \$5.*b.status = \$6.*b.due_date >= to_date\(\$7, 'YYYY-MM'\).*b.due_date < to_date\(\$7, 'YYYY-MM'\) \+ INTERVAL '1 month'.*LIMIT \$8 OFFSET \$9`).
+		WithArgs("property-1", propertyID, leaseID, tenantID, billType, status, month, 25, 50).
 		WillReturnRows(billRows())
 
-	_, err := repo.ListAccessible(context.Background(), Scope{
+	result, err := repo.ListAccessible(context.Background(), Scope{
 		Role:                "staff",
 		AssignedPropertyIDs: []string{"property-1"},
 	}, BillFilter{
 		PropertyID: &propertyID,
 		LeaseID:    &leaseID,
 		TenantID:   &tenantID,
+		Type:       &billType,
 		Status:     &status,
 		Month:      &month,
 		Limit:      25,
@@ -241,6 +255,9 @@ func TestListAccessibleAppliesFiltersAndPagination(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("ListAccessible: %v", err)
+	}
+	if result.Total != 2 {
+		t.Fatalf("Total = %d, want 2", result.Total)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/platform/database/journal/repository.go
+++ b/internal/platform/database/journal/repository.go
@@ -21,52 +21,30 @@ func NewRepository(db *sql.DB) *SQLRepository {
 }
 
 // List returns active journal logs visible to the actor scope.
-func (r *SQLRepository) List(ctx context.Context, query appjournal.ListQuery) ([]appjournal.JournalLog, error) {
-	base := selectJournalLogColumns + `
+func (r *SQLRepository) List(ctx context.Context, query appjournal.ListQuery) (appjournal.ListResult, error) {
+	filterSQL, args, scoped := buildJournalListFilter(query)
+	if !scoped {
+		return appjournal.ListResult{Items: []appjournal.JournalLog{}}, nil
+	}
+
+	countQuery := `
+SELECT COUNT(*)
 FROM journal_logs jl
-WHERE jl.deleted_at IS NULL
-`
-	args := make([]any, 0)
-
-	switch strings.TrimSpace(query.ActorRole) {
-	case "organizer", "staff":
-		if len(query.AssignedPropertyIDs) == 0 {
-			return []appjournal.JournalLog{}, nil
-		}
-		placeholders := make([]string, 0, len(query.AssignedPropertyIDs))
-		for _, id := range query.AssignedPropertyIDs {
-			args = append(args, id)
-			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
-		}
-		base += "\n  AND jl.property_id IN (" + strings.Join(placeholders, ", ") + ")"
-	case "admin":
-	default:
-		return []appjournal.JournalLog{}, nil
+` + filterSQL
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return appjournal.ListResult{}, fmt.Errorf("count journal logs: %w", err)
 	}
 
-	if query.PropertyID != nil {
-		args = append(args, *query.PropertyID)
-		base += fmt.Sprintf("\n  AND jl.property_id = $%d", len(args))
-	}
-	if query.RoomID != nil {
-		args = append(args, *query.RoomID)
-		base += fmt.Sprintf("\n  AND jl.room_id = $%d", len(args))
-	}
-	if query.DateFrom != nil {
-		args = append(args, query.DateFrom.UTC())
-		base += fmt.Sprintf("\n  AND jl.created_at >= $%d", len(args))
-	}
-	if query.DateTo != nil {
-		args = append(args, query.DateTo.UTC().AddDate(0, 0, 1))
-		base += fmt.Sprintf("\n  AND jl.created_at < $%d", len(args))
-	}
+	listArgs := append([]any{}, args...)
+	listArgs = append(listArgs, query.Limit, query.Offset)
+	listQuery := selectJournalLogColumns + `
+FROM journal_logs jl
+` + filterSQL + fmt.Sprintf("\nORDER BY jl.created_at DESC, jl.id DESC LIMIT $%d OFFSET $%d", len(listArgs)-1, len(listArgs))
 
-	args = append(args, query.Limit, query.Offset)
-	base += fmt.Sprintf("\nORDER BY jl.created_at DESC, jl.id DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
-
-	rows, err := r.db.QueryContext(ctx, base, args...)
+	rows, err := r.db.QueryContext(ctx, listQuery, listArgs...)
 	if err != nil {
-		return nil, fmt.Errorf("list journal logs: %w", err)
+		return appjournal.ListResult{}, fmt.Errorf("list journal logs: %w", err)
 	}
 	defer rows.Close()
 
@@ -74,15 +52,56 @@ WHERE jl.deleted_at IS NULL
 	for rows.Next() {
 		item, err := scanJournalLog(rows)
 		if err != nil {
-			return nil, fmt.Errorf("scan journal log: %w", err)
+			return appjournal.ListResult{}, fmt.Errorf("scan journal log: %w", err)
 		}
 		items = append(items, *item)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate journal logs: %w", err)
+		return appjournal.ListResult{}, fmt.Errorf("iterate journal logs: %w", err)
 	}
 
-	return items, nil
+	return appjournal.ListResult{Items: items, Total: total}, nil
+}
+
+func buildJournalListFilter(query appjournal.ListQuery) (string, []any, bool) {
+	filter := `WHERE jl.deleted_at IS NULL
+`
+	args := make([]any, 0)
+
+	switch strings.TrimSpace(query.ActorRole) {
+	case "organizer", "staff":
+		if len(query.AssignedPropertyIDs) == 0 {
+			return "", nil, false
+		}
+		placeholders := make([]string, 0, len(query.AssignedPropertyIDs))
+		for _, id := range query.AssignedPropertyIDs {
+			args = append(args, id)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		filter += "\n  AND jl.property_id IN (" + strings.Join(placeholders, ", ") + ")"
+	case "admin":
+	default:
+		return "", nil, false
+	}
+
+	if query.PropertyID != nil {
+		args = append(args, *query.PropertyID)
+		filter += fmt.Sprintf("\n  AND jl.property_id = $%d", len(args))
+	}
+	if query.RoomID != nil {
+		args = append(args, *query.RoomID)
+		filter += fmt.Sprintf("\n  AND jl.room_id = $%d", len(args))
+	}
+	if query.DateFrom != nil {
+		args = append(args, query.DateFrom.UTC())
+		filter += fmt.Sprintf("\n  AND jl.created_at >= $%d", len(args))
+	}
+	if query.DateTo != nil {
+		args = append(args, query.DateTo.UTC().AddDate(0, 0, 1))
+		filter += fmt.Sprintf("\n  AND jl.created_at < $%d", len(args))
+	}
+
+	return filter, args, true
 }
 
 // FindByID returns one active journal log.

--- a/internal/platform/database/journal/repository_test.go
+++ b/internal/platform/database/journal/repository_test.go
@@ -25,12 +25,15 @@ func TestListAppliesFiltersPaginationAndScope(t *testing.T) {
 	createdAt := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
 	updatedAt := createdAt
 
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WithArgs(propertyID, propertyID, roomID, dateFrom, dateTo.AddDate(0, 0, 1)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(7))
 	mock.ExpectQuery(regexp.QuoteMeta("FROM journal_logs jl")).
 		WithArgs(propertyID, propertyID, roomID, dateFrom, dateTo.AddDate(0, 0, 1), 20, 40).
 		WillReturnRows(journalLogRows().
 			AddRow("60000000-0000-0000-0000-000000000001", propertyID, roomID, "00000000-0000-0000-0000-000000000002", "Inspection", nil, nil, createdAt, updatedAt))
 
-	items, err := repo.List(context.Background(), appjournal.ListQuery{
+	result, err := repo.List(context.Background(), appjournal.ListQuery{
 		ActorRole:           "staff",
 		AssignedPropertyIDs: []string{propertyID},
 		PropertyID:          &propertyID,
@@ -43,6 +46,10 @@ func TestListAppliesFiltersPaginationAndScope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
+	if result.Total != 7 {
+		t.Fatalf("Total = %d, want 7", result.Total)
+	}
+	items := result.Items
 	if len(items) != 1 {
 		t.Fatalf("items = %d, want 1", len(items))
 	}
@@ -58,15 +65,18 @@ func TestListReturnsEmptyForUnscopedStaff(t *testing.T) {
 	db, mock, repo := newJournalRepoTest(t)
 	defer db.Close()
 
-	items, err := repo.List(context.Background(), appjournal.ListQuery{
+	result, err := repo.List(context.Background(), appjournal.ListQuery{
 		ActorRole: "staff",
 		Limit:     20,
 	})
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
-	if len(items) != 0 {
-		t.Fatalf("items = %d, want 0", len(items))
+	if len(result.Items) != 0 {
+		t.Fatalf("items = %d, want 0", len(result.Items))
+	}
+	if result.Total != 0 {
+		t.Fatalf("Total = %d, want 0", result.Total)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)
@@ -174,6 +184,9 @@ func TestListQueryContainsSoftDeletePredicate(t *testing.T) {
 	db, mock, repo := newJournalRepoTest(t)
 	defer db.Close()
 
+	mock.ExpectQuery("(?s)" + regexp.QuoteMeta("SELECT COUNT(*)") + ".*" + regexp.QuoteMeta("FROM journal_logs jl") + ".*" + regexp.QuoteMeta("WHERE jl.deleted_at IS NULL")).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectQuery("(?s)"+regexp.QuoteMeta("FROM journal_logs jl")+".*"+regexp.QuoteMeta("WHERE jl.deleted_at IS NULL")).
 		WithArgs(20, 0).
 		WillReturnRows(journalLogRows())
@@ -195,6 +208,9 @@ func TestListOrdersByCreatedAtAndID(t *testing.T) {
 	defer db.Close()
 
 	orderPattern := strings.ReplaceAll("ORDER BY jl.created_at DESC, jl.id DESC LIMIT", " ", `\s+`)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WithArgs().
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 	mock.ExpectQuery("(?s)"+orderPattern).
 		WithArgs(20, 0).
 		WillReturnRows(journalLogRows())

--- a/internal/platform/database/leasequery/repository.go
+++ b/internal/platform/database/leasequery/repository.go
@@ -38,6 +38,12 @@ type Lease struct {
 	Version                   int
 }
 
+// LeaseListResult is the paginated lease list query result.
+type LeaseListResult struct {
+	Items []Lease
+	Total int
+}
+
 // ListParams captures supported filters for lease listing.
 type ListParams struct {
 	PropertyID *string
@@ -50,7 +56,7 @@ type ListParams struct {
 
 // Repository serves read-model queries for leases.
 type Repository interface {
-	ListAccessible(ctx context.Context, role string, assignedPropertyIDs []string, params ListParams) ([]Lease, error)
+	ListAccessible(ctx context.Context, role string, assignedPropertyIDs []string, params ListParams) (LeaseListResult, error)
 	FindByIDAccessible(ctx context.Context, leaseID string, role string, assignedPropertyIDs []string) (*Lease, error)
 }
 
@@ -64,7 +70,42 @@ func NewRepository(db *sql.DB) *SQLRepository {
 	return &SQLRepository{db: db}
 }
 
-func (r *SQLRepository) ListAccessible(ctx context.Context, role string, assignedPropertyIDs []string, params ListParams) ([]Lease, error) {
+func (r *SQLRepository) ListAccessible(ctx context.Context, role string, assignedPropertyIDs []string, params ListParams) (LeaseListResult, error) {
+	countQuery, countArgs, ok := buildAccessibleLeaseListQuery(role, assignedPropertyIDs, params, true)
+	if !ok {
+		return LeaseListResult{Items: []Lease{}}, nil
+	}
+
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total); err != nil {
+		return LeaseListResult{}, fmt.Errorf("count accessible leases: %w", err)
+	}
+
+	listQuery, listArgs, _ := buildAccessibleLeaseListQuery(role, assignedPropertyIDs, params, false)
+	rows, err := r.db.QueryContext(ctx, listQuery, listArgs...)
+	if err != nil {
+		return LeaseListResult{}, fmt.Errorf("list accessible leases: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	leases := make([]Lease, 0)
+	for rows.Next() {
+		lease, err := scanLease(rows)
+		if err != nil {
+			return LeaseListResult{}, fmt.Errorf("scan lease row: %w", err)
+		}
+		leases = append(leases, *lease)
+	}
+	if err := rows.Err(); err != nil {
+		return LeaseListResult{}, fmt.Errorf("iterate lease rows: %w", err)
+	}
+
+	return LeaseListResult{Items: leases, Total: total}, nil
+}
+
+func buildAccessibleLeaseListQuery(role string, assignedPropertyIDs []string, params ListParams, count bool) (string, []any, bool) {
 	base := `
 SELECT
 	l.id,
@@ -91,13 +132,20 @@ SELECT
 FROM leases l
 WHERE l.deleted_at IS NULL
 `
+	if count {
+		base = `
+SELECT COUNT(*)::int
+FROM leases l
+WHERE l.deleted_at IS NULL
+`
+	}
 
 	args := make([]any, 0)
 	role = strings.TrimSpace(role)
 	switch role {
 	case "organizer", "staff":
 		if len(assignedPropertyIDs) == 0 {
-			return []Lease{}, nil
+			return "", nil, false
 		}
 		placeholders := make([]string, 0, len(assignedPropertyIDs))
 		for _, id := range assignedPropertyIDs {
@@ -107,7 +155,7 @@ WHERE l.deleted_at IS NULL
 		base += "\n  AND l.property_id IN (" + strings.Join(placeholders, ", ") + ")"
 	case "admin":
 	default:
-		return []Lease{}, nil
+		return "", nil, false
 	}
 
 	if params.PropertyID != nil && strings.TrimSpace(*params.PropertyID) != "" {
@@ -127,30 +175,13 @@ WHERE l.deleted_at IS NULL
 		base += fmt.Sprintf("\n  AND l.status = $%d", len(args))
 	}
 
+	if count {
+		return base, args, true
+	}
+
 	args = append(args, params.Limit, params.Offset)
 	base += fmt.Sprintf("\nORDER BY l.created_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
-
-	rows, err := r.db.QueryContext(ctx, base, args...)
-	if err != nil {
-		return nil, fmt.Errorf("list accessible leases: %w", err)
-	}
-	defer func() {
-		_ = rows.Close()
-	}()
-
-	leases := make([]Lease, 0)
-	for rows.Next() {
-		lease, err := scanLease(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan lease row: %w", err)
-		}
-		leases = append(leases, *lease)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate lease rows: %w", err)
-	}
-
-	return leases, nil
+	return base, args, true
 }
 
 func (r *SQLRepository) FindByIDAccessible(ctx context.Context, leaseID string, role string, assignedPropertyIDs []string) (*Lease, error) {

--- a/internal/platform/database/leasequery/repository_test.go
+++ b/internal/platform/database/leasequery/repository_test.go
@@ -19,6 +19,12 @@ func TestListAccessibleAdminDoesNotApplyPropertyScope(t *testing.T) {
 	startDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
 
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)::int
+FROM leases l
+WHERE l.deleted_at IS NULL
+`)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
+
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT
 	l.id,
 	l.tenant_id,
@@ -51,10 +57,14 @@ ORDER BY l.created_at DESC LIMIT $1 OFFSET $2`)).
 			"monthly", "monthly", "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 		))
 
-	leases, err := repo.ListAccessible(context.Background(), "admin", []string{"property-ignored"}, ListParams{Limit: 10, Offset: 20})
+	result, err := repo.ListAccessible(context.Background(), "admin", []string{"property-ignored"}, ListParams{Limit: 10, Offset: 20})
 	if err != nil {
 		t.Fatalf("ListAccessible: %v", err)
 	}
+	if result.Total != 3 {
+		t.Fatalf("expected total 3, got %d", result.Total)
+	}
+	leases := result.Items
 	if len(leases) != 1 {
 		t.Fatalf("expected 1 lease, got %d", len(leases))
 	}
@@ -79,16 +89,23 @@ func TestListAccessibleOrganizerAndStaffApplyAssignedPropertyScope(t *testing.T)
 			db, mock, repo := newLeaseQueryRepoTest(t)
 			defer closeLeaseQueryDB(t, db)
 
+			mock.ExpectQuery(`(?s)SELECT COUNT\(\*\)::int\s+FROM leases l\s+WHERE l\.deleted_at IS NULL\s+AND l\.property_id IN \(\$1, \$2\)`).
+				WithArgs("property-1", "property-2").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
 			mock.ExpectQuery(`(?s)WHERE l\.deleted_at IS NULL\s+AND l\.property_id IN \(\$1, \$2\)\s+ORDER BY l\.created_at DESC LIMIT \$3 OFFSET \$4`).
 				WithArgs("property-1", "property-2", 25, 50).
 				WillReturnRows(leaseQueryRows())
 
-			leases, err := repo.ListAccessible(context.Background(), tc.role, []string{"property-1", "property-2"}, ListParams{Limit: 25, Offset: 50})
+			result, err := repo.ListAccessible(context.Background(), tc.role, []string{"property-1", "property-2"}, ListParams{Limit: 25, Offset: 50})
 			if err != nil {
 				t.Fatalf("ListAccessible: %v", err)
 			}
-			if len(leases) != 0 {
-				t.Fatalf("expected no leases, got %d", len(leases))
+			if result.Total != 0 {
+				t.Fatalf("expected total 0, got %d", result.Total)
+			}
+			if len(result.Items) != 0 {
+				t.Fatalf("expected no leases, got %d", len(result.Items))
 			}
 
 			if err := mock.ExpectationsWereMet(); err != nil {
@@ -112,12 +129,15 @@ func TestListAccessibleEmptyAssignedAndUnknownRoleReturnEmptyWithoutQuery(t *tes
 			db, mock, repo := newLeaseQueryRepoTest(t)
 			defer closeLeaseQueryDB(t, db)
 
-			leases, err := repo.ListAccessible(context.Background(), tc.role, tc.assignedPropertyIDs, ListParams{Limit: 10})
+			result, err := repo.ListAccessible(context.Background(), tc.role, tc.assignedPropertyIDs, ListParams{Limit: 10})
 			if err != nil {
 				t.Fatalf("ListAccessible: %v", err)
 			}
-			if len(leases) != 0 {
-				t.Fatalf("expected empty leases, got %d", len(leases))
+			if result.Total != 0 {
+				t.Fatalf("expected total 0, got %d", result.Total)
+			}
+			if len(result.Items) != 0 {
+				t.Fatalf("expected empty leases, got %d", len(result.Items))
 			}
 
 			if err := mock.ExpectationsWereMet(); err != nil {
@@ -135,11 +155,15 @@ func TestListAccessibleAppliesFiltersAndPagination(t *testing.T) {
 	roomID := "room-filter"
 	tenantID := "tenant-filter"
 
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\)::int\s+FROM leases l\s+WHERE l\.deleted_at IS NULL\s+AND l\.property_id IN \(\$1\).*l\.property_id = \$2.*l\.room_id = \$3.*l\.tenant_id = \$4.*l\.status = \$5`).
+		WithArgs("property-assigned", propertyID, roomID, tenantID, "active").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(12))
+
 	mock.ExpectQuery(`(?s)l\.property_id IN \(\$1\).*l\.property_id = \$2.*l\.room_id = \$3.*l\.tenant_id = \$4.*l\.status = \$5.*LIMIT \$6 OFFSET \$7`).
 		WithArgs("property-assigned", propertyID, roomID, tenantID, "active", 30, 60).
 		WillReturnRows(leaseQueryRows())
 
-	_, err := repo.ListAccessible(context.Background(), "staff", []string{"property-assigned"}, ListParams{
+	result, err := repo.ListAccessible(context.Background(), "staff", []string{"property-assigned"}, ListParams{
 		PropertyID: &propertyID,
 		RoomID:     &roomID,
 		TenantID:   &tenantID,
@@ -149,6 +173,9 @@ func TestListAccessibleAppliesFiltersAndPagination(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("ListAccessible: %v", err)
+	}
+	if result.Total != 12 {
+		t.Fatalf("expected total 12, got %d", result.Total)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -164,6 +191,9 @@ func TestListAccessibleScansNullableFieldsAndSettlementDetail(t *testing.T) {
 	startDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	endDate := time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)
 
+	mock.ExpectQuery(`(?s)SELECT COUNT\(\*\)::int\s+FROM leases l\s+WHERE l\.deleted_at IS NULL`).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
+
 	mock.ExpectQuery(`(?s)WHERE l\.deleted_at IS NULL\s+ORDER BY l\.created_at DESC LIMIT \$1 OFFSET \$2`).
 		WithArgs(10, 0).
 		WillReturnRows(leaseQueryRows().
@@ -177,10 +207,14 @@ func TestListAccessibleScansNullableFieldsAndSettlementDetail(t *testing.T) {
 				"monthly", "bi_monthly", "active", 30000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 			))
 
-	leases, err := repo.ListAccessible(context.Background(), "admin", nil, ListParams{Limit: 10})
+	result, err := repo.ListAccessible(context.Background(), "admin", nil, ListParams{Limit: 10})
 	if err != nil {
 		t.Fatalf("ListAccessible: %v", err)
 	}
+	if result.Total != 2 {
+		t.Fatalf("expected total 2, got %d", result.Total)
+	}
+	leases := result.Items
 	if len(leases) != 2 {
 		t.Fatalf("expected 2 leases, got %d", len(leases))
 	}

--- a/internal/platform/database/propertyquery/repository.go
+++ b/internal/platform/database/propertyquery/repository.go
@@ -55,11 +55,17 @@ type Room struct {
 	UpdatedAt         time.Time
 }
 
+// RoomListResult is the paginated room list query result.
+type RoomListResult struct {
+	Items []Room
+	Total int
+}
+
 // Repository serves read-model queries for properties.
 type Repository interface {
 	FindByID(ctx context.Context, propertyID string) (*Property, error)
 	ListAccessible(ctx context.Context, role string, userID string, assignedPropertyIDs []string) ([]Property, error)
-	ListRoomsByProperty(ctx context.Context, propertyID string, status string, limit int, offset int) ([]Room, error)
+	ListRoomsByProperty(ctx context.Context, propertyID string, status string, limit int, offset int) (RoomListResult, error)
 	FindRoomByID(ctx context.Context, roomID string) (*Room, error)
 }
 
@@ -174,26 +180,17 @@ WHERE p.deleted_at IS NULL
 }
 
 // ListRoomsByProperty returns active rooms for a property with optional status filtering.
-func (r *SQLRepository) ListRoomsByProperty(ctx context.Context, propertyID string, status string, limit int, offset int) ([]Room, error) {
-	base := `
-SELECT id, property_id, name, status, size, floor, room_type, facilities::text, default_rent_amount, notes, zone, created_at, updated_at
-FROM rooms
-WHERE property_id = $1
-  AND deleted_at IS NULL
-`
-	args := []any{propertyID}
-
-	if status != "" {
-		args = append(args, status)
-		base += fmt.Sprintf(" AND status = $%d", len(args))
+func (r *SQLRepository) ListRoomsByProperty(ctx context.Context, propertyID string, status string, limit int, offset int) (RoomListResult, error) {
+	countQuery, countArgs := buildRoomsByPropertyListQuery(propertyID, status, 0, 0, true)
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total); err != nil {
+		return RoomListResult{}, fmt.Errorf("count rooms by property: %w", err)
 	}
 
-	args = append(args, limit, offset)
-	base += fmt.Sprintf(" ORDER BY created_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
-
-	rows, err := r.db.QueryContext(ctx, base, args...)
+	query, args := buildRoomsByPropertyListQuery(propertyID, status, limit, offset, false)
+	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf("list rooms by property: %w", err)
+		return RoomListResult{}, fmt.Errorf("list rooms by property: %w", err)
 	}
 	defer rows.Close()
 
@@ -201,16 +198,47 @@ WHERE property_id = $1
 	for rows.Next() {
 		room, err := scanRoom(rows)
 		if err != nil {
-			return nil, fmt.Errorf("scan room row: %w", err)
+			return RoomListResult{}, fmt.Errorf("scan room row: %w", err)
 		}
 		rooms = append(rooms, *room)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate rooms rows: %w", err)
+		return RoomListResult{}, fmt.Errorf("iterate rooms rows: %w", err)
 	}
 
-	return rooms, nil
+	return RoomListResult{Items: rooms, Total: total}, nil
+}
+
+func buildRoomsByPropertyListQuery(propertyID string, status string, limit int, offset int, count bool) (string, []any) {
+	base := `
+SELECT id, property_id, name, status, size, floor, room_type, facilities::text, default_rent_amount, notes, zone, created_at, updated_at
+FROM rooms
+WHERE property_id = $1
+  AND deleted_at IS NULL
+`
+	if count {
+		base = `
+SELECT COUNT(*)::int
+FROM rooms
+WHERE property_id = $1
+  AND deleted_at IS NULL
+`
+	}
+	args := []any{propertyID}
+
+	if status != "" {
+		args = append(args, status)
+		base += fmt.Sprintf(" AND status = $%d", len(args))
+	}
+
+	if count {
+		return base, args
+	}
+
+	args = append(args, limit, offset)
+	base += fmt.Sprintf(" ORDER BY created_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
+	return base, args
 }
 
 // FindRoomByID returns a single active room.

--- a/internal/platform/database/propertyquery/repository_test.go
+++ b/internal/platform/database/propertyquery/repository_test.go
@@ -70,6 +70,14 @@ func TestListRoomsByPropertyReturnsActiveRoomsWithStatusFilterAndPagination(t *t
 	repo := NewRepository(db)
 	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
 
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)::int
+FROM rooms
+WHERE property_id = $1
+  AND deleted_at IS NULL
+ AND status = $2`)).
+		WithArgs("10000000-0000-0000-0000-000000000001", "vacant").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(4))
+
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, property_id, name, status, size, floor, room_type, facilities::text, default_rent_amount, notes, zone, created_at, updated_at
 FROM rooms
 WHERE property_id = $1
@@ -94,11 +102,15 @@ WHERE property_id = $1
 			now,
 		))
 
-	rooms, err := repo.ListRoomsByProperty(context.Background(), "10000000-0000-0000-0000-000000000001", "vacant", 10, 20)
+	result, err := repo.ListRoomsByProperty(context.Background(), "10000000-0000-0000-0000-000000000001", "vacant", 10, 20)
 	if err != nil {
 		t.Fatalf("ListRoomsByProperty: %v", err)
 	}
 
+	if result.Total != 4 {
+		t.Fatalf("expected total 4, got %d", result.Total)
+	}
+	rooms := result.Items
 	if len(rooms) != 1 {
 		t.Fatalf("expected 1 room, got %d", len(rooms))
 	}
@@ -183,6 +195,14 @@ func TestListRoomsByPropertyIgnoresNonObjectFacilities(t *testing.T) {
 	repo := NewRepository(db)
 	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
 
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)::int
+FROM rooms
+WHERE property_id = $1
+  AND deleted_at IS NULL
+`)).
+		WithArgs("10000000-0000-0000-0000-000000000001").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT id, property_id, name, status, size, floor, room_type, facilities::text, default_rent_amount, notes, zone, created_at, updated_at
 FROM rooms
 WHERE property_id = $1
@@ -207,11 +227,15 @@ WHERE property_id = $1
 			now,
 		))
 
-	rooms, err := repo.ListRoomsByProperty(context.Background(), "10000000-0000-0000-0000-000000000001", "", 20, 0)
+	result, err := repo.ListRoomsByProperty(context.Background(), "10000000-0000-0000-0000-000000000001", "", 20, 0)
 	if err != nil {
 		t.Fatalf("ListRoomsByProperty: %v", err)
 	}
 
+	if result.Total != 1 {
+		t.Fatalf("expected total 1, got %d", result.Total)
+	}
+	rooms := result.Items
 	if len(rooms) != 1 {
 		t.Fatalf("expected 1 room, got %d", len(rooms))
 	}

--- a/internal/platform/database/repair/repository.go
+++ b/internal/platform/database/repair/repository.go
@@ -22,52 +22,30 @@ func NewRepository(db *sql.DB) *SQLRepository {
 }
 
 // List returns active repair requests visible to the actor scope.
-func (r *SQLRepository) List(ctx context.Context, query apprepair.ListQuery) ([]apprepair.RepairRequest, error) {
-	base := selectRepairRequestColumns + `
+func (r *SQLRepository) List(ctx context.Context, query apprepair.ListQuery) (apprepair.ListResult, error) {
+	filterSQL, args, scoped := buildRepairListFilter(query)
+	if !scoped {
+		return apprepair.ListResult{Items: []apprepair.RepairRequest{}}, nil
+	}
+
+	countQuery := `
+SELECT COUNT(*)
 FROM repair_requests rr
-WHERE rr.deleted_at IS NULL
-`
-	args := make([]any, 0)
-
-	switch strings.TrimSpace(query.ActorRole) {
-	case "organizer", "staff":
-		if len(query.AssignedPropertyIDs) == 0 {
-			return []apprepair.RepairRequest{}, nil
-		}
-		placeholders := make([]string, 0, len(query.AssignedPropertyIDs))
-		for _, id := range query.AssignedPropertyIDs {
-			args = append(args, id)
-			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
-		}
-		base += "\n  AND rr.property_id IN (" + strings.Join(placeholders, ", ") + ")"
-	case "admin":
-	default:
-		return []apprepair.RepairRequest{}, nil
+` + filterSQL
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		return apprepair.ListResult{}, fmt.Errorf("count repair requests: %w", err)
 	}
 
-	if query.PropertyID != nil {
-		args = append(args, *query.PropertyID)
-		base += fmt.Sprintf("\n  AND rr.property_id = $%d", len(args))
-	}
-	if query.RoomID != nil {
-		args = append(args, *query.RoomID)
-		base += fmt.Sprintf("\n  AND rr.room_id = $%d", len(args))
-	}
-	if query.Status != nil {
-		args = append(args, *query.Status)
-		base += fmt.Sprintf("\n  AND rr.status = $%d", len(args))
-	}
-	if query.AssignedTo != nil {
-		args = append(args, *query.AssignedTo)
-		base += fmt.Sprintf("\n  AND rr.assigned_to = $%d", len(args))
-	}
+	listArgs := append([]any{}, args...)
+	listArgs = append(listArgs, query.Limit, query.Offset)
+	listQuery := selectRepairRequestColumns + `
+FROM repair_requests rr
+` + filterSQL + fmt.Sprintf("\nORDER BY rr.created_at DESC, rr.id DESC LIMIT $%d OFFSET $%d", len(listArgs)-1, len(listArgs))
 
-	args = append(args, query.Limit, query.Offset)
-	base += fmt.Sprintf("\nORDER BY rr.created_at DESC, rr.id DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
-
-	rows, err := r.db.QueryContext(ctx, base, args...)
+	rows, err := r.db.QueryContext(ctx, listQuery, listArgs...)
 	if err != nil {
-		return nil, fmt.Errorf("list repair requests: %w", err)
+		return apprepair.ListResult{}, fmt.Errorf("list repair requests: %w", err)
 	}
 	defer rows.Close()
 
@@ -75,15 +53,56 @@ WHERE rr.deleted_at IS NULL
 	for rows.Next() {
 		item, err := scanRepairRequest(rows)
 		if err != nil {
-			return nil, fmt.Errorf("scan repair request: %w", err)
+			return apprepair.ListResult{}, fmt.Errorf("scan repair request: %w", err)
 		}
 		items = append(items, *item)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate repair requests: %w", err)
+		return apprepair.ListResult{}, fmt.Errorf("iterate repair requests: %w", err)
 	}
 
-	return items, nil
+	return apprepair.ListResult{Items: items, Total: total}, nil
+}
+
+func buildRepairListFilter(query apprepair.ListQuery) (string, []any, bool) {
+	filter := `WHERE rr.deleted_at IS NULL
+`
+	args := make([]any, 0)
+
+	switch strings.TrimSpace(query.ActorRole) {
+	case "organizer", "staff":
+		if len(query.AssignedPropertyIDs) == 0 {
+			return "", nil, false
+		}
+		placeholders := make([]string, 0, len(query.AssignedPropertyIDs))
+		for _, id := range query.AssignedPropertyIDs {
+			args = append(args, id)
+			placeholders = append(placeholders, fmt.Sprintf("$%d", len(args)))
+		}
+		filter += "\n  AND rr.property_id IN (" + strings.Join(placeholders, ", ") + ")"
+	case "admin":
+	default:
+		return "", nil, false
+	}
+
+	if query.PropertyID != nil {
+		args = append(args, *query.PropertyID)
+		filter += fmt.Sprintf("\n  AND rr.property_id = $%d", len(args))
+	}
+	if query.RoomID != nil {
+		args = append(args, *query.RoomID)
+		filter += fmt.Sprintf("\n  AND rr.room_id = $%d", len(args))
+	}
+	if query.Status != nil {
+		args = append(args, *query.Status)
+		filter += fmt.Sprintf("\n  AND rr.status = $%d", len(args))
+	}
+	if query.AssignedTo != nil {
+		args = append(args, *query.AssignedTo)
+		filter += fmt.Sprintf("\n  AND rr.assigned_to = $%d", len(args))
+	}
+
+	return filter, args, true
 }
 
 // FindByID returns one active repair request.

--- a/internal/platform/database/repair/repository_test.go
+++ b/internal/platform/database/repair/repository_test.go
@@ -20,6 +20,9 @@ func TestListScopesOrganizerToAssignedPropertiesAndFilters(t *testing.T) {
 	defer db.Close()
 
 	now := time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT COUNT(*)")).
+		WithArgs(testPropertyID, testPropertyID, testRoomID, "submitted", testStaffID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(3))
 	mock.ExpectQuery(regexp.QuoteMeta("FROM repair_requests rr")).
 		WithArgs(testPropertyID, testPropertyID, testRoomID, "submitted", testStaffID, 20, 0).
 		WillReturnRows(repairRows().AddRow(
@@ -44,7 +47,7 @@ func TestListScopesOrganizerToAssignedPropertiesAndFilters(t *testing.T) {
 	roomID := testRoomID
 	assignedTo := testStaffID
 	propertyID := testPropertyID
-	items, err := repo.List(context.Background(), apprepair.ListQuery{
+	result, err := repo.List(context.Background(), apprepair.ListQuery{
 		ActorRole:           "organizer",
 		AssignedPropertyIDs: []string{testPropertyID},
 		PropertyID:          &propertyID,
@@ -57,8 +60,38 @@ func TestListScopesOrganizerToAssignedPropertiesAndFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
+	if result.Total != 3 {
+		t.Fatalf("Total = %d, want 3", result.Total)
+	}
+	items := result.Items
 	if len(items) != 1 || items[0].ID != testRepairID {
 		t.Fatalf("unexpected items: %+v", items)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListReturnsEmptyForUnscopedStaff(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	repo := NewRepository(db)
+	result, err := repo.List(context.Background(), apprepair.ListQuery{
+		ActorRole: "staff",
+		Limit:     20,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(result.Items) != 0 {
+		t.Fatalf("items = %d, want 0", len(result.Items))
+	}
+	if result.Total != 0 {
+		t.Fatalf("Total = %d, want 0", result.Total)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet sql expectations: %v", err)

--- a/internal/platform/database/tenantquery/repository.go
+++ b/internal/platform/database/tenantquery/repository.go
@@ -30,6 +30,12 @@ type Tenant struct {
 	Version    int
 }
 
+// TenantListResult is the paginated tenant list query result.
+type TenantListResult struct {
+	Items []Tenant
+	Total int
+}
+
 // Lease is the read model returned by tenant lease-history queries.
 type Lease struct {
 	ID                        string
@@ -57,7 +63,7 @@ type Lease struct {
 
 // Repository serves read-model queries for tenants.
 type Repository interface {
-	ListAccessible(ctx context.Context, role string, assignedPropertyIDs []string, propertyID *string, status string, limit int, offset int) ([]Tenant, error)
+	ListAccessible(ctx context.Context, role string, assignedPropertyIDs []string, propertyID *string, status string, limit int, offset int) (TenantListResult, error)
 	FindByIDAccessible(ctx context.Context, tenantID string, role string, assignedPropertyIDs []string) (*Tenant, error)
 	ListLeasesByTenantAccessible(ctx context.Context, tenantID string, role string, assignedPropertyIDs []string, status string) ([]Lease, error)
 }
@@ -73,7 +79,42 @@ func NewRepository(db *sql.DB) *SQLRepository {
 }
 
 // ListAccessible returns tenants visible to the authenticated principal.
-func (r *SQLRepository) ListAccessible(ctx context.Context, role string, assignedPropertyIDs []string, propertyID *string, status string, limit int, offset int) ([]Tenant, error) {
+func (r *SQLRepository) ListAccessible(ctx context.Context, role string, assignedPropertyIDs []string, propertyID *string, status string, limit int, offset int) (TenantListResult, error) {
+	countQuery, countArgs, ok := buildAccessibleTenantListQuery(role, assignedPropertyIDs, propertyID, status, 0, 0, true)
+	if !ok {
+		return TenantListResult{Items: []Tenant{}}, nil
+	}
+
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total); err != nil {
+		return TenantListResult{}, fmt.Errorf("count accessible tenants: %w", err)
+	}
+
+	listQuery, listArgs, _ := buildAccessibleTenantListQuery(role, assignedPropertyIDs, propertyID, status, limit, offset, false)
+	rows, err := r.db.QueryContext(ctx, listQuery, listArgs...)
+	if err != nil {
+		return TenantListResult{}, fmt.Errorf("list accessible tenants: %w", err)
+	}
+	defer func() {
+		_ = rows.Close()
+	}()
+
+	tenants := make([]Tenant, 0)
+	for rows.Next() {
+		tenant, err := scanTenant(rows)
+		if err != nil {
+			return TenantListResult{}, fmt.Errorf("scan tenant row: %w", err)
+		}
+		tenants = append(tenants, *tenant)
+	}
+	if err := rows.Err(); err != nil {
+		return TenantListResult{}, fmt.Errorf("iterate tenant rows: %w", err)
+	}
+
+	return TenantListResult{Items: tenants, Total: total}, nil
+}
+
+func buildAccessibleTenantListQuery(role string, assignedPropertyIDs []string, propertyID *string, status string, limit int, offset int, count bool) (string, []any, bool) {
 	base := `
 SELECT DISTINCT
 	t.id,
@@ -91,6 +132,12 @@ SELECT DISTINCT
 	t.version
 FROM tenants t
 `
+	if count {
+		base = `
+SELECT COUNT(DISTINCT t.id)::int
+FROM tenants t
+`
+	}
 	args := []any{}
 	joins := []string{}
 	conditions := []string{"t.deleted_at IS NULL"}
@@ -99,7 +146,7 @@ FROM tenants t
 	switch role {
 	case "organizer", "staff":
 		if len(assignedPropertyIDs) == 0 {
-			return []Tenant{}, nil
+			return "", nil, false
 		}
 		joins = append(joins, "JOIN leases l ON l.tenant_id = t.id AND l.deleted_at IS NULL")
 		placeholders := make([]string, 0, len(assignedPropertyIDs))
@@ -113,7 +160,7 @@ FROM tenants t
 			joins = append(joins, "JOIN leases l ON l.tenant_id = t.id AND l.deleted_at IS NULL")
 		}
 	default:
-		return []Tenant{}, nil
+		return "", nil, false
 	}
 
 	if propertyID != nil && strings.TrimSpace(*propertyID) != "" {
@@ -134,30 +181,12 @@ FROM tenants t
 	}
 
 	base += "WHERE " + strings.Join(conditions, "\n  AND ")
+	if count {
+		return base, args, true
+	}
 	args = append(args, limit, offset)
 	base += fmt.Sprintf("\nORDER BY t.created_at DESC LIMIT $%d OFFSET $%d", len(args)-1, len(args))
-
-	rows, err := r.db.QueryContext(ctx, base, args...)
-	if err != nil {
-		return nil, fmt.Errorf("list accessible tenants: %w", err)
-	}
-	defer func() {
-		_ = rows.Close()
-	}()
-
-	tenants := make([]Tenant, 0)
-	for rows.Next() {
-		tenant, err := scanTenant(rows)
-		if err != nil {
-			return nil, fmt.Errorf("scan tenant row: %w", err)
-		}
-		tenants = append(tenants, *tenant)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate tenant rows: %w", err)
-	}
-
-	return tenants, nil
+	return base, args, true
 }
 
 // FindByIDAccessible returns one tenant visible to the authenticated principal.

--- a/internal/platform/database/tenantquery/repository_test.go
+++ b/internal/platform/database/tenantquery/repository_test.go
@@ -27,6 +27,15 @@ func TestListAccessibleReturnsAssignedPropertyTenants(t *testing.T) {
 	repo := NewRepository(db)
 	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
 
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(DISTINCT t.id)::int
+FROM tenants t
+JOIN leases l ON l.tenant_id = t.id AND l.deleted_at IS NULL
+WHERE t.deleted_at IS NULL
+  AND l.property_id IN ($1)
+  AND t.status = $2`)).
+		WithArgs("10000000-0000-0000-0000-000000000001", "active").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(7))
+
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT DISTINCT
 	t.id,
 	t.name,
@@ -67,10 +76,14 @@ ORDER BY t.created_at DESC LIMIT $3 OFFSET $4`)).
 		))
 	mock.ExpectClose()
 
-	tenants, err := repo.ListAccessible(context.Background(), "organizer", []string{"10000000-0000-0000-0000-000000000001"}, nil, "active", 10, 20)
+	result, err := repo.ListAccessible(context.Background(), "organizer", []string{"10000000-0000-0000-0000-000000000001"}, nil, "active", 10, 20)
 	if err != nil {
 		t.Fatalf("ListAccessible: %v", err)
 	}
+	if result.Total != 7 {
+		t.Fatalf("expected total 7, got %d", result.Total)
+	}
+	tenants := result.Items
 	if len(tenants) != 1 {
 		t.Fatalf("expected 1 tenant, got %d", len(tenants))
 	}

--- a/internal/platform/database/users/repository.go
+++ b/internal/platform/database/users/repository.go
@@ -36,6 +36,12 @@ type User struct {
 	Version             int
 }
 
+// UserListResult is the paginated user list query result.
+type UserListResult struct {
+	Items []User
+	Total int
+}
+
 // JobNotificationRecipient is the active user shape needed by scheduler notifications.
 type JobNotificationRecipient struct {
 	Email string
@@ -72,7 +78,7 @@ type ListParams struct {
 type Repository interface {
 	FindByFirebaseUID(ctx context.Context, firebaseUID string) (*User, error)
 	FindByID(ctx context.Context, id string) (*User, error)
-	List(ctx context.Context, params ListParams) ([]User, error)
+	List(ctx context.Context, params ListParams) (UserListResult, error)
 	Create(ctx context.Context, params CreateUserParams) (*User, error)
 	UpdateCurrentUser(ctx context.Context, id string, params UpdateCurrentUserParams) (*User, error)
 	UpdateManagedUser(ctx context.Context, id string, params UpdateManagedUserParams) (*User, error)
@@ -175,26 +181,23 @@ LIMIT 1
 }
 
 // List returns active users filtered by role and paginated by limit/offset.
-func (r *SQLRepository) List(ctx context.Context, params ListParams) ([]User, error) {
-	query := selectUserColumns + `
-FROM users
-WHERE deleted_at IS NULL
-`
-
-	args := make([]any, 0, 3)
-	argPos := 1
-	if params.Role != "" {
-		query += fmt.Sprintf("  AND role = $%d\n", argPos)
-		args = append(args, params.Role)
-		argPos++
+func (r *SQLRepository) List(ctx context.Context, params ListParams) (UserListResult, error) {
+	countQuery, countArgs := buildUserListQuery(params, true)
+	var total int
+	if err := r.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total); err != nil {
+		return UserListResult{}, fmt.Errorf(
+			"count users query role=%q limit=%d offset=%d: %w",
+			params.Role,
+			params.Limit,
+			params.Offset,
+			err,
+		)
 	}
 
-	query += fmt.Sprintf("ORDER BY created_at DESC, id DESC\nLIMIT $%d OFFSET $%d", argPos, argPos+1)
-	args = append(args, params.Limit, params.Offset)
-
+	query, args := buildUserListQuery(params, false)
 	rows, err := r.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return UserListResult{}, fmt.Errorf(
 			"list users query role=%q limit=%d offset=%d: %w",
 			params.Role,
 			params.Limit,
@@ -208,7 +211,7 @@ WHERE deleted_at IS NULL
 	for rows.Next() {
 		user, err := scanUser(rows)
 		if err != nil {
-			return nil, fmt.Errorf(
+			return UserListResult{}, fmt.Errorf(
 				"scan listed user role=%q limit=%d offset=%d: %w",
 				params.Role,
 				params.Limit,
@@ -220,7 +223,7 @@ WHERE deleted_at IS NULL
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf(
+		return UserListResult{}, fmt.Errorf(
 			"iterate listed users role=%q limit=%d offset=%d: %w",
 			params.Role,
 			params.Limit,
@@ -229,7 +232,37 @@ WHERE deleted_at IS NULL
 		)
 	}
 
-	return items, nil
+	return UserListResult{Items: items, Total: total}, nil
+}
+
+func buildUserListQuery(params ListParams, count bool) (string, []any) {
+	query := selectUserColumns + `
+FROM users
+WHERE deleted_at IS NULL
+`
+	if count {
+		query = `
+SELECT COUNT(*)::int
+FROM users
+WHERE deleted_at IS NULL
+`
+	}
+
+	args := make([]any, 0, 3)
+	argPos := 1
+	if params.Role != "" {
+		query += fmt.Sprintf("  AND role = $%d\n", argPos)
+		args = append(args, params.Role)
+		argPos++
+	}
+
+	if count {
+		return query, args
+	}
+
+	query += fmt.Sprintf("ORDER BY created_at DESC, id DESC\nLIMIT $%d OFFSET $%d", argPos, argPos+1)
+	args = append(args, params.Limit, params.Offset)
+	return query, args
 }
 
 // Create persists a new user row and returns the created record.

--- a/internal/platform/database/users/repository_test.go
+++ b/internal/platform/database/users/repository_test.go
@@ -21,6 +21,12 @@ func TestListReturnsActiveUsersWithPagination(t *testing.T) {
 	repo := NewRepository(db)
 	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
 
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)::int
+FROM users
+WHERE deleted_at IS NULL
+`)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(5))
+
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT
 	id,
 	firebase_uid,
@@ -52,11 +58,15 @@ LIMIT $1 OFFSET $2`)).
 			1,
 		))
 
-	items, err := repo.List(context.Background(), ListParams{Limit: 20, Offset: 0})
+	result, err := repo.List(context.Background(), ListParams{Limit: 20, Offset: 0})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
 
+	if result.Total != 5 {
+		t.Fatalf("expected total 5, got %d", result.Total)
+	}
+	items := result.Items
 	if len(items) != 1 {
 		t.Fatalf("expected 1 user, got %d", len(items))
 	}
@@ -78,6 +88,14 @@ func TestListSupportsRoleFilter(t *testing.T) {
 
 	repo := NewRepository(db)
 	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)::int
+FROM users
+WHERE deleted_at IS NULL
+  AND role = $1
+`)).
+		WithArgs("staff").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(2))
 
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT
 	id,
@@ -111,11 +129,15 @@ LIMIT $2 OFFSET $3`)).
 			1,
 		))
 
-	items, err := repo.List(context.Background(), ListParams{Role: "staff", Limit: 10, Offset: 10})
+	result, err := repo.List(context.Background(), ListParams{Role: "staff", Limit: 10, Offset: 10})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
 
+	if result.Total != 2 {
+		t.Fatalf("expected total 2, got %d", result.Total)
+	}
+	items := result.Items
 	if len(items) != 1 {
 		t.Fatalf("expected 1 user, got %d", len(items))
 	}
@@ -137,6 +159,12 @@ func TestListWrapsQueryErrorsWithOperationContext(t *testing.T) {
 
 	repo := NewRepository(db)
 	queryErr := errors.New("db down")
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT COUNT(*)::int
+FROM users
+WHERE deleted_at IS NULL
+`)).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT
 	id,

--- a/internal/server/billing_adapters.go
+++ b/internal/server/billing_adapters.go
@@ -47,29 +47,34 @@ type billingQueryServiceAdapter struct {
 	getBill   *appbilling.GetBillService
 }
 
-func (a billingQueryServiceAdapter) ListBills(ctx context.Context, input handler.BillingListInput) ([]handler.BillingBill, error) {
+func (a billingQueryServiceAdapter) ListBills(ctx context.Context, input handler.BillingListInput) (handler.BillingListResult, error) {
+	var billType *string
+	if input.Type != "" {
+		billType = &input.Type
+	}
 	var status *string
 	if input.Status != "" {
 		status = &input.Status
 	}
 
-	bills, err := a.listBills.Execute(ctx, appbilling.ListBillsInput{
+	result, err := a.listBills.Execute(ctx, appbilling.ListBillsInput{
 		ActorRole:           input.ActorRole,
 		ActorUserID:         input.ActorUserID,
 		AssignedPropertyIDs: input.AssignedPropertyIDs,
 		PropertyID:          input.PropertyID,
 		LeaseID:             input.LeaseID,
 		TenantID:            input.TenantID,
+		Type:                billType,
 		Status:              status,
 		Month:               input.Month,
 		Limit:               input.Limit,
 		Offset:              input.Offset,
 	})
 	if err != nil {
-		return nil, err
+		return handler.BillingListResult{}, err
 	}
 
-	return toHandlerBills(bills), nil
+	return handler.BillingListResult{Items: toHandlerBills(result.Items), Total: result.Total}, nil
 }
 
 func (a billingQueryServiceAdapter) GetBill(ctx context.Context, input handler.BillingGetInput) (*handler.BillingBill, error) {
@@ -296,14 +301,14 @@ type billingRepositoryAdapter struct {
 	repo *dbbilling.SQLRepository
 }
 
-func (a billingRepositoryAdapter) ListBills(ctx context.Context, query appbilling.ListBillsQuery) ([]appbilling.Bill, error) {
+func (a billingRepositoryAdapter) ListBills(ctx context.Context, query appbilling.ListBillsQuery) (appbilling.ListBillsResult, error) {
 	var month *string
 	if query.Month != nil {
 		value := query.Month.Format("2006-01")
 		month = &value
 	}
 
-	bills, err := a.repo.ListAccessible(ctx, dbbilling.Scope{
+	result, err := a.repo.ListAccessible(ctx, dbbilling.Scope{
 		Role:                query.ActorRole,
 		UserID:              query.ActorUserID,
 		AssignedPropertyIDs: query.AssignedPropertyIDs,
@@ -311,16 +316,17 @@ func (a billingRepositoryAdapter) ListBills(ctx context.Context, query appbillin
 		PropertyID: query.PropertyID,
 		LeaseID:    query.LeaseID,
 		TenantID:   query.TenantID,
+		Type:       query.Type,
 		Status:     query.Status,
 		Month:      month,
 		Limit:      query.Limit,
 		Offset:     query.Offset,
 	})
 	if err != nil {
-		return nil, mapBillingRepositoryError(err)
+		return appbilling.ListBillsResult{}, mapBillingRepositoryError(err)
 	}
 
-	return toAppBills(bills), nil
+	return appbilling.ListBillsResult{Items: toAppBills(result.Items), Total: result.Total}, nil
 }
 
 func (a billingRepositoryAdapter) FindBillByID(ctx context.Context, query appbilling.GetBillQuery) (*appbilling.Bill, error) {

--- a/test/e2e/billing_payment_report_test.go
+++ b/test/e2e/billing_payment_report_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 )
@@ -47,6 +48,27 @@ func TestE2EBillingPaymentAndFinancialReportAcceptance(t *testing.T) {
 	bills := billingFlowE2EListBills(t, ctx, adminClient, lease.ID)
 	rentBill := billingFlowE2EFindBill(t, bills, "rent")
 	electricityBill := billingFlowE2EFindBill(t, bills, "electricity")
+	rentBills := billingFlowE2EListBillsByType(t, ctx, adminClient, lease.ID, "rent")
+	if len(rentBills.Data) == 0 {
+		t.Fatalf("expected rent bills for lease %q", lease.ID)
+	}
+	for _, bill := range rentBills.Data {
+		if bill.Type != "rent" {
+			t.Fatalf("expected only rent bills, got %+v", rentBills.Data)
+		}
+	}
+	billingFlowE2ERequirePagination(t, rentBills.Pagination, 1, 100, len(rentBills.Data))
+
+	electricityBills := billingFlowE2EListBillsByType(t, ctx, adminClient, lease.ID, "electricity")
+	if len(electricityBills.Data) == 0 {
+		t.Fatalf("expected electricity bills for lease %q", lease.ID)
+	}
+	for _, bill := range electricityBills.Data {
+		if bill.Type != "electricity" {
+			t.Fatalf("expected only electricity bills, got %+v", electricityBills.Data)
+		}
+	}
+	billingFlowE2ERequirePagination(t, electricityBills.Pagination, 1, 100, len(electricityBills.Data))
 
 	if rentBill.Amount == nil {
 		t.Fatalf("expected rent bill amount: %+v", rentBill)
@@ -137,7 +159,16 @@ type billingFlowE2EBillResponse struct {
 }
 
 type billingFlowE2EBillListResponse struct {
-	Data []billingFlowE2EBillResponse `json:"data"`
+	Data       []billingFlowE2EBillResponse `json:"data"`
+	Pagination billingFlowE2EPagination     `json:"pagination"`
+}
+
+type billingFlowE2EPagination struct {
+	Page       int  `json:"page"`
+	Limit      int  `json:"limit"`
+	Total      int  `json:"total"`
+	TotalPages int  `json:"total_pages"`
+	HasNext    bool `json:"has_next"`
 }
 
 type billingFlowE2EFinancialReportResponse struct {
@@ -203,7 +234,27 @@ func billingFlowE2ECreateLease(t *testing.T, ctx context.Context, client apiClie
 func billingFlowE2EListBills(t *testing.T, ctx context.Context, client apiClient, leaseID string) []billingFlowE2EBillResponse {
 	t.Helper()
 
-	resp, body, err := client.getJSON(ctx, "/api/v1/bills?lease_id="+leaseID+"&limit=100")
+	result := billingFlowE2EListBillsByQuery(t, ctx, client, url.Values{
+		"lease_id": []string{leaseID},
+		"limit":    []string{"100"},
+	})
+	return result.Data
+}
+
+func billingFlowE2EListBillsByType(t *testing.T, ctx context.Context, client apiClient, leaseID string, billType string) billingFlowE2EBillListResponse {
+	t.Helper()
+
+	return billingFlowE2EListBillsByQuery(t, ctx, client, url.Values{
+		"lease_id": []string{leaseID},
+		"type":     []string{billType},
+		"limit":    []string{"100"},
+	})
+}
+
+func billingFlowE2EListBillsByQuery(t *testing.T, ctx context.Context, client apiClient, query url.Values) billingFlowE2EBillListResponse {
+	t.Helper()
+
+	resp, body, err := client.getJSON(ctx, "/api/v1/bills?"+query.Encode())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +262,23 @@ func billingFlowE2EListBills(t *testing.T, ctx context.Context, client apiClient
 
 	var result billingFlowE2EBillListResponse
 	decodeJSON(t, body, &result)
-	return result.Data
+	return result
+}
+
+func billingFlowE2ERequirePagination(t *testing.T, got billingFlowE2EPagination, page int, limit int, total int) {
+	t.Helper()
+
+	if got.Page != page || got.Limit != limit || got.Total != total {
+		t.Fatalf("pagination = %+v, want page=%d limit=%d total=%d", got, page, limit, total)
+	}
+	wantTotalPages := 0
+	if total > 0 {
+		wantTotalPages = (total + limit - 1) / limit
+	}
+	wantHasNext := page < wantTotalPages
+	if got.TotalPages != wantTotalPages || got.HasNext != wantHasNext {
+		t.Fatalf("pagination derived fields = %+v, want total_pages=%d has_next=%t", got, wantTotalPages, wantHasNext)
+	}
 }
 
 func billingFlowE2EFindBill(t *testing.T, bills []billingFlowE2EBillResponse, billType string) billingFlowE2EBillResponse {


### PR DESCRIPTION
Closes #136

## Summary
- add `type=rent|electricity` filtering to `GET /bills`
- add a shared `pagination` response object to existing paginated list endpoints
- add repository count contracts using the same filters and access scope as each list query
- wire HTTP/server responses and generated OpenAPI types for the new contract
- extend focused unit tests and billing E2E coverage for bill type filtering and pagination metadata

## Validation
- `npm run openapi:generate`
- `npm run openapi:lint`
- `git diff --check`
- `GOCACHE=/tmp/go-cache go test ./...`
- `GOCACHE=/tmp/go-cache go test -tags=e2e ./test/e2e -run TestE2EBillingPaymentAndFinancialReportAcceptance -count=0`
- `GOCACHE=/tmp/go-cache E2E_BASE_URL=http://127.0.0.1:8081 ./scripts/e2e_test.sh -run TestE2EBillingPaymentAndFinancialReportAcceptance -count=1`
