### PR TITLE
[feature] journal expense accounting title contract

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -5223,6 +5223,48 @@ paths:
                   value:
                     error_code: PROPERTY_NOT_FOUND
                     message: Property not found.
+  /journal-expense-accounting-titles:
+    get:
+      operationId: listJournalExpenseAccountingTitles
+      summary: 日誌費用會計科目選項
+      description: |
+        x-required-role: admin, organizer, staff
+
+        Returns active expense accounting titles that can be selected when creating
+        or updating a journal log with expense_amount. The frontend must send the
+        selected id as expense_accounting_title_id; code/name are response snapshots.
+      tags:
+        - Journal
+      x-required-role:
+        - admin
+        - organizer
+        - staff
+      responses:
+        '200':
+          description: 日誌費用會計科目選項
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountingTitleOptionListResponse'
+              examples:
+                success:
+                  value:
+                    data:
+                      - id: 70000000-0000-0000-0000-000000000001
+                        code: '6681'
+                        name: 其他支出
+                        kind: expense
+        '401':
+          description: 未認證
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                unauthorized:
+                  value:
+                    error_code: UNAUTHORIZED
+                    message: Unauthorized.
   /journal-logs:
     get:
       operationId: listJournalLogs
@@ -5324,6 +5366,7 @@ paths:
                   content: 浴室漏水修繕
                   expense_amount: 3500
                   expense_description: 水管更換費用
+                  expense_accounting_title_id: 70000000-0000-0000-0000-000000000001
               without_expense:
                 summary: 一般日誌
                 value:
@@ -5343,6 +5386,9 @@ paths:
                     property_id: 10000000-0000-0000-0000-000000000001
                     content: 浴室漏水修繕
                     expense_amount: 3500
+                    expense_accounting_title_id: 70000000-0000-0000-0000-000000000001
+                    expense_accounting_title_code: '6681'
+                    expense_accounting_title_name: 其他支出
                     created_at: '2026-04-15T11:00:00Z'
         '400':
           description: 欄位驗證錯誤
@@ -5377,6 +5423,17 @@ paths:
                   value:
                     error_code: FORBIDDEN
                     message: Forbidden.
+        '409':
+          description: 日誌費用所屬月份已月結，不能改變會計影響
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                snapshot_finalized:
+                  value:
+                    error_code: JOURNAL_EXPENSE_SNAPSHOT_FINALIZED
+                    message: Journal expense belongs to a finalized monthly snapshot.
   /journal-logs/{id}:
     get:
       operationId: getJournalLog
@@ -5472,6 +5529,7 @@ paths:
               default:
                 value:
                   content: 浴室漏水修繕（已完成）
+                  expense_accounting_title_id: 70000000-0000-0000-0000-000000000001
       responses:
         '200':
           description: 更新成功
@@ -5484,6 +5542,8 @@ paths:
                   value:
                     id: 60000000-0000-0000-0000-000000000001
                     content: 浴室漏水修繕（已完成）
+                    expense_accounting_title_code: '6681'
+                    expense_accounting_title_name: 其他支出
                     updated_at: '2026-04-15T15:00:00Z'
         '401':
           description: 未認證
@@ -5518,6 +5578,17 @@ paths:
                   value:
                     error_code: JOURNAL_LOG_NOT_FOUND
                     message: Journal log not found.
+        '409':
+          description: 日誌費用所屬月份已月結，不能改變會計影響
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                snapshot_finalized:
+                  value:
+                    error_code: JOURNAL_EXPENSE_SNAPSHOT_FINALIZED
+                    message: Journal expense belongs to a finalized monthly snapshot.
     delete:
       operationId: deleteJournalLog
       summary: 刪除日誌（軟刪除）
@@ -5570,6 +5641,17 @@ paths:
                   value:
                     error_code: JOURNAL_LOG_NOT_FOUND
                     message: Journal log not found.
+        '409':
+          description: 日誌費用所屬月份已月結，不能刪除會計影響
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                snapshot_finalized:
+                  value:
+                    error_code: JOURNAL_EXPENSE_SNAPSHOT_FINALIZED
+                    message: Journal expense belongs to a finalized monthly snapshot.
   /journal-logs/{id}/attachments:
     get:
       operationId: listJournalLogAttachments
@@ -8325,6 +8407,28 @@ components:
             $ref: '#/components/schemas/PropertyTenantLeaseRosterRow'
         pagination:
           $ref: '#/components/schemas/PaginationResponse'
+    AccountingTitleOption:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        kind:
+          type: string
+          enum:
+            - expense
+            - income
+    AccountingTitleOptionListResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountingTitleOption'
     JournalLogResponse:
       type: object
       properties:
@@ -8347,6 +8451,16 @@ components:
           type: integer
           nullable: true
         expense_description:
+          type: string
+          nullable: true
+        expense_accounting_title_id:
+          type: string
+          format: uuid
+          nullable: true
+        expense_accounting_title_code:
+          type: string
+          nullable: true
+        expense_accounting_title_name:
           type: string
           nullable: true
         created_at:
@@ -8385,6 +8499,11 @@ components:
         expense_description:
           type: string
           nullable: true
+        expense_accounting_title_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Required by new clients when expense_amount is present. Omitted legacy requests use the default journal expense title.
     UpdateJournalLogRequest:
       type: object
       properties:
@@ -8394,6 +8513,11 @@ components:
           type: integer
         expense_description:
           type: string
+        expense_accounting_title_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Updates the selected expense accounting title when the journal has an expense amount.
     RepairRequestListResponse:
       type: object
       properties:

--- a/docs/spec/src/components/schemas/journal/AccountingTitleOption.yaml
+++ b/docs/spec/src/components/schemas/journal/AccountingTitleOption.yaml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+  code:
+    type: string
+  name:
+    type: string
+  kind:
+    type: string
+    enum:
+      - expense
+      - income

--- a/docs/spec/src/components/schemas/journal/AccountingTitleOptionListResponse.yaml
+++ b/docs/spec/src/components/schemas/journal/AccountingTitleOptionListResponse.yaml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  data:
+    type: array
+    items:
+      $ref: ./AccountingTitleOption.yaml

--- a/docs/spec/src/components/schemas/journal/CreateJournalLogRequest.yaml
+++ b/docs/spec/src/components/schemas/journal/CreateJournalLogRequest.yaml
@@ -18,3 +18,8 @@ properties:
   expense_description:
     type: string
     nullable: true
+  expense_accounting_title_id:
+    type: string
+    format: uuid
+    nullable: true
+    description: Required by new clients when expense_amount is present. Omitted legacy requests use the default journal expense title.

--- a/docs/spec/src/components/schemas/journal/JournalLogResponse.yaml
+++ b/docs/spec/src/components/schemas/journal/JournalLogResponse.yaml
@@ -21,6 +21,16 @@ properties:
   expense_description:
     type: string
     nullable: true
+  expense_accounting_title_id:
+    type: string
+    format: uuid
+    nullable: true
+  expense_accounting_title_code:
+    type: string
+    nullable: true
+  expense_accounting_title_name:
+    type: string
+    nullable: true
   created_at:
     type: string
     format: date-time

--- a/docs/spec/src/components/schemas/journal/UpdateJournalLogRequest.yaml
+++ b/docs/spec/src/components/schemas/journal/UpdateJournalLogRequest.yaml
@@ -6,3 +6,8 @@ properties:
     type: integer
   expense_description:
     type: string
+  expense_accounting_title_id:
+    type: string
+    format: uuid
+    nullable: true
+    description: Updates the selected expense accounting title when the journal has an expense amount.

--- a/docs/spec/src/openapi.yaml
+++ b/docs/spec/src/openapi.yaml
@@ -169,6 +169,8 @@ paths:
     $ref: paths/billing/properties_{id}_tenant-roster.yaml
   /properties/{id}/tenant-lease-roster:
     $ref: paths/billing/properties_{id}_tenant-lease-roster.yaml
+  /journal-expense-accounting-titles:
+    $ref: paths/journal/journal-expense-accounting-titles.yaml
   /journal-logs:
     $ref: paths/journal/journal-logs.yaml
   /journal-logs/{id}:

--- a/docs/spec/src/paths/journal/journal-expense-accounting-titles.yaml
+++ b/docs/spec/src/paths/journal/journal-expense-accounting-titles.yaml
@@ -1,0 +1,41 @@
+get:
+  operationId: listJournalExpenseAccountingTitles
+  summary: 日誌費用會計科目選項
+  description: |
+    x-required-role: admin, organizer, staff
+
+    Returns active expense accounting titles that can be selected when creating
+    or updating a journal log with expense_amount. The frontend must send the
+    selected id as expense_accounting_title_id; code/name are response snapshots.
+  tags:
+    - Journal
+  x-required-role:
+    - admin
+    - organizer
+    - staff
+  responses:
+    '200':
+      description: 日誌費用會計科目選項
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/journal/AccountingTitleOptionListResponse.yaml
+          examples:
+            success:
+              value:
+                data:
+                  - id: 70000000-0000-0000-0000-000000000001
+                    code: '6681'
+                    name: 其他支出
+                    kind: expense
+    '401':
+      description: 未認證
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+          examples:
+            unauthorized:
+              value:
+                error_code: UNAUTHORIZED
+                message: Unauthorized.

--- a/docs/spec/src/paths/journal/journal-logs.yaml
+++ b/docs/spec/src/paths/journal/journal-logs.yaml
@@ -101,6 +101,7 @@ post:
               content: 浴室漏水修繕
               expense_amount: 3500
               expense_description: 水管更換費用
+              expense_accounting_title_id: 70000000-0000-0000-0000-000000000001
           without_expense:
             summary: 一般日誌
             value:
@@ -120,6 +121,9 @@ post:
                 property_id: 10000000-0000-0000-0000-000000000001
                 content: 浴室漏水修繕
                 expense_amount: 3500
+                expense_accounting_title_id: 70000000-0000-0000-0000-000000000001
+                expense_accounting_title_code: '6681'
+                expense_accounting_title_name: 其他支出
                 created_at: '2026-04-15T11:00:00Z'
     '400':
       description: 欄位驗證錯誤
@@ -154,3 +158,14 @@ post:
               value:
                 error_code: FORBIDDEN
                 message: Forbidden.
+    '409':
+      description: 日誌費用所屬月份已月結，不能改變會計影響
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+          examples:
+            snapshot_finalized:
+              value:
+                error_code: JOURNAL_EXPENSE_SNAPSHOT_FINALIZED
+                message: Journal expense belongs to a finalized monthly snapshot.

--- a/docs/spec/src/paths/journal/journal-logs_{id}.yaml
+++ b/docs/spec/src/paths/journal/journal-logs_{id}.yaml
@@ -92,6 +92,7 @@ patch:
           default:
             value:
               content: 浴室漏水修繕（已完成）
+              expense_accounting_title_id: 70000000-0000-0000-0000-000000000001
   responses:
     '200':
       description: 更新成功
@@ -104,6 +105,8 @@ patch:
               value:
                 id: 60000000-0000-0000-0000-000000000001
                 content: 浴室漏水修繕（已完成）
+                expense_accounting_title_code: '6681'
+                expense_accounting_title_name: 其他支出
                 updated_at: '2026-04-15T15:00:00Z'
     '401':
       description: 未認證
@@ -138,6 +141,17 @@ patch:
               value:
                 error_code: JOURNAL_LOG_NOT_FOUND
                 message: Journal log not found.
+    '409':
+      description: 日誌費用所屬月份已月結，不能改變會計影響
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+          examples:
+            snapshot_finalized:
+              value:
+                error_code: JOURNAL_EXPENSE_SNAPSHOT_FINALIZED
+                message: Journal expense belongs to a finalized monthly snapshot.
 delete:
   operationId: deleteJournalLog
   summary: 刪除日誌（軟刪除）
@@ -190,3 +204,14 @@ delete:
               value:
                 error_code: JOURNAL_LOG_NOT_FOUND
                 message: Journal log not found.
+    '409':
+      description: 日誌費用所屬月份已月結，不能刪除會計影響
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+          examples:
+            snapshot_finalized:
+              value:
+                error_code: JOURNAL_EXPENSE_SNAPSHOT_FINALIZED
+                message: Journal expense belongs to a finalized monthly snapshot.

--- a/internal/application/journal/accounting_titles.go
+++ b/internal/application/journal/accounting_titles.go
@@ -1,0 +1,29 @@
+package journal
+
+import (
+	"context"
+)
+
+// ListExpenseAccountingTitlesService lists active expense accounting titles for journal expenses.
+type ListExpenseAccountingTitlesService struct {
+	repo Repository
+}
+
+// NewListExpenseAccountingTitlesService returns a ListExpenseAccountingTitlesService.
+func NewListExpenseAccountingTitlesService(repo Repository) *ListExpenseAccountingTitlesService {
+	return &ListExpenseAccountingTitlesService{repo: repo}
+}
+
+// Execute returns active expense accounting title options.
+func (s *ListExpenseAccountingTitlesService) Execute(ctx context.Context) ([]AccountingTitle, error) {
+	if s.repo == nil {
+		return nil, nil
+	}
+
+	titles, err := s.repo.ListExpenseAccountingTitles(ctx)
+	if err != nil {
+		return nil, mapRepositoryError(err)
+	}
+
+	return titles, nil
+}

--- a/internal/application/journal/create.go
+++ b/internal/application/journal/create.go
@@ -3,6 +3,7 @@ package journal
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	domainevents "stds_backend/internal/domain/events"
 	domainjournal "stds_backend/internal/domain/journal"
@@ -17,14 +18,15 @@ const (
 
 // CreateInput is the command payload for journal log creation.
 type CreateInput struct {
-	ActorRole           string
-	ActorUserID         string
-	AssignedPropertyIDs []string
-	PropertyID          string
-	RoomID              *string
-	Content             string
-	ExpenseAmount       *int
-	ExpenseDescription  *string
+	ActorRole                string
+	ActorUserID              string
+	AssignedPropertyIDs      []string
+	PropertyID               string
+	RoomID                   *string
+	Content                  string
+	ExpenseAmount            *int
+	ExpenseDescription       *string
+	ExpenseAccountingTitleID *string
 }
 
 // CreateService creates journal logs.
@@ -93,26 +95,46 @@ func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*Journa
 				return apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "room_id"})
 			}
 		}
+		var expenseTitle *AccountingTitle
+		if journalExpenseAmountPresent(state.ExpenseAmount) {
+			expenseTitle, err = s.resolveExpenseAccountingTitle(ctx, tx, input.ExpenseAccountingTitleID, nil)
+			if err != nil {
+				return err
+			}
+		}
 
 		journalLog, err := s.repo.Create(ctx, tx, CreateParams{
-			PropertyID:         state.PropertyID,
-			RoomID:             state.RoomID,
-			AuthorID:           state.AuthorID,
-			Content:            state.Content,
-			ExpenseAmount:      state.ExpenseAmount,
-			ExpenseDescription: state.ExpenseDescription,
+			PropertyID:                 state.PropertyID,
+			RoomID:                     state.RoomID,
+			AuthorID:                   state.AuthorID,
+			Content:                    state.Content,
+			ExpenseAmount:              state.ExpenseAmount,
+			ExpenseDescription:         state.ExpenseDescription,
+			ExpenseAccountingTitleID:   accountingTitleID(expenseTitle),
+			ExpenseAccountingTitleCode: accountingTitleCode(expenseTitle),
+			ExpenseAccountingTitleName: accountingTitleName(expenseTitle),
 		})
 		if err != nil {
 			return mapRepositoryError(err)
 		}
 
 		if journalLog.ExpenseAmount != nil {
+			if expenseTitle == nil {
+				return apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "journal_accounting_title"})
+			}
 			year, month := journalAccountingPeriod(journalLog.CreatedAt)
+			exists, err := s.accountingRepo.JournalExpenseSnapshotExists(ctx, tx, journalLog.PropertyID, year, month)
+			if err != nil {
+				return mapAccountingRepositoryError(err)
+			}
+			if exists {
+				return ErrJournalExpenseSnapshotFinalized
+			}
 			sourceDate := journalLog.CreatedAt.In(journalAccountingLocation)
 			if err := s.accountingRepo.CreateExpenseAccountingEntry(ctx, tx, ExpenseAccountingEntryParams{
 				PropertyID:          journalLog.PropertyID,
 				Category:            accountingCategoryJournalExpense,
-				AccountingTitleCode: accountingTitleCodeJournalExpense,
+				AccountingTitleCode: expenseTitle.Code,
 				Amount:              *journalLog.ExpenseAmount,
 				Description:         journalLog.ExpenseDescription,
 				SourceRef:           map[string]interface{}{"type": "JournalExpenseRecorded", "journal_log_id": journalLog.ID},
@@ -142,4 +164,61 @@ func (s *CreateService) Execute(ctx context.Context, input CreateInput) (*Journa
 	}
 
 	return created, nil
+}
+
+func (s *CreateService) resolveExpenseAccountingTitle(ctx context.Context, tx *sql.Tx, requestedID *string, current *JournalLog) (*AccountingTitle, error) {
+	if requestedID != nil {
+		titleID, err := normalizeRequiredUUID(*requestedID, "expense_accounting_title_id", ErrAccountingTitleNotFound)
+		if err != nil {
+			if errors.Is(err, ErrAccountingTitleNotFound) {
+				return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "expense_accounting_title_id"})
+			}
+			return nil, err
+		}
+		title, err := s.repo.FindExpenseAccountingTitleByID(ctx, tx, titleID)
+		if err != nil {
+			return nil, mapRepositoryError(err)
+		}
+		return title, nil
+	}
+
+	if current != nil && current.ExpenseAccountingTitleID != nil && current.ExpenseAccountingTitleCode != nil && current.ExpenseAccountingTitleName != nil {
+		return &AccountingTitle{
+			ID:   *current.ExpenseAccountingTitleID,
+			Code: *current.ExpenseAccountingTitleCode,
+			Name: *current.ExpenseAccountingTitleName,
+			Kind: "expense",
+		}, nil
+	}
+
+	title, err := s.repo.FindExpenseAccountingTitleByCode(ctx, tx, accountingTitleCodeJournalExpense)
+	if err != nil {
+		return nil, mapRepositoryError(err)
+	}
+	return title, nil
+}
+
+func accountingTitleID(title *AccountingTitle) *string {
+	if title == nil {
+		return nil
+	}
+	return &title.ID
+}
+
+func accountingTitleCode(title *AccountingTitle) *string {
+	if title == nil {
+		return nil
+	}
+	return &title.Code
+}
+
+func accountingTitleName(title *AccountingTitle) *string {
+	if title == nil {
+		return nil
+	}
+	return &title.Name
+}
+
+func journalExpenseAmountPresent(amount *int) bool {
+	return amount != nil
 }

--- a/internal/application/journal/create_test.go
+++ b/internal/application/journal/create_test.go
@@ -19,6 +19,7 @@ const (
 	testPropertyID = "10000000-0000-0000-0000-000000000001"
 	testRoomID     = "20000000-0000-0000-0000-000000000001"
 	testActorID    = "00000000-0000-0000-0000-000000000002"
+	testTitleID    = "70000000-0000-0000-0000-000000000001"
 )
 
 func TestCreateServiceCreatesAccountingEntryAndPublishesEventWhenExpensePresent(t *testing.T) {
@@ -98,6 +99,52 @@ func TestCreateServiceCreatesAccountingEntryAndPublishesEventWhenExpensePresent(
 	}
 }
 
+func TestCreateServiceUsesRequestedExpenseAccountingTitle(t *testing.T) {
+	amount := 3500
+	requestedTitleID := "70000000-0000-0000-0000-000000000099"
+	requestedTitle := AccountingTitle{ID: requestedTitleID, Code: "6115", Name: "維護修繕費", Kind: "expense"}
+	repo := &journalRepositoryStub{
+		propertyExists: true,
+		titlesByID: map[string]AccountingTitle{
+			requestedTitleID: requestedTitle,
+		},
+		created: &JournalLog{
+			ID:                         testJournalID,
+			PropertyID:                 testPropertyID,
+			AuthorID:                   testActorID,
+			Content:                    "Bathroom repair",
+			ExpenseAmount:              &amount,
+			ExpenseAccountingTitleID:   &requestedTitle.ID,
+			ExpenseAccountingTitleCode: &requestedTitle.Code,
+			ExpenseAccountingTitleName: &requestedTitle.Name,
+			CreatedAt:                  time.Date(2026, 4, 15, 11, 0, 0, 0, time.UTC),
+			UpdatedAt:                  time.Date(2026, 4, 15, 11, 0, 0, 0, time.UTC),
+		},
+	}
+	accountingRepo := &expenseAccountingRepositoryStub{}
+	runner, _, cleanup := newJournalTxRunner(t)
+	defer cleanup()
+	service := NewCreateService(repo, accountingRepo, runner)
+
+	created, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:                "admin",
+		ActorUserID:              testActorID,
+		PropertyID:               testPropertyID,
+		Content:                  "Bathroom repair",
+		ExpenseAmount:            &amount,
+		ExpenseAccountingTitleID: &requestedTitleID,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if accountingRepo.entry.AccountingTitleCode != requestedTitle.Code {
+		t.Fatalf("AccountingTitleCode = %q, want %q", accountingRepo.entry.AccountingTitleCode, requestedTitle.Code)
+	}
+	if created.ExpenseAccountingTitleID == nil || *created.ExpenseAccountingTitleID != requestedTitleID {
+		t.Fatalf("created title id = %+v, want %s", created.ExpenseAccountingTitleID, requestedTitleID)
+	}
+}
+
 func TestCreateServiceDoesNotCreateAccountingEntryOrPublishExpenseEventWithoutExpense(t *testing.T) {
 	repo := &journalRepositoryStub{
 		propertyExists: true,
@@ -164,6 +211,43 @@ func TestCreateServiceRollsBackWhenAccountingEntryFails(t *testing.T) {
 	}
 	if accountingRepo.createCalls != 1 {
 		t.Fatalf("CreateExpenseAccountingEntry calls = %d, want 1", accountingRepo.createCalls)
+	}
+	if len(publisher.events) != 0 {
+		t.Fatalf("published events = %d, want 0", len(publisher.events))
+	}
+}
+
+func TestCreateServiceRejectsExpenseAfterMonthlySnapshot(t *testing.T) {
+	amount := 3500
+	repo := &journalRepositoryStub{
+		propertyExists: true,
+		created: &JournalLog{
+			ID:            testJournalID,
+			PropertyID:    testPropertyID,
+			AuthorID:      testActorID,
+			Content:       "Bathroom repair",
+			ExpenseAmount: &amount,
+			CreatedAt:     time.Date(2026, 4, 15, 11, 0, 0, 0, time.UTC),
+			UpdatedAt:     time.Date(2026, 4, 15, 11, 0, 0, 0, time.UTC),
+		},
+	}
+	accountingRepo := &expenseAccountingRepositoryStub{snapshotExists: true}
+	runner, publisher, cleanup := newJournalTxRunnerExpectRollback(t)
+	defer cleanup()
+	service := NewCreateService(repo, accountingRepo, runner)
+
+	_, err := service.Execute(context.Background(), CreateInput{
+		ActorRole:     "admin",
+		ActorUserID:   testActorID,
+		PropertyID:    testPropertyID,
+		Content:       "Bathroom repair",
+		ExpenseAmount: &amount,
+	})
+	if !errors.Is(err, ErrJournalExpenseSnapshotFinalized) {
+		t.Fatalf("Execute() error = %v, want ErrJournalExpenseSnapshotFinalized", err)
+	}
+	if accountingRepo.createCalls != 0 {
+		t.Fatalf("CreateExpenseAccountingEntry calls = %d, want 0", accountingRepo.createCalls)
 	}
 	if len(publisher.events) != 0 {
 		t.Fatalf("published events = %d, want 0", len(publisher.events))
@@ -404,17 +488,146 @@ func TestUpdateServiceRejectsEmptyContent(t *testing.T) {
 	}
 }
 
-func TestDeleteServiceSoftDeletesJournalLog(t *testing.T) {
-	repo := &journalRepositoryStub{}
+func TestUpdateServiceDoesNotSyncAccountingEntryForContentOnlyExpenseUpdate(t *testing.T) {
+	amount := 3500
+	repo := &journalRepositoryStub{
+		current: &JournalLog{
+			ID:                         testJournalID,
+			PropertyID:                 testPropertyID,
+			AuthorID:                   testActorID,
+			Content:                    "Original",
+			ExpenseAmount:              &amount,
+			ExpenseDescription:         stringPtr("Pipe repair"),
+			ExpenseAccountingTitleID:   stringPtr(testTitleID),
+			ExpenseAccountingTitleCode: stringPtr(accountingTitleCodeJournalExpense),
+			ExpenseAccountingTitleName: stringPtr("其他支出"),
+			CreatedAt:                  time.Date(2026, 4, 15, 11, 0, 0, 0, time.UTC),
+			UpdatedAt:                  time.Now(),
+		},
+	}
 	runner, _, cleanup := newJournalTxRunner(t)
 	defer cleanup()
-	service := NewDeleteService(repo, runner)
+	accountingRepo := &expenseAccountingRepositoryStub{snapshotExists: true}
+	service := NewUpdateService(repo, accountingRepo, runner)
+	content := " Updated content "
+
+	updated, err := service.Execute(context.Background(), UpdateInput{
+		ID:      testJournalID,
+		Content: &content,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if updated.Content != "Updated content" {
+		t.Fatalf("Content = %q, want trimmed content", updated.Content)
+	}
+	if accountingRepo.syncCalls != 0 {
+		t.Fatalf("SyncExpenseAccountingEntry calls = %d, want 0", accountingRepo.syncCalls)
+	}
+}
+
+func TestUpdateServiceRejectsExpenseChangeAfterMonthlySnapshot(t *testing.T) {
+	amount := 3500
+	updatedAmount := 4200
+	repo := &journalRepositoryStub{
+		current: &JournalLog{
+			ID:                         testJournalID,
+			PropertyID:                 testPropertyID,
+			AuthorID:                   testActorID,
+			Content:                    "Original",
+			ExpenseAmount:              &amount,
+			ExpenseAccountingTitleID:   stringPtr(testTitleID),
+			ExpenseAccountingTitleCode: stringPtr(accountingTitleCodeJournalExpense),
+			ExpenseAccountingTitleName: stringPtr("其他支出"),
+			CreatedAt:                  time.Date(2026, 4, 15, 11, 0, 0, 0, time.UTC),
+			UpdatedAt:                  time.Now(),
+		},
+	}
+	runner, _, cleanup := newJournalTxRunnerExpectRollback(t)
+	defer cleanup()
+	service := NewUpdateService(repo, &expenseAccountingRepositoryStub{snapshotExists: true}, runner)
+
+	_, err := service.Execute(context.Background(), UpdateInput{
+		ID:            testJournalID,
+		ExpenseAmount: &updatedAmount,
+	})
+	if !errors.Is(err, ErrJournalExpenseSnapshotFinalized) {
+		t.Fatalf("Execute() error = %v, want ErrJournalExpenseSnapshotFinalized", err)
+	}
+}
+
+func TestDeleteServiceSoftDeletesJournalLog(t *testing.T) {
+	repo := &journalRepositoryStub{
+		current: &JournalLog{
+			ID:         testJournalID,
+			PropertyID: testPropertyID,
+			AuthorID:   testActorID,
+			Content:    "Original",
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+	}
+	runner, _, cleanup := newJournalTxRunner(t)
+	defer cleanup()
+	service := NewDeleteService(repo, &expenseAccountingRepositoryStub{}, runner)
 
 	if err := service.Execute(context.Background(), DeleteInput{ID: testJournalID}); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 	if repo.deletedID != testJournalID {
 		t.Fatalf("deletedID = %s, want %s", repo.deletedID, testJournalID)
+	}
+}
+
+func TestDeleteServiceDeletesLiveExpenseAccountingEntry(t *testing.T) {
+	amount := 3500
+	repo := &journalRepositoryStub{
+		current: &JournalLog{
+			ID:            testJournalID,
+			PropertyID:    testPropertyID,
+			AuthorID:      testActorID,
+			Content:       "Original",
+			ExpenseAmount: &amount,
+			CreatedAt:     time.Date(2026, 4, 15, 11, 0, 0, 0, time.UTC),
+			UpdatedAt:     time.Now(),
+		},
+	}
+	accountingRepo := &expenseAccountingRepositoryStub{}
+	runner, _, cleanup := newJournalTxRunner(t)
+	defer cleanup()
+	service := NewDeleteService(repo, accountingRepo, runner)
+
+	if err := service.Execute(context.Background(), DeleteInput{ID: testJournalID}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if accountingRepo.syncCalls != 1 || accountingRepo.syncedEntry != nil {
+		t.Fatalf("expected accounting delete sync, calls=%d entry=%+v", accountingRepo.syncCalls, accountingRepo.syncedEntry)
+	}
+}
+
+func TestDeleteServiceRejectsExpenseAfterMonthlySnapshot(t *testing.T) {
+	amount := 3500
+	repo := &journalRepositoryStub{
+		current: &JournalLog{
+			ID:            testJournalID,
+			PropertyID:    testPropertyID,
+			AuthorID:      testActorID,
+			Content:       "Original",
+			ExpenseAmount: &amount,
+			CreatedAt:     time.Date(2026, 4, 15, 11, 0, 0, 0, time.UTC),
+			UpdatedAt:     time.Now(),
+		},
+	}
+	runner, _, cleanup := newJournalTxRunnerExpectRollback(t)
+	defer cleanup()
+	service := NewDeleteService(repo, &expenseAccountingRepositoryStub{snapshotExists: true}, runner)
+
+	err := service.Execute(context.Background(), DeleteInput{ID: testJournalID})
+	if !errors.Is(err, ErrJournalExpenseSnapshotFinalized) {
+		t.Fatalf("Execute() error = %v, want ErrJournalExpenseSnapshotFinalized", err)
+	}
+	if repo.deletedID != "" {
+		t.Fatalf("deletedID = %s, want empty", repo.deletedID)
 	}
 }
 
@@ -432,6 +645,8 @@ type expenseAccountingRepositoryStub struct {
 	syncedEntry        *ExpenseAccountingEntryParams
 	syncedJournalLogID string
 	err                error
+	snapshotExists     bool
+	snapshotErr        error
 	createCalls        int
 	syncCalls          int
 }
@@ -447,6 +662,10 @@ func (s *expenseAccountingRepositoryStub) SyncExpenseAccountingEntry(_ context.C
 	s.syncedJournalLogID = journalLogID
 	s.syncedEntry = params
 	return s.err
+}
+
+func (s *expenseAccountingRepositoryStub) JournalExpenseSnapshotExists(context.Context, *sql.Tx, string, int, int) (bool, error) {
+	return s.snapshotExists, s.snapshotErr
 }
 
 func newJournalTxRunner(t *testing.T) (*txrunner.Runner, *journalPublisherStub, func()) {
@@ -488,6 +707,8 @@ func newJournalTxRunnerWithExpectation(t *testing.T, commit bool) (*txrunner.Run
 type journalRepositoryStub struct {
 	propertyExists bool
 	room           *Room
+	titles         []AccountingTitle
+	titlesByID     map[string]AccountingTitle
 	created        *JournalLog
 	current        *JournalLog
 	listResult     ListResult
@@ -514,6 +735,29 @@ func (s *journalRepositoryStub) FindByIDForUpdate(context.Context, *sql.Tx, stri
 	return s.current, nil
 }
 
+func (s *journalRepositoryStub) ListExpenseAccountingTitles(context.Context) ([]AccountingTitle, error) {
+	if s.titles != nil {
+		return s.titles, nil
+	}
+	return []AccountingTitle{defaultAccountingTitle()}, nil
+}
+
+func (s *journalRepositoryStub) FindExpenseAccountingTitleByID(_ context.Context, _ *sql.Tx, id string) (*AccountingTitle, error) {
+	if s.titlesByID != nil {
+		if title, ok := s.titlesByID[id]; ok {
+			return &title, nil
+		}
+		return nil, ErrAccountingTitleNotFound
+	}
+	title := defaultAccountingTitle()
+	return &title, nil
+}
+
+func (s *journalRepositoryStub) FindExpenseAccountingTitleByCode(context.Context, *sql.Tx, string) (*AccountingTitle, error) {
+	title := defaultAccountingTitle()
+	return &title, nil
+}
+
 func (s *journalRepositoryStub) EnsurePropertyExists(context.Context, *sql.Tx, string) error {
 	if !s.propertyExists {
 		return ErrPropertyNotFound
@@ -536,15 +780,18 @@ func (s *journalRepositoryStub) Create(_ context.Context, _ *sql.Tx, params Crea
 	}
 
 	return &JournalLog{
-		ID:                 testJournalID,
-		PropertyID:         params.PropertyID,
-		RoomID:             params.RoomID,
-		AuthorID:           params.AuthorID,
-		Content:            params.Content,
-		ExpenseAmount:      params.ExpenseAmount,
-		ExpenseDescription: params.ExpenseDescription,
-		CreatedAt:          time.Now(),
-		UpdatedAt:          time.Now(),
+		ID:                         testJournalID,
+		PropertyID:                 params.PropertyID,
+		RoomID:                     params.RoomID,
+		AuthorID:                   params.AuthorID,
+		Content:                    params.Content,
+		ExpenseAmount:              params.ExpenseAmount,
+		ExpenseDescription:         params.ExpenseDescription,
+		ExpenseAccountingTitleID:   params.ExpenseAccountingTitleID,
+		ExpenseAccountingTitleCode: params.ExpenseAccountingTitleCode,
+		ExpenseAccountingTitleName: params.ExpenseAccountingTitleName,
+		CreatedAt:                  time.Now(),
+		UpdatedAt:                  time.Now(),
 	}, nil
 }
 
@@ -554,15 +801,18 @@ func (s *journalRepositoryStub) Update(_ context.Context, _ *sql.Tx, params Upda
 	}
 
 	return &JournalLog{
-		ID:                 params.ID,
-		PropertyID:         s.current.PropertyID,
-		RoomID:             s.current.RoomID,
-		AuthorID:           s.current.AuthorID,
-		Content:            params.Content,
-		ExpenseAmount:      params.ExpenseAmount,
-		ExpenseDescription: params.ExpenseDescription,
-		CreatedAt:          s.current.CreatedAt,
-		UpdatedAt:          time.Now(),
+		ID:                         params.ID,
+		PropertyID:                 s.current.PropertyID,
+		RoomID:                     s.current.RoomID,
+		AuthorID:                   s.current.AuthorID,
+		Content:                    params.Content,
+		ExpenseAmount:              params.ExpenseAmount,
+		ExpenseDescription:         params.ExpenseDescription,
+		ExpenseAccountingTitleID:   params.ExpenseAccountingTitleID,
+		ExpenseAccountingTitleCode: params.ExpenseAccountingTitleCode,
+		ExpenseAccountingTitleName: params.ExpenseAccountingTitleName,
+		CreatedAt:                  s.current.CreatedAt,
+		UpdatedAt:                  time.Now(),
 	}, nil
 }
 
@@ -573,4 +823,13 @@ func (s *journalRepositoryStub) SoftDelete(_ context.Context, _ *sql.Tx, id stri
 
 func stringPtr(value string) *string {
 	return &value
+}
+
+func defaultAccountingTitle() AccountingTitle {
+	return AccountingTitle{
+		ID:   testTitleID,
+		Code: accountingTitleCodeJournalExpense,
+		Name: "其他支出",
+		Kind: "expense",
+	}
 }

--- a/internal/application/journal/delete.go
+++ b/internal/application/journal/delete.go
@@ -15,13 +15,14 @@ type DeleteInput struct {
 
 // DeleteService soft-deletes journal logs.
 type DeleteService struct {
-	repo     Repository
-	txRunner TransactionRunner
+	repo           Repository
+	accountingRepo ExpenseAccountingRepository
+	txRunner       TransactionRunner
 }
 
 // NewDeleteService returns a DeleteService.
-func NewDeleteService(repo Repository, txRunner TransactionRunner) *DeleteService {
-	return &DeleteService{repo: repo, txRunner: txRunner}
+func NewDeleteService(repo Repository, accountingRepo ExpenseAccountingRepository, txRunner TransactionRunner) *DeleteService {
+	return &DeleteService{repo: repo, accountingRepo: accountingRepo, txRunner: txRunner}
 }
 
 // Execute performs a soft delete.
@@ -35,8 +36,30 @@ func (s *DeleteService) Execute(ctx context.Context, input DeleteInput) error {
 	}
 
 	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		current, err := s.repo.FindByIDForUpdate(ctx, tx, id)
+		if err != nil {
+			return mapRepositoryError(err)
+		}
+		if current.ExpenseAmount != nil {
+			if s.accountingRepo == nil {
+				return apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "journal_accounting"})
+			}
+			year, month := journalAccountingPeriod(current.CreatedAt)
+			exists, err := s.accountingRepo.JournalExpenseSnapshotExists(ctx, tx, current.PropertyID, year, month)
+			if err != nil {
+				return mapAccountingRepositoryError(err)
+			}
+			if exists {
+				return ErrJournalExpenseSnapshotFinalized
+			}
+		}
 		if err := s.repo.SoftDelete(ctx, tx, id); err != nil {
 			return mapRepositoryError(err)
+		}
+		if current.ExpenseAmount != nil {
+			if err := s.accountingRepo.SyncExpenseAccountingEntry(ctx, tx, id, nil); err != nil {
+				return mapAccountingRepositoryError(err)
+			}
 		}
 
 		return nil

--- a/internal/application/journal/errors.go
+++ b/internal/application/journal/errors.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	CodeValidationJournalContentRequired = "VALIDATION_JOURNAL_CONTENT_REQUIRED"
+	CodeJournalExpenseSnapshotFinalized  = "JOURNAL_EXPENSE_SNAPSHOT_FINALIZED"
 )
 
 var (
@@ -17,6 +18,11 @@ var (
 		CodeValidationJournalContentRequired,
 		http.StatusBadRequest,
 		"Journal content is required.",
+	)
+	ErrJournalExpenseSnapshotFinalized = apperr.New(
+		CodeJournalExpenseSnapshotFinalized,
+		http.StatusConflict,
+		"Journal expense belongs to a finalized monthly snapshot.",
 	)
 )
 
@@ -32,6 +38,8 @@ func mapRepositoryError(err error) error {
 		return apperr.ErrPropertyNotFound
 	case errors.Is(err, ErrRoomNotFound):
 		return apperr.ErrRoomNotFound
+	case errors.Is(err, ErrAccountingTitleNotFound):
+		return apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "expense_accounting_title_id"})
 	default:
 		return apperr.ErrInternalServerError.WithCause(err)
 	}

--- a/internal/application/journal/repository.go
+++ b/internal/application/journal/repository.go
@@ -14,6 +14,7 @@ var (
 	ErrPropertyNotFound        = errors.New("journal property not found")
 	ErrRoomNotFound            = errors.New("journal room not found")
 	ErrPropertyAccountNotFound = errors.New("journal property account not found")
+	ErrAccountingTitleNotFound = errors.New("journal accounting title not found")
 )
 
 // TransactionRunner is the txrunner.Runner surface required by journal use cases.
@@ -23,21 +24,32 @@ type TransactionRunner interface {
 
 // JournalLog is the application-facing journal log shape.
 type JournalLog struct {
-	ID                 string
-	PropertyID         string
-	RoomID             *string
-	AuthorID           string
-	Content            string
-	ExpenseAmount      *int
-	ExpenseDescription *string
-	CreatedAt          time.Time
-	UpdatedAt          time.Time
+	ID                         string
+	PropertyID                 string
+	RoomID                     *string
+	AuthorID                   string
+	Content                    string
+	ExpenseAmount              *int
+	ExpenseDescription         *string
+	ExpenseAccountingTitleID   *string
+	ExpenseAccountingTitleCode *string
+	ExpenseAccountingTitleName *string
+	CreatedAt                  time.Time
+	UpdatedAt                  time.Time
 }
 
 // Room captures room ownership needed by journal creation.
 type Room struct {
 	ID         string
 	PropertyID string
+}
+
+// AccountingTitle is an active accounting title selectable for journal expenses.
+type AccountingTitle struct {
+	ID   string
+	Code string
+	Name string
+	Kind string
 }
 
 // ListQuery defines filtering, pagination, and role scoping for journal lists.
@@ -60,12 +72,15 @@ type ListResult struct {
 
 // CreateParams contains fields for journal log creation.
 type CreateParams struct {
-	PropertyID         string
-	RoomID             *string
-	AuthorID           string
-	Content            string
-	ExpenseAmount      *int
-	ExpenseDescription *string
+	PropertyID                 string
+	RoomID                     *string
+	AuthorID                   string
+	Content                    string
+	ExpenseAmount              *int
+	ExpenseDescription         *string
+	ExpenseAccountingTitleID   *string
+	ExpenseAccountingTitleCode *string
+	ExpenseAccountingTitleName *string
 }
 
 // ExpenseAccountingEntryParams contains accounting data derived from journal expense creation.
@@ -84,10 +99,13 @@ type ExpenseAccountingEntryParams struct {
 
 // UpdateParams contains mutable journal log fields.
 type UpdateParams struct {
-	ID                 string
-	Content            string
-	ExpenseAmount      *int
-	ExpenseDescription *string
+	ID                         string
+	Content                    string
+	ExpenseAmount              *int
+	ExpenseDescription         *string
+	ExpenseAccountingTitleID   *string
+	ExpenseAccountingTitleCode *string
+	ExpenseAccountingTitleName *string
 }
 
 // Repository defines persistence required by journal use cases.
@@ -95,6 +113,9 @@ type Repository interface {
 	List(ctx context.Context, query ListQuery) (ListResult, error)
 	FindByID(ctx context.Context, id string) (*JournalLog, error)
 	FindByIDForUpdate(ctx context.Context, tx *sql.Tx, id string) (*JournalLog, error)
+	ListExpenseAccountingTitles(ctx context.Context) ([]AccountingTitle, error)
+	FindExpenseAccountingTitleByID(ctx context.Context, tx *sql.Tx, id string) (*AccountingTitle, error)
+	FindExpenseAccountingTitleByCode(ctx context.Context, tx *sql.Tx, code string) (*AccountingTitle, error)
 	EnsurePropertyExists(ctx context.Context, tx *sql.Tx, id string) error
 	FindRoomByID(ctx context.Context, tx *sql.Tx, id string) (*Room, error)
 	Create(ctx context.Context, tx *sql.Tx, params CreateParams) (*JournalLog, error)
@@ -106,4 +127,5 @@ type Repository interface {
 type ExpenseAccountingRepository interface {
 	CreateExpenseAccountingEntry(ctx context.Context, tx *sql.Tx, params ExpenseAccountingEntryParams) error
 	SyncExpenseAccountingEntry(ctx context.Context, tx *sql.Tx, journalLogID string, params *ExpenseAccountingEntryParams) error
+	JournalExpenseSnapshotExists(ctx context.Context, tx *sql.Tx, propertyID string, year int, month int) (bool, error)
 }

--- a/internal/application/journal/update.go
+++ b/internal/application/journal/update.go
@@ -11,10 +11,11 @@ import (
 
 // UpdateInput is the command payload for journal log updates.
 type UpdateInput struct {
-	ID                 string
-	Content            *string
-	ExpenseAmount      *int
-	ExpenseDescription *string
+	ID                       string
+	Content                  *string
+	ExpenseAmount            *int
+	ExpenseDescription       *string
+	ExpenseAccountingTitleID *string
 }
 
 // UpdateService updates journal logs.
@@ -35,7 +36,7 @@ func (s *UpdateService) Execute(ctx context.Context, input UpdateInput) (*Journa
 	if err != nil {
 		return nil, err
 	}
-	if input.Content == nil && input.ExpenseAmount == nil && input.ExpenseDescription == nil {
+	if input.Content == nil && input.ExpenseAmount == nil && input.ExpenseDescription == nil && input.ExpenseAccountingTitleID == nil {
 		return nil, apperr.ErrBadRequest
 	}
 	if s.txRunner == nil {
@@ -61,28 +62,57 @@ func (s *UpdateService) Execute(ctx context.Context, input UpdateInput) (*Journa
 		}
 
 		state := aggregate.State()
+		var expenseTitle *AccountingTitle
+		if journalExpenseAmountPresent(state.ExpenseAmount) {
+			expenseTitle, err = (&CreateService{repo: s.repo}).resolveExpenseAccountingTitle(ctx, tx, input.ExpenseAccountingTitleID, current)
+			if err != nil {
+				return err
+			}
+		} else if input.ExpenseAccountingTitleID != nil {
+			return apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "expense_accounting_title_id"})
+		}
+		accountingChanged := journalExpenseAccountingChanges(current, state.ExpenseAmount, state.ExpenseDescription, expenseTitle)
+		if accountingChanged {
+			if s.accountingRepo == nil {
+				return apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "journal_accounting"})
+			}
+			year, month := journalAccountingPeriod(current.CreatedAt)
+			exists, err := s.accountingRepo.JournalExpenseSnapshotExists(ctx, tx, current.PropertyID, year, month)
+			if err != nil {
+				return mapAccountingRepositoryError(err)
+			}
+			if exists {
+				return ErrJournalExpenseSnapshotFinalized
+			}
+		}
 		journalLog, err := s.repo.Update(ctx, tx, UpdateParams{
-			ID:                 id,
-			Content:            state.Content,
-			ExpenseAmount:      state.ExpenseAmount,
-			ExpenseDescription: state.ExpenseDescription,
+			ID:                         id,
+			Content:                    state.Content,
+			ExpenseAmount:              state.ExpenseAmount,
+			ExpenseDescription:         state.ExpenseDescription,
+			ExpenseAccountingTitleID:   accountingTitleID(expenseTitle),
+			ExpenseAccountingTitleCode: accountingTitleCode(expenseTitle),
+			ExpenseAccountingTitleName: accountingTitleName(expenseTitle),
 		})
 		if err != nil {
 			return mapRepositoryError(err)
 		}
 
-		if current.ExpenseAmount != nil || journalLog.ExpenseAmount != nil {
+		if accountingChanged {
 			if s.accountingRepo == nil {
 				return apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "journal_accounting"})
 			}
 			var entry *ExpenseAccountingEntryParams
 			if journalLog.ExpenseAmount != nil {
+				if expenseTitle == nil {
+					return apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "journal_accounting_title"})
+				}
 				year, month := journalAccountingPeriod(journalLog.CreatedAt)
 				sourceDate := journalLog.CreatedAt.In(journalAccountingLocation)
 				entry = &ExpenseAccountingEntryParams{
 					PropertyID:          journalLog.PropertyID,
 					Category:            accountingCategoryJournalExpense,
-					AccountingTitleCode: accountingTitleCodeJournalExpense,
+					AccountingTitleCode: expenseTitle.Code,
 					Amount:              *journalLog.ExpenseAmount,
 					Description:         journalLog.ExpenseDescription,
 					SourceRef:           map[string]interface{}{"type": "JournalExpenseRecorded", "journal_log_id": journalLog.ID},
@@ -107,6 +137,30 @@ func (s *UpdateService) Execute(ctx context.Context, input UpdateInput) (*Journa
 	return updated, nil
 }
 
+func journalExpenseAccountingChanges(current *JournalLog, nextAmount *int, nextDescription *string, nextTitle *AccountingTitle) bool {
+	if current == nil {
+		return nextAmount != nil
+	}
+	if !journalIntPtrEqual(current.ExpenseAmount, nextAmount) {
+		return true
+	}
+	if !journalStringPtrEqual(current.ExpenseDescription, nextDescription) {
+		return true
+	}
+	if current.ExpenseAmount == nil && nextAmount == nil {
+		return false
+	}
+	currentTitleID := ""
+	if current.ExpenseAccountingTitleID != nil {
+		currentTitleID = *current.ExpenseAccountingTitleID
+	}
+	nextTitleID := ""
+	if nextTitle != nil {
+		nextTitleID = nextTitle.ID
+	}
+	return currentTitleID != nextTitleID
+}
+
 func toDomainState(journalLog *JournalLog) domainjournal.State {
 	if journalLog == nil {
 		return domainjournal.State{}
@@ -121,4 +175,18 @@ func toDomainState(journalLog *JournalLog) domainjournal.State {
 		ExpenseAmount:      journalLog.ExpenseAmount,
 		ExpenseDescription: journalLog.ExpenseDescription,
 	}
+}
+
+func journalIntPtrEqual(left *int, right *int) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func journalStringPtrEqual(left *string, right *string) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
 }

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -18,6 +18,12 @@ const (
 	SchedulerKeyScopes = "SchedulerKey.Scopes"
 )
 
+// Defines values for AccountingTitleOptionKind.
+const (
+	Expense AccountingTitleOptionKind = "expense"
+	Income  AccountingTitleOptionKind = "income"
+)
+
 // Defines values for AttachmentResponsePhotoStage.
 const (
 	AttachmentResponsePhotoStageAfter  AttachmentResponsePhotoStage = "after"
@@ -413,6 +419,22 @@ const (
 	ListUsersParamsRoleStaff     ListUsersParamsRole = "staff"
 )
 
+// AccountingTitleOption defines model for AccountingTitleOption.
+type AccountingTitleOption struct {
+	Code *string                    `json:"code,omitempty"`
+	Id   *openapi_types.UUID        `json:"id,omitempty"`
+	Kind *AccountingTitleOptionKind `json:"kind,omitempty"`
+	Name *string                    `json:"name,omitempty"`
+}
+
+// AccountingTitleOptionKind defines model for AccountingTitleOption.Kind.
+type AccountingTitleOptionKind string
+
+// AccountingTitleOptionListResponse defines model for AccountingTitleOptionListResponse.
+type AccountingTitleOptionListResponse struct {
+	Data *[]AccountingTitleOption `json:"data,omitempty"`
+}
+
 // AssignRepairRequest defines model for AssignRepairRequest.
 type AssignRepairRequest struct {
 	// AssignedTo 被指派的員工 user ID
@@ -628,11 +650,14 @@ type CheckoutSettlementWarningCode string
 
 // CreateJournalLogRequest defines model for CreateJournalLogRequest.
 type CreateJournalLogRequest struct {
-	Content            string              `json:"content"`
-	ExpenseAmount      *int                `json:"expense_amount"`
-	ExpenseDescription *string             `json:"expense_description"`
-	PropertyId         openapi_types.UUID  `json:"property_id"`
-	RoomId             *openapi_types.UUID `json:"room_id"`
+	Content string `json:"content"`
+
+	// ExpenseAccountingTitleId Required by new clients when expense_amount is present. Omitted legacy requests use the default journal expense title.
+	ExpenseAccountingTitleId *openapi_types.UUID `json:"expense_accounting_title_id"`
+	ExpenseAmount            *int                `json:"expense_amount"`
+	ExpenseDescription       *string             `json:"expense_description"`
+	PropertyId               openapi_types.UUID  `json:"property_id"`
+	RoomId                   *openapi_types.UUID `json:"room_id"`
 }
 
 // CreateLeaseRequest defines model for CreateLeaseRequest.
@@ -859,15 +884,18 @@ type JournalLogListResponse struct {
 
 // JournalLogResponse defines model for JournalLogResponse.
 type JournalLogResponse struct {
-	AuthorId           *openapi_types.UUID `json:"author_id,omitempty"`
-	Content            *string             `json:"content,omitempty"`
-	CreatedAt          *time.Time          `json:"created_at,omitempty"`
-	ExpenseAmount      *int                `json:"expense_amount"`
-	ExpenseDescription *string             `json:"expense_description"`
-	Id                 *openapi_types.UUID `json:"id,omitempty"`
-	PropertyId         *openapi_types.UUID `json:"property_id,omitempty"`
-	RoomId             *openapi_types.UUID `json:"room_id"`
-	UpdatedAt          *time.Time          `json:"updated_at,omitempty"`
+	AuthorId                   *openapi_types.UUID `json:"author_id,omitempty"`
+	Content                    *string             `json:"content,omitempty"`
+	CreatedAt                  *time.Time          `json:"created_at,omitempty"`
+	ExpenseAccountingTitleCode *string             `json:"expense_accounting_title_code"`
+	ExpenseAccountingTitleId   *openapi_types.UUID `json:"expense_accounting_title_id"`
+	ExpenseAccountingTitleName *string             `json:"expense_accounting_title_name"`
+	ExpenseAmount              *int                `json:"expense_amount"`
+	ExpenseDescription         *string             `json:"expense_description"`
+	Id                         *openapi_types.UUID `json:"id,omitempty"`
+	PropertyId                 *openapi_types.UUID `json:"property_id,omitempty"`
+	RoomId                     *openapi_types.UUID `json:"room_id"`
+	UpdatedAt                  *time.Time          `json:"updated_at,omitempty"`
 }
 
 // LeaseListResponse defines model for LeaseListResponse.
@@ -1253,9 +1281,12 @@ type UpdateDepositRequest struct {
 
 // UpdateJournalLogRequest defines model for UpdateJournalLogRequest.
 type UpdateJournalLogRequest struct {
-	Content            *string `json:"content,omitempty"`
-	ExpenseAmount      *int    `json:"expense_amount,omitempty"`
-	ExpenseDescription *string `json:"expense_description,omitempty"`
+	Content *string `json:"content,omitempty"`
+
+	// ExpenseAccountingTitleId Updates the selected expense accounting title when the journal has an expense amount.
+	ExpenseAccountingTitleId *openapi_types.UUID `json:"expense_accounting_title_id"`
+	ExpenseAmount            *int                `json:"expense_amount,omitempty"`
+	ExpenseDescription       *string             `json:"expense_description,omitempty"`
 }
 
 // UpdateLeaseRequest defines model for UpdateLeaseRequest.
@@ -1711,6 +1742,9 @@ type ServerInterface interface {
 	// 觸發逾期帳單掃描 job
 	// (POST /internal/jobs/overdue-bills/scan)
 	RunOverdueBillsScanJob(c *gin.Context, params RunOverdueBillsScanJobParams)
+	// 日誌費用會計科目選項
+	// (GET /journal-expense-accounting-titles)
+	ListJournalExpenseAccountingTitles(c *gin.Context)
 	// 日誌列表
 	// (GET /journal-logs)
 	ListJournalLogs(c *gin.Context, params ListJournalLogsParams)
@@ -2497,6 +2531,21 @@ func (siw *ServerInterfaceWrapper) RunOverdueBillsScanJob(c *gin.Context) {
 	}
 
 	siw.Handler.RunOverdueBillsScanJob(c, params)
+}
+
+// ListJournalExpenseAccountingTitles operation middleware
+func (siw *ServerInterfaceWrapper) ListJournalExpenseAccountingTitles(c *gin.Context) {
+
+	c.Set(BearerAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.ListJournalExpenseAccountingTitles(c)
 }
 
 // ListJournalLogs operation middleware
@@ -4780,6 +4829,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/internal/jobs/monthly-snapshots/run", wrapper.RunMonthlySnapshotJob)
 	router.POST(options.BaseURL+"/internal/jobs/overdue-bills/reminders", wrapper.RunOverdueBillReminderJob)
 	router.POST(options.BaseURL+"/internal/jobs/overdue-bills/scan", wrapper.RunOverdueBillsScanJob)
+	router.GET(options.BaseURL+"/journal-expense-accounting-titles", wrapper.ListJournalExpenseAccountingTitles)
 	router.GET(options.BaseURL+"/journal-logs", wrapper.ListJournalLogs)
 	router.POST(options.BaseURL+"/journal-logs", wrapper.CreateJournalLog)
 	router.DELETE(options.BaseURL+"/journal-logs/:id", wrapper.DeleteJournalLog)

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -134,11 +134,12 @@ type BillingServices struct {
 
 // JournalServices groups journal log application services used by the transport layer.
 type JournalServices struct {
-	List   *appjournal.ListService
-	Get    *appjournal.GetService
-	Create *appjournal.CreateService
-	Update *appjournal.UpdateService
-	Delete *appjournal.DeleteService
+	List                     *appjournal.ListService
+	Get                      *appjournal.GetService
+	ListExpenseAccountTitles *appjournal.ListExpenseAccountingTitlesService
+	Create                   *appjournal.CreateService
+	Update                   *appjournal.UpdateService
+	Delete                   *appjournal.DeleteService
 }
 
 // RepairServices groups repair request application services used by the transport layer.
@@ -523,6 +524,7 @@ func validateAPIServerDeps(deps APIServerDeps) {
 		{"billing_financial_reports", deps.Billing.FinancialReports},
 		{"journal_list", deps.Journal.List},
 		{"journal_get", deps.Journal.Get},
+		{"journal_accounting_titles", deps.Journal.ListExpenseAccountTitles},
 		{"journal_create", deps.Journal.Create},
 		{"journal_update", deps.Journal.Update},
 		{"journal_delete", deps.Journal.Delete},
@@ -893,6 +895,21 @@ func (s *APIServer) RunOverdueBillsScanJob(c *gin.Context, params api.RunOverdue
 	s.runJob(c, appjobs.JobOverdueBillsScan, params.WindowKey)
 }
 
+// ListJournalExpenseAccountingTitles handles the journal expense accounting title option endpoint.
+func (s *APIServer) ListJournalExpenseAccountingTitles(c *gin.Context) {
+	titles, err := s.journal.ListExpenseAccountTitles.Execute(c.Request.Context())
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	responses := make([]api.AccountingTitleOption, 0, len(titles))
+	for i := range titles {
+		responses = append(responses, toAccountingTitleOption(titles[i]))
+	}
+	c.JSON(http.StatusOK, api.AccountingTitleOptionListResponse{Data: &responses})
+}
+
 // ListJournalLogs handles the journal log listing endpoint.
 func (s *APIServer) ListJournalLogs(c *gin.Context, params api.ListJournalLogsParams) {
 	principal, ok := requestctx.GetPrincipal(c)
@@ -966,15 +983,21 @@ func (s *APIServer) CreateJournalLog(c *gin.Context) {
 		value := request.RoomId.String()
 		roomID = &value
 	}
+	var expenseAccountingTitleID *string
+	if request.ExpenseAccountingTitleId != nil {
+		value := request.ExpenseAccountingTitleId.String()
+		expenseAccountingTitleID = &value
+	}
 	journalLog, err := s.journal.Create.Execute(c.Request.Context(), appjournal.CreateInput{
-		ActorRole:           principal.Role,
-		ActorUserID:         principal.UserID,
-		AssignedPropertyIDs: principal.AssignedPropertyIDs,
-		PropertyID:          request.PropertyId.String(),
-		RoomID:              roomID,
-		Content:             request.Content,
-		ExpenseAmount:       request.ExpenseAmount,
-		ExpenseDescription:  request.ExpenseDescription,
+		ActorRole:                principal.Role,
+		ActorUserID:              principal.UserID,
+		AssignedPropertyIDs:      principal.AssignedPropertyIDs,
+		PropertyID:               request.PropertyId.String(),
+		RoomID:                   roomID,
+		Content:                  request.Content,
+		ExpenseAmount:            request.ExpenseAmount,
+		ExpenseDescription:       request.ExpenseDescription,
+		ExpenseAccountingTitleID: expenseAccountingTitleID,
 	})
 	if err != nil {
 		c.Error(err)
@@ -1023,11 +1046,17 @@ func (s *APIServer) UpdateJournalLog(c *gin.Context, id string) {
 		return
 	}
 
+	var expenseAccountingTitleID *string
+	if request.ExpenseAccountingTitleId != nil {
+		value := request.ExpenseAccountingTitleId.String()
+		expenseAccountingTitleID = &value
+	}
 	journalLog, err := s.journal.Update.Execute(c.Request.Context(), appjournal.UpdateInput{
-		ID:                 id,
-		Content:            request.Content,
-		ExpenseAmount:      request.ExpenseAmount,
-		ExpenseDescription: request.ExpenseDescription,
+		ID:                       id,
+		Content:                  request.Content,
+		ExpenseAmount:            request.ExpenseAmount,
+		ExpenseDescription:       request.ExpenseDescription,
+		ExpenseAccountingTitleID: expenseAccountingTitleID,
 	})
 	if err != nil {
 		c.Error(err)
@@ -3113,11 +3142,13 @@ func toJournalLogResponse(journalLog *appjournal.JournalLog) api.JournalLogRespo
 	updatedAt := journalLog.UpdatedAt
 
 	response := api.JournalLogResponse{
-		Content:            &content,
-		CreatedAt:          &createdAt,
-		ExpenseAmount:      journalLog.ExpenseAmount,
-		ExpenseDescription: journalLog.ExpenseDescription,
-		UpdatedAt:          &updatedAt,
+		Content:                    &content,
+		CreatedAt:                  &createdAt,
+		ExpenseAccountingTitleCode: journalLog.ExpenseAccountingTitleCode,
+		ExpenseAccountingTitleName: journalLog.ExpenseAccountingTitleName,
+		ExpenseAmount:              journalLog.ExpenseAmount,
+		ExpenseDescription:         journalLog.ExpenseDescription,
+		UpdatedAt:                  &updatedAt,
 	}
 	if idOK {
 		response.Id = &id
@@ -3134,7 +3165,29 @@ func toJournalLogResponse(journalLog *appjournal.JournalLog) api.JournalLogRespo
 			response.RoomId = &roomID
 		}
 	}
+	if journalLog.ExpenseAccountingTitleID != nil {
+		titleID, titleOK := parseUUID(*journalLog.ExpenseAccountingTitleID)
+		if titleOK {
+			response.ExpenseAccountingTitleId = &titleID
+		}
+	}
 
+	return response
+}
+
+func toAccountingTitleOption(title appjournal.AccountingTitle) api.AccountingTitleOption {
+	id, idOK := parseUUID(title.ID)
+	code := title.Code
+	name := title.Name
+	kind := api.AccountingTitleOptionKind(title.Kind)
+	response := api.AccountingTitleOption{
+		Code: &code,
+		Kind: &kind,
+		Name: &name,
+	}
+	if idOK {
+		response.Id = &id
+	}
 	return response
 }
 

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -176,6 +176,7 @@ func routePolicies(authzRepos AuthorizationRepositories) []routePolicy {
 		{method: "POST", path: "/api/v1/internal/jobs/overdue-bills/reminders", authStrategy: authStrategyScheduler},
 		{method: "POST", path: "/api/v1/internal/jobs/overdue-bills/scan", authStrategy: authStrategyScheduler},
 
+		{method: "GET", path: "/api/v1/journal-expense-accounting-titles", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "GET", path: "/api/v1/journal-logs", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.QueryPropertyID("property_id")},
 		{method: "POST", path: "/api/v1/journal-logs", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "GET", path: "/api/v1/journal-logs/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByJournalLogID, apperr.ErrJournalLogNotFound)},

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -6057,11 +6057,12 @@ func defaultAPIServerDeps(userRepo *fakeUserRepo, authenticator fakeAuthenticato
 			FinancialReports:  fakeBillingFinancialReports{},
 		},
 		Journal: handler.JournalServices{
-			List:   appjournal.NewListService(nil),
-			Get:    appjournal.NewGetService(nil),
-			Create: appjournal.NewCreateService(nil, nil, nil),
-			Update: appjournal.NewUpdateService(nil, nil, nil),
-			Delete: appjournal.NewDeleteService(nil, nil),
+			List:                     appjournal.NewListService(nil),
+			Get:                      appjournal.NewGetService(nil),
+			ListExpenseAccountTitles: appjournal.NewListExpenseAccountingTitlesService(nil),
+			Create:                   appjournal.NewCreateService(nil, nil, nil),
+			Update:                   appjournal.NewUpdateService(nil, nil, nil),
+			Delete:                   appjournal.NewDeleteService(nil, nil, nil),
 		},
 		Repair: handler.RepairServices{
 			Create:   apprepair.NewCreateService(nil, nil),

--- a/internal/platform/database/journal/repository.go
+++ b/internal/platform/database/journal/repository.go
@@ -142,6 +142,62 @@ FOR UPDATE
 	return journalLog, nil
 }
 
+// ListExpenseAccountingTitles returns active expense accounting titles for journal expense selection.
+func (r *SQLRepository) ListExpenseAccountingTitles(ctx context.Context) ([]appjournal.AccountingTitle, error) {
+	const query = `
+SELECT id, code, name, kind
+FROM accounting_titles
+WHERE kind = 'expense'
+  AND is_active = true
+ORDER BY code ASC, name ASC
+`
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list journal expense accounting titles: %w", err)
+	}
+	defer rows.Close()
+
+	titles := []appjournal.AccountingTitle{}
+	for rows.Next() {
+		var title appjournal.AccountingTitle
+		if err := rows.Scan(&title.ID, &title.Code, &title.Name, &title.Kind); err != nil {
+			return nil, fmt.Errorf("scan journal expense accounting title: %w", err)
+		}
+		titles = append(titles, title)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate journal expense accounting titles: %w", err)
+	}
+
+	return titles, nil
+}
+
+// FindExpenseAccountingTitleByID returns one active expense accounting title.
+func (r *SQLRepository) FindExpenseAccountingTitleByID(ctx context.Context, tx *sql.Tx, id string) (*appjournal.AccountingTitle, error) {
+	const query = `
+SELECT id, code, name, kind
+FROM accounting_titles
+WHERE id = $1
+  AND kind = 'expense'
+  AND is_active = true
+LIMIT 1
+`
+	return scanAccountingTitle(tx.QueryRowContext(ctx, query, id), "query journal expense accounting title by id")
+}
+
+// FindExpenseAccountingTitleByCode returns one active expense accounting title by code.
+func (r *SQLRepository) FindExpenseAccountingTitleByCode(ctx context.Context, tx *sql.Tx, code string) (*appjournal.AccountingTitle, error) {
+	const query = `
+SELECT id, code, name, kind
+FROM accounting_titles
+WHERE code = $1
+  AND kind = 'expense'
+  AND is_active = true
+LIMIT 1
+`
+	return scanAccountingTitle(tx.QueryRowContext(ctx, query, code), "query journal expense accounting title by code")
+}
+
 // EnsurePropertyExists verifies that an active property exists for journal writes.
 func (r *SQLRepository) EnsurePropertyExists(ctx context.Context, tx *sql.Tx, id string) error {
 	const query = `
@@ -191,8 +247,11 @@ INSERT INTO journal_logs (
 	author_id,
 	content,
 	expense_amount,
-	expense_description
-) VALUES ($1, $2, $3, $4, $5, $6)
+	expense_description,
+	expense_accounting_title_id,
+	expense_accounting_title_code,
+	expense_accounting_title_name
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 ` + returningJournalLogColumns
 
 	journalLog, err := scanJournalLog(tx.QueryRowContext(ctx, query,
@@ -202,6 +261,9 @@ INSERT INTO journal_logs (
 		params.Content,
 		nullableInt(params.ExpenseAmount),
 		nullableString(params.ExpenseDescription),
+		nullableString(params.ExpenseAccountingTitleID),
+		nullableString(params.ExpenseAccountingTitleCode),
+		nullableString(params.ExpenseAccountingTitleName),
 	))
 	if err != nil {
 		return nil, fmt.Errorf("create journal log: %w", err)
@@ -217,6 +279,9 @@ UPDATE journal_logs
 SET content = $2,
     expense_amount = $3,
     expense_description = $4,
+    expense_accounting_title_id = $5,
+    expense_accounting_title_code = $6,
+    expense_accounting_title_name = $7,
     updated_at = now()
 WHERE id = $1
   AND deleted_at IS NULL
@@ -227,6 +292,9 @@ WHERE id = $1
 		params.Content,
 		nullableInt(params.ExpenseAmount),
 		nullableString(params.ExpenseDescription),
+		nullableString(params.ExpenseAccountingTitleID),
+		nullableString(params.ExpenseAccountingTitleCode),
+		nullableString(params.ExpenseAccountingTitleName),
 	))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -271,6 +339,9 @@ SELECT
 	jl.content,
 	jl.expense_amount,
 	jl.expense_description,
+	jl.expense_accounting_title_id,
+	jl.expense_accounting_title_code,
+	jl.expense_accounting_title_name,
 	jl.created_at,
 	jl.updated_at
 `
@@ -284,6 +355,9 @@ RETURNING
 	content,
 	expense_amount,
 	expense_description,
+	expense_accounting_title_id,
+	expense_accounting_title_code,
+	expense_accounting_title_name,
 	created_at,
 	updated_at
 `
@@ -297,6 +371,9 @@ func scanJournalLog(scanner journalLogScanner) (*appjournal.JournalLog, error) {
 	var roomID sql.NullString
 	var expenseAmount sql.NullInt64
 	var expenseDescription sql.NullString
+	var expenseAccountingTitleID sql.NullString
+	var expenseAccountingTitleCode sql.NullString
+	var expenseAccountingTitleName sql.NullString
 
 	if err := scanner.Scan(
 		&item.ID,
@@ -306,6 +383,9 @@ func scanJournalLog(scanner journalLogScanner) (*appjournal.JournalLog, error) {
 		&item.Content,
 		&expenseAmount,
 		&expenseDescription,
+		&expenseAccountingTitleID,
+		&expenseAccountingTitleCode,
+		&expenseAccountingTitleName,
 		&item.CreatedAt,
 		&item.UpdatedAt,
 	); err != nil {
@@ -322,8 +402,28 @@ func scanJournalLog(scanner journalLogScanner) (*appjournal.JournalLog, error) {
 	if expenseDescription.Valid {
 		item.ExpenseDescription = &expenseDescription.String
 	}
+	if expenseAccountingTitleID.Valid {
+		item.ExpenseAccountingTitleID = &expenseAccountingTitleID.String
+	}
+	if expenseAccountingTitleCode.Valid {
+		item.ExpenseAccountingTitleCode = &expenseAccountingTitleCode.String
+	}
+	if expenseAccountingTitleName.Valid {
+		item.ExpenseAccountingTitleName = &expenseAccountingTitleName.String
+	}
 
 	return &item, nil
+}
+
+func scanAccountingTitle(scanner journalLogScanner, context string) (*appjournal.AccountingTitle, error) {
+	var title appjournal.AccountingTitle
+	if err := scanner.Scan(&title.ID, &title.Code, &title.Name, &title.Kind); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, appjournal.ErrAccountingTitleNotFound
+		}
+		return nil, fmt.Errorf("%s: %w", context, err)
+	}
+	return &title, nil
 }
 
 func nullableString(value *string) any {

--- a/internal/platform/database/journal/repository_test.go
+++ b/internal/platform/database/journal/repository_test.go
@@ -31,7 +31,7 @@ func TestListAppliesFiltersPaginationAndScope(t *testing.T) {
 	mock.ExpectQuery(regexp.QuoteMeta("FROM journal_logs jl")).
 		WithArgs(propertyID, propertyID, roomID, dateFrom, dateTo.AddDate(0, 0, 1), 20, 40).
 		WillReturnRows(journalLogRows().
-			AddRow("60000000-0000-0000-0000-000000000001", propertyID, roomID, "00000000-0000-0000-0000-000000000002", "Inspection", nil, nil, createdAt, updatedAt))
+			AddRow("60000000-0000-0000-0000-000000000001", propertyID, roomID, "00000000-0000-0000-0000-000000000002", "Inspection", nil, nil, nil, nil, nil, createdAt, updatedAt))
 
 	result, err := repo.List(context.Background(), appjournal.ListQuery{
 		ActorRole:           "staff",
@@ -155,6 +155,164 @@ func TestSoftDeleteMapsZeroRowsToNotFound(t *testing.T) {
 	}
 }
 
+func TestListExpenseAccountingTitlesReturnsActiveExpenseTitles(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta("FROM accounting_titles")).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "code", "name", "kind"}).
+			AddRow("70000000-0000-0000-0000-000000000001", "6681", "其他支出", "expense"))
+
+	titles, err := repo.ListExpenseAccountingTitles(context.Background())
+	if err != nil {
+		t.Fatalf("ListExpenseAccountingTitles() error = %v", err)
+	}
+	if len(titles) != 1 || titles[0].Code != "6681" || titles[0].Kind != "expense" {
+		t.Fatalf("titles = %+v", titles)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCreatePersistsAndScansExpenseAccountingTitleSnapshot(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin() error = %v", err)
+	}
+	propertyID := "10000000-0000-0000-0000-000000000001"
+	roomID := "20000000-0000-0000-0000-000000000001"
+	authorID := "00000000-0000-0000-0000-000000000002"
+	expenseAmount := 3500
+	expenseDescription := "Pipe repair"
+	titleID := "70000000-0000-0000-0000-000000000001"
+	titleCode := "6115"
+	titleName := "維護修繕費"
+	createdAt := time.Date(2026, 4, 10, 9, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta("INSERT INTO journal_logs")).
+		WithArgs(propertyID, roomID, authorID, "Bathroom repair", expenseAmount, expenseDescription, titleID, titleCode, titleName).
+		WillReturnRows(journalLogRows().
+			AddRow("60000000-0000-0000-0000-000000000001", propertyID, roomID, authorID, "Bathroom repair", expenseAmount, expenseDescription, titleID, titleCode, titleName, createdAt, createdAt))
+	mock.ExpectCommit()
+
+	created, err := repo.Create(context.Background(), tx, appjournal.CreateParams{
+		PropertyID:                 propertyID,
+		RoomID:                     &roomID,
+		AuthorID:                   authorID,
+		Content:                    "Bathroom repair",
+		ExpenseAmount:              &expenseAmount,
+		ExpenseDescription:         &expenseDescription,
+		ExpenseAccountingTitleID:   &titleID,
+		ExpenseAccountingTitleCode: &titleCode,
+		ExpenseAccountingTitleName: &titleName,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if created.ExpenseAccountingTitleID == nil || *created.ExpenseAccountingTitleID != titleID {
+		t.Fatalf("ExpenseAccountingTitleID = %+v, want %s", created.ExpenseAccountingTitleID, titleID)
+	}
+	if created.ExpenseAccountingTitleCode == nil || *created.ExpenseAccountingTitleCode != titleCode {
+		t.Fatalf("ExpenseAccountingTitleCode = %+v, want %s", created.ExpenseAccountingTitleCode, titleCode)
+	}
+	if created.ExpenseAccountingTitleName == nil || *created.ExpenseAccountingTitleName != titleName {
+		t.Fatalf("ExpenseAccountingTitleName = %+v, want %s", created.ExpenseAccountingTitleName, titleName)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestUpdatePersistsAndScansExpenseAccountingTitleSnapshot(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin() error = %v", err)
+	}
+	journalID := "60000000-0000-0000-0000-000000000001"
+	propertyID := "10000000-0000-0000-0000-000000000001"
+	authorID := "00000000-0000-0000-0000-000000000002"
+	expenseAmount := 4200
+	expenseDescription := "Pipe repair and cleanup"
+	titleID := "70000000-0000-0000-0000-000000000099"
+	titleCode := "6190"
+	titleName := "其他費用"
+	updatedAt := time.Date(2026, 4, 11, 9, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(regexp.QuoteMeta("UPDATE journal_logs")).
+		WithArgs(journalID, "Bathroom repair updated", expenseAmount, expenseDescription, titleID, titleCode, titleName).
+		WillReturnRows(journalLogRows().
+			AddRow(journalID, propertyID, nil, authorID, "Bathroom repair updated", expenseAmount, expenseDescription, titleID, titleCode, titleName, updatedAt, updatedAt))
+	mock.ExpectCommit()
+
+	updated, err := repo.Update(context.Background(), tx, appjournal.UpdateParams{
+		ID:                         journalID,
+		Content:                    "Bathroom repair updated",
+		ExpenseAmount:              &expenseAmount,
+		ExpenseDescription:         &expenseDescription,
+		ExpenseAccountingTitleID:   &titleID,
+		ExpenseAccountingTitleCode: &titleCode,
+		ExpenseAccountingTitleName: &titleName,
+	})
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	if updated.ExpenseAccountingTitleID == nil || *updated.ExpenseAccountingTitleID != titleID {
+		t.Fatalf("ExpenseAccountingTitleID = %+v, want %s", updated.ExpenseAccountingTitleID, titleID)
+	}
+	if updated.ExpenseAccountingTitleCode == nil || *updated.ExpenseAccountingTitleCode != titleCode {
+		t.Fatalf("ExpenseAccountingTitleCode = %+v, want %s", updated.ExpenseAccountingTitleCode, titleCode)
+	}
+	if updated.ExpenseAccountingTitleName == nil || *updated.ExpenseAccountingTitleName != titleName {
+		t.Fatalf("ExpenseAccountingTitleName = %+v, want %s", updated.ExpenseAccountingTitleName, titleName)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestUpdateMapsNoRowsToNotFound(t *testing.T) {
+	db, mock, repo := newJournalRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("Begin() error = %v", err)
+	}
+	journalID := "60000000-0000-0000-0000-000000000099"
+	mock.ExpectQuery(regexp.QuoteMeta("UPDATE journal_logs")).
+		WithArgs(journalID, "Missing journal", nil, nil, nil, nil, nil).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectRollback()
+
+	_, err = repo.Update(context.Background(), tx, appjournal.UpdateParams{
+		ID:      journalID,
+		Content: "Missing journal",
+	})
+	if !errors.Is(err, appjournal.ErrJournalLogNotFound) {
+		t.Fatalf("Update() error = %v, want ErrJournalLogNotFound", err)
+	}
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback() error = %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
 func newJournalRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
 	t.Helper()
 
@@ -175,6 +333,9 @@ func journalLogRows() *sqlmock.Rows {
 		"content",
 		"expense_amount",
 		"expense_description",
+		"expense_accounting_title_id",
+		"expense_accounting_title_code",
+		"expense_accounting_title_name",
 		"created_at",
 		"updated_at",
 	})

--- a/internal/platform/database/migrate/migrations/000018_add_journal_expense_accounting_title.down.sql
+++ b/internal/platform/database/migrate/migrations/000018_add_journal_expense_accounting_title.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_journal_logs_expense_accounting_title_id;
+
+ALTER TABLE journal_logs
+    DROP COLUMN IF EXISTS expense_accounting_title_name,
+    DROP COLUMN IF EXISTS expense_accounting_title_code,
+    DROP COLUMN IF EXISTS expense_accounting_title_id;

--- a/internal/platform/database/migrate/migrations/000018_add_journal_expense_accounting_title.up.sql
+++ b/internal/platform/database/migrate/migrations/000018_add_journal_expense_accounting_title.up.sql
@@ -1,0 +1,37 @@
+ALTER TABLE journal_logs
+    ADD COLUMN IF NOT EXISTS expense_accounting_title_id UUID REFERENCES accounting_titles(id),
+    ADD COLUMN IF NOT EXISTS expense_accounting_title_code VARCHAR(20),
+    ADD COLUMN IF NOT EXISTS expense_accounting_title_name VARCHAR(100);
+
+UPDATE journal_logs jl
+SET
+    expense_accounting_title_id = ae.accounting_title_id,
+    expense_accounting_title_code = ae.accounting_title_code,
+    expense_accounting_title_name = ae.accounting_title_name
+FROM accounting_entries ae
+WHERE jl.expense_amount IS NOT NULL
+  AND ae.category = 'journal_expense'
+  AND ae.source_ref->>'journal_log_id' = jl.id::text
+  AND ae.accounting_title_id IS NOT NULL
+  AND (
+      jl.expense_accounting_title_id IS NULL
+      OR jl.expense_accounting_title_code IS NULL
+      OR jl.expense_accounting_title_name IS NULL
+  );
+
+UPDATE journal_logs jl
+SET
+    expense_accounting_title_id = at.id,
+    expense_accounting_title_code = at.code,
+    expense_accounting_title_name = at.name
+FROM accounting_titles at
+WHERE jl.expense_amount IS NOT NULL
+  AND at.code = '6681'
+  AND (
+      jl.expense_accounting_title_id IS NULL
+      OR jl.expense_accounting_title_code IS NULL
+      OR jl.expense_accounting_title_name IS NULL
+  );
+
+CREATE INDEX IF NOT EXISTS idx_journal_logs_expense_accounting_title_id
+    ON journal_logs (expense_accounting_title_id);

--- a/internal/platform/database/migrate/runner_test.go
+++ b/internal/platform/database/migrate/runner_test.go
@@ -33,6 +33,7 @@ var expectedMigrationVersions = []string{
 	"000015",
 	"000016",
 	"000017",
+	"000018",
 }
 
 func TestRunnerUpAppliesMigrationsAndRecordsVersions(t *testing.T) {
@@ -78,8 +79,8 @@ func TestRunnerDownRollsBackAppliedMigrationsInDescendingOrder(t *testing.T) {
 	defer db.Close()
 
 	migrations := migrationsByVersion(t, "down")
-	appliedVersions := []string{"000012", "000013", "000014", "000015", "000016", "000017"}
-	expectedRollbackOrder := []string{"000017", "000016", "000015", "000014", "000013", "000012"}
+	appliedVersions := []string{"000012", "000013", "000014", "000015", "000016", "000017", "000018"}
+	expectedRollbackOrder := []string{"000018", "000017", "000016", "000015", "000014", "000013", "000012"}
 
 	expectSchemaMigrationsQuery(mock, appliedVersions)
 	for _, version := range expectedRollbackOrder {

--- a/internal/server/journal_adapters.go
+++ b/internal/server/journal_adapters.go
@@ -64,3 +64,7 @@ func (a journalExpenseAccountingAdapter) SyncExpenseAccountingEntry(ctx context.
 		DisplayNote:         params.DisplayNote,
 	})
 }
+
+func (a journalExpenseAccountingAdapter) JournalExpenseSnapshotExists(ctx context.Context, tx *sql.Tx, propertyID string, year int, month int) (bool, error) {
+	return a.repo.MonthlySnapshotExists(ctx, tx, propertyID, year, month)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -147,11 +147,12 @@ func New(cfg *config.Config) (*Server, error) {
 	}
 	journalAccounting := journalExpenseAccountingAdapter{repo: billingRepo}
 	journalServices := handler.JournalServices{
-		List:   appjournal.NewListService(journalRepo),
-		Get:    appjournal.NewGetService(journalRepo),
-		Create: appjournal.NewCreateService(journalRepo, journalAccounting, txRunner),
-		Update: appjournal.NewUpdateService(journalRepo, journalAccounting, txRunner),
-		Delete: appjournal.NewDeleteService(journalRepo, txRunner),
+		List:                     appjournal.NewListService(journalRepo),
+		Get:                      appjournal.NewGetService(journalRepo),
+		ListExpenseAccountTitles: appjournal.NewListExpenseAccountingTitlesService(journalRepo),
+		Create:                   appjournal.NewCreateService(journalRepo, journalAccounting, txRunner),
+		Update:                   appjournal.NewUpdateService(journalRepo, journalAccounting, txRunner),
+		Delete:                   appjournal.NewDeleteService(journalRepo, journalAccounting, txRunner),
 	}
 	jobTriggerService := appjobs.NewTriggerService(jobRunStoreAdapter{repo: jobRunsRepo}, newJobRunners(db, txRunner, notificationService), cfg.App.SchedulerJobTimeout, cfg.App.SchedulerMaxRetries)
 	registerLeaseEventSubscribers(bus, leaseRepositoryAdapter{repo: leaseRepo}, txRunner)

--- a/test/e2e/journal_acceptance_test.go
+++ b/test/e2e/journal_acceptance_test.go
@@ -57,6 +57,7 @@ func TestE2EJournalAcceptance(t *testing.T) {
 	scopedClient := newAPIClient(cfg.BaseURL, scopedToken.IDToken)
 
 	t.Run("create list detail update and report expense", func(t *testing.T) {
+		expenseTitle := journalE2EFirstExpenseAccountingTitle(t, ctx, scopedClient)
 		plain := journalE2ECreateLog(t, ctx, scopedClient, journalE2ECreateRequest{
 			PropertyID: assignedProperty.ID,
 			Content:    "E2E property inspection",
@@ -68,18 +69,22 @@ func TestE2EJournalAcceptance(t *testing.T) {
 		expense := 3500
 		description := "Pipe repair"
 		withExpense := journalE2ECreateLog(t, ctx, scopedClient, journalE2ECreateRequest{
-			PropertyID:         assignedProperty.ID,
-			RoomID:             &room.ID,
-			Content:            "E2E bathroom repair",
-			ExpenseAmount:      &expense,
-			ExpenseDescription: &description,
+			PropertyID:               assignedProperty.ID,
+			RoomID:                   &room.ID,
+			Content:                  "E2E bathroom repair",
+			ExpenseAmount:            &expense,
+			ExpenseDescription:       &description,
+			ExpenseAccountingTitleID: &expenseTitle.ID,
 		})
 		journalE2ERequireLog(t, withExpense, journalE2EExpectation{
-			PropertyID:         assignedProperty.ID,
-			RoomID:             &room.ID,
-			Content:            "E2E bathroom repair",
-			ExpenseAmount:      &expense,
-			ExpenseDescription: &description,
+			PropertyID:                 assignedProperty.ID,
+			RoomID:                     &room.ID,
+			Content:                    "E2E bathroom repair",
+			ExpenseAmount:              &expense,
+			ExpenseDescription:         &description,
+			ExpenseAccountingTitleID:   &expenseTitle.ID,
+			ExpenseAccountingTitleCode: &expenseTitle.Code,
+			ExpenseAccountingTitleName: &expenseTitle.Name,
 		})
 
 		list := journalE2EListLogs(t, ctx, scopedClient, assignedProperty.ID)
@@ -88,26 +93,33 @@ func TestE2EJournalAcceptance(t *testing.T) {
 
 		detail := journalE2EGetLog(t, ctx, scopedClient, withExpense.ID)
 		journalE2ERequireLog(t, detail, journalE2EExpectation{
-			PropertyID:         assignedProperty.ID,
-			RoomID:             &room.ID,
-			Content:            "E2E bathroom repair",
-			ExpenseAmount:      &expense,
-			ExpenseDescription: &description,
+			PropertyID:                 assignedProperty.ID,
+			RoomID:                     &room.ID,
+			Content:                    "E2E bathroom repair",
+			ExpenseAmount:              &expense,
+			ExpenseDescription:         &description,
+			ExpenseAccountingTitleID:   &expenseTitle.ID,
+			ExpenseAccountingTitleCode: &expenseTitle.Code,
+			ExpenseAccountingTitleName: &expenseTitle.Name,
 		})
 
 		updatedExpense := 4200
 		updatedDescription := "Pipe repair and cleanup"
 		updated := journalE2EUpdateLog(t, ctx, scopedClient, withExpense.ID, map[string]any{
-			"content":             "E2E bathroom repair updated",
-			"expense_amount":      updatedExpense,
-			"expense_description": updatedDescription,
+			"content":                     "E2E bathroom repair updated",
+			"expense_amount":              updatedExpense,
+			"expense_description":         updatedDescription,
+			"expense_accounting_title_id": expenseTitle.ID,
 		})
 		journalE2ERequireLog(t, updated, journalE2EExpectation{
-			PropertyID:         assignedProperty.ID,
-			RoomID:             &room.ID,
-			Content:            "E2E bathroom repair updated",
-			ExpenseAmount:      &updatedExpense,
-			ExpenseDescription: &updatedDescription,
+			PropertyID:                 assignedProperty.ID,
+			RoomID:                     &room.ID,
+			Content:                    "E2E bathroom repair updated",
+			ExpenseAmount:              &updatedExpense,
+			ExpenseDescription:         &updatedDescription,
+			ExpenseAccountingTitleID:   &expenseTitle.ID,
+			ExpenseAccountingTitleCode: &expenseTitle.Code,
+			ExpenseAccountingTitleName: &expenseTitle.Name,
 		})
 
 		year, month := journalE2ECurrentReportPeriod()
@@ -147,35 +159,73 @@ func TestE2EJournalAcceptance(t *testing.T) {
 }
 
 type journalE2ECreateRequest struct {
-	PropertyID         string
-	RoomID             *string
-	Content            string
-	ExpenseAmount      *int
-	ExpenseDescription *string
+	PropertyID               string
+	RoomID                   *string
+	Content                  string
+	ExpenseAmount            *int
+	ExpenseDescription       *string
+	ExpenseAccountingTitleID *string
 }
 
 type journalE2EExpectation struct {
-	PropertyID         string
-	RoomID             *string
-	Content            string
-	ExpenseAmount      *int
-	ExpenseDescription *string
+	PropertyID                 string
+	RoomID                     *string
+	Content                    string
+	ExpenseAmount              *int
+	ExpenseDescription         *string
+	ExpenseAccountingTitleID   *string
+	ExpenseAccountingTitleCode *string
+	ExpenseAccountingTitleName *string
 }
 
 type journalE2ELogResponse struct {
-	ID                 string  `json:"id"`
-	PropertyID         string  `json:"property_id"`
-	RoomID             *string `json:"room_id"`
-	AuthorID           string  `json:"author_id"`
-	Content            string  `json:"content"`
-	ExpenseAmount      *int    `json:"expense_amount"`
-	ExpenseDescription *string `json:"expense_description"`
-	CreatedAt          string  `json:"created_at"`
-	UpdatedAt          string  `json:"updated_at"`
+	ID                         string  `json:"id"`
+	PropertyID                 string  `json:"property_id"`
+	RoomID                     *string `json:"room_id"`
+	AuthorID                   string  `json:"author_id"`
+	Content                    string  `json:"content"`
+	ExpenseAmount              *int    `json:"expense_amount"`
+	ExpenseDescription         *string `json:"expense_description"`
+	ExpenseAccountingTitleID   *string `json:"expense_accounting_title_id"`
+	ExpenseAccountingTitleCode *string `json:"expense_accounting_title_code"`
+	ExpenseAccountingTitleName *string `json:"expense_accounting_title_name"`
+	CreatedAt                  string  `json:"created_at"`
+	UpdatedAt                  string  `json:"updated_at"`
 }
 
 type journalE2EListResponse struct {
 	Data []journalE2ELogResponse `json:"data"`
+}
+
+type journalE2EAccountingTitle struct {
+	ID   string `json:"id"`
+	Code string `json:"code"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+}
+
+type journalE2EAccountingTitleListResponse struct {
+	Data []journalE2EAccountingTitle `json:"data"`
+}
+
+func journalE2EFirstExpenseAccountingTitle(t *testing.T, ctx context.Context, client apiClient) journalE2EAccountingTitle {
+	t.Helper()
+
+	resp, body, err := client.getJSON(ctx, "/api/v1/journal-expense-accounting-titles")
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireStatus(t, resp, body, http.StatusOK)
+
+	var list journalE2EAccountingTitleListResponse
+	decodeJSON(t, body, &list)
+	if len(list.Data) == 0 {
+		t.Fatalf("expected expense accounting title options: %s", string(body))
+	}
+	if list.Data[0].ID == "" || list.Data[0].Code == "" || list.Data[0].Name == "" || list.Data[0].Kind != "expense" {
+		t.Fatalf("unexpected expense accounting title option: %+v", list.Data[0])
+	}
+	return list.Data[0]
 }
 
 func journalE2ECreateLog(t *testing.T, ctx context.Context, client apiClient, request journalE2ECreateRequest) journalE2ELogResponse {
@@ -193,6 +243,9 @@ func journalE2ECreateLog(t *testing.T, ctx context.Context, client apiClient, re
 	}
 	if request.ExpenseDescription != nil {
 		body["expense_description"] = *request.ExpenseDescription
+	}
+	if request.ExpenseAccountingTitleID != nil {
+		body["expense_accounting_title_id"] = *request.ExpenseAccountingTitleID
 	}
 
 	resp, respBody, err := client.postJSON(ctx, "/api/v1/journal-logs", body)
@@ -269,6 +322,15 @@ func journalE2ERequireLog(t *testing.T, log journalE2ELogResponse, expected jour
 	}
 	if !stringPtrEqual(log.ExpenseDescription, expected.ExpenseDescription) {
 		t.Fatalf("expected expense_description %+v, got %+v", expected.ExpenseDescription, log.ExpenseDescription)
+	}
+	if !stringPtrEqual(log.ExpenseAccountingTitleID, expected.ExpenseAccountingTitleID) {
+		t.Fatalf("expected expense_accounting_title_id %+v, got %+v", expected.ExpenseAccountingTitleID, log.ExpenseAccountingTitleID)
+	}
+	if !stringPtrEqual(log.ExpenseAccountingTitleCode, expected.ExpenseAccountingTitleCode) {
+		t.Fatalf("expected expense_accounting_title_code %+v, got %+v", expected.ExpenseAccountingTitleCode, log.ExpenseAccountingTitleCode)
+	}
+	if !stringPtrEqual(log.ExpenseAccountingTitleName, expected.ExpenseAccountingTitleName) {
+		t.Fatalf("expected expense_accounting_title_name %+v, got %+v", expected.ExpenseAccountingTitleName, log.ExpenseAccountingTitleName)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #131

- add active journal expense accounting title options and expose selected title snapshots on journal create/update/read responses
- persist journal expense accounting title snapshots with migration `000018`, including backfill for existing expense-bearing journal logs
- keep journal expense accounting side effects backend-owned in the command transaction, including finalized-snapshot guards for accounting-impacting create/update/delete paths
- update OpenAPI generated types, router policy, server wiring, repository contracts, unit coverage, and journal E2E coverage

## Validation

- `npm run openapi:generate`
- `npm run openapi:lint`
- `go test ./internal/platform/database/journal ./internal/application/journal ./internal/http/handler ./internal/http/router ./internal/server`
- `go test ./...`
- `./scripts/e2e_test.sh -run TestE2EJournalAcceptance -count=1`
- `git diff --check`
