### PR TITLE
Expose financial report entry display fields

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -8299,9 +8299,32 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FinancialReportSummaryItem'
+    FinancialReportEntrySource:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - bill
+            - journal_log
+            - lease
+        id:
+          type: string
+          format: uuid
+        detail:
+          type: string
+          enum:
+            - payment
+            - journal_expense
+            - deposit_refund
+            - deposit_deduction
     FinancialReportEntryItem:
       type: object
       properties:
+        entry_id:
+          type: string
+          format: uuid
+          description: Stable report-row identifier from accounting_entries or monthly_snapshot_entries.
         category:
           type: string
           enum:
@@ -8310,10 +8333,30 @@ components:
             - deposit_refund
             - deposit_deduction
             - journal_expense
+        accounting_title_id:
+          type: string
+          format: uuid
+        accounting_title_code:
+          type: string
+        accounting_title_name:
+          type: string
+        source_date:
+          type: string
+          format: date
+        room_label:
+          type: string
+        tenant_label:
+          type: string
+        period_label:
+          type: string
+        display_note:
+          type: string
         description:
           type: string
         amount:
           type: integer
+        source:
+          $ref: '#/components/schemas/FinancialReportEntrySource'
     FinancialReportResponse:
       type: object
       properties:

--- a/docs/spec/src/components/schemas/billing/FinancialReportEntryItem.yaml
+++ b/docs/spec/src/components/schemas/billing/FinancialReportEntryItem.yaml
@@ -1,5 +1,9 @@
 type: object
 properties:
+  entry_id:
+    type: string
+    format: uuid
+    description: Stable report-row identifier from accounting_entries or monthly_snapshot_entries.
   category:
     type: string
     enum:
@@ -8,7 +12,27 @@ properties:
       - deposit_refund
       - deposit_deduction
       - journal_expense
+  accounting_title_id:
+    type: string
+    format: uuid
+  accounting_title_code:
+    type: string
+  accounting_title_name:
+    type: string
+  source_date:
+    type: string
+    format: date
+  room_label:
+    type: string
+  tenant_label:
+    type: string
+  period_label:
+    type: string
+  display_note:
+    type: string
   description:
     type: string
   amount:
     type: integer
+  source:
+    $ref: ./FinancialReportEntrySource.yaml

--- a/docs/spec/src/components/schemas/billing/FinancialReportEntrySource.yaml
+++ b/docs/spec/src/components/schemas/billing/FinancialReportEntrySource.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  type:
+    type: string
+    enum:
+      - bill
+      - journal_log
+      - lease
+  id:
+    type: string
+    format: uuid
+  detail:
+    type: string
+    enum:
+      - payment
+      - journal_expense
+      - deposit_refund
+      - deposit_deduction

--- a/internal/application/billing/reports.go
+++ b/internal/application/billing/reports.go
@@ -158,9 +158,26 @@ type FinancialReportSummary struct {
 
 // FinancialReportEntry is the application read model for one report entry.
 type FinancialReportEntry struct {
-	Category    string
-	Description *string
-	Amount      int
+	ID                  string
+	Category            string
+	AccountingTitleID   *string
+	AccountingTitleCode *string
+	AccountingTitleName *string
+	SourceDate          *time.Time
+	RoomLabel           *string
+	TenantLabel         *string
+	PeriodLabel         *string
+	DisplayNote         *string
+	Description         *string
+	Amount              int
+	Source              *FinancialReportEntrySource
+}
+
+// FinancialReportEntrySource is a frontend-safe source pointer for one report row.
+type FinancialReportEntrySource struct {
+	Type   string
+	ID     string
+	Detail *string
 }
 
 // FinancialReport is the application read model for a property monthly report.
@@ -1602,6 +1619,60 @@ func cashflowSourceRefNote(sourceRef json.RawMessage) string {
 		return reason
 	}
 	return ""
+}
+
+// FinancialReportEntrySourceFromRef normalizes internal accounting source refs for API display.
+func FinancialReportEntrySourceFromRef(category string, sourceRef json.RawMessage) *FinancialReportEntrySource {
+	if len(sourceRef) == 0 || string(sourceRef) == "null" {
+		return nil
+	}
+
+	var values map[string]string
+	if err := json.Unmarshal(sourceRef, &values); err != nil {
+		return nil
+	}
+
+	if billID := strings.TrimSpace(values["bill_id"]); billID != "" {
+		detail := "payment"
+		return &FinancialReportEntrySource{
+			Type:   "bill",
+			ID:     billID,
+			Detail: &detail,
+		}
+	}
+
+	if journalLogID := strings.TrimSpace(values["journal_log_id"]); journalLogID != "" {
+		detail := "journal_expense"
+		return &FinancialReportEntrySource{
+			Type:   "journal_log",
+			ID:     journalLogID,
+			Detail: &detail,
+		}
+	}
+
+	if leaseID := strings.TrimSpace(values["lease_id"]); leaseID != "" {
+		detail := depositSourceDetail(category, values["type"])
+		return &FinancialReportEntrySource{
+			Type:   "lease",
+			ID:     leaseID,
+			Detail: detail,
+		}
+	}
+
+	return nil
+}
+
+func depositSourceDetail(category string, sourceType string) *string {
+	switch {
+	case category == "deposit_refund" || sourceType == "DepositRefunded":
+		detail := "deposit_refund"
+		return &detail
+	case category == "deposit_deduction" || sourceType == "DepositDeducted":
+		detail := "deposit_deduction"
+		return &detail
+	default:
+		return nil
+	}
 }
 
 func absValue(value int) int {

--- a/internal/application/billing/reports_test.go
+++ b/internal/application/billing/reports_test.go
@@ -836,6 +836,77 @@ func TestExportMonthlyCashflowFallsBackFromDisplayNoteToDescriptionThenSourceRef
 	}
 }
 
+func TestFinancialReportEntrySourceFromRefNormalizesKnownSourceRefs(t *testing.T) {
+	tests := []struct {
+		name       string
+		category   string
+		sourceRef  []byte
+		wantType   string
+		wantID     string
+		wantDetail string
+	}{
+		{
+			name:       "bill payment",
+			category:   AccountingCategoryRentPayment,
+			sourceRef:  []byte(`{"type":"BillPaid","bill_id":"10000000-0000-0000-0000-000000000011"}`),
+			wantType:   "bill",
+			wantID:     "10000000-0000-0000-0000-000000000011",
+			wantDetail: "payment",
+		},
+		{
+			name:       "journal expense",
+			category:   "journal_expense",
+			sourceRef:  []byte(`{"type":"JournalExpenseRecorded","journal_log_id":"10000000-0000-0000-0000-000000000012"}`),
+			wantType:   "journal_log",
+			wantID:     "10000000-0000-0000-0000-000000000012",
+			wantDetail: "journal_expense",
+		},
+		{
+			name:       "deposit refund",
+			category:   "deposit_refund",
+			sourceRef:  []byte(`{"type":"DepositRefunded","lease_id":"10000000-0000-0000-0000-000000000013"}`),
+			wantType:   "lease",
+			wantID:     "10000000-0000-0000-0000-000000000013",
+			wantDetail: "deposit_refund",
+		},
+		{
+			name:       "deposit deduction",
+			category:   "deposit_deduction",
+			sourceRef:  []byte(`{"type":"DepositDeducted","lease_id":"10000000-0000-0000-0000-000000000014"}`),
+			wantType:   "lease",
+			wantID:     "10000000-0000-0000-0000-000000000014",
+			wantDetail: "deposit_deduction",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := FinancialReportEntrySourceFromRef(tc.category, tc.sourceRef)
+			if source == nil {
+				t.Fatal("source = nil")
+			}
+			if source.Type != tc.wantType || source.ID != tc.wantID || source.Detail == nil || *source.Detail != tc.wantDetail {
+				t.Fatalf("source = %+v, want type %q id %q detail %q", source, tc.wantType, tc.wantID, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestFinancialReportEntrySourceFromRefIgnoresUnknownOrMalformedSourceRefs(t *testing.T) {
+	tests := [][]byte{
+		nil,
+		[]byte(`null`),
+		[]byte(`{"type":"Unknown"}`),
+		[]byte(`not json`),
+	}
+
+	for _, sourceRef := range tests {
+		if source := FinancialReportEntrySourceFromRef("rent_payment", sourceRef); source != nil {
+			t.Fatalf("source = %+v, want nil for %s", source, sourceRef)
+		}
+	}
+}
+
 func TestExportMonthlyCashflowUsesSnapshotRowsForHistoricalMonth(t *testing.T) {
 	repo := &reportRepositoryStub{
 		snapshotCashflow: &MonthlyCashflow{

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -41,13 +41,13 @@ const (
 
 // Defines values for AttachmentUploadURLRequestResourceType.
 const (
-	Bill          AttachmentUploadURLRequestResourceType = "bill"
-	JournalLog    AttachmentUploadURLRequestResourceType = "journal_log"
-	Lease         AttachmentUploadURLRequestResourceType = "lease"
-	Property      AttachmentUploadURLRequestResourceType = "property"
-	RepairRequest AttachmentUploadURLRequestResourceType = "repair_request"
-	Room          AttachmentUploadURLRequestResourceType = "room"
-	Tenant        AttachmentUploadURLRequestResourceType = "tenant"
+	AttachmentUploadURLRequestResourceTypeBill          AttachmentUploadURLRequestResourceType = "bill"
+	AttachmentUploadURLRequestResourceTypeJournalLog    AttachmentUploadURLRequestResourceType = "journal_log"
+	AttachmentUploadURLRequestResourceTypeLease         AttachmentUploadURLRequestResourceType = "lease"
+	AttachmentUploadURLRequestResourceTypeProperty      AttachmentUploadURLRequestResourceType = "property"
+	AttachmentUploadURLRequestResourceTypeRepairRequest AttachmentUploadURLRequestResourceType = "repair_request"
+	AttachmentUploadURLRequestResourceTypeRoom          AttachmentUploadURLRequestResourceType = "room"
+	AttachmentUploadURLRequestResourceTypeTenant        AttachmentUploadURLRequestResourceType = "tenant"
 )
 
 // Defines values for BillResponsePaymentMethod.
@@ -155,6 +155,21 @@ const (
 	FinancialReportEntryItemCategoryElectricityPayment FinancialReportEntryItemCategory = "electricity_payment"
 	FinancialReportEntryItemCategoryJournalExpense     FinancialReportEntryItemCategory = "journal_expense"
 	FinancialReportEntryItemCategoryRentPayment        FinancialReportEntryItemCategory = "rent_payment"
+)
+
+// Defines values for FinancialReportEntrySourceDetail.
+const (
+	DepositDeduction FinancialReportEntrySourceDetail = "deposit_deduction"
+	DepositRefund    FinancialReportEntrySourceDetail = "deposit_refund"
+	JournalExpense   FinancialReportEntrySourceDetail = "journal_expense"
+	Payment          FinancialReportEntrySourceDetail = "payment"
+)
+
+// Defines values for FinancialReportEntrySourceType.
+const (
+	FinancialReportEntrySourceTypeBill       FinancialReportEntrySourceType = "bill"
+	FinancialReportEntrySourceTypeJournalLog FinancialReportEntrySourceType = "journal_log"
+	FinancialReportEntrySourceTypeLease      FinancialReportEntrySourceType = "lease"
 )
 
 // Defines values for ForceTerminateRequestDepositHandling.
@@ -772,13 +787,38 @@ type ErrorResponse struct {
 
 // FinancialReportEntryItem defines model for FinancialReportEntryItem.
 type FinancialReportEntryItem struct {
-	Amount      *int                              `json:"amount,omitempty"`
-	Category    *FinancialReportEntryItemCategory `json:"category,omitempty"`
-	Description *string                           `json:"description,omitempty"`
+	AccountingTitleCode *string                           `json:"accounting_title_code,omitempty"`
+	AccountingTitleId   *openapi_types.UUID               `json:"accounting_title_id,omitempty"`
+	AccountingTitleName *string                           `json:"accounting_title_name,omitempty"`
+	Amount              *int                              `json:"amount,omitempty"`
+	Category            *FinancialReportEntryItemCategory `json:"category,omitempty"`
+	Description         *string                           `json:"description,omitempty"`
+	DisplayNote         *string                           `json:"display_note,omitempty"`
+
+	// EntryId Stable report-row identifier from accounting_entries or monthly_snapshot_entries.
+	EntryId     *openapi_types.UUID         `json:"entry_id,omitempty"`
+	PeriodLabel *string                     `json:"period_label,omitempty"`
+	RoomLabel   *string                     `json:"room_label,omitempty"`
+	Source      *FinancialReportEntrySource `json:"source,omitempty"`
+	SourceDate  *openapi_types.Date         `json:"source_date,omitempty"`
+	TenantLabel *string                     `json:"tenant_label,omitempty"`
 }
 
 // FinancialReportEntryItemCategory defines model for FinancialReportEntryItem.Category.
 type FinancialReportEntryItemCategory string
+
+// FinancialReportEntrySource defines model for FinancialReportEntrySource.
+type FinancialReportEntrySource struct {
+	Detail *FinancialReportEntrySourceDetail `json:"detail,omitempty"`
+	Id     *openapi_types.UUID               `json:"id,omitempty"`
+	Type   *FinancialReportEntrySourceType   `json:"type,omitempty"`
+}
+
+// FinancialReportEntrySourceDetail defines model for FinancialReportEntrySource.Detail.
+type FinancialReportEntrySourceDetail string
+
+// FinancialReportEntrySourceType defines model for FinancialReportEntrySource.Type.
+type FinancialReportEntrySourceType string
 
 // FinancialReportListResponse defines model for FinancialReportListResponse.
 type FinancialReportListResponse struct {

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -427,9 +427,25 @@ type BillingFinancialReport struct {
 }
 
 type BillingFinancialReportEntry struct {
-	Category    string
-	Description *string
-	Amount      int
+	ID                  string
+	Category            string
+	AccountingTitleID   *string
+	AccountingTitleCode *string
+	AccountingTitleName *string
+	SourceDate          *time.Time
+	RoomLabel           *string
+	TenantLabel         *string
+	PeriodLabel         *string
+	DisplayNote         *string
+	Description         *string
+	Amount              int
+	Source              *BillingFinancialReportEntrySource
+}
+
+type BillingFinancialReportEntrySource struct {
+	Type   string
+	ID     string
+	Detail *string
 }
 
 // NewAPIServer returns an API server with all exposed endpoint dependencies
@@ -3223,12 +3239,54 @@ func toFinancialReportResponse(report *BillingFinancialReport) api.FinancialRepo
 func toFinancialReportEntryItem(entry BillingFinancialReportEntry) api.FinancialReportEntryItem {
 	amount := entry.Amount
 	category := api.FinancialReportEntryItemCategory(entry.Category)
+	entryID, entryIDOK := parseUUID(entry.ID)
 
-	return api.FinancialReportEntryItem{
-		Amount:      &amount,
-		Category:    &category,
-		Description: entry.Description,
+	response := api.FinancialReportEntryItem{
+		AccountingTitleCode: entry.AccountingTitleCode,
+		AccountingTitleName: entry.AccountingTitleName,
+		Amount:              &amount,
+		Category:            &category,
+		Description:         entry.Description,
+		DisplayNote:         entry.DisplayNote,
+		PeriodLabel:         entry.PeriodLabel,
+		RoomLabel:           entry.RoomLabel,
+		Source:              toFinancialReportEntrySource(entry.Source),
+		TenantLabel:         entry.TenantLabel,
 	}
+	if entryIDOK {
+		response.EntryId = &entryID
+	}
+	if entry.AccountingTitleID != nil {
+		if accountingTitleID, ok := parseUUID(*entry.AccountingTitleID); ok {
+			response.AccountingTitleId = &accountingTitleID
+		}
+	}
+	if entry.SourceDate != nil {
+		sourceDate := openapi_types.Date{Time: *entry.SourceDate}
+		response.SourceDate = &sourceDate
+	}
+
+	return response
+}
+
+func toFinancialReportEntrySource(source *BillingFinancialReportEntrySource) *api.FinancialReportEntrySource {
+	if source == nil {
+		return nil
+	}
+	sourceID, ok := parseUUID(source.ID)
+	if !ok {
+		return nil
+	}
+	sourceType := api.FinancialReportEntrySourceType(source.Type)
+	response := api.FinancialReportEntrySource{
+		Id:   &sourceID,
+		Type: &sourceType,
+	}
+	if source.Detail != nil {
+		detail := api.FinancialReportEntrySourceDetail(*source.Detail)
+		response.Detail = &detail
+	}
+	return &response
 }
 
 func toDashboardResponse(dashboard *appproperty.Dashboard) api.DashboardResponse {

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -909,6 +909,19 @@ func TestGetPropertyFinancialReportReturnsDetailResponse(t *testing.T) {
 	if response.Entries == nil || len(*response.Entries) != 1 || (*response.Entries)[0].Category == nil || *(*response.Entries)[0].Category != api.FinancialReportEntryItemCategoryRentPayment {
 		t.Fatalf("unexpected financial report entries: %+v", response.Entries)
 	}
+	entry := (*response.Entries)[0]
+	if entry.EntryId == nil || entry.EntryId.String() != "10000000-0000-0000-0000-000000000101" {
+		t.Fatalf("entry_id = %+v, want 10000000-0000-0000-0000-000000000101", entry.EntryId)
+	}
+	if entry.AccountingTitleCode == nil || *entry.AccountingTitleCode != "4603" || entry.AccountingTitleName == nil || *entry.AccountingTitleName != "租金收入" {
+		t.Fatalf("accounting title = %+v/%+v, want 4603 租金收入", entry.AccountingTitleCode, entry.AccountingTitleName)
+	}
+	if entry.SourceDate == nil || entry.SourceDate.Time.Format("2006-01-02") != "2026-04-24" || entry.RoomLabel == nil || *entry.RoomLabel != "101" || entry.TenantLabel == nil || *entry.TenantLabel != "王小明" || entry.PeriodLabel == nil || *entry.PeriodLabel != "2026-04" || entry.DisplayNote == nil || *entry.DisplayNote != "101 王小明 2026-04 rent" {
+		t.Fatalf("display fields = %+v", entry)
+	}
+	if entry.Source == nil || entry.Source.Type == nil || *entry.Source.Type != api.FinancialReportEntrySourceTypeBill || entry.Source.Id == nil || entry.Source.Id.String() != "10000000-0000-0000-0000-000000000201" || entry.Source.Detail == nil || *entry.Source.Detail != api.Payment {
+		t.Fatalf("source = %+v, want bill payment source", entry.Source)
+	}
 }
 
 func TestSendPropertyFinancialReportReturnsReportResponse(t *testing.T) {
@@ -1592,6 +1605,15 @@ func testPropertyMeterHistoryRow() BillingPropertyMeterHistoryRow {
 
 func testFinancialReport() BillingFinancialReport {
 	description := "101 room April rent"
+	sourceDate := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	roomLabel := "101"
+	tenantLabel := "王小明"
+	periodLabel := "2026-04"
+	displayNote := "101 王小明 2026-04 rent"
+	accountingTitleID := "10000000-0000-0000-0000-000000000301"
+	accountingTitleCode := "4603"
+	accountingTitleName := "租金收入"
+	sourceDetail := "payment"
 	return BillingFinancialReport{
 		PropertyID:   "10000000-0000-0000-0000-000000000001",
 		Year:         2026,
@@ -1601,7 +1623,25 @@ func testFinancialReport() BillingFinancialReport {
 		Net:          173000,
 		IsFinalized:  true,
 		Entries: []BillingFinancialReportEntry{
-			{Category: "rent_payment", Description: &description, Amount: 18000},
+			{
+				ID:                  "10000000-0000-0000-0000-000000000101",
+				Category:            "rent_payment",
+				AccountingTitleID:   &accountingTitleID,
+				AccountingTitleCode: &accountingTitleCode,
+				AccountingTitleName: &accountingTitleName,
+				SourceDate:          &sourceDate,
+				RoomLabel:           &roomLabel,
+				TenantLabel:         &tenantLabel,
+				PeriodLabel:         &periodLabel,
+				DisplayNote:         &displayNote,
+				Description:         &description,
+				Amount:              18000,
+				Source: &BillingFinancialReportEntrySource{
+					Type:   "bill",
+					ID:     "10000000-0000-0000-0000-000000000201",
+					Detail: &sourceDetail,
+				},
+			},
 		},
 	}
 }

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -160,12 +160,20 @@ type FinancialReport struct {
 
 // FinancialReportEntry is one financial report detail entry.
 type FinancialReportEntry struct {
-	ID          string
-	Category    string
-	Description *string
-	Amount      int
-	SourceRef   json.RawMessage
-	CreatedAt   time.Time
+	ID                  string
+	Category            string
+	AccountingTitleID   *string
+	AccountingTitleCode *string
+	AccountingTitleName *string
+	SourceDate          *time.Time
+	RoomLabel           *string
+	TenantLabel         *string
+	PeriodLabel         *string
+	DisplayNote         *string
+	Description         *string
+	Amount              int
+	SourceRef           json.RawMessage
+	CreatedAt           time.Time
 }
 
 // MonthlyCashflow is one monthly cashflow export source read model.
@@ -1960,6 +1968,11 @@ SELECT
 	mse.accounting_title_id,
 	mse.accounting_title_code,
 	mse.accounting_title_name,
+	mse.source_date,
+	mse.room_label,
+	mse.tenant_label,
+	mse.period_label,
+	mse.display_note,
 	mse.description,
 	mse.amount,
 	mse.source_ref,
@@ -2022,6 +2035,11 @@ SELECT
 	ae.accounting_title_id,
 	ae.accounting_title_code,
 	ae.accounting_title_name,
+	ae.source_date,
+	ae.room_label,
+	ae.tenant_label,
+	ae.period_label,
+	ae.display_note,
 	ae.description,
 	ae.amount,
 	ae.source_ref,
@@ -2709,6 +2727,11 @@ func scanFinalizedFinancialReportRow(row rowScanner) (FinancialReportEntry, bool
 	var accountingTitleID sql.NullString
 	var accountingTitleCode sql.NullString
 	var accountingTitleName sql.NullString
+	var sourceDate sql.NullTime
+	var roomLabel sql.NullString
+	var tenantLabel sql.NullString
+	var periodLabel sql.NullString
+	var displayNote sql.NullString
 	var description sql.NullString
 	var amount sql.NullInt64
 	var sourceRef sql.NullString
@@ -2726,6 +2749,11 @@ func scanFinalizedFinancialReportRow(row rowScanner) (FinancialReportEntry, bool
 		&accountingTitleID,
 		&accountingTitleCode,
 		&accountingTitleName,
+		&sourceDate,
+		&roomLabel,
+		&tenantLabel,
+		&periodLabel,
+		&displayNote,
 		&description,
 		&amount,
 		&sourceRef,
@@ -2739,6 +2767,30 @@ func scanFinalizedFinancialReportRow(row rowScanner) (FinancialReportEntry, bool
 	}
 	if category.Valid {
 		entry.Category = category.String
+	}
+	if accountingTitleID.Valid {
+		entry.AccountingTitleID = &accountingTitleID.String
+	}
+	if accountingTitleCode.Valid {
+		entry.AccountingTitleCode = &accountingTitleCode.String
+	}
+	if accountingTitleName.Valid {
+		entry.AccountingTitleName = &accountingTitleName.String
+	}
+	if sourceDate.Valid {
+		entry.SourceDate = &sourceDate.Time
+	}
+	if roomLabel.Valid {
+		entry.RoomLabel = &roomLabel.String
+	}
+	if tenantLabel.Valid {
+		entry.TenantLabel = &tenantLabel.String
+	}
+	if periodLabel.Valid {
+		entry.PeriodLabel = &periodLabel.String
+	}
+	if displayNote.Valid {
+		entry.DisplayNote = &displayNote.String
 	}
 	if description.Valid {
 		entry.Description = &description.String
@@ -2765,6 +2817,11 @@ func scanLiveFinancialReportRow(row rowScanner, report *FinancialReport) (Financ
 	var accountingTitleID sql.NullString
 	var accountingTitleCode sql.NullString
 	var accountingTitleName sql.NullString
+	var sourceDate sql.NullTime
+	var roomLabel sql.NullString
+	var tenantLabel sql.NullString
+	var periodLabel sql.NullString
+	var displayNote sql.NullString
 	var description sql.NullString
 	var amount sql.NullInt64
 	var sourceRef sql.NullString
@@ -2779,6 +2836,11 @@ func scanLiveFinancialReportRow(row rowScanner, report *FinancialReport) (Financ
 		&accountingTitleID,
 		&accountingTitleCode,
 		&accountingTitleName,
+		&sourceDate,
+		&roomLabel,
+		&tenantLabel,
+		&periodLabel,
+		&displayNote,
 		&description,
 		&amount,
 		&sourceRef,
@@ -2792,6 +2854,30 @@ func scanLiveFinancialReportRow(row rowScanner, report *FinancialReport) (Financ
 	}
 	if category.Valid {
 		entry.Category = category.String
+	}
+	if accountingTitleID.Valid {
+		entry.AccountingTitleID = &accountingTitleID.String
+	}
+	if accountingTitleCode.Valid {
+		entry.AccountingTitleCode = &accountingTitleCode.String
+	}
+	if accountingTitleName.Valid {
+		entry.AccountingTitleName = &accountingTitleName.String
+	}
+	if sourceDate.Valid {
+		entry.SourceDate = &sourceDate.Time
+	}
+	if roomLabel.Valid {
+		entry.RoomLabel = &roomLabel.String
+	}
+	if tenantLabel.Valid {
+		entry.TenantLabel = &tenantLabel.String
+	}
+	if periodLabel.Valid {
+		entry.PeriodLabel = &periodLabel.String
+	}
+	if displayNote.Valid {
+		entry.DisplayNote = &displayNote.String
 	}
 	if description.Valid {
 		entry.Description = &description.String

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -753,11 +753,23 @@ func TestGetFinancialReportFinalizedMapsSnapshotEntries(t *testing.T) {
 	defer closeBillingDB(t, db)
 
 	createdAt := time.Date(2026, 4, 30, 23, 0, 0, 0, time.UTC)
-	mock.ExpectQuery(`(?s)FROM monthly_snapshots ms\s+JOIN properties p ON p.id = ms.property_id AND p.deleted_at IS NULL\s+LEFT JOIN monthly_snapshot_entries mse ON mse.snapshot_id = ms.id\s+WHERE ms.property_id = \$1\s+AND ms.year = \$2\s+AND ms.month = \$3`).
+	sourceDate := time.Date(2026, 4, 29, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(queryContainsInOrder(
+		"mse.accounting_title_name,",
+		"mse.source_date,",
+		"mse.room_label,",
+		"mse.tenant_label,",
+		"mse.period_label,",
+		"mse.display_note,",
+		"mse.source_ref,",
+		"FROM monthly_snapshots ms",
+		"LEFT JOIN monthly_snapshot_entries mse ON mse.snapshot_id = ms.id",
+		"WHERE ms.property_id = $1",
+	)).
 		WithArgs("property-1", 2026, 4).
 		WillReturnRows(financialReportFinalizedRows().
-			AddRow("property-1", 2026, 4, 13000, 1500, 11500, "entry-1", "rent_payment", "title-4603", "4603", "租金收入", "rent", 12000, []byte(`{"bill_id":"bill-1"}`), createdAt).
-			AddRow("property-1", 2026, 4, 13000, 1500, 11500, "entry-2", "journal_expense", "title-6681", "6681", "其他支出", nil, 1500, []byte(`{"journal_log_id":"journal-1"}`), createdAt))
+			AddRow("property-1", 2026, 4, 13000, 1500, 11500, "entry-1", "rent_payment", "title-4603", "4603", "租金收入", sourceDate, "101", "王小明", "2026-04", "101 王小明 2026-04 rent", "rent", 12000, []byte(`{"bill_id":"bill-1"}`), createdAt).
+			AddRow("property-1", 2026, 4, 13000, 1500, 11500, "entry-2", "journal_expense", "title-6681", "6681", "其他支出", nil, nil, nil, nil, "水電修繕", nil, 1500, []byte(`{"journal_log_id":"journal-1"}`), createdAt))
 
 	report, err := repo.GetFinancialReport(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 4, false)
 	if err != nil {
@@ -775,6 +787,15 @@ func TestGetFinancialReportFinalizedMapsSnapshotEntries(t *testing.T) {
 	if report.Entries[0].Category != "rent_payment" || report.Entries[0].Description == nil || *report.Entries[0].Description != "rent" {
 		t.Fatalf("first entry = %+v, want rent_payment with description", report.Entries[0])
 	}
+	if report.Entries[0].AccountingTitleCode == nil || *report.Entries[0].AccountingTitleCode != "4603" || report.Entries[0].AccountingTitleName == nil || *report.Entries[0].AccountingTitleName != "租金收入" {
+		t.Fatalf("first entry title = %+v/%+v, want 4603 租金收入", report.Entries[0].AccountingTitleCode, report.Entries[0].AccountingTitleName)
+	}
+	if report.Entries[0].SourceDate == nil || !report.Entries[0].SourceDate.Equal(sourceDate) || report.Entries[0].RoomLabel == nil || *report.Entries[0].RoomLabel != "101" || report.Entries[0].TenantLabel == nil || *report.Entries[0].TenantLabel != "王小明" || report.Entries[0].PeriodLabel == nil || *report.Entries[0].PeriodLabel != "2026-04" || report.Entries[0].DisplayNote == nil || *report.Entries[0].DisplayNote != "101 王小明 2026-04 rent" {
+		t.Fatalf("first entry display fields = %+v", report.Entries[0])
+	}
+	if report.Entries[1].DisplayNote == nil || *report.Entries[1].DisplayNote != "水電修繕" {
+		t.Fatalf("second entry display note = %+v, want 水電修繕", report.Entries[1].DisplayNote)
+	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
@@ -786,13 +807,25 @@ func TestGetFinancialReportLiveMapsAccountingEntriesAndAggregatesTotals(t *testi
 	defer closeBillingDB(t, db)
 
 	createdAt := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
-	mock.ExpectQuery(`(?s)FROM property_accounts pa\s+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL\s+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id\s+AND ae.year = \$2\s+AND ae.month = \$3\s+WHERE pa.property_id = \$1\s+AND pa.deleted_at IS NULL`).
+	sourceDate := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(queryContainsInOrder(
+		"ae.accounting_title_name,",
+		"ae.source_date,",
+		"ae.room_label,",
+		"ae.tenant_label,",
+		"ae.period_label,",
+		"ae.display_note,",
+		"ae.source_ref,",
+		"FROM property_accounts pa",
+		"LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id",
+		"WHERE pa.property_id = $1",
+	)).
 		WithArgs("property-1", 2026, 4).
 		WillReturnRows(financialReportLiveRows().
-			AddRow("property-1", 2026, 4, "entry-1", "rent_payment", "title-4603", "4603", "租金收入", "rent", 12000, []byte(`{"bill_id":"bill-1"}`), createdAt).
-			AddRow("property-1", 2026, 4, "entry-2", "electricity_payment", "title-4605", "4605", "房客電費收入", nil, 1000, []byte(`{"bill_id":"bill-2"}`), createdAt).
-			AddRow("property-1", 2026, 4, "entry-3", "deposit_refund", "title-4602", "4602", "押金退回(減項)", "refund", -3000, []byte(`{"lease_id":"lease-1"}`), createdAt).
-			AddRow("property-1", 2026, 4, "entry-4", "journal_expense", "title-6681", "6681", "其他支出", nil, 500, []byte(`{"journal_log_id":"journal-1"}`), createdAt))
+			AddRow("property-1", 2026, 4, "entry-1", "rent_payment", "title-4603", "4603", "租金收入", sourceDate, "101", "王小明", "2026-04", "101 王小明 2026-04 rent", "rent", 12000, []byte(`{"bill_id":"bill-1"}`), createdAt).
+			AddRow("property-1", 2026, 4, "entry-2", "electricity_payment", "title-4605", "4605", "房客電費收入", nil, nil, nil, nil, nil, nil, 1000, []byte(`{"bill_id":"bill-2"}`), createdAt).
+			AddRow("property-1", 2026, 4, "entry-3", "deposit_refund", "title-4602", "4602", "押金退回(減項)", nil, nil, nil, nil, "refund", "refund", -3000, []byte(`{"lease_id":"lease-1"}`), createdAt).
+			AddRow("property-1", 2026, 4, "entry-4", "journal_expense", "title-6681", "6681", "其他支出", nil, nil, nil, nil, nil, nil, 500, []byte(`{"journal_log_id":"journal-1"}`), createdAt))
 
 	report, err := repo.GetFinancialReport(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 4, true)
 	if err != nil {
@@ -810,6 +843,12 @@ func TestGetFinancialReportLiveMapsAccountingEntriesAndAggregatesTotals(t *testi
 	if report.Entries[2].Amount != -3000 {
 		t.Fatalf("deposit refund amount = %d, want stored -3000", report.Entries[2].Amount)
 	}
+	if report.Entries[0].AccountingTitleCode == nil || *report.Entries[0].AccountingTitleCode != "4603" || report.Entries[0].SourceDate == nil || !report.Entries[0].SourceDate.Equal(sourceDate) || report.Entries[0].DisplayNote == nil || *report.Entries[0].DisplayNote != "101 王小明 2026-04 rent" {
+		t.Fatalf("first entry fields = %+v", report.Entries[0])
+	}
+	if report.Entries[2].DisplayNote == nil || *report.Entries[2].DisplayNote != "refund" {
+		t.Fatalf("deposit refund display note = %+v, want refund", report.Entries[2].DisplayNote)
+	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
@@ -823,7 +862,7 @@ func TestGetFinancialReportFinalizedAllowsEmptyEntries(t *testing.T) {
 	mock.ExpectQuery(`(?s)FROM monthly_snapshots ms\s+JOIN properties p ON p.id = ms.property_id AND p.deleted_at IS NULL\s+LEFT JOIN monthly_snapshot_entries mse ON mse.snapshot_id = ms.id\s+WHERE ms.property_id = \$1\s+AND ms.year = \$2\s+AND ms.month = \$3`).
 		WithArgs("property-1", 2026, 4).
 		WillReturnRows(financialReportFinalizedRows().
-			AddRow("property-1", 2026, 4, 0, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil))
+			AddRow("property-1", 2026, 4, 0, 0, 0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil))
 
 	report, err := repo.GetFinancialReport(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 4, false)
 	if err != nil {
@@ -848,7 +887,7 @@ func TestGetFinancialReportLiveAllowsEmptyEntries(t *testing.T) {
 	mock.ExpectQuery(`(?s)FROM property_accounts pa\s+JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL\s+LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id\s+AND ae.year = \$2\s+AND ae.month = \$3\s+WHERE pa.property_id = \$1\s+AND pa.deleted_at IS NULL`).
 		WithArgs("property-1", 2026, 4).
 		WillReturnRows(financialReportLiveRows().
-			AddRow("property-1", 2026, 4, nil, nil, nil, nil, nil, nil, nil, nil, nil))
+			AddRow("property-1", 2026, 4, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil))
 
 	report, err := repo.GetFinancialReport(context.Background(), Scope{Role: "admin"}, "property-1", 2026, 4, true)
 	if err != nil {
@@ -1487,6 +1526,11 @@ func financialReportFinalizedRows() *sqlmock.Rows {
 		"accounting_title_id",
 		"accounting_title_code",
 		"accounting_title_name",
+		"source_date",
+		"room_label",
+		"tenant_label",
+		"period_label",
+		"display_note",
 		"description",
 		"amount",
 		"source_ref",
@@ -1504,6 +1548,11 @@ func financialReportLiveRows() *sqlmock.Rows {
 		"accounting_title_id",
 		"accounting_title_code",
 		"accounting_title_name",
+		"source_date",
+		"room_label",
+		"tenant_label",
+		"period_label",
+		"display_note",
 		"description",
 		"amount",
 		"source_ref",

--- a/internal/server/billing_adapters.go
+++ b/internal/server/billing_adapters.go
@@ -777,9 +777,19 @@ func toAppFinancialReport(report dbbilling.FinancialReport) *appbilling.Financia
 	entries := make([]appbilling.FinancialReportEntry, 0, len(report.Entries))
 	for i := range report.Entries {
 		entries = append(entries, appbilling.FinancialReportEntry{
-			Category:    report.Entries[i].Category,
-			Description: report.Entries[i].Description,
-			Amount:      report.Entries[i].Amount,
+			ID:                  report.Entries[i].ID,
+			Category:            report.Entries[i].Category,
+			AccountingTitleID:   report.Entries[i].AccountingTitleID,
+			AccountingTitleCode: report.Entries[i].AccountingTitleCode,
+			AccountingTitleName: report.Entries[i].AccountingTitleName,
+			SourceDate:          report.Entries[i].SourceDate,
+			RoomLabel:           report.Entries[i].RoomLabel,
+			TenantLabel:         report.Entries[i].TenantLabel,
+			PeriodLabel:         report.Entries[i].PeriodLabel,
+			DisplayNote:         report.Entries[i].DisplayNote,
+			Description:         report.Entries[i].Description,
+			Amount:              report.Entries[i].Amount,
+			Source:              appbilling.FinancialReportEntrySourceFromRef(report.Entries[i].Category, report.Entries[i].SourceRef),
 		})
 	}
 
@@ -879,9 +889,19 @@ func toHandlerFinancialReport(report appbilling.FinancialReport) *handler.Billin
 	entries := make([]handler.BillingFinancialReportEntry, 0, len(report.Entries))
 	for i := range report.Entries {
 		entries = append(entries, handler.BillingFinancialReportEntry{
-			Category:    report.Entries[i].Category,
-			Description: report.Entries[i].Description,
-			Amount:      report.Entries[i].Amount,
+			ID:                  report.Entries[i].ID,
+			Category:            report.Entries[i].Category,
+			AccountingTitleID:   report.Entries[i].AccountingTitleID,
+			AccountingTitleCode: report.Entries[i].AccountingTitleCode,
+			AccountingTitleName: report.Entries[i].AccountingTitleName,
+			SourceDate:          report.Entries[i].SourceDate,
+			RoomLabel:           report.Entries[i].RoomLabel,
+			TenantLabel:         report.Entries[i].TenantLabel,
+			PeriodLabel:         report.Entries[i].PeriodLabel,
+			DisplayNote:         report.Entries[i].DisplayNote,
+			Description:         report.Entries[i].Description,
+			Amount:              report.Entries[i].Amount,
+			Source:              toHandlerFinancialReportEntrySource(report.Entries[i].Source),
 		})
 	}
 
@@ -894,6 +914,17 @@ func toHandlerFinancialReport(report appbilling.FinancialReport) *handler.Billin
 		Net:          report.Net,
 		IsFinalized:  report.IsFinalized,
 		Entries:      entries,
+	}
+}
+
+func toHandlerFinancialReportEntrySource(source *appbilling.FinancialReportEntrySource) *handler.BillingFinancialReportEntrySource {
+	if source == nil {
+		return nil
+	}
+	return &handler.BillingFinancialReportEntrySource{
+		Type:   source.Type,
+		ID:     source.ID,
+		Detail: source.Detail,
 	}
 }
 

--- a/test/e2e/billing_payment_report_test.go
+++ b/test/e2e/billing_payment_report_test.go
@@ -122,8 +122,9 @@ func TestE2EBillingPaymentAndFinancialReportAcceptance(t *testing.T) {
 	if report.TotalIncome < expectedIncome {
 		t.Fatalf("expected total_income at least %d, got %d", expectedIncome, report.TotalIncome)
 	}
-	billingFlowE2ERequireReportEntry(t, report, "rent_payment", *rentBill.Amount)
+	rentEntry := billingFlowE2ERequireReportEntry(t, report, "rent_payment", *rentBill.Amount)
 	billingFlowE2ERequireReportEntry(t, report, "electricity_payment", *electricityBill.Amount)
+	billingFlowE2ERequireReportEntryDisplaySource(t, rentEntry, rentBill.ID, paidAt)
 }
 
 type billingFlowE2ELeaseResponse struct {
@@ -209,9 +210,25 @@ type billingFlowE2EFinancialReportResponse struct {
 }
 
 type billingFlowE2EFinancialReportEntry struct {
-	Category    string `json:"category"`
-	Description string `json:"description"`
-	Amount      int    `json:"amount"`
+	EntryID             string                                  `json:"entry_id"`
+	Category            string                                  `json:"category"`
+	AccountingTitleID   string                                  `json:"accounting_title_id"`
+	AccountingTitleCode string                                  `json:"accounting_title_code"`
+	AccountingTitleName string                                  `json:"accounting_title_name"`
+	SourceDate          string                                  `json:"source_date"`
+	RoomLabel           string                                  `json:"room_label"`
+	TenantLabel         string                                  `json:"tenant_label"`
+	PeriodLabel         string                                  `json:"period_label"`
+	DisplayNote         string                                  `json:"display_note"`
+	Description         string                                  `json:"description"`
+	Amount              int                                     `json:"amount"`
+	Source              *billingFlowE2EFinancialReportSourceRef `json:"source"`
+}
+
+type billingFlowE2EFinancialReportSourceRef struct {
+	Type   string `json:"type"`
+	ID     string `json:"id"`
+	Detail string `json:"detail"`
 }
 
 func billingFlowE2ECreateLease(t *testing.T, ctx context.Context, client apiClient, tenantID string, roomID string, year int, month int) billingFlowE2ELeaseResponse {
@@ -435,15 +452,37 @@ func billingFlowE2EGetFinancialReport(t *testing.T, ctx context.Context, client 
 	return report
 }
 
-func billingFlowE2ERequireReportEntry(t *testing.T, report billingFlowE2EFinancialReportResponse, category string, amount int) {
+func billingFlowE2ERequireReportEntry(t *testing.T, report billingFlowE2EFinancialReportResponse, category string, amount int) billingFlowE2EFinancialReportEntry {
 	t.Helper()
 
 	for _, entry := range report.Entries {
 		if entry.Category == category && entry.Amount == amount {
-			return
+			return entry
 		}
 	}
 	t.Fatalf("expected report entry category %q amount %d in %+v", category, amount, report.Entries)
+	return billingFlowE2EFinancialReportEntry{}
+}
+
+func billingFlowE2ERequireReportEntryDisplaySource(t *testing.T, entry billingFlowE2EFinancialReportEntry, billID string, paidAt time.Time) {
+	t.Helper()
+
+	if entry.EntryID == "" {
+		t.Fatalf("expected entry_id on report entry: %+v", entry)
+	}
+	if entry.AccountingTitleID == "" || entry.AccountingTitleCode == "" || entry.AccountingTitleName == "" {
+		t.Fatalf("expected accounting title fields on report entry: %+v", entry)
+	}
+	wantSourceDate := paidAt.In(time.FixedZone("Asia/Taipei", 8*60*60)).Format("2006-01-02")
+	if entry.SourceDate != wantSourceDate {
+		t.Fatalf("source_date = %q, want %q", entry.SourceDate, wantSourceDate)
+	}
+	if entry.PeriodLabel == "" || entry.DisplayNote == "" {
+		t.Fatalf("expected period_label and display_note on report entry: %+v", entry)
+	}
+	if entry.Source == nil || entry.Source.Type != "bill" || entry.Source.ID != billID || entry.Source.Detail != "payment" {
+		t.Fatalf("source = %+v, want bill payment source for %s", entry.Source, billID)
+	}
 }
 
 func billingFlowE2EReportPaymentTime() (int, int, time.Time) {


### PR DESCRIPTION
Closes #135

## Summary

- Expand the financial report entry OpenAPI contract with display-ready row fields and a typed `source` object.
- Propagate preserved accounting title/display fields from repository rows through application/server/handler mapping.
- Normalize internal `source_ref` into frontend-safe source pointers instead of exposing raw JSON.
- Add unit and E2E coverage for the new financial report row contract.

## Notes

No schema migration is included. The existing `accounting_entries` and `monthly_snapshot_entries` schema already contains the accounting title linkage, display fields, and `source_ref` needed for this API contract. This PR only exposes and normalizes those existing fields for the financial report JSON endpoint.

Frontend handoff was added on issue #135:
https://github.com/ifan0927/STDS_backend_go/issues/135#issuecomment-4408321138

## Validation

- `npm run openapi:generate`
- `npm run openapi:lint`
- `go test -tags=e2e ./test/e2e -run '^$' -count=1`
- `go test ./internal/server ./internal/http/handler ./internal/application/billing ./internal/platform/database/billing -count=1`
- `go test ./...`
- `./scripts/e2e_test.sh -run TestE2EBillingPaymentAndFinancialReportAcceptance -count=1`
- `git diff --check`
