### PR TITLE
[frontend] Add property meter history grid read model

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -4299,17 +4299,29 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BillListResponse'
+                $ref: '#/components/schemas/PropertyMeterHistoryResponse'
               examples:
                 success:
                   value:
                     data:
-                      - id: 50000000-0000-0000-0000-000000000002
+                      - bill_id: 50000000-0000-0000-0000-000000000002
+                        property_id: 10000000-0000-0000-0000-000000000001
                         room_id: 20000000-0000-0000-0000-000000000002
+                        room_label: '101'
+                        tenant_id: 30000000-0000-0000-0000-000000000002
+                        tenant_label: 王小明
+                        lease_id: 40000000-0000-0000-0000-000000000002
+                        period_start: '2026-04-01'
+                        period_end: '2026-04-30'
+                        period_label: 2026-04-01..2026-04-30
                         due_date: '2026-04-01'
-                        meter_previous_reading: 1120
-                        meter_current_reading: 1250
+                        previous_reading: 1120
+                        current_reading: 1250
+                        usage: 130
+                        unit_price: 5
                         amount: 650
+                        status: paid
+                        meter_recorded_at: '2026-04-24T10:00:00Z'
         '401':
           description: 未認證
           content:
@@ -8004,6 +8016,68 @@ components:
           type: string
           format: date-time
           description: Payment timestamp. Optional; defaults to the server time.
+    PropertyMeterHistoryRow:
+      type: object
+      properties:
+        bill_id:
+          type: string
+          format: uuid
+        property_id:
+          type: string
+          format: uuid
+        room_id:
+          type: string
+          format: uuid
+        room_label:
+          type: string
+        tenant_id:
+          type: string
+          format: uuid
+        tenant_label:
+          type: string
+        lease_id:
+          type: string
+          format: uuid
+        period_start:
+          type: string
+          format: date
+        period_end:
+          type: string
+          format: date
+        period_label:
+          type: string
+        due_date:
+          type: string
+          format: date
+        previous_reading:
+          type: integer
+        current_reading:
+          type: integer
+        usage:
+          type: integer
+        unit_price:
+          type: number
+          format: double
+        amount:
+          type: integer
+          nullable: true
+        status:
+          type: string
+          enum:
+            - pending_payment
+            - paid
+            - overdue
+        meter_recorded_at:
+          type: string
+          format: date-time
+          nullable: true
+    PropertyMeterHistoryResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PropertyMeterHistoryRow'
     FinancialReportSummaryItem:
       type: object
       properties:

--- a/docs/spec/src/components/schemas/billing/PropertyMeterHistoryResponse.yaml
+++ b/docs/spec/src/components/schemas/billing/PropertyMeterHistoryResponse.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  data:
+    type: array
+    items:
+      $ref: ./PropertyMeterHistoryRow.yaml

--- a/docs/spec/src/components/schemas/billing/PropertyMeterHistoryRow.yaml
+++ b/docs/spec/src/components/schemas/billing/PropertyMeterHistoryRow.yaml
@@ -1,0 +1,54 @@
+type: object
+properties:
+  bill_id:
+    type: string
+    format: uuid
+  property_id:
+    type: string
+    format: uuid
+  room_id:
+    type: string
+    format: uuid
+  room_label:
+    type: string
+  tenant_id:
+    type: string
+    format: uuid
+  tenant_label:
+    type: string
+  lease_id:
+    type: string
+    format: uuid
+  period_start:
+    type: string
+    format: date
+  period_end:
+    type: string
+    format: date
+  period_label:
+    type: string
+  due_date:
+    type: string
+    format: date
+  previous_reading:
+    type: integer
+  current_reading:
+    type: integer
+  usage:
+    type: integer
+  unit_price:
+    type: number
+    format: double
+  amount:
+    type: integer
+    nullable: true
+  status:
+    type: string
+    enum:
+      - pending_payment
+      - paid
+      - overdue
+  meter_recorded_at:
+    type: string
+    format: date-time
+    nullable: true

--- a/docs/spec/src/paths/billing/properties_{id}_meter-history.yaml
+++ b/docs/spec/src/paths/billing/properties_{id}_meter-history.yaml
@@ -25,17 +25,29 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/billing/BillListResponse.yaml
+            $ref: ../../components/schemas/billing/PropertyMeterHistoryResponse.yaml
           examples:
             success:
               value:
                 data:
-                  - id: 50000000-0000-0000-0000-000000000002
+                  - bill_id: 50000000-0000-0000-0000-000000000002
+                    property_id: 10000000-0000-0000-0000-000000000001
                     room_id: 20000000-0000-0000-0000-000000000002
+                    room_label: '101'
+                    tenant_id: 30000000-0000-0000-0000-000000000002
+                    tenant_label: 王小明
+                    lease_id: 40000000-0000-0000-0000-000000000002
+                    period_start: '2026-04-01'
+                    period_end: '2026-04-30'
+                    period_label: 2026-04-01..2026-04-30
                     due_date: '2026-04-01'
-                    meter_previous_reading: 1120
-                    meter_current_reading: 1250
+                    previous_reading: 1120
+                    current_reading: 1250
+                    usage: 130
+                    unit_price: 5
                     amount: 650
+                    status: paid
+                    meter_recorded_at: '2026-04-24T10:00:00Z'
     '401':
       description: 未認證
       content:

--- a/internal/application/billing/reports.go
+++ b/internal/application/billing/reports.go
@@ -56,6 +56,28 @@ type MeterHistoryQuery struct {
 	Month               *int
 }
 
+// PropertyMeterHistoryRow is one grid-ready electricity meter history row.
+type PropertyMeterHistoryRow struct {
+	BillID          string
+	PropertyID      string
+	RoomID          string
+	RoomLabel       string
+	TenantID        string
+	TenantLabel     string
+	LeaseID         string
+	PeriodStart     time.Time
+	PeriodEnd       time.Time
+	PeriodLabel     string
+	DueDate         time.Time
+	PreviousReading int
+	CurrentReading  int
+	Usage           int
+	UnitPrice       float64
+	Amount          *int
+	Status          string
+	MeterRecordedAt *time.Time
+}
+
 // FinancialReportSummaryQuery defines role scoping for financial report summary reads.
 type FinancialReportSummaryQuery struct {
 	ActorRole           string
@@ -286,7 +308,7 @@ type ProfitLossRow struct {
 // ReportRepository defines read operations required by billing report use cases.
 type ReportRepository interface {
 	ListPendingMeterBills(ctx context.Context, query PendingMeterQuery) ([]Bill, error)
-	ListPropertyMeterHistory(ctx context.Context, query MeterHistoryQuery) ([]Bill, error)
+	ListPropertyMeterHistory(ctx context.Context, query MeterHistoryQuery) ([]PropertyMeterHistoryRow, error)
 	ListRoomMeterHistory(ctx context.Context, query MeterHistoryQuery) ([]Bill, error)
 	ListFinancialReportSummaries(ctx context.Context, query FinancialReportSummaryQuery) ([]FinancialReportSummary, error)
 	FindLiveFinancialReport(ctx context.Context, query FinancialReportQuery) (*FinancialReport, error)
@@ -363,7 +385,7 @@ func NewListPropertyMeterHistoryService(repo ReportRepository) *ListPropertyMete
 }
 
 // Execute validates report read scope and returns property meter history.
-func (s *ListPropertyMeterHistoryService) Execute(ctx context.Context, input ListPropertyMeterHistoryInput) ([]Bill, error) {
+func (s *ListPropertyMeterHistoryService) Execute(ctx context.Context, input ListPropertyMeterHistoryInput) ([]PropertyMeterHistoryRow, error) {
 	actorRole, err := normalizeMeterReportRole(input.ActorRole)
 	if err != nil {
 		return nil, err

--- a/internal/application/billing/reports_test.go
+++ b/internal/application/billing/reports_test.go
@@ -99,6 +99,47 @@ func TestReportServicesValidateRoles(t *testing.T) {
 	})
 }
 
+func TestListPropertyMeterHistoryReturnsGridRowsAndForwardsScope(t *testing.T) {
+	repo := &reportRepositoryStub{
+		propertyMeterHistoryRows: []PropertyMeterHistoryRow{{
+			BillID:          "bill-1",
+			PropertyID:      testPropertyID,
+			RoomID:          testRoomID,
+			RoomLabel:       "101",
+			TenantID:        testTenantID,
+			TenantLabel:     "王小明",
+			LeaseID:         testLeaseID,
+			PreviousReading: 1120,
+			CurrentReading:  1250,
+			Usage:           130,
+			UnitPrice:       5,
+			Status:          "paid",
+		}},
+	}
+	service := NewListPropertyMeterHistoryService(repo)
+	year := 2026
+
+	rows, err := service.Execute(context.Background(), ListPropertyMeterHistoryInput{
+		ActorRole:           "staff",
+		ActorUserID:         "user-1",
+		AssignedPropertyIDs: []string{testPropertyID},
+		PropertyID:          testPropertyID,
+		Year:                &year,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if len(rows) != 1 || rows[0].RoomLabel != "101" || rows[0].Usage != 130 {
+		t.Fatalf("unexpected rows: %+v", rows)
+	}
+	if repo.propertyMeterHistoryQuery == nil || repo.propertyMeterHistoryQuery.ActorRole != "staff" || repo.propertyMeterHistoryQuery.PropertyID != testPropertyID {
+		t.Fatalf("unexpected query: %+v", repo.propertyMeterHistoryQuery)
+	}
+	if repo.propertyMeterHistoryQuery.Year == nil || *repo.propertyMeterHistoryQuery.Year != 2026 {
+		t.Fatalf("unexpected year query: %+v", repo.propertyMeterHistoryQuery)
+	}
+}
+
 func TestFinancialReportDetailMissingMapsToNotFound(t *testing.T) {
 	t.Run("snapshot missing", func(t *testing.T) {
 		repo := &reportRepositoryStub{snapshotReportErr: ErrFinancialReportNotFoundRepository}
@@ -1151,7 +1192,7 @@ func TestExportOperationReportUsesCurrentMonthLiveRows(t *testing.T) {
 type reportRepositoryStub struct {
 	pendingMeterBills            []Bill
 	pendingMeterQuery            *PendingMeterQuery
-	propertyMeterHistoryBills    []Bill
+	propertyMeterHistoryRows     []PropertyMeterHistoryRow
 	propertyMeterHistoryQuery    *MeterHistoryQuery
 	roomMeterHistoryBills        []Bill
 	roomMeterHistoryQuery        *MeterHistoryQuery
@@ -1198,12 +1239,12 @@ func (s *reportRepositoryStub) ListPendingMeterBills(_ context.Context, query Pe
 	return s.pendingMeterBills, nil
 }
 
-func (s *reportRepositoryStub) ListPropertyMeterHistory(_ context.Context, query MeterHistoryQuery) ([]Bill, error) {
+func (s *reportRepositoryStub) ListPropertyMeterHistory(_ context.Context, query MeterHistoryQuery) ([]PropertyMeterHistoryRow, error) {
 	s.propertyMeterHistoryQuery = &query
 	if s.err != nil {
 		return nil, s.err
 	}
-	return s.propertyMeterHistoryBills, nil
+	return s.propertyMeterHistoryRows, nil
 }
 
 func (s *reportRepositoryStub) ListRoomMeterHistory(_ context.Context, query MeterHistoryQuery) ([]Bill, error) {

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -236,6 +236,13 @@ const (
 	LeaseResponseStatusTerminated      LeaseResponseStatus = "terminated"
 )
 
+// Defines values for PropertyMeterHistoryRowStatus.
+const (
+	Overdue        PropertyMeterHistoryRowStatus = "overdue"
+	Paid           PropertyMeterHistoryRowStatus = "paid"
+	PendingPayment PropertyMeterHistoryRowStatus = "pending_payment"
+)
+
 // Defines values for PropertyResponseDefaultElectricityBillingCadence.
 const (
 	PropertyResponseDefaultElectricityBillingCadenceBimonthly PropertyResponseDefaultElectricityBillingCadence = "bimonthly"
@@ -984,6 +991,36 @@ type PropertyAssignmentRequest struct {
 type PropertyListResponse struct {
 	Data *[]PropertyResponse `json:"data,omitempty"`
 }
+
+// PropertyMeterHistoryResponse defines model for PropertyMeterHistoryResponse.
+type PropertyMeterHistoryResponse struct {
+	Data *[]PropertyMeterHistoryRow `json:"data,omitempty"`
+}
+
+// PropertyMeterHistoryRow defines model for PropertyMeterHistoryRow.
+type PropertyMeterHistoryRow struct {
+	Amount          *int                           `json:"amount"`
+	BillId          *openapi_types.UUID            `json:"bill_id,omitempty"`
+	CurrentReading  *int                           `json:"current_reading,omitempty"`
+	DueDate         *openapi_types.Date            `json:"due_date,omitempty"`
+	LeaseId         *openapi_types.UUID            `json:"lease_id,omitempty"`
+	MeterRecordedAt *time.Time                     `json:"meter_recorded_at"`
+	PeriodEnd       *openapi_types.Date            `json:"period_end,omitempty"`
+	PeriodLabel     *string                        `json:"period_label,omitempty"`
+	PeriodStart     *openapi_types.Date            `json:"period_start,omitempty"`
+	PreviousReading *int                           `json:"previous_reading,omitempty"`
+	PropertyId      *openapi_types.UUID            `json:"property_id,omitempty"`
+	RoomId          *openapi_types.UUID            `json:"room_id,omitempty"`
+	RoomLabel       *string                        `json:"room_label,omitempty"`
+	Status          *PropertyMeterHistoryRowStatus `json:"status,omitempty"`
+	TenantId        *openapi_types.UUID            `json:"tenant_id,omitempty"`
+	TenantLabel     *string                        `json:"tenant_label,omitempty"`
+	UnitPrice       *float64                       `json:"unit_price,omitempty"`
+	Usage           *int                           `json:"usage,omitempty"`
+}
+
+// PropertyMeterHistoryRowStatus defines model for PropertyMeterHistoryRow.Status.
+type PropertyMeterHistoryRowStatus string
 
 // PropertyResponse defines model for PropertyResponse.
 type PropertyResponse struct {

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -169,7 +169,7 @@ type BillingPaymentService interface {
 
 type BillingPropertyMeterService interface {
 	ListPropertyPendingMeters(ctx context.Context, input BillingPropertyMetersInput) ([]BillingBill, error)
-	ListPropertyMeterHistory(ctx context.Context, input BillingPropertyMeterHistoryInput) ([]BillingBill, error)
+	ListPropertyMeterHistory(ctx context.Context, input BillingPropertyMeterHistoryInput) ([]BillingPropertyMeterHistoryRow, error)
 }
 
 type BillingRoomMeterService interface {
@@ -342,6 +342,27 @@ type BillingBill struct {
 	CreatedAt            time.Time
 	UpdatedAt            time.Time
 	Version              int
+}
+
+type BillingPropertyMeterHistoryRow struct {
+	BillID          string
+	PropertyID      string
+	RoomID          string
+	RoomLabel       string
+	TenantID        string
+	TenantLabel     string
+	LeaseID         string
+	PeriodStart     time.Time
+	PeriodEnd       time.Time
+	PeriodLabel     string
+	DueDate         time.Time
+	PreviousReading int
+	CurrentReading  int
+	Usage           int
+	UnitPrice       float64
+	Amount          *int
+	Status          string
+	MeterRecordedAt *time.Time
 }
 
 type BillingFinancialReportSummary struct {
@@ -1794,7 +1815,7 @@ func (s *APIServer) ListPropertyMeterHistory(c *gin.Context, id string, params a
 		return
 	}
 
-	bills, err := s.billing.PropertyMeters.ListPropertyMeterHistory(c.Request.Context(), BillingPropertyMeterHistoryInput{
+	rows, err := s.billing.PropertyMeters.ListPropertyMeterHistory(c.Request.Context(), BillingPropertyMeterHistoryInput{
 		ActorRole:           principal.Role,
 		ActorUserID:         principal.UserID,
 		AssignedPropertyIDs: principal.AssignedPropertyIDs,
@@ -1806,7 +1827,7 @@ func (s *APIServer) ListPropertyMeterHistory(c *gin.Context, id string, params a
 		return
 	}
 
-	c.JSON(http.StatusOK, toBillListResponse(bills))
+	c.JSON(http.StatusOK, toPropertyMeterHistoryResponse(rows))
 }
 
 func writeHTMLDocument(c *gin.Context, document *reporthtml.Document) {
@@ -2781,6 +2802,60 @@ func toBillListResponse(bills []BillingBill) api.BillListResponse {
 	}
 
 	return api.BillListResponse{Data: &items}
+}
+
+func toPropertyMeterHistoryResponse(rows []BillingPropertyMeterHistoryRow) api.PropertyMeterHistoryResponse {
+	items := make([]api.PropertyMeterHistoryRow, 0, len(rows))
+	for i := range rows {
+		items = append(items, toPropertyMeterHistoryRowResponse(rows[i]))
+	}
+
+	return api.PropertyMeterHistoryResponse{Data: &items}
+}
+
+func toPropertyMeterHistoryRowResponse(row BillingPropertyMeterHistoryRow) api.PropertyMeterHistoryRow {
+	billID, billOK := parseUUID(row.BillID)
+	propertyID, propertyOK := parseUUID(row.PropertyID)
+	roomID, roomOK := parseUUID(row.RoomID)
+	tenantID, tenantOK := parseUUID(row.TenantID)
+	leaseID, leaseOK := parseUUID(row.LeaseID)
+	status := api.PropertyMeterHistoryRowStatus(row.Status)
+	periodStart := openapi_types.Date{Time: row.PeriodStart}
+	periodEnd := openapi_types.Date{Time: row.PeriodEnd}
+	dueDate := openapi_types.Date{Time: row.DueDate}
+
+	response := api.PropertyMeterHistoryRow{
+		Amount:          row.Amount,
+		CurrentReading:  &row.CurrentReading,
+		DueDate:         &dueDate,
+		MeterRecordedAt: row.MeterRecordedAt,
+		PeriodEnd:       &periodEnd,
+		PeriodLabel:     &row.PeriodLabel,
+		PeriodStart:     &periodStart,
+		PreviousReading: &row.PreviousReading,
+		RoomLabel:       &row.RoomLabel,
+		Status:          &status,
+		TenantLabel:     &row.TenantLabel,
+		UnitPrice:       &row.UnitPrice,
+		Usage:           &row.Usage,
+	}
+	if billOK {
+		response.BillId = &billID
+	}
+	if propertyOK {
+		response.PropertyId = &propertyID
+	}
+	if roomOK {
+		response.RoomId = &roomID
+	}
+	if tenantOK {
+		response.TenantId = &tenantID
+	}
+	if leaseOK {
+		response.LeaseId = &leaseID
+	}
+
+	return response
 }
 
 func toPaginationResponse(pagination queryparams.Pagination, total int) *api.PaginationResponse {

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -461,7 +461,7 @@ func TestListPropertyMeterHistoryReturnsBillPeriodsForYear(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	meters := &recordingPropertyMeters{
-		historyBills: []BillingBill{testBillingBill()},
+		historyRows: []BillingPropertyMeterHistoryRow{testPropertyMeterHistoryRow()},
 	}
 	server := &APIServer{billing: BillingServices{PropertyMeters: meters}}
 	recorder := httptest.NewRecorder()
@@ -486,19 +486,22 @@ func TestListPropertyMeterHistoryReturnsBillPeriodsForYear(t *testing.T) {
 		t.Fatalf("Year = %v, want 2026", meters.historyInput.Year)
 	}
 
-	var response api.BillListResponse
+	var response api.PropertyMeterHistoryResponse
 	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 	if response.Data == nil || len(*response.Data) != 1 {
-		t.Fatalf("expected one meter history bill, got %+v", response.Data)
+		t.Fatalf("expected one meter history row, got %+v", response.Data)
 	}
-	bill := (*response.Data)[0]
-	if bill.PeriodStart == nil || bill.PeriodEnd == nil {
-		t.Fatalf("expected bill period in response: %+v", bill)
+	row := (*response.Data)[0]
+	if row.BillId == nil || row.RoomLabel == nil || *row.RoomLabel != "101" || row.TenantLabel == nil || *row.TenantLabel != "王小明" {
+		t.Fatalf("unexpected meter history labels: %+v", row)
 	}
-	if bill.Amount == nil || *bill.Amount != 12000 {
-		t.Fatalf("unexpected meter history bill response: %+v", bill)
+	if row.PreviousReading == nil || *row.PreviousReading != 1120 || row.CurrentReading == nil || *row.CurrentReading != 1250 || row.Usage == nil || *row.Usage != 130 {
+		t.Fatalf("unexpected meter history readings: %+v", row)
+	}
+	if row.UnitPrice == nil || *row.UnitPrice != 5 || row.Amount == nil || *row.Amount != 650 {
+		t.Fatalf("unexpected meter history amount: %+v", row)
 	}
 }
 
@@ -1140,7 +1143,7 @@ type recordingPropertyMeters struct {
 	pendingInput BillingPropertyMetersInput
 	historyInput BillingPropertyMeterHistoryInput
 	pendingBills []BillingBill
-	historyBills []BillingBill
+	historyRows  []BillingPropertyMeterHistoryRow
 }
 
 func (m *recordingPropertyMeters) ListPropertyPendingMeters(_ context.Context, input BillingPropertyMetersInput) ([]BillingBill, error) {
@@ -1148,9 +1151,9 @@ func (m *recordingPropertyMeters) ListPropertyPendingMeters(_ context.Context, i
 	return m.pendingBills, nil
 }
 
-func (m *recordingPropertyMeters) ListPropertyMeterHistory(_ context.Context, input BillingPropertyMeterHistoryInput) ([]BillingBill, error) {
+func (m *recordingPropertyMeters) ListPropertyMeterHistory(_ context.Context, input BillingPropertyMeterHistoryInput) ([]BillingPropertyMeterHistoryRow, error) {
 	m.historyInput = input
-	return m.historyBills, nil
+	return m.historyRows, nil
 }
 
 type recordingRoomMeters struct {
@@ -1456,6 +1459,31 @@ func testPendingMeterBill() BillingBill {
 	bill.Amount = nil
 	bill.MeterPreviousReading = &previousReading
 	return bill
+}
+
+func testPropertyMeterHistoryRow() BillingPropertyMeterHistoryRow {
+	amount := 650
+	recordedAt := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	return BillingPropertyMeterHistoryRow{
+		BillID:          "30000000-0000-0000-0000-000000000001",
+		PropertyID:      "10000000-0000-0000-0000-000000000001",
+		RoomID:          "20000000-0000-0000-0000-000000000001",
+		RoomLabel:       "101",
+		TenantID:        "50000000-0000-0000-0000-000000000001",
+		TenantLabel:     "王小明",
+		LeaseID:         "40000000-0000-0000-0000-000000000001",
+		PeriodStart:     time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		PeriodEnd:       time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
+		PeriodLabel:     "2026-04-01..2026-04-30",
+		DueDate:         time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		PreviousReading: 1120,
+		CurrentReading:  1250,
+		Usage:           130,
+		UnitPrice:       5,
+		Amount:          &amount,
+		Status:          "paid",
+		MeterRecordedAt: &recordedAt,
+	}
 }
 
 func testFinancialReport() BillingFinancialReport {

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -4426,7 +4426,7 @@ func (fakeBillingPropertyMeters) ListPropertyPendingMeters(_ context.Context, _ 
 	return nil, nil
 }
 
-func (fakeBillingPropertyMeters) ListPropertyMeterHistory(_ context.Context, _ handler.BillingPropertyMeterHistoryInput) ([]handler.BillingBill, error) {
+func (fakeBillingPropertyMeters) ListPropertyMeterHistory(_ context.Context, _ handler.BillingPropertyMeterHistoryInput) ([]handler.BillingPropertyMeterHistoryRow, error) {
 	return nil, nil
 }
 

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -70,6 +70,28 @@ type Bill struct {
 	Version              int
 }
 
+// PropertyMeterHistoryRow is one property-scoped meter history grid row.
+type PropertyMeterHistoryRow struct {
+	BillID          string
+	PropertyID      string
+	RoomID          string
+	RoomLabel       string
+	TenantID        string
+	TenantLabel     string
+	LeaseID         string
+	PeriodStart     time.Time
+	PeriodEnd       time.Time
+	PeriodLabel     string
+	DueDate         time.Time
+	PreviousReading int
+	CurrentReading  int
+	Usage           int
+	UnitPrice       float64
+	Amount          *int
+	Status          string
+	MeterRecordedAt *time.Time
+}
+
 // UpdateMeterParams contains the fields persisted after recording electricity meter usage.
 type UpdateMeterParams struct {
 	BillID               string
@@ -820,46 +842,45 @@ WHERE b.property_id = $1
 	return bills, nil
 }
 
-// ListPropertyMeterHistory returns recorded electricity bills for a property.
-func (r *SQLRepository) ListPropertyMeterHistory(ctx context.Context, scope Scope, propertyID string, year *int) ([]Bill, error) {
+// ListPropertyMeterHistory returns grid-ready recorded electricity history rows for a property.
+func (r *SQLRepository) ListPropertyMeterHistory(ctx context.Context, scope Scope, propertyID string, year *int) (rows []PropertyMeterHistoryRow, err error) {
 	query := `
 SELECT
 	b.id,
-	b.lease_id,
-	b.tenant_id,
-	b.room_id,
 	b.property_id,
-	b.type,
-	b.amount,
+	b.room_id,
+	COALESCE(r.name, b.room_id::text) AS room_label,
+	b.tenant_id,
+	COALESCE(t.name, b.tenant_id::text) AS tenant_label,
+	b.lease_id,
 	b.period_start,
 	b.period_end,
+	concat(b.period_start::text, '..', b.period_end::text) AS period_label,
 	b.due_date,
-	b.status,
-	b.payment_method,
-	b.paid_at,
-	b.paid_amount,
 	b.meter_previous_reading,
 	b.meter_current_reading,
+	b.meter_current_reading - b.meter_previous_reading AS usage,
 	b.meter_unit_price,
-	b.meter_recorded_at,
-	b.written_off_reason,
-	b.overdue_notice_count,
-	b.created_at,
-	b.updated_at,
-	b.version
+	b.amount,
+	b.status,
+	b.meter_recorded_at
 FROM bills b
 JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL
+LEFT JOIN rooms r ON r.id = b.room_id
+LEFT JOIN tenants t ON t.id = b.tenant_id
 WHERE b.property_id = $1
   AND b.type = 'electricity'
+  AND b.meter_previous_reading IS NOT NULL
   AND b.meter_current_reading IS NOT NULL
-  AND b.status NOT IN ('voided', 'written_off')
+  AND b.meter_unit_price IS NOT NULL
+  AND b.status IN ('pending_payment', 'paid', 'overdue')
   AND b.deleted_at IS NULL
 `
 	args := []any{propertyID}
 	var ok bool
 	query, args, ok = appendPropertyScope(query, args, scope, "p")
 	if !ok {
-		return []Bill{}, nil
+		return []PropertyMeterHistoryRow{}, nil
 	}
 	if year != nil {
 		periodStart := time.Date(*year, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -869,7 +890,48 @@ WHERE b.property_id = $1
 	}
 	query += "ORDER BY b.period_start DESC, b.period_end DESC, b.created_at DESC\n"
 
-	return r.listBills(ctx, query, "list property meter history", args...)
+	resultRows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list property meter history: %w", err)
+	}
+	defer func() {
+		if cerr := resultRows.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close property meter history rows: %w", cerr)
+		}
+	}()
+
+	rows = make([]PropertyMeterHistoryRow, 0)
+	for resultRows.Next() {
+		var row PropertyMeterHistoryRow
+		if err := resultRows.Scan(
+			&row.BillID,
+			&row.PropertyID,
+			&row.RoomID,
+			&row.RoomLabel,
+			&row.TenantID,
+			&row.TenantLabel,
+			&row.LeaseID,
+			&row.PeriodStart,
+			&row.PeriodEnd,
+			&row.PeriodLabel,
+			&row.DueDate,
+			&row.PreviousReading,
+			&row.CurrentReading,
+			&row.Usage,
+			&row.UnitPrice,
+			&row.Amount,
+			&row.Status,
+			&row.MeterRecordedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan property meter history row: %w", err)
+		}
+		rows = append(rows, row)
+	}
+	if err := resultRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate property meter history rows: %w", err)
+	}
+
+	return rows, nil
 }
 
 // ListRoomMeterHistory returns recorded electricity bills for a room.

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -448,13 +448,24 @@ func TestListPropertyMeterHistoryYearFilterUsesPeriodOverlap(t *testing.T) {
 	year := 2026
 	rangeStart := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	rangeEnd := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
-	mock.ExpectQuery(`(?s)b.property_id = \$1\s+AND b.type = 'electricity'\s+AND b.meter_current_reading IS NOT NULL\s+AND b.status NOT IN \('voided', 'written_off'\)\s+AND b.deleted_at IS NULL\s+AND b.period_start < \$2\s+AND b.period_end >= \$3`).
+	recordedAt := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`(?s)LEFT JOIN rooms r ON r.id = b.room_id\s+LEFT JOIN tenants t ON t.id = b.tenant_id\s+WHERE b.property_id = \$1\s+AND b.type = 'electricity'\s+AND b.meter_previous_reading IS NOT NULL\s+AND b.meter_current_reading IS NOT NULL\s+AND b.meter_unit_price IS NOT NULL\s+AND b.status IN \('pending_payment', 'paid', 'overdue'\)\s+AND b.deleted_at IS NULL\s+AND b.period_start < \$2\s+AND b.period_end >= \$3`).
 		WithArgs("property-1", rangeEnd, rangeStart).
-		WillReturnRows(billRows())
+		WillReturnRows(propertyMeterHistoryRows().AddRow(
+			"bill-1", "property-1", "room-1", "101", "tenant-1", "王小明", "lease-1",
+			time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC), "2026-04-01..2026-04-30",
+			time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), 1120, 1250, 130, 5.0, 650, "paid", recordedAt,
+		))
 
-	_, err := repo.ListPropertyMeterHistory(context.Background(), Scope{Role: "admin"}, "property-1", &year)
+	rows, err := repo.ListPropertyMeterHistory(context.Background(), Scope{Role: "admin"}, "property-1", &year)
 	if err != nil {
 		t.Fatalf("ListPropertyMeterHistory: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].RoomLabel != "101" || rows[0].TenantLabel != "王小明" || rows[0].Usage != 130 || rows[0].UnitPrice != 5 {
+		t.Fatalf("unexpected history row: %+v", rows[0])
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -1378,6 +1389,29 @@ func billRows() *sqlmock.Rows {
 		"created_at",
 		"updated_at",
 		"version",
+	})
+}
+
+func propertyMeterHistoryRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"bill_id",
+		"property_id",
+		"room_id",
+		"room_label",
+		"tenant_id",
+		"tenant_label",
+		"lease_id",
+		"period_start",
+		"period_end",
+		"period_label",
+		"due_date",
+		"previous_reading",
+		"current_reading",
+		"usage",
+		"unit_price",
+		"amount",
+		"status",
+		"meter_recorded_at",
 	})
 }
 

--- a/internal/server/billing_adapters.go
+++ b/internal/server/billing_adapters.go
@@ -146,8 +146,8 @@ func (a billingPropertyMeterServiceAdapter) ListPropertyPendingMeters(ctx contex
 	return toHandlerBills(bills), nil
 }
 
-func (a billingPropertyMeterServiceAdapter) ListPropertyMeterHistory(ctx context.Context, input handler.BillingPropertyMeterHistoryInput) ([]handler.BillingBill, error) {
-	bills, err := a.meterHistory.Execute(ctx, appbilling.ListPropertyMeterHistoryInput{
+func (a billingPropertyMeterServiceAdapter) ListPropertyMeterHistory(ctx context.Context, input handler.BillingPropertyMeterHistoryInput) ([]handler.BillingPropertyMeterHistoryRow, error) {
+	rows, err := a.meterHistory.Execute(ctx, appbilling.ListPropertyMeterHistoryInput{
 		ActorRole:           input.ActorRole,
 		ActorUserID:         input.ActorUserID,
 		AssignedPropertyIDs: input.AssignedPropertyIDs,
@@ -158,7 +158,7 @@ func (a billingPropertyMeterServiceAdapter) ListPropertyMeterHistory(ctx context
 		return nil, err
 	}
 
-	return toHandlerBills(bills), nil
+	return toHandlerPropertyMeterHistoryRows(rows), nil
 }
 
 type billingRoomMeterServiceAdapter struct {
@@ -422,8 +422,8 @@ func (a billingReportRepositoryAdapter) ListPendingMeterBills(ctx context.Contex
 	return toAppBills(bills), nil
 }
 
-func (a billingReportRepositoryAdapter) ListPropertyMeterHistory(ctx context.Context, query appbilling.MeterHistoryQuery) ([]appbilling.Bill, error) {
-	bills, err := a.repo.ListPropertyMeterHistory(ctx, dbbilling.Scope{
+func (a billingReportRepositoryAdapter) ListPropertyMeterHistory(ctx context.Context, query appbilling.MeterHistoryQuery) ([]appbilling.PropertyMeterHistoryRow, error) {
+	rows, err := a.repo.ListPropertyMeterHistory(ctx, dbbilling.Scope{
 		Role:                query.ActorRole,
 		UserID:              query.ActorUserID,
 		AssignedPropertyIDs: query.AssignedPropertyIDs,
@@ -432,7 +432,7 @@ func (a billingReportRepositoryAdapter) ListPropertyMeterHistory(ctx context.Con
 		return nil, mapBillingReportRepositoryError(err)
 	}
 
-	return toAppBills(bills), nil
+	return toAppPropertyMeterHistoryRows(rows), nil
 }
 
 func (a billingReportRepositoryAdapter) ListRoomMeterHistory(ctx context.Context, query appbilling.MeterHistoryQuery) ([]appbilling.Bill, error) {
@@ -693,6 +693,34 @@ func toAppBill(bill dbbilling.Bill) *appbilling.Bill {
 	}
 }
 
+func toAppPropertyMeterHistoryRows(rows []dbbilling.PropertyMeterHistoryRow) []appbilling.PropertyMeterHistoryRow {
+	result := make([]appbilling.PropertyMeterHistoryRow, 0, len(rows))
+	for i := range rows {
+		result = append(result, appbilling.PropertyMeterHistoryRow{
+			BillID:          rows[i].BillID,
+			PropertyID:      rows[i].PropertyID,
+			RoomID:          rows[i].RoomID,
+			RoomLabel:       rows[i].RoomLabel,
+			TenantID:        rows[i].TenantID,
+			TenantLabel:     rows[i].TenantLabel,
+			LeaseID:         rows[i].LeaseID,
+			PeriodStart:     rows[i].PeriodStart,
+			PeriodEnd:       rows[i].PeriodEnd,
+			PeriodLabel:     rows[i].PeriodLabel,
+			DueDate:         rows[i].DueDate,
+			PreviousReading: rows[i].PreviousReading,
+			CurrentReading:  rows[i].CurrentReading,
+			Usage:           rows[i].Usage,
+			UnitPrice:       rows[i].UnitPrice,
+			Amount:          rows[i].Amount,
+			Status:          rows[i].Status,
+			MeterRecordedAt: rows[i].MeterRecordedAt,
+		})
+	}
+
+	return result
+}
+
 func toAppFinancialReportSummaries(summaries []dbbilling.FinancialReportSummary) []appbilling.FinancialReportSummary {
 	result := make([]appbilling.FinancialReportSummary, 0, len(summaries))
 	for i := range summaries {
@@ -765,6 +793,34 @@ func toHandlerBill(bill appbilling.Bill) *handler.BillingBill {
 		UpdatedAt:            bill.UpdatedAt,
 		Version:              bill.Version,
 	}
+}
+
+func toHandlerPropertyMeterHistoryRows(rows []appbilling.PropertyMeterHistoryRow) []handler.BillingPropertyMeterHistoryRow {
+	result := make([]handler.BillingPropertyMeterHistoryRow, 0, len(rows))
+	for i := range rows {
+		result = append(result, handler.BillingPropertyMeterHistoryRow{
+			BillID:          rows[i].BillID,
+			PropertyID:      rows[i].PropertyID,
+			RoomID:          rows[i].RoomID,
+			RoomLabel:       rows[i].RoomLabel,
+			TenantID:        rows[i].TenantID,
+			TenantLabel:     rows[i].TenantLabel,
+			LeaseID:         rows[i].LeaseID,
+			PeriodStart:     rows[i].PeriodStart,
+			PeriodEnd:       rows[i].PeriodEnd,
+			PeriodLabel:     rows[i].PeriodLabel,
+			DueDate:         rows[i].DueDate,
+			PreviousReading: rows[i].PreviousReading,
+			CurrentReading:  rows[i].CurrentReading,
+			Usage:           rows[i].Usage,
+			UnitPrice:       rows[i].UnitPrice,
+			Amount:          rows[i].Amount,
+			Status:          rows[i].Status,
+			MeterRecordedAt: rows[i].MeterRecordedAt,
+		})
+	}
+
+	return result
 }
 
 func toHandlerFinancialReportSummaries(summaries []appbilling.FinancialReportSummary) []handler.BillingFinancialReportSummary {

--- a/test/e2e/billing_payment_report_test.go
+++ b/test/e2e/billing_payment_report_test.go
@@ -99,6 +99,7 @@ func TestE2EBillingPaymentAndFinancialReportAcceptance(t *testing.T) {
 	if electricityBill.MeterUnitPrice == nil || *electricityBill.MeterUnitPrice != property.ElectricityUnitPrice {
 		t.Fatalf("expected meter_unit_price %v, got %+v", property.ElectricityUnitPrice, electricityBill.MeterUnitPrice)
 	}
+	billingFlowE2ERequirePropertyMeterHistory(t, ctx, adminClient, property.ID, reportYear, room, tenant, electricityBill)
 
 	rentBill = billingFlowE2ERecordPayment(t, ctx, adminClient, rentBill.ID, *rentBill.Amount, paidAt)
 	electricityBill = billingFlowE2ERecordPayment(t, ctx, adminClient, electricityBill.ID, *electricityBill.Amount, paidAt)
@@ -161,6 +162,31 @@ type billingFlowE2EBillResponse struct {
 type billingFlowE2EBillListResponse struct {
 	Data       []billingFlowE2EBillResponse `json:"data"`
 	Pagination billingFlowE2EPagination     `json:"pagination"`
+}
+
+type billingFlowE2EPropertyMeterHistoryResponse struct {
+	Data []billingFlowE2EPropertyMeterHistoryRow `json:"data"`
+}
+
+type billingFlowE2EPropertyMeterHistoryRow struct {
+	BillID          string  `json:"bill_id"`
+	PropertyID      string  `json:"property_id"`
+	RoomID          string  `json:"room_id"`
+	RoomLabel       string  `json:"room_label"`
+	TenantID        string  `json:"tenant_id"`
+	TenantLabel     string  `json:"tenant_label"`
+	LeaseID         string  `json:"lease_id"`
+	PeriodStart     string  `json:"period_start"`
+	PeriodEnd       string  `json:"period_end"`
+	PeriodLabel     string  `json:"period_label"`
+	DueDate         string  `json:"due_date"`
+	PreviousReading int     `json:"previous_reading"`
+	CurrentReading  int     `json:"current_reading"`
+	Usage           int     `json:"usage"`
+	UnitPrice       float64 `json:"unit_price"`
+	Amount          *int    `json:"amount"`
+	Status          string  `json:"status"`
+	MeterRecordedAt *string `json:"meter_recorded_at"`
 }
 
 type billingFlowE2EPagination struct {
@@ -279,6 +305,45 @@ func billingFlowE2ERequirePagination(t *testing.T, got billingFlowE2EPagination,
 	if got.TotalPages != wantTotalPages || got.HasNext != wantHasNext {
 		t.Fatalf("pagination derived fields = %+v, want total_pages=%d has_next=%t", got, wantTotalPages, wantHasNext)
 	}
+}
+
+func billingFlowE2ERequirePropertyMeterHistory(t *testing.T, ctx context.Context, client apiClient, propertyID string, year int, room e2eRoomResponse, tenant e2eTenantResponse, bill billingFlowE2EBillResponse) {
+	t.Helper()
+
+	resp, body, err := client.getJSON(ctx, fmt.Sprintf("/api/v1/properties/%s/meter-history?year=%d", propertyID, year))
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var result billingFlowE2EPropertyMeterHistoryResponse
+	decodeJSON(t, body, &result)
+	for _, row := range result.Data {
+		if row.BillID != bill.ID {
+			continue
+		}
+		if row.PropertyID != propertyID || row.RoomID != room.ID || row.TenantID != tenant.ID || row.LeaseID != bill.LeaseID {
+			t.Fatalf("unexpected meter history IDs: %+v", row)
+		}
+		if row.RoomLabel != room.Name || row.TenantLabel != tenant.Name {
+			t.Fatalf("unexpected meter history labels: %+v", row)
+		}
+		if row.PeriodStart != bill.PeriodStart || row.PeriodEnd != bill.PeriodEnd || row.PeriodLabel == "" || row.DueDate != bill.DueDate {
+			t.Fatalf("unexpected meter history period: %+v", row)
+		}
+		if row.PreviousReading != *bill.MeterPreviousReading || row.CurrentReading != *bill.MeterCurrentReading || row.Usage != *bill.MeterCurrentReading-*bill.MeterPreviousReading {
+			t.Fatalf("unexpected meter history readings: %+v", row)
+		}
+		if row.UnitPrice != *bill.MeterUnitPrice || row.Amount == nil || *row.Amount != *bill.Amount || row.Status != bill.Status {
+			t.Fatalf("unexpected meter history billing fields: %+v", row)
+		}
+		if row.MeterRecordedAt == nil || *row.MeterRecordedAt == "" {
+			t.Fatalf("expected meter_recorded_at: %+v", row)
+		}
+		return
+	}
+
+	t.Fatalf("expected property meter history row for bill %q in %+v", bill.ID, result.Data)
 }
 
 func billingFlowE2EFindBill(t *testing.T, bills []billingFlowE2EBillResponse, billType string) billingFlowE2EBillResponse {


### PR DESCRIPTION
Closes #139

## Summary

- Replace GET /properties/{id}/meter-history with a dedicated flat grid read model response.
- Add backend-owned room and tenant labels, period label, usage, unit price, amount, status, and meter recorded timestamp fields.
- Keep room-level meter history unchanged and avoid schema migration.

## Validation

- npm run openapi:generate
- npm run openapi:lint
- GOCACHE=/tmp/go-cache go test ./...
- GOCACHE=/tmp/go-cache go test -tags=e2e ./test/e2e -run ^$ 
- ./scripts/e2e_test.sh -run TestE2EBillingPaymentAndFinancialReportAcceptance -count=1
- git diff --check
