### PR TITLE
Add lease starting meter baseline

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -2444,7 +2444,8 @@ paths:
         BR-03：押金不得為負
         BR-12：目標房間必須為 vacant（取悲觀鎖後檢查）
         rent_billing_cadence 可於建約時指定；未提供時預設 monthly。rent_amount 為每個租金計費週期的金額。
-        electricity_billing_cadence 可於建約時覆寫，未提供時套用 Property 預設值
+        electricity_billing_cadence 可於建約時覆寫，未提供時套用 Property 預設值。
+        starting_meter_reading 由 backend 保存為此 lease 第一張電費帳單的 previous reading baseline。
       tags:
         - Leasing
       x-required-role:
@@ -2469,6 +2470,7 @@ paths:
                   end_date: '2027-04-30'
                   deposit_amount: 36000
                   electricity_billing_cadence: monthly
+                  starting_meter_reading: 1250
       responses:
         '201':
           description: 租約建立成功（LeaseCreated event 已發出，帳單已預產）
@@ -2487,6 +2489,7 @@ paths:
                     start_date: '2026-05-01'
                     end_date: '2027-04-30'
                     electricity_billing_cadence: monthly
+                    starting_meter_reading: 1250
                     deposit_amount: 36000
                     deposit_status: held
                     status: active
@@ -7702,6 +7705,10 @@ components:
           enum:
             - monthly
             - bimonthly
+        starting_meter_reading:
+          type: integer
+          nullable: true
+          description: Move-in starting meter reading. Existing or legacy leases may be null.
         status:
           type: string
           enum:
@@ -7762,6 +7769,7 @@ components:
         - start_date
         - end_date
         - deposit_amount
+        - starting_meter_reading
       properties:
         tenant_id:
           type: string
@@ -7793,6 +7801,11 @@ components:
             - monthly
             - bimonthly
           description: 可省略；若未提供則套用 Property 的 default_electricity_billing_cadence
+        starting_meter_reading:
+          type: integer
+          minimum: 0
+          description: Move-in starting meter reading. Backend uses it as the previous reading baseline for the first electricity bill in this lease.
+          x-go-type: '*int'
     LeaseCheckoutReviewResponse:
       type: object
       properties:

--- a/docs/spec/schema.sql
+++ b/docs/spec/schema.sql
@@ -168,6 +168,7 @@ CREATE TABLE leases (
     end_date                DATE         NOT NULL,
     rent_billing_cadence     VARCHAR(20)  NOT NULL DEFAULT 'monthly' CHECK (rent_billing_cadence IN ('monthly', 'quarterly', 'semiannual', 'annual')),
     electricity_billing_cadence VARCHAR(20) NOT NULL DEFAULT 'monthly' CHECK (electricity_billing_cadence IN ('monthly', 'bimonthly')),
+    starting_meter_reading  INTEGER CHECK (starting_meter_reading IS NULL OR starting_meter_reading >= 0),
     -- status：active | expired | terminated | force_terminated
     status                  VARCHAR(30)  NOT NULL CHECK (status IN ('active', 'expired', 'terminated', 'force_terminated'))
                                          DEFAULT 'active',

--- a/docs/spec/src/components/schemas/tenancy/CreateLeaseRequest.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CreateLeaseRequest.yaml
@@ -6,6 +6,7 @@ required:
   - start_date
   - end_date
   - deposit_amount
+  - starting_meter_reading
 properties:
   tenant_id:
     type: string
@@ -37,3 +38,8 @@ properties:
       - monthly
       - bimonthly
     description: 可省略；若未提供則套用 Property 的 default_electricity_billing_cadence
+  starting_meter_reading:
+    type: integer
+    minimum: 0
+    description: Move-in starting meter reading. Backend uses it as the previous reading baseline for the first electricity bill in this lease.
+    x-go-type: '*int'

--- a/docs/spec/src/components/schemas/tenancy/LeaseResponse.yaml
+++ b/docs/spec/src/components/schemas/tenancy/LeaseResponse.yaml
@@ -38,6 +38,10 @@ properties:
     enum:
       - monthly
       - bimonthly
+  starting_meter_reading:
+    type: integer
+    nullable: true
+    description: Move-in starting meter reading. Existing or legacy leases may be null.
   status:
     type: string
     enum:

--- a/docs/spec/src/paths/tenancy/leases.yaml
+++ b/docs/spec/src/paths/tenancy/leases.yaml
@@ -84,7 +84,8 @@ post:
     BR-03：押金不得為負
     BR-12：目標房間必須為 vacant（取悲觀鎖後檢查）
     rent_billing_cadence 可於建約時指定；未提供時預設 monthly。rent_amount 為每個租金計費週期的金額。
-    electricity_billing_cadence 可於建約時覆寫，未提供時套用 Property 預設值
+    electricity_billing_cadence 可於建約時覆寫，未提供時套用 Property 預設值。
+    starting_meter_reading 由 backend 保存為此 lease 第一張電費帳單的 previous reading baseline。
   tags:
     - Leasing
   x-required-role:
@@ -109,6 +110,7 @@ post:
               end_date: '2027-04-30'
               deposit_amount: 36000
               electricity_billing_cadence: monthly
+              starting_meter_reading: 1250
   responses:
     '201':
       description: 租約建立成功（LeaseCreated event 已發出，帳單已預產）
@@ -127,6 +129,7 @@ post:
                 start_date: '2026-05-01'
                 end_date: '2027-04-30'
                 electricity_billing_cadence: monthly
+                starting_meter_reading: 1250
                 deposit_amount: 36000
                 deposit_status: held
                 status: active

--- a/internal/application/billing/record_commands_test.go
+++ b/internal/application/billing/record_commands_test.go
@@ -168,8 +168,8 @@ func TestRecordMeterServiceRecordsMeterAndPublishesEventAfterCommit(t *testing.T
 	if bill == nil || bill.Status != domainbilling.StatusPendingPayment || bill.Amount == nil || *bill.Amount != 585 {
 		t.Fatalf("unexpected bill: %+v", bill)
 	}
-	if repo.previousLookupRoomID != testRoomID || !repo.previousLookupBeforePeriodStart.Equal(repo.billForUpdate.PeriodStart) {
-		t.Fatalf("previous lookup = room %q before %v, want room %q before %v", repo.previousLookupRoomID, repo.previousLookupBeforePeriodStart, testRoomID, repo.billForUpdate.PeriodStart)
+	if repo.previousLookupLeaseID != testLeaseID || !repo.previousLookupBeforePeriodStart.Equal(repo.billForUpdate.PeriodStart) {
+		t.Fatalf("previous lookup = lease %q before %v, want lease %q before %v", repo.previousLookupLeaseID, repo.previousLookupBeforePeriodStart, testLeaseID, repo.billForUpdate.PeriodStart)
 	}
 	if repo.previousLookupTx == nil {
 		t.Fatal("expected previous reading lookup to receive transaction")
@@ -585,7 +585,7 @@ type billingRepositoryStub struct {
 	previousReading                 int
 	previousErr                     error
 	previousLookupTx                *sql.Tx
-	previousLookupRoomID            string
+	previousLookupLeaseID           string
 	previousLookupBeforePeriodStart time.Time
 	electricityUnitPrice            *float64
 	unitPriceLookupTx               *sql.Tx
@@ -621,9 +621,9 @@ func (s *billingRepositoryStub) FindBillByIDForUpdate(_ context.Context, _ *sql.
 	return s.billForUpdate, nil
 }
 
-func (s *billingRepositoryStub) FindPreviousElectricityReading(_ context.Context, tx *sql.Tx, roomID string, beforePeriodStart time.Time) (int, error) {
+func (s *billingRepositoryStub) FindPreviousElectricityReading(_ context.Context, tx *sql.Tx, leaseID string, beforePeriodStart time.Time) (int, error) {
 	s.previousLookupTx = tx
-	s.previousLookupRoomID = roomID
+	s.previousLookupLeaseID = leaseID
 	s.previousLookupBeforePeriodStart = beforePeriodStart
 	if s.previousErr != nil {
 		return 0, s.previousErr

--- a/internal/application/billing/record_meter.go
+++ b/internal/application/billing/record_meter.go
@@ -58,7 +58,7 @@ func (s *RecordMeterService) Execute(ctx context.Context, input RecordMeterInput
 			return mapRepositoryError(err)
 		}
 
-		previousReading, err := s.repo.FindPreviousElectricityReading(ctx, tx, current.RoomID, current.PeriodStart)
+		previousReading, err := s.repo.FindPreviousElectricityReading(ctx, tx, current.LeaseID, current.PeriodStart)
 		if err != nil {
 			return mapRepositoryError(err)
 		}

--- a/internal/application/billing/repository.go
+++ b/internal/application/billing/repository.go
@@ -106,7 +106,7 @@ type Repository interface {
 	ListBills(ctx context.Context, query ListBillsQuery) (ListBillsResult, error)
 	FindBillByID(ctx context.Context, query GetBillQuery) (*Bill, error)
 	FindBillByIDForUpdate(ctx context.Context, tx *sql.Tx, billID string) (*Bill, error)
-	FindPreviousElectricityReading(ctx context.Context, tx *sql.Tx, roomID string, beforePeriodStart time.Time) (int, error)
+	FindPreviousElectricityReading(ctx context.Context, tx *sql.Tx, leaseID string, beforePeriodStart time.Time) (int, error)
 	FindPropertyElectricityUnitPrice(ctx context.Context, tx *sql.Tx, propertyID string) (*float64, error)
 	UpdateBillMeter(ctx context.Context, tx *sql.Tx, params UpdateMeterParams) (*Bill, error)
 	UpdateBillPayment(ctx context.Context, tx *sql.Tx, params UpdatePaymentParams) (*Bill, error)

--- a/internal/application/lease/create_lease.go
+++ b/internal/application/lease/create_lease.go
@@ -37,6 +37,7 @@ type CreateLeaseInput struct {
 	DepositAmount             int
 	RentBillingCadence        string
 	ElectricityBillingCadence *string
+	StartingMeterReading      int
 }
 
 // CreateLeaseService creates a lease and pre-generates bills.
@@ -66,6 +67,9 @@ func (s *CreateLeaseService) Execute(ctx context.Context, input CreateLeaseInput
 	}
 	if input.EndDate.IsZero() {
 		return nil, errValidationEndDateRequired
+	}
+	if input.StartingMeterReading < 0 {
+		return nil, errValidationStartingMeterReadingInvalid
 	}
 
 	actorRole := strings.ToLower(strings.TrimSpace(input.ActorRole))
@@ -136,6 +140,7 @@ func (s *CreateLeaseService) Execute(ctx context.Context, input CreateLeaseInput
 			EndDate:                   state.EndDate,
 			RentBillingCadence:        state.RentBillingCadence,
 			ElectricityBillingCadence: state.ElectricityBillingCadence,
+			StartingMeterReading:      input.StartingMeterReading,
 			DepositAmount:             state.DepositAmount,
 		})
 		if err != nil {

--- a/internal/application/lease/create_lease_test.go
+++ b/internal/application/lease/create_lease_test.go
@@ -50,16 +50,19 @@ func TestCreateLeaseServiceCreatesLeaseAndPreGeneratesBills(t *testing.T) {
 			Version:                   1,
 		},
 	}
+	startingMeterReading := 1250
+	repo.createdLease.StartingMeterReading = &startingMeterReading
 
 	service := NewCreateLeaseService(repo, dbtxrunner.New(db, publisher))
 	lease, err := service.Execute(context.Background(), CreateLeaseInput{
-		TenantID:      "tenant-1",
-		RoomID:        "room-1",
-		RentAmount:    18000,
-		StartDate:     time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
-		EndDate:       time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
-		DepositAmount: 36000,
-		ActorRole:     "admin",
+		TenantID:             "tenant-1",
+		RoomID:               "room-1",
+		RentAmount:           18000,
+		StartDate:            time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC),
+		EndDate:              time.Date(2026, 7, 20, 0, 0, 0, 0, time.UTC),
+		DepositAmount:        36000,
+		StartingMeterReading: 1250,
+		ActorRole:            "admin",
 	})
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -67,6 +70,12 @@ func TestCreateLeaseServiceCreatesLeaseAndPreGeneratesBills(t *testing.T) {
 
 	if lease.ID != "lease-1" {
 		t.Fatalf("expected lease-1, got %q", lease.ID)
+	}
+	if repo.createLeaseParams == nil || repo.createLeaseParams.StartingMeterReading != 1250 {
+		t.Fatalf("unexpected starting meter reading params: %+v", repo.createLeaseParams)
+	}
+	if lease.StartingMeterReading == nil || *lease.StartingMeterReading != 1250 {
+		t.Fatalf("unexpected starting meter reading: %+v", lease.StartingMeterReading)
 	}
 	if len(repo.createdBills) != 6 {
 		t.Fatalf("expected 6 created bills, got %d", len(repo.createdBills))
@@ -323,6 +332,20 @@ func TestCreateLeaseServiceRejectsBusinessRuleViolationsAndMissingReferences(t *
 		}
 		if err := mock.ExpectationsWereMet(); err != nil {
 			t.Fatalf("ExpectationsWereMet: %v", err)
+		}
+	})
+
+	t.Run("negative starting meter reading", func(t *testing.T) {
+		service := NewCreateLeaseService(nil, nil)
+		_, err := service.Execute(context.Background(), CreateLeaseInput{
+			TenantID:             "tenant-1",
+			RoomID:               "room-1",
+			StartDate:            time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			EndDate:              time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC),
+			StartingMeterReading: -1,
+		})
+		if !errors.Is(err, errValidationStartingMeterReadingInvalid) {
+			t.Fatalf("expected errValidationStartingMeterReadingInvalid, got %v", err)
 		}
 	})
 

--- a/internal/application/lease/errors.go
+++ b/internal/application/lease/errors.go
@@ -9,32 +9,33 @@ import (
 )
 
 const (
-	codeValidationTenantIDRequired    = "VALIDATION_TENANT_ID_REQUIRED"
-	codeValidationRoomIDRequired      = "VALIDATION_ROOM_ID_REQUIRED"
-	codeValidationStartDateRequired   = "VALIDATION_START_DATE_REQUIRED"
-	codeValidationEndDateRequired     = "VALIDATION_END_DATE_REQUIRED"
-	codeLeaseInvalidDateRange         = "LEASE_INVALID_DATE_RANGE"
-	codeLeaseRentAmountNonPositive    = "LEASE_RENT_AMOUNT_NON_POSITIVE"
-	codeLeaseDepositNegative          = "LEASE_DEPOSIT_NEGATIVE"
-	codeSettlementNegative            = "LEASE_SETTLEMENT_NEGATIVE"
-	codeLeaseUnsupportedUpdate        = "LEASE_UNSUPPORTED_UPDATE"
-	codeDepositDeductionReason        = "DEPOSIT_DEDUCTION_REASON_REQUIRED"
-	codeDepositSettlementMismatch     = "DEPOSIT_SETTLEMENT_AMOUNT_MISMATCH"
-	codeDepositNotHeld                = "DEPOSIT_NOT_HELD"
-	codeLeaseHasUnpaidBills           = "LEASE_HAS_UNPAID_BILLS"
-	codeCheckoutSettlementBlocked     = "CHECKOUT_SETTLEMENT_BLOCKED"
-	codeCheckoutSettlementStale       = "CHECKOUT_SETTLEMENT_STALE"
-	codeCheckoutSettlementNotFound    = "CHECKOUT_SETTLEMENT_NOT_FOUND"
-	codeForbiddenForceTermination     = "FORBIDDEN_FORCE_TERMINATION"
-	codeForceTerminationReason        = "FORCE_TERMINATION_REASON_REQUIRED"
-	codeForceTerminationDeposit       = "FORCE_TERMINATION_DEPOSIT_HANDLING_REQUIRED"
-	codeLeaseUpdateLockedBills        = "LEASE_UPDATE_HAS_LOCKED_FUTURE_BILLS"
-	codeLeaseNotActive                = "LEASE_NOT_ACTIVE"
-	codeRoomNotVacant                 = "ROOM_NOT_VACANT"
-	codeReplacementNotBoundary        = "LEASE_REPLACEMENT_NOT_AT_BILLING_BOUNDARY"
-	codeReplacementUnsettledBills     = "LEASE_REPLACEMENT_HAS_UNSETTLED_BILLS"
-	codeReplacementScopeMismatch      = "LEASE_REPLACEMENT_SCOPE_MISMATCH"
-	codeReplacementDepositUnsupported = "LEASE_REPLACEMENT_DEPOSIT_HANDLING_UNSUPPORTED"
+	codeValidationTenantIDRequired     = "VALIDATION_TENANT_ID_REQUIRED"
+	codeValidationRoomIDRequired       = "VALIDATION_ROOM_ID_REQUIRED"
+	codeValidationStartDateRequired    = "VALIDATION_START_DATE_REQUIRED"
+	codeValidationEndDateRequired      = "VALIDATION_END_DATE_REQUIRED"
+	codeValidationStartingMeterReading = "VALIDATION_STARTING_METER_READING"
+	codeLeaseInvalidDateRange          = "LEASE_INVALID_DATE_RANGE"
+	codeLeaseRentAmountNonPositive     = "LEASE_RENT_AMOUNT_NON_POSITIVE"
+	codeLeaseDepositNegative           = "LEASE_DEPOSIT_NEGATIVE"
+	codeSettlementNegative             = "LEASE_SETTLEMENT_NEGATIVE"
+	codeLeaseUnsupportedUpdate         = "LEASE_UNSUPPORTED_UPDATE"
+	codeDepositDeductionReason         = "DEPOSIT_DEDUCTION_REASON_REQUIRED"
+	codeDepositSettlementMismatch      = "DEPOSIT_SETTLEMENT_AMOUNT_MISMATCH"
+	codeDepositNotHeld                 = "DEPOSIT_NOT_HELD"
+	codeLeaseHasUnpaidBills            = "LEASE_HAS_UNPAID_BILLS"
+	codeCheckoutSettlementBlocked      = "CHECKOUT_SETTLEMENT_BLOCKED"
+	codeCheckoutSettlementStale        = "CHECKOUT_SETTLEMENT_STALE"
+	codeCheckoutSettlementNotFound     = "CHECKOUT_SETTLEMENT_NOT_FOUND"
+	codeForbiddenForceTermination      = "FORBIDDEN_FORCE_TERMINATION"
+	codeForceTerminationReason         = "FORCE_TERMINATION_REASON_REQUIRED"
+	codeForceTerminationDeposit        = "FORCE_TERMINATION_DEPOSIT_HANDLING_REQUIRED"
+	codeLeaseUpdateLockedBills         = "LEASE_UPDATE_HAS_LOCKED_FUTURE_BILLS"
+	codeLeaseNotActive                 = "LEASE_NOT_ACTIVE"
+	codeRoomNotVacant                  = "ROOM_NOT_VACANT"
+	codeReplacementNotBoundary         = "LEASE_REPLACEMENT_NOT_AT_BILLING_BOUNDARY"
+	codeReplacementUnsettledBills      = "LEASE_REPLACEMENT_HAS_UNSETTLED_BILLS"
+	codeReplacementScopeMismatch       = "LEASE_REPLACEMENT_SCOPE_MISMATCH"
+	codeReplacementDepositUnsupported  = "LEASE_REPLACEMENT_DEPOSIT_HANDLING_UNSUPPORTED"
 )
 
 var (
@@ -57,6 +58,11 @@ var (
 		codeValidationEndDateRequired,
 		http.StatusBadRequest,
 		"end_date is required.",
+	)
+	errValidationStartingMeterReadingInvalid = apperr.New(
+		codeValidationStartingMeterReading,
+		http.StatusBadRequest,
+		"starting_meter_reading must be greater than or equal to zero.",
 	)
 	errLeaseInvalidDateRange = apperr.New(
 		codeLeaseInvalidDateRange,

--- a/internal/application/lease/repository.go
+++ b/internal/application/lease/repository.go
@@ -26,6 +26,7 @@ type Lease struct {
 	EndDate                   time.Time
 	RentBillingCadence        string
 	ElectricityBillingCadence string
+	StartingMeterReading      *int
 	Status                    string
 	DepositAmount             int
 	DepositRefundAmount       *int
@@ -64,6 +65,7 @@ type CreateLeaseParams struct {
 	EndDate                   time.Time
 	RentBillingCadence        string
 	ElectricityBillingCadence string
+	StartingMeterReading      int
 	DepositAmount             int
 	Notes                     *string
 }

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -725,7 +725,10 @@ type CreateLeaseRequest struct {
 	RentBillingCadence *CreateLeaseRequestRentBillingCadence `json:"rent_billing_cadence,omitempty"`
 	RoomId             openapi_types.UUID                    `json:"room_id"`
 	StartDate          openapi_types.Date                    `json:"start_date"`
-	TenantId           openapi_types.UUID                    `json:"tenant_id"`
+
+	// StartingMeterReading Move-in starting meter reading. Backend uses it as the previous reading baseline for the first electricity bill in this lease.
+	StartingMeterReading *int               `json:"starting_meter_reading"`
+	TenantId             openapi_types.UUID `json:"tenant_id"`
 }
 
 // CreateLeaseRequestElectricityBillingCadence 可省略；若未提供則套用 Property 的 default_electricity_billing_cadence
@@ -1099,12 +1102,15 @@ type LeaseResponse struct {
 	RoomLabel                 *string                                 `json:"room_label,omitempty"`
 	SettlementDetail          *map[string]interface{}                 `json:"settlement_detail"`
 	StartDate                 *openapi_types.Date                     `json:"start_date,omitempty"`
-	Status                    *LeaseResponseStatus                    `json:"status,omitempty"`
-	TenantId                  *openapi_types.UUID                     `json:"tenant_id,omitempty"`
-	TenantLabel               *string                                 `json:"tenant_label,omitempty"`
-	TerminationReason         *string                                 `json:"termination_reason"`
-	UpdatedAt                 *time.Time                              `json:"updated_at,omitempty"`
-	Version                   *int                                    `json:"version,omitempty"`
+
+	// StartingMeterReading Move-in starting meter reading. Existing or legacy leases may be null.
+	StartingMeterReading *int                 `json:"starting_meter_reading"`
+	Status               *LeaseResponseStatus `json:"status,omitempty"`
+	TenantId             *openapi_types.UUID  `json:"tenant_id,omitempty"`
+	TenantLabel          *string              `json:"tenant_label,omitempty"`
+	TerminationReason    *string              `json:"termination_reason"`
+	UpdatedAt            *time.Time           `json:"updated_at,omitempty"`
+	Version              *int                 `json:"version,omitempty"`
 }
 
 // LeaseResponseDepositStatus defines model for LeaseResponse.DepositStatus.

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -1192,6 +1192,10 @@ func (s *APIServer) CreateLease(c *gin.Context) {
 	if request.RentBillingCadence != nil {
 		rentCadence = string(*request.RentBillingCadence)
 	}
+	if request.StartingMeterReading == nil {
+		c.Error(apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "starting_meter_reading"}))
+		return
+	}
 
 	lease, err := s.createLeaseSvc.Execute(c.Request.Context(), applease.CreateLeaseInput{
 		ActorRole:                 principal.Role,
@@ -1204,6 +1208,7 @@ func (s *APIServer) CreateLease(c *gin.Context) {
 		DepositAmount:             request.DepositAmount,
 		RentBillingCadence:        rentCadence,
 		ElectricityBillingCadence: cadence,
+		StartingMeterReading:      *request.StartingMeterReading,
 	})
 	if err != nil {
 		c.Error(err)
@@ -3738,6 +3743,7 @@ func toTenantLeaseResponse(lease *dbtenantquery.Lease) api.LeaseResponse {
 		UpdatedAt:                 &updatedAt,
 		Version:                   &version,
 	}
+	response.StartingMeterReading = lease.StartingMeterReading
 	if ok {
 		response.Id = &id
 	}
@@ -3765,6 +3771,7 @@ func toLeaseResponse(lease *dbleasequery.Lease) api.LeaseResponse {
 		EndDate:                   lease.EndDate,
 		RentBillingCadence:        lease.RentBillingCadence,
 		ElectricityBillingCadence: lease.ElectricityBillingCadence,
+		StartingMeterReading:      lease.StartingMeterReading,
 		Status:                    lease.Status,
 		DepositAmount:             lease.DepositAmount,
 		DepositRefundAmount:       lease.DepositRefundAmount,
@@ -3855,6 +3862,7 @@ func toCreatedLeaseResponse(lease *applease.Lease) api.LeaseResponse {
 		EndDate:                   lease.EndDate,
 		RentBillingCadence:        lease.RentBillingCadence,
 		ElectricityBillingCadence: lease.ElectricityBillingCadence,
+		StartingMeterReading:      lease.StartingMeterReading,
 		Status:                    lease.Status,
 		DepositAmount:             lease.DepositAmount,
 		DepositRefundAmount:       lease.DepositRefundAmount,

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -982,7 +982,8 @@ func TestCreateLeaseReturnsCreatedLease(t *testing.T) {
 		"rent_billing_cadence":"quarterly",
 		"start_date":"2026-05-01",
 		"end_date":"2026-12-31",
-		"deposit_amount":36000
+		"deposit_amount":36000,
+		"starting_meter_reading":1250
 	}`))
 	req.Header.Set("Authorization", "Bearer valid-token")
 	req.Header.Set("Content-Type", "application/json")
@@ -1027,6 +1028,9 @@ func TestCreateLeaseReturnsCreatedLease(t *testing.T) {
 	}
 	if createParams.DepositAmount != 36000 {
 		t.Fatalf("expected deposit_amount 36000, got %d", createParams.DepositAmount)
+	}
+	if createParams.StartingMeterReading != 1250 {
+		t.Fatalf("expected starting_meter_reading 1250, got %d", createParams.StartingMeterReading)
 	}
 	if !createParams.StartDate.Equal(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
 		t.Fatalf("expected start_date 2026-05-01, got %s", createParams.StartDate)
@@ -1073,7 +1077,8 @@ func TestCreateLeaseRejectsInvalidRentBillingCadence(t *testing.T) {
 		"rent_billing_cadence":"weekly",
 		"start_date":"2026-05-01",
 		"end_date":"2026-12-31",
-		"deposit_amount":36000
+		"deposit_amount":36000,
+		"starting_meter_reading":1250
 	}`))
 	req.Header.Set("Authorization", "Bearer valid-token")
 	req.Header.Set("Content-Type", "application/json")
@@ -1109,7 +1114,8 @@ func TestCreateLeaseRejectsMissingTenantID(t *testing.T) {
 		"rent_amount":18000,
 		"start_date":"2026-05-01",
 		"end_date":"2026-12-31",
-		"deposit_amount":36000
+		"deposit_amount":36000,
+		"starting_meter_reading":1250
 	}`))
 	req.Header.Set("Authorization", "Bearer valid-token")
 	req.Header.Set("Content-Type", "application/json")
@@ -1128,6 +1134,39 @@ func TestCreateLeaseRejectsMissingTenantID(t *testing.T) {
 	if payload["error_code"] != "VALIDATION_TENANT_ID_REQUIRED" {
 		t.Fatalf("expected VALIDATION_TENANT_ID_REQUIRED, got %v", payload["error_code"])
 	}
+}
+
+func TestCreateLeaseRejectsMissingStartingMeterReading(t *testing.T) {
+	engine := newTestEngineWithAllQueryRepos(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
+		fakeTenantQueryRepo{},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/leases", strings.NewReader(`{
+		"tenant_id":"30000000-0000-0000-0000-000000000001",
+		"room_id":"20000000-0000-0000-0000-000000000001",
+		"rent_amount":18000,
+		"start_date":"2026-05-01",
+		"end_date":"2026-12-31",
+		"deposit_amount":36000
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+	assertErrorField(t, resp.Body.Bytes(), "BAD_REQUEST", "starting_meter_reading")
 }
 
 func TestCreateLeaseRejectsUnassignedRoomProperty(t *testing.T) {
@@ -1170,7 +1209,8 @@ func TestCreateLeaseRejectsUnassignedRoomProperty(t *testing.T) {
 		"rent_amount":18000,
 		"start_date":"2026-05-01",
 		"end_date":"2026-12-31",
-		"deposit_amount":36000
+		"deposit_amount":36000,
+		"starting_meter_reading":1250
 	}`))
 	req.Header.Set("Authorization", "Bearer valid-token")
 	req.Header.Set("Content-Type", "application/json")
@@ -5448,9 +5488,11 @@ func (f fakeLeaseRepo) CreateLease(_ context.Context, _ *sql.Tx, params applease
 		return nil, f.createErr
 	}
 	if f.createdLease != nil {
+		f.createdLease.StartingMeterReading = &params.StartingMeterReading
 		return f.createdLease, nil
 	}
 
+	startingMeterReading := params.StartingMeterReading
 	return &applease.Lease{
 		ID:                        "40000000-0000-0000-0000-000000000001",
 		TenantID:                  "30000000-0000-0000-0000-000000000001",
@@ -5461,6 +5503,7 @@ func (f fakeLeaseRepo) CreateLease(_ context.Context, _ *sql.Tx, params applease
 		EndDate:                   time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
 		RentBillingCadence:        params.RentBillingCadence,
 		ElectricityBillingCadence: "monthly",
+		StartingMeterReading:      &startingMeterReading,
 		Status:                    "active",
 		DepositAmount:             36000,
 		DepositStatus:             "held",

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -708,7 +708,7 @@ func (r *SQLRepository) ListAccessible(ctx context.Context, scope Scope, filter 
 }
 
 // FindByIDAccessible returns one visible bill. Pending electricity bills with a NULL
-// previous reading receive the previous completed bill reading when one exists.
+// previous reading receive the previous completed lease reading or lease baseline.
 func (r *SQLRepository) FindByIDAccessible(ctx context.Context, billID string, scope Scope) (*Bill, error) {
 	filter := BillFilter{Limit: 1}
 	query, args, ok := buildAccessibleBillQuery(scope, filter, true, &billID)
@@ -725,7 +725,7 @@ func (r *SQLRepository) FindByIDAccessible(ctx context.Context, billID string, s
 	}
 
 	if bill.Type == "electricity" && bill.MeterPreviousReading == nil {
-		previous, err := r.FindPreviousMeterReading(ctx, bill.RoomID, bill.PeriodStart)
+		previous, err := r.FindPreviousMeterReading(ctx, bill.LeaseID, bill.PeriodStart)
 		if err != nil {
 			if !errors.Is(err, ErrNotFound) {
 				return nil, err
@@ -789,34 +789,40 @@ FOR UPDATE OF b
 	return bill, nil
 }
 
-// FindPreviousMeterReading returns the prior completed electricity reading for a room.
-func (r *SQLRepository) FindPreviousMeterReading(ctx context.Context, roomID string, periodStart time.Time) (int, error) {
-	return r.findPreviousMeterReading(ctx, r.db, roomID, periodStart, false)
+// FindPreviousMeterReading returns the prior completed electricity reading for a lease, or the lease baseline.
+func (r *SQLRepository) FindPreviousMeterReading(ctx context.Context, leaseID string, periodStart time.Time) (int, error) {
+	return r.findPreviousMeterReading(ctx, r.db, leaseID, periodStart, false)
 }
 
 // FindPreviousMeterReadingForUpdate returns the prior completed electricity reading inside a transaction.
-func (r *SQLRepository) FindPreviousMeterReadingForUpdate(ctx context.Context, tx *sql.Tx, roomID string, periodStart time.Time) (int, error) {
-	return r.findPreviousMeterReading(ctx, tx, roomID, periodStart, true)
+func (r *SQLRepository) FindPreviousMeterReadingForUpdate(ctx context.Context, tx *sql.Tx, leaseID string, periodStart time.Time) (int, error) {
+	return r.findPreviousMeterReading(ctx, tx, leaseID, periodStart, true)
 }
 
-func (r *SQLRepository) findPreviousMeterReading(ctx context.Context, queryer rowQueryer, roomID string, periodStart time.Time, forUpdate bool) (int, error) {
+func (r *SQLRepository) findPreviousMeterReading(ctx context.Context, queryer rowQueryer, leaseID string, periodStart time.Time, forUpdate bool) (int, error) {
 	query := `
-SELECT meter_current_reading
-FROM bills
-WHERE room_id = $1
-  AND type = 'electricity'
-  AND meter_current_reading IS NOT NULL
-  AND period_end < $2
-  AND deleted_at IS NULL
-ORDER BY period_end DESC, due_date DESC, created_at DESC
-LIMIT 1
+SELECT COALESCE(previous.meter_current_reading, l.starting_meter_reading, 0)
+FROM leases l
+LEFT JOIN LATERAL (
+	SELECT b.meter_current_reading
+	FROM bills b
+	WHERE b.lease_id = l.id
+	  AND b.type = 'electricity'
+	  AND b.meter_current_reading IS NOT NULL
+	  AND b.period_end < $2
+	  AND b.deleted_at IS NULL
+	ORDER BY b.period_end DESC, b.due_date DESC, b.created_at DESC
+	LIMIT 1
+) previous ON true
+WHERE l.id = $1
+  AND l.deleted_at IS NULL
 `
 	if forUpdate {
-		query += "FOR UPDATE\n"
+		query += "FOR UPDATE OF l\n"
 	}
 
 	var reading int
-	if err := queryer.QueryRowContext(ctx, query, roomID, periodStart).Scan(&reading); err != nil {
+	if err := queryer.QueryRowContext(ctx, query, leaseID, periodStart).Scan(&reading); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return 0, ErrNotFound
 		}
@@ -848,7 +854,7 @@ SELECT
 	b.payment_method,
 	b.paid_at,
 	b.paid_amount,
-	b.meter_previous_reading,
+	COALESCE(b.meter_previous_reading, previous.meter_current_reading, l.starting_meter_reading, 0),
 	b.meter_current_reading,
 	b.meter_unit_price,
 	b.meter_recorded_at,
@@ -859,8 +865,20 @@ SELECT
 	b.version
 FROM bills b
 JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL
+JOIN leases l ON l.id = b.lease_id AND l.deleted_at IS NULL
 LEFT JOIN rooms r ON r.id = b.room_id
 LEFT JOIN tenants t ON t.id = b.tenant_id
+LEFT JOIN LATERAL (
+	SELECT previous_bill.meter_current_reading
+	FROM bills previous_bill
+	WHERE previous_bill.lease_id = b.lease_id
+	  AND previous_bill.type = 'electricity'
+	  AND previous_bill.meter_current_reading IS NOT NULL
+	  AND previous_bill.period_end < b.period_start
+	  AND previous_bill.deleted_at IS NULL
+	ORDER BY previous_bill.period_end DESC, previous_bill.due_date DESC, previous_bill.created_at DESC
+	LIMIT 1
+) previous ON true
 WHERE b.property_id = $1
   AND b.type = 'electricity'
   AND b.status = 'pending_meter'

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -337,19 +337,9 @@ func TestFindByIDAccessibleComputesPreviousReadingWhenMissing(t *testing.T) {
 			periodStart, time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC), now, "pending_meter",
 			nil, nil, nil, nil, nil, nil, nil, nil, 0, now, now, 1,
 		))
-	mock.ExpectQuery(regexp.QuoteMeta(`
-SELECT meter_current_reading
-FROM bills
-WHERE room_id = $1
-  AND type = 'electricity'
-  AND meter_current_reading IS NOT NULL
-  AND period_end < $2
-  AND deleted_at IS NULL
-ORDER BY period_end DESC, due_date DESC, created_at DESC
-LIMIT 1
-`)).
-		WithArgs("room-1", periodStart).
-		WillReturnRows(sqlmock.NewRows([]string{"meter_current_reading"}).AddRow(1250))
+	mock.ExpectQuery(`(?s)SELECT COALESCE\(previous\.meter_current_reading, l\.starting_meter_reading, 0\)\s+FROM leases l\s+LEFT JOIN LATERAL.*WHERE l.id = \$1\s+AND l.deleted_at IS NULL`).
+		WithArgs("lease-1", periodStart).
+		WillReturnRows(sqlmock.NewRows([]string{"reading"}).AddRow(1250))
 
 	bill, err := repo.FindByIDAccessible(context.Background(), "bill-1", Scope{Role: "admin"})
 	if err != nil {
@@ -364,7 +354,7 @@ LIMIT 1
 	}
 }
 
-func TestFindByIDAccessiblePreservesNilPreviousReadingWhenNoHistory(t *testing.T) {
+func TestFindByIDAccessibleUsesZeroPreviousReadingWhenLegacyLeaseHasNoBaseline(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)
 
@@ -377,16 +367,16 @@ func TestFindByIDAccessiblePreservesNilPreviousReadingWhenNoHistory(t *testing.T
 			periodStart, time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC), now, "pending_meter",
 			nil, nil, nil, nil, nil, nil, nil, nil, 0, now, now, 1,
 		))
-	mock.ExpectQuery(`(?s)SELECT meter_current_reading\s+FROM bills.*period_end < \$2.*LIMIT 1`).
-		WithArgs("room-1", periodStart).
-		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`(?s)SELECT COALESCE\(previous\.meter_current_reading, l\.starting_meter_reading, 0\)\s+FROM leases l\s+LEFT JOIN LATERAL.*WHERE l.id = \$1\s+AND l.deleted_at IS NULL`).
+		WithArgs("lease-1", periodStart).
+		WillReturnRows(sqlmock.NewRows([]string{"reading"}).AddRow(0))
 
 	bill, err := repo.FindByIDAccessible(context.Background(), "bill-1", Scope{Role: "admin"})
 	if err != nil {
 		t.Fatalf("FindByIDAccessible: %v", err)
 	}
-	if bill.MeterPreviousReading != nil {
-		t.Fatalf("MeterPreviousReading = %v, want nil", bill.MeterPreviousReading)
+	if bill.MeterPreviousReading == nil || *bill.MeterPreviousReading != 0 {
+		t.Fatalf("MeterPreviousReading = %v, want 0", bill.MeterPreviousReading)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -394,26 +384,16 @@ func TestFindByIDAccessiblePreservesNilPreviousReadingWhenNoHistory(t *testing.T
 	}
 }
 
-func TestFindPreviousMeterReadingChoosesLatestSameRoomCompletedElectricityBill(t *testing.T) {
+func TestFindPreviousMeterReadingChoosesLatestSameLeaseCompletedElectricityBill(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)
 
 	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-SELECT meter_current_reading
-FROM bills
-WHERE room_id = $1
-  AND type = 'electricity'
-  AND meter_current_reading IS NOT NULL
-  AND period_end < $2
-  AND deleted_at IS NULL
-ORDER BY period_end DESC, due_date DESC, created_at DESC
-LIMIT 1
-`)).
-		WithArgs("room-1", periodStart).
-		WillReturnRows(sqlmock.NewRows([]string{"meter_current_reading"}).AddRow(1250))
+	mock.ExpectQuery(`(?s)SELECT COALESCE\(previous\.meter_current_reading, l\.starting_meter_reading, 0\)\s+FROM leases l\s+LEFT JOIN LATERAL.*WHERE l.id = \$1\s+AND l.deleted_at IS NULL`).
+		WithArgs("lease-1", periodStart).
+		WillReturnRows(sqlmock.NewRows([]string{"reading"}).AddRow(1250))
 
-	reading, err := repo.FindPreviousMeterReading(context.Background(), "room-1", periodStart)
+	reading, err := repo.FindPreviousMeterReading(context.Background(), "lease-1", periodStart)
 	if err != nil {
 		t.Fatalf("FindPreviousMeterReading: %v", err)
 	}
@@ -426,29 +406,18 @@ LIMIT 1
 	}
 }
 
-func TestFindPreviousMeterReadingForUpdateUsesTransaction(t *testing.T) {
+func TestFindPreviousMeterReadingForUpdateUsesLeaseBaselineInsideTransaction(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)
 
 	tx := beginBillingTx(t, db, mock)
 	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
-	mock.ExpectQuery(regexp.QuoteMeta(`
-SELECT meter_current_reading
-FROM bills
-WHERE room_id = $1
-  AND type = 'electricity'
-  AND meter_current_reading IS NOT NULL
-  AND period_end < $2
-  AND deleted_at IS NULL
-ORDER BY period_end DESC, due_date DESC, created_at DESC
-LIMIT 1
-FOR UPDATE
-`)).
-		WithArgs("room-1", periodStart).
-		WillReturnRows(sqlmock.NewRows([]string{"meter_current_reading"}).AddRow(1250))
+	mock.ExpectQuery(`(?s)SELECT COALESCE\(previous\.meter_current_reading, l\.starting_meter_reading, 0\)\s+FROM leases l\s+LEFT JOIN LATERAL.*WHERE l.id = \$1\s+AND l.deleted_at IS NULL\s+FOR UPDATE OF l`).
+		WithArgs("lease-1", periodStart).
+		WillReturnRows(sqlmock.NewRows([]string{"reading"}).AddRow(1250))
 	mock.ExpectCommit()
 
-	reading, err := repo.FindPreviousMeterReadingForUpdate(context.Background(), tx, "room-1", periodStart)
+	reading, err := repo.FindPreviousMeterReadingForUpdate(context.Background(), tx, "lease-1", periodStart)
 	if err != nil {
 		t.Fatalf("FindPreviousMeterReadingForUpdate: %v", err)
 	}
@@ -471,15 +440,12 @@ func TestListPropertyPendingMetersFiltersPendingMeterAndReturnsPeriodBounds(t *t
 	periodStart := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	periodEnd := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
 	now := time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC)
-	mock.ExpectQuery(`(?s)FROM bills b\s+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL.*WHERE b.property_id = \$1\s+AND b.type = 'electricity'\s+AND b.status = 'pending_meter'\s+AND b.deleted_at IS NULL`).
+	mock.ExpectQuery(`(?s)FROM bills b\s+JOIN properties p ON p.id = b.property_id AND p.deleted_at IS NULL\s+JOIN leases l ON l.id = b.lease_id AND l.deleted_at IS NULL.*LEFT JOIN LATERAL.*WHERE b.property_id = \$1\s+AND b.type = 'electricity'\s+AND b.status = 'pending_meter'\s+AND b.deleted_at IS NULL`).
 		WithArgs("property-1").
 		WillReturnRows(billRows().AddRow(
 			"bill-1", "lease-1", "tenant-1", "room-1", "property-1", "Property", "Room", "Tenant", "2026-04-01..2026-04-30", "electricity", nil,
-			periodStart, periodEnd, now, "pending_meter", nil, nil, nil, nil, nil, nil, nil, nil, 0, now, now, 1,
+			periodStart, periodEnd, now, "pending_meter", nil, nil, nil, 1250, nil, nil, nil, nil, 0, now, now, 1,
 		))
-	mock.ExpectQuery(`(?s)SELECT meter_current_reading\s+FROM bills\s+WHERE room_id = \$1\s+AND type = 'electricity'\s+AND meter_current_reading IS NOT NULL\s+AND period_end < \$2\s+AND deleted_at IS NULL\s+ORDER BY period_end DESC, due_date DESC, created_at DESC\s+LIMIT 1`).
-		WithArgs("room-1", periodStart).
-		WillReturnRows(sqlmock.NewRows([]string{"meter_current_reading"}).AddRow(1250))
 
 	bills, err := repo.ListPropertyPendingMeters(context.Background(), Scope{Role: "admin"}, "property-1")
 	if err != nil {

--- a/internal/platform/database/leasequery/repository.go
+++ b/internal/platform/database/leasequery/repository.go
@@ -27,6 +27,7 @@ type Lease struct {
 	EndDate                   time.Time
 	RentBillingCadence        string
 	ElectricityBillingCadence string
+	StartingMeterReading      *int
 	Status                    string
 	DepositAmount             int
 	DepositRefundAmount       *int
@@ -162,6 +163,7 @@ SELECT
 	l.end_date,
 	l.rent_billing_cadence,
 	l.electricity_billing_cadence,
+	l.starting_meter_reading,
 	l.status,
 	l.deposit_amount,
 	l.deposit_refund_amount,
@@ -247,6 +249,7 @@ SELECT
 	l.end_date,
 	l.rent_billing_cadence,
 	l.electricity_billing_cadence,
+	l.starting_meter_reading,
 	l.status,
 	l.deposit_amount,
 	l.deposit_refund_amount,
@@ -415,6 +418,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 	var lease Lease
 	var depositRefundAmount sql.NullInt64
 	var depositDeductionAmount sql.NullInt64
+	var startingMeterReading sql.NullInt64
 	var depositDeductionReason sql.NullString
 	var notes sql.NullString
 	var terminationReason sql.NullString
@@ -433,6 +437,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 		&lease.EndDate,
 		&lease.RentBillingCadence,
 		&lease.ElectricityBillingCadence,
+		&startingMeterReading,
 		&lease.Status,
 		&lease.DepositAmount,
 		&depositRefundAmount,
@@ -451,6 +456,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 
 	lease.DepositRefundAmount = nullIntPtr(depositRefundAmount)
 	lease.DepositDeductionAmount = nullIntPtr(depositDeductionAmount)
+	lease.StartingMeterReading = nullIntPtr(startingMeterReading)
 	lease.DepositDeductionReason = nullStringPtr(depositDeductionReason)
 	lease.Notes = nullStringPtr(notes)
 	lease.TerminationReason = nullStringPtr(terminationReason)

--- a/internal/platform/database/leasequery/repository_test.go
+++ b/internal/platform/database/leasequery/repository_test.go
@@ -29,7 +29,7 @@ WHERE l.deleted_at IS NULL
 		WithArgs(10, 20).
 		WillReturnRows(leaseQueryRows().AddRow(
 			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate,
-			"monthly", "monthly", "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
+			"monthly", "monthly", nil, "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 		))
 
 	result, err := repo.ListAccessible(context.Background(), "admin", []string{"property-ignored"}, ListParams{Limit: 10, Offset: 20})
@@ -174,12 +174,12 @@ func TestListAccessibleScansNullableFieldsAndSettlementDetail(t *testing.T) {
 		WillReturnRows(leaseQueryRows().
 			AddRow(
 				"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate,
-				"monthly", "monthly", "terminated", 24000, 18000, 6000, "refunded", "cleaning",
+				"monthly", "monthly", nil, "terminated", 24000, 18000, 6000, "refunded", "cleaning",
 				"tenant note", "early termination", `{"refund_method":"bank","deduction":6000}`, now, now, 2,
 			).
 			AddRow(
 				"lease-2", "tenant-2", "property-2", "room-2", "Property 2", "Tenant 2", "Room 2", 15000, startDate, endDate,
-				"monthly", "bi_monthly", "active", 30000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
+				"monthly", "bi_monthly", nil, "active", 30000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 			))
 
 	result, err := repo.ListAccessible(context.Background(), "admin", nil, ListParams{Limit: 10})
@@ -289,7 +289,7 @@ func TestFindByIDAccessibleAdminSuccess(t *testing.T) {
 		WithArgs("lease-1").
 		WillReturnRows(leaseQueryRows().AddRow(
 			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate,
-			"monthly", "monthly", "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
+			"monthly", "monthly", nil, "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 		))
 
 	lease, err := repo.FindByIDAccessible(context.Background(), "lease-1", "admin", []string{"property-ignored"})
@@ -325,7 +325,7 @@ func TestFindByIDAccessibleOrganizerAndStaffApplyAssignedPropertyScope(t *testin
 				WithArgs("lease-1", "property-1", "property-2").
 				WillReturnRows(leaseQueryRows().AddRow(
 					"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate,
-					"monthly", "monthly", "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
+					"monthly", "monthly", nil, "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 				))
 
 			lease, err := repo.FindByIDAccessible(context.Background(), "lease-1", tc.role, []string{"property-1", "property-2"})
@@ -405,7 +405,7 @@ func TestFindByIDAccessibleInvalidSettlementDetailReturnsError(t *testing.T) {
 		WithArgs("lease-1").
 		WillReturnRows(leaseQueryRows().AddRow(
 			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate,
-			"monthly", "monthly", "terminated", 24000, nil, nil, "held", nil, nil, nil, `{"broken"`, now, now, 1,
+			"monthly", "monthly", nil, "terminated", 24000, nil, nil, "held", nil, nil, nil, `{"broken"`, now, now, 1,
 		))
 
 	lease, err := repo.FindByIDAccessible(context.Background(), "lease-1", "admin", nil)
@@ -436,7 +436,7 @@ func TestFindByIDAccessibleScansRentBillingCadence(t *testing.T) {
 		WithArgs("lease-1").
 		WillReturnRows(leaseQueryRowsWithRentCadence().AddRow(
 			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 54000, startDate, endDate,
-			"quarterly", "monthly", "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
+			"quarterly", "monthly", 1250, "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 		))
 
 	lease, err := repo.FindByIDAccessible(context.Background(), "lease-1", "admin", nil)
@@ -486,6 +486,7 @@ func leaseQueryRows() *sqlmock.Rows {
 		"end_date",
 		"rent_billing_cadence",
 		"electricity_billing_cadence",
+		"starting_meter_reading",
 		"status",
 		"deposit_amount",
 		"deposit_refund_amount",
@@ -515,6 +516,7 @@ func leaseQueryRowsWithRentCadence() *sqlmock.Rows {
 		"end_date",
 		"rent_billing_cadence",
 		"electricity_billing_cadence",
+		"starting_meter_reading",
 		"status",
 		"deposit_amount",
 		"deposit_refund_amount",

--- a/internal/platform/database/leases/repository.go
+++ b/internal/platform/database/leases/repository.go
@@ -57,6 +57,7 @@ type Lease struct {
 	EndDate                   time.Time
 	RentBillingCadence        string
 	ElectricityBillingCadence string
+	StartingMeterReading      *int
 	Status                    string
 	DepositAmount             int
 	DepositRefundAmount       *int
@@ -95,6 +96,7 @@ type CreateLeaseParams struct {
 	EndDate                   time.Time
 	RentBillingCadence        string
 	ElectricityBillingCadence string
+	StartingMeterReading      int
 	DepositAmount             int
 	Notes                     *string
 }
@@ -461,6 +463,7 @@ SELECT
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -510,6 +513,7 @@ SELECT
 	l.end_date,
 	l.rent_billing_cadence,
 	l.electricity_billing_cadence,
+	l.starting_meter_reading,
 	l.status,
 	l.deposit_amount,
 	l.deposit_refund_amount,
@@ -566,10 +570,11 @@ INSERT INTO leases (
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	deposit_amount,
 	deposit_status,
 	notes
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'held', $10)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'held', $11)
 RETURNING
 	id,
 	tenant_id,
@@ -580,6 +585,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -603,6 +609,7 @@ RETURNING
 		params.EndDate,
 		params.RentBillingCadence,
 		params.ElectricityBillingCadence,
+		params.StartingMeterReading,
 		params.DepositAmount,
 		params.Notes,
 	))
@@ -634,6 +641,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -687,6 +695,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -961,6 +970,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -1007,6 +1017,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -1237,6 +1248,7 @@ func scanLeaseWithExtra(row rowScanner, extras ...interface{}) (*Lease, error) {
 	var lease Lease
 	var depositRefundAmount sql.NullInt64
 	var depositDeductionAmount sql.NullInt64
+	var startingMeterReading sql.NullInt64
 	var depositDeductionReason sql.NullString
 	var notes sql.NullString
 	var terminationReason sql.NullString
@@ -1252,6 +1264,7 @@ func scanLeaseWithExtra(row rowScanner, extras ...interface{}) (*Lease, error) {
 		&lease.EndDate,
 		&lease.RentBillingCadence,
 		&lease.ElectricityBillingCadence,
+		&startingMeterReading,
 		&lease.Status,
 		&lease.DepositAmount,
 		&depositRefundAmount,
@@ -1272,6 +1285,7 @@ func scanLeaseWithExtra(row rowScanner, extras ...interface{}) (*Lease, error) {
 
 	lease.DepositRefundAmount = nullIntPtr(depositRefundAmount)
 	lease.DepositDeductionAmount = nullIntPtr(depositDeductionAmount)
+	lease.StartingMeterReading = nullIntPtr(startingMeterReading)
 	lease.DepositDeductionReason = nullStringPtr(depositDeductionReason)
 	lease.Notes = nullStringPtr(notes)
 	lease.TerminationReason = nullStringPtr(terminationReason)

--- a/internal/platform/database/leases/repository_test.go
+++ b/internal/platform/database/leases/repository_test.go
@@ -94,6 +94,7 @@ func TestFindLeaseByIDForUpdateScansNullableFieldsAndSettlementDetail(t *testing
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -112,7 +113,7 @@ WHERE id = $1
 FOR UPDATE`)).
 		WithArgs("lease-1").
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly",
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", nil,
 			"terminated", 50000, 30000, 20000, "settled", "cleaning", "renewal candidate",
 			"tenant requested move-out", `{"deductions":[{"type":"cleaning","amount":20000}],"refund":30000}`,
 			now, now, 7,
@@ -168,10 +169,11 @@ func TestCreateLeasePersistsHeldDepositStatusAndNotes(t *testing.T) {
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	deposit_amount,
 	deposit_status,
 	notes
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'held', $10)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'held', $11)
 RETURNING
 	id,
 	tenant_id,
@@ -182,6 +184,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -194,9 +197,9 @@ RETURNING
 	created_at,
 	updated_at,
 	version`)).
-		WithArgs("tenant-1", "room-1", "property-1", 25000, startDate, endDate, "monthly", "monthly", 50000, &notes).
+		WithArgs("tenant-1", "room-1", "property-1", 25000, startDate, endDate, "monthly", "monthly", 1250, 50000, &notes).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly",
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", 1250,
 			"active", 50000, nil, nil, "held", nil, notes, nil, nil, now, now, 1,
 		))
 
@@ -209,6 +212,7 @@ RETURNING
 		EndDate:                   endDate,
 		RentBillingCadence:        "monthly",
 		ElectricityBillingCadence: "monthly",
+		StartingMeterReading:      1250,
 		DepositAmount:             50000,
 		Notes:                     &notes,
 	})
@@ -248,10 +252,11 @@ func TestCreateLeasePersistsAndReturnsRentBillingCadence(t *testing.T) {
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	deposit_amount,
 	deposit_status,
 	notes
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'held', $10)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'held', $11)
 RETURNING
 	id,
 	tenant_id,
@@ -262,6 +267,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -274,9 +280,9 @@ RETURNING
 	created_at,
 	updated_at,
 	version`)).
-		WithArgs("tenant-1", "room-1", "property-1", 54000, startDate, endDate, "quarterly", "monthly", 50000, nil).
+		WithArgs("tenant-1", "room-1", "property-1", 54000, startDate, endDate, "quarterly", "monthly", 1300, 50000, nil).
 		WillReturnRows(newLeaseRowsWithRentCadence().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 54000, startDate, endDate, "quarterly", "monthly",
+			"lease-1", "tenant-1", "property-1", "room-1", 54000, startDate, endDate, "quarterly", "monthly", 1300,
 			"active", 50000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 		))
 
@@ -289,6 +295,7 @@ RETURNING
 		EndDate:                   endDate,
 		RentBillingCadence:        "quarterly",
 		ElectricityBillingCadence: "monthly",
+		StartingMeterReading:      1300,
 		DepositAmount:             50000,
 	})
 	if err != nil {
@@ -411,6 +418,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -425,7 +433,7 @@ RETURNING
 	version`)).
 		WithArgs("lease-1", endDate, "tenant requested", nil).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly",
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", nil,
 			"terminated", 50000, nil, nil, "held", nil, nil, "tenant requested", nil, now, now, 2,
 		))
 
@@ -483,6 +491,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -497,7 +506,7 @@ RETURNING
 	version`)).
 		WithArgs("lease-1", endDate, "tenant requested", `{"ExportAvailable":true,"LeaseID":"lease-1","NetAmount":45000,"NetDirection":"refund"}`).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly",
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", nil,
 			"terminated", 50000, nil, nil, "held", nil, nil, "tenant requested",
 			`{"ExportAvailable":true,"LeaseID":"lease-1","NetAmount":45000,"NetDirection":"refund"}`,
 			now, now, 2,
@@ -548,6 +557,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -562,7 +572,7 @@ RETURNING
 	version`)).
 		WithArgs("lease-1", "breach", "forfeited").
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly",
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", nil,
 			"force_terminated", 50000, nil, nil, "forfeited", nil, nil, "breach", nil, now, now, 3,
 		))
 
@@ -611,6 +621,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -625,7 +636,7 @@ RETURNING
 	version`)).
 		WithArgs("lease-1", 28000).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 28000, startDate, endDate, "monthly", "monthly",
+			"lease-1", "tenant-1", "property-1", "room-1", 28000, startDate, endDate, "monthly", "monthly", nil,
 			"active", 50000, nil, nil, "held", nil, nil, nil, nil, now, now, 4,
 		))
 
@@ -677,6 +688,7 @@ RETURNING
 	end_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
+	starting_meter_reading,
 	status,
 	deposit_amount,
 	deposit_refund_amount,
@@ -691,7 +703,7 @@ RETURNING
 	version`)).
 		WithArgs("lease-1", 30000, 20000, reason).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly",
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", nil,
 			"terminated", 50000, 30000, 20000, "settled", reason, nil, nil, nil, now, now, 5,
 		))
 
@@ -1197,6 +1209,7 @@ func newLeaseRows() *sqlmock.Rows {
 		"end_date",
 		"rent_billing_cadence",
 		"electricity_billing_cadence",
+		"starting_meter_reading",
 		"status",
 		"deposit_amount",
 		"deposit_refund_amount",
@@ -1223,6 +1236,7 @@ func newLeaseRowsWithRentCadence() *sqlmock.Rows {
 		"end_date",
 		"rent_billing_cadence",
 		"electricity_billing_cadence",
+		"starting_meter_reading",
 		"status",
 		"deposit_amount",
 		"deposit_refund_amount",

--- a/internal/platform/database/migrate/migrations/000019_add_lease_starting_meter_reading.down.sql
+++ b/internal/platform/database/migrate/migrations/000019_add_lease_starting_meter_reading.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE leases
+    DROP CONSTRAINT IF EXISTS leases_starting_meter_reading_check,
+    DROP COLUMN IF EXISTS starting_meter_reading;

--- a/internal/platform/database/migrate/migrations/000019_add_lease_starting_meter_reading.up.sql
+++ b/internal/platform/database/migrate/migrations/000019_add_lease_starting_meter_reading.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE leases
+    ADD COLUMN starting_meter_reading INTEGER,
+    ADD CONSTRAINT leases_starting_meter_reading_check
+        CHECK (starting_meter_reading IS NULL OR starting_meter_reading >= 0);

--- a/internal/platform/database/migrate/runner_test.go
+++ b/internal/platform/database/migrate/runner_test.go
@@ -34,6 +34,7 @@ var expectedMigrationVersions = []string{
 	"000016",
 	"000017",
 	"000018",
+	"000019",
 }
 
 func TestRunnerUpAppliesMigrationsAndRecordsVersions(t *testing.T) {
@@ -79,8 +80,8 @@ func TestRunnerDownRollsBackAppliedMigrationsInDescendingOrder(t *testing.T) {
 	defer db.Close()
 
 	migrations := migrationsByVersion(t, "down")
-	appliedVersions := []string{"000012", "000013", "000014", "000015", "000016", "000017", "000018"}
-	expectedRollbackOrder := []string{"000018", "000017", "000016", "000015", "000014", "000013", "000012"}
+	appliedVersions := []string{"000012", "000013", "000014", "000015", "000016", "000017", "000018", "000019"}
+	expectedRollbackOrder := []string{"000019", "000018", "000017", "000016", "000015", "000014", "000013", "000012"}
 
 	expectSchemaMigrationsQuery(mock, appliedVersions)
 	for _, version := range expectedRollbackOrder {

--- a/internal/platform/database/tenantquery/repository.go
+++ b/internal/platform/database/tenantquery/repository.go
@@ -47,6 +47,7 @@ type Lease struct {
 	EndDate                   time.Time
 	RentBillingCadence        string
 	ElectricityBillingCadence string
+	StartingMeterReading      *int
 	Status                    string
 	DepositAmount             int
 	DepositRefundAmount       *int
@@ -262,6 +263,7 @@ SELECT
 	l.end_date,
 	l.rent_billing_cadence,
 	l.electricity_billing_cadence,
+	l.starting_meter_reading,
 	l.status,
 	l.deposit_amount,
 	l.deposit_refund_amount,
@@ -377,6 +379,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 	var lease Lease
 	var depositRefundAmount sql.NullInt64
 	var depositDeductionAmount sql.NullInt64
+	var startingMeterReading sql.NullInt64
 	var depositDeductionReason sql.NullString
 	var notes sql.NullString
 	var terminationReason sql.NullString
@@ -392,6 +395,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 		&lease.EndDate,
 		&lease.RentBillingCadence,
 		&lease.ElectricityBillingCadence,
+		&startingMeterReading,
 		&lease.Status,
 		&lease.DepositAmount,
 		&depositRefundAmount,
@@ -410,6 +414,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 
 	lease.DepositRefundAmount = nullIntPtr(depositRefundAmount)
 	lease.DepositDeductionAmount = nullIntPtr(depositDeductionAmount)
+	lease.StartingMeterReading = nullIntPtr(startingMeterReading)
 	lease.DepositDeductionReason = nullStringPtr(depositDeductionReason)
 	lease.Notes = nullStringPtr(notes)
 	lease.TerminationReason = nullStringPtr(terminationReason)

--- a/internal/platform/database/tenantquery/repository_test.go
+++ b/internal/platform/database/tenantquery/repository_test.go
@@ -201,6 +201,7 @@ LIMIT 1`)).
 	l.end_date,
 	l.rent_billing_cadence,
 	l.electricity_billing_cadence,
+	l.starting_meter_reading,
 	l.status,
 	l.deposit_amount,
 	l.deposit_refund_amount,
@@ -221,7 +222,7 @@ WHERE l.tenant_id = $1
 ORDER BY l.created_at DESC`)).
 		WithArgs("30000000-0000-0000-0000-000000000001", "10000000-0000-0000-0000-000000000001", "active").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "tenant_id", "property_id", "room_id", "rent_amount", "start_date", "end_date", "rent_billing_cadence", "electricity_billing_cadence", "status", "deposit_amount", "deposit_refund_amount", "deposit_deduction_amount", "deposit_status", "deposit_deduction_reason", "notes", "termination_reason", "settlement_detail", "created_at", "updated_at", "version",
+			"id", "tenant_id", "property_id", "room_id", "rent_amount", "start_date", "end_date", "rent_billing_cadence", "electricity_billing_cadence", "starting_meter_reading", "status", "deposit_amount", "deposit_refund_amount", "deposit_deduction_amount", "deposit_status", "deposit_deduction_reason", "notes", "termination_reason", "settlement_detail", "created_at", "updated_at", "version",
 		}).AddRow(
 			"40000000-0000-0000-0000-000000000001",
 			"30000000-0000-0000-0000-000000000001",
@@ -232,6 +233,7 @@ ORDER BY l.created_at DESC`)).
 			endDate,
 			"quarterly",
 			"monthly",
+			1250,
 			"active",
 			24000,
 			nil,

--- a/internal/server/billing_adapters.go
+++ b/internal/server/billing_adapters.go
@@ -375,12 +375,9 @@ func (a billingRepositoryAdapter) FindBillByIDForUpdate(ctx context.Context, tx 
 	return toAppBill(*bill), nil
 }
 
-func (a billingRepositoryAdapter) FindPreviousElectricityReading(ctx context.Context, tx *sql.Tx, roomID string, beforePeriodStart time.Time) (int, error) {
-	reading, err := a.repo.FindPreviousMeterReadingForUpdate(ctx, tx, roomID, beforePeriodStart)
+func (a billingRepositoryAdapter) FindPreviousElectricityReading(ctx context.Context, tx *sql.Tx, leaseID string, beforePeriodStart time.Time) (int, error) {
+	reading, err := a.repo.FindPreviousMeterReadingForUpdate(ctx, tx, leaseID, beforePeriodStart)
 	if err != nil {
-		if errors.Is(err, dbbilling.ErrNotFound) {
-			return 0, nil
-		}
 		return 0, mapBillingRepositoryError(err)
 	}
 

--- a/internal/server/lease_adapters.go
+++ b/internal/server/lease_adapters.go
@@ -132,6 +132,7 @@ func (a leaseRepositoryAdapter) CreateLease(ctx context.Context, tx *sql.Tx, par
 		EndDate:                   params.EndDate,
 		RentBillingCadence:        params.RentBillingCadence,
 		ElectricityBillingCadence: params.ElectricityBillingCadence,
+		StartingMeterReading:      params.StartingMeterReading,
 		DepositAmount:             params.DepositAmount,
 		Notes:                     params.Notes,
 	})
@@ -383,6 +384,7 @@ func toApplicationLease(lease *dbleases.Lease) *applease.Lease {
 		EndDate:                   lease.EndDate,
 		RentBillingCadence:        lease.RentBillingCadence,
 		ElectricityBillingCadence: lease.ElectricityBillingCadence,
+		StartingMeterReading:      lease.StartingMeterReading,
 		Status:                    lease.Status,
 		DepositAmount:             lease.DepositAmount,
 		DepositRefundAmount:       lease.DepositRefundAmount,

--- a/internal/server/server_wiring_test.go
+++ b/internal/server/server_wiring_test.go
@@ -264,6 +264,7 @@ func TestLeaseMappingsPreserveContractFields(t *testing.T) {
 	notes := "renewal"
 	terminationReason := "tenant_request"
 	settlementDetail := map[string]interface{}{"refund": float64(1000)}
+	startingMeterReading := 1250
 
 	lease := toApplicationLease(&dbleases.Lease{
 		ID:                        "lease-1",
@@ -274,6 +275,7 @@ func TestLeaseMappingsPreserveContractFields(t *testing.T) {
 		StartDate:                 startDate,
 		EndDate:                   endDate,
 		ElectricityBillingCadence: "monthly",
+		StartingMeterReading:      &startingMeterReading,
 		Status:                    "terminated",
 		DepositAmount:             36000,
 		DepositRefundAmount:       &refundAmount,
@@ -296,6 +298,7 @@ func TestLeaseMappingsPreserveContractFields(t *testing.T) {
 		StartDate:                 startDate,
 		EndDate:                   endDate,
 		ElectricityBillingCadence: "monthly",
+		StartingMeterReading:      &startingMeterReading,
 		Status:                    "terminated",
 		DepositAmount:             36000,
 		DepositRefundAmount:       &refundAmount,

--- a/test/e2e/billing_payment_report_test.go
+++ b/test/e2e/billing_payment_report_test.go
@@ -87,11 +87,11 @@ func TestE2EBillingPaymentAndFinancialReportAcceptance(t *testing.T) {
 	if electricityBill.Status != "pending_payment" {
 		t.Fatalf("expected electricity bill status pending_payment, got %q", electricityBill.Status)
 	}
-	if electricityBill.Amount == nil || *electricityBill.Amount != 540 {
-		t.Fatalf("expected electricity amount 540, got %+v", electricityBill.Amount)
+	if electricityBill.Amount == nil || *electricityBill.Amount != 315 {
+		t.Fatalf("expected electricity amount 315, got %+v", electricityBill.Amount)
 	}
-	if electricityBill.MeterPreviousReading == nil || *electricityBill.MeterPreviousReading != 0 {
-		t.Fatalf("expected meter_previous_reading 0, got %+v", electricityBill.MeterPreviousReading)
+	if electricityBill.MeterPreviousReading == nil || *electricityBill.MeterPreviousReading != 50 {
+		t.Fatalf("expected meter_previous_reading 50, got %+v", electricityBill.MeterPreviousReading)
 	}
 	if electricityBill.MeterCurrentReading == nil || *electricityBill.MeterCurrentReading != 120 {
 		t.Fatalf("expected meter_current_reading 120, got %+v", electricityBill.MeterCurrentReading)
@@ -136,6 +136,7 @@ type billingFlowE2ELeaseResponse struct {
 	StartDate                 string `json:"start_date"`
 	EndDate                   string `json:"end_date"`
 	ElectricityBillingCadence string `json:"electricity_billing_cadence"`
+	StartingMeterReading      *int   `json:"starting_meter_reading"`
 	DepositAmount             int    `json:"deposit_amount"`
 	DepositStatus             string `json:"deposit_status"`
 	Status                    string `json:"status"`
@@ -246,6 +247,7 @@ func billingFlowE2ECreateLease(t *testing.T, ctx context.Context, client apiClie
 		"end_date":                    endDate.Format("2006-01-02"),
 		"deposit_amount":              36000,
 		"electricity_billing_cadence": "monthly",
+		"starting_meter_reading":      50,
 	}
 	resp, body, err := client.postJSON(ctx, "/api/v1/leases", request)
 	if err != nil {
@@ -257,6 +259,9 @@ func billingFlowE2ECreateLease(t *testing.T, ctx context.Context, client apiClie
 	decodeJSON(t, body, &lease)
 	if lease.ID == "" {
 		t.Fatalf("expected lease id in response: %s", string(body))
+	}
+	if lease.StartingMeterReading == nil || *lease.StartingMeterReading != 50 {
+		t.Fatalf("expected starting_meter_reading 50, got %+v", lease.StartingMeterReading)
 	}
 	if lease.TenantID != tenantID {
 		t.Fatalf("expected lease tenant_id %q, got %q", tenantID, lease.TenantID)

--- a/test/e2e/lease_billing_lifecycle_test.go
+++ b/test/e2e/lease_billing_lifecycle_test.go
@@ -221,6 +221,7 @@ type leaseLifecycleE2ECreateLeaseParams struct {
 	Cadence                   string
 	RentCadence               string
 	ElectricityBillingCadence string
+	StartingMeterReading      int
 }
 
 type leaseLifecycleE2ELeaseResponse struct {
@@ -233,6 +234,7 @@ type leaseLifecycleE2ELeaseResponse struct {
 	StartDate                 string  `json:"start_date"`
 	EndDate                   string  `json:"end_date"`
 	ElectricityBillingCadence string  `json:"electricity_billing_cadence"`
+	StartingMeterReading      *int    `json:"starting_meter_reading"`
 	Status                    string  `json:"status"`
 	DepositAmount             int     `json:"deposit_amount"`
 	DepositStatus             string  `json:"deposit_status"`
@@ -313,6 +315,7 @@ func leaseLifecycleE2ECreateLease(t *testing.T, ctx context.Context, client apiC
 		"end_date":                    params.EndDate,
 		"deposit_amount":              params.Deposit,
 		"electricity_billing_cadence": leaseLifecycleE2EElectricityCadence(params),
+		"starting_meter_reading":      leaseLifecycleE2EStartingMeterReading(params),
 	}
 	if params.RentCadence != "" {
 		request["rent_billing_cadence"] = params.RentCadence
@@ -336,6 +339,13 @@ func leaseLifecycleE2EElectricityCadence(params leaseLifecycleE2ECreateLeasePara
 		return params.ElectricityBillingCadence
 	}
 	return params.Cadence
+}
+
+func leaseLifecycleE2EStartingMeterReading(params leaseLifecycleE2ECreateLeaseParams) int {
+	if params.StartingMeterReading != 0 {
+		return params.StartingMeterReading
+	}
+	return 50
 }
 
 func leaseLifecycleE2EGetLease(t *testing.T, ctx context.Context, client apiClient, leaseID string) leaseLifecycleE2ELeaseResponse {
@@ -462,6 +472,9 @@ func leaseLifecycleE2ERequireLease(t *testing.T, lease leaseLifecycleE2ELeaseRes
 	}
 	if lease.ElectricityBillingCadence != leaseLifecycleE2EElectricityCadence(expected) {
 		t.Fatalf("expected electricity_billing_cadence %q, got %q", leaseLifecycleE2EElectricityCadence(expected), lease.ElectricityBillingCadence)
+	}
+	if lease.StartingMeterReading == nil || *lease.StartingMeterReading != leaseLifecycleE2EStartingMeterReading(expected) {
+		t.Fatalf("expected starting_meter_reading %d, got %+v", leaseLifecycleE2EStartingMeterReading(expected), lease.StartingMeterReading)
 	}
 	if lease.RentAmount != expected.RentAmount {
 		t.Fatalf("expected rent_amount %d, got %d", expected.RentAmount, lease.RentAmount)

--- a/test/e2e/lease_termination_acceptance_test.go
+++ b/test/e2e/lease_termination_acceptance_test.go
@@ -186,6 +186,7 @@ type terminationE2ELeaseResponse struct {
 	StartDate                 string `json:"start_date"`
 	EndDate                   string `json:"end_date"`
 	ElectricityBillingCadence string `json:"electricity_billing_cadence"`
+	StartingMeterReading      *int   `json:"starting_meter_reading"`
 	Status                    string `json:"status"`
 	DepositAmount             int    `json:"deposit_amount"`
 	DepositStatus             string `json:"deposit_status"`
@@ -284,6 +285,7 @@ func terminationE2ECreateLease(t *testing.T, ctx context.Context, client apiClie
 		"end_date":                    "2026-08-31",
 		"deposit_amount":              36000,
 		"electricity_billing_cadence": "monthly",
+		"starting_meter_reading":      50,
 	}
 	resp, body, err := client.postJSON(ctx, "/api/v1/leases", request)
 	if err != nil {


### PR DESCRIPTION
Closes #138

## Summary
- add `starting_meter_reading` to lease creation and lease responses
- persist the move-in meter baseline on leases with a nullable DB column for existing/legacy rows
- use the lease baseline as the first electricity bill previous reading when no prior same-lease reading exists
- expose backend-computed previous readings in pending-meter and bill reads
- keep true bulk meter submit out of scope; frontend can use pending-meter plus per-bill meter submit

## Frontend handoff
- Posted on #138: https://github.com/ifan0927/STDS_backend_go/issues/138#issuecomment-4408827981
- Frontend must send `starting_meter_reading` on `POST /leases`; explicit `0` is valid, omission is rejected.

## Validation
- `npm run openapi:generate`
- `npm run openapi:lint`
- `GOCACHE=/tmp/go-cache go test ./...`
- `GOCACHE=/tmp/go-cache ./scripts/e2e_test.sh -run TestE2EBillingPaymentAndFinancialReportAcceptance -count=1`

## Notes
The targeted E2E was run with local PostgreSQL, Firebase Auth Emulator, and E2E API server. The emulator/API processes were stopped after the run.