### PR TITLE
[codex] Implement issue 133 writable schema cleanup

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -7268,8 +7268,8 @@ components:
           type: string
           nullable: true
         facilities:
-          type: array
-          items: {}
+          type: object
+          additionalProperties: true
           nullable: true
         occupancy_summary:
           $ref: '#/components/schemas/OccupancySummary'
@@ -7299,6 +7299,9 @@ components:
       properties:
         name:
           type: string
+        subtitle:
+          type: string
+          nullable: true
         address:
           type: string
         electricity_unit_price:
@@ -7316,11 +7319,28 @@ components:
         owner_id:
           type: string
           format: uuid
+        contact_phone:
+          type: string
+          nullable: true
+        contact_email:
+          type: string
+          format: email
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        facilities:
+          type: object
+          additionalProperties: true
+          nullable: true
     UpdatePropertyRequest:
       type: object
       properties:
         name:
           type: string
+        subtitle:
+          type: string
+          nullable: true
         address:
           type: string
         electricity_unit_price:
@@ -7335,6 +7355,20 @@ components:
             - monthly
             - bimonthly
           description: 僅影響之後新建的 Lease，不回頭修改既有 Lease
+        contact_phone:
+          type: string
+          nullable: true
+        contact_email:
+          type: string
+          format: email
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        facilities:
+          type: object
+          additionalProperties: true
+          nullable: true
     AttachmentResponse:
       type: object
       properties:
@@ -7441,11 +7475,57 @@ components:
       properties:
         name:
           type: string
+        size:
+          type: number
+          format: double
+          nullable: true
+        floor:
+          type: string
+          nullable: true
+        room_type:
+          type: string
+          nullable: true
+        facilities:
+          type: object
+          additionalProperties: true
+          nullable: true
+        default_rent_amount:
+          type: integer
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        zone:
+          type: string
+          nullable: true
     UpdateRoomRequest:
       type: object
       properties:
         name:
           type: string
+        size:
+          type: number
+          format: double
+          nullable: true
+        floor:
+          type: string
+          nullable: true
+        room_type:
+          type: string
+          nullable: true
+        facilities:
+          type: object
+          additionalProperties: true
+          nullable: true
+        default_rent_amount:
+          type: integer
+          nullable: true
+        notes:
+          type: string
+          nullable: true
+        zone:
+          type: string
+          nullable: true
     SetMaintenanceRequest:
       type: object
       required:
@@ -7579,6 +7659,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/DashboardRecentJournalItem'
+    TenantContact:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          nullable: true
+        phone:
+          type: string
+          nullable: true
+        email:
+          type: string
+          format: email
+          nullable: true
+        relation:
+          type: string
+          nullable: true
+        notes:
+          type: string
+          nullable: true
     TenantResponse:
       type: object
       properties:
@@ -7597,7 +7697,7 @@ components:
         contacts:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/TenantContact'
         birth_date:
           type: string
           format: date
@@ -7649,7 +7749,20 @@ components:
         contacts:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/TenantContact'
+        birth_date:
+          type: string
+          format: date
+          nullable: true
+        national_id:
+          type: string
+          nullable: true
+        address:
+          type: string
+          nullable: true
+        occupation:
+          type: string
+          nullable: true
     UpdateTenantRequest:
       type: object
       properties:
@@ -7663,7 +7776,20 @@ components:
         contacts:
           type: array
           items:
-            type: object
+            $ref: '#/components/schemas/TenantContact'
+        birth_date:
+          type: string
+          format: date
+          nullable: true
+        national_id:
+          type: string
+          nullable: true
+        address:
+          type: string
+          nullable: true
+        occupation:
+          type: string
+          nullable: true
     LeaseResponse:
       type: object
       properties:
@@ -7806,6 +7932,9 @@ components:
           minimum: 0
           description: Move-in starting meter reading. Backend uses it as the previous reading baseline for the first electricity bill in this lease.
           x-go-type: '*int'
+        notes:
+          type: string
+          nullable: true
     LeaseCheckoutReviewResponse:
       type: object
       properties:
@@ -7893,14 +8022,6 @@ components:
       properties:
         rent_amount:
           type: integer
-        rent_billing_cadence:
-          type: string
-          enum:
-            - monthly
-            - quarterly
-            - semiannual
-            - annual
-          description: 不支援透過 PATCH 修改；若需更動 rent cadence，請使用 Lease replacement。
         end_date:
           type: string
           format: date

--- a/docs/spec/src/components/schemas/property/CreatePropertyRequest.yaml
+++ b/docs/spec/src/components/schemas/property/CreatePropertyRequest.yaml
@@ -8,6 +8,9 @@ required:
 properties:
   name:
     type: string
+  subtitle:
+    type: string
+    nullable: true
   address:
     type: string
   electricity_unit_price:
@@ -25,3 +28,17 @@ properties:
   owner_id:
     type: string
     format: uuid
+  contact_phone:
+    type: string
+    nullable: true
+  contact_email:
+    type: string
+    format: email
+    nullable: true
+  notes:
+    type: string
+    nullable: true
+  facilities:
+    type: object
+    additionalProperties: true
+    nullable: true

--- a/docs/spec/src/components/schemas/property/CreateRoomRequest.yaml
+++ b/docs/spec/src/components/schemas/property/CreateRoomRequest.yaml
@@ -4,3 +4,26 @@ required:
 properties:
   name:
     type: string
+  size:
+    type: number
+    format: double
+    nullable: true
+  floor:
+    type: string
+    nullable: true
+  room_type:
+    type: string
+    nullable: true
+  facilities:
+    type: object
+    additionalProperties: true
+    nullable: true
+  default_rent_amount:
+    type: integer
+    nullable: true
+  notes:
+    type: string
+    nullable: true
+  zone:
+    type: string
+    nullable: true

--- a/docs/spec/src/components/schemas/property/PropertyResponse.yaml
+++ b/docs/spec/src/components/schemas/property/PropertyResponse.yaml
@@ -36,8 +36,8 @@ properties:
     type: string
     nullable: true
   facilities:
-    type: array
-    items: {}
+    type: object
+    additionalProperties: true
     nullable: true
   occupancy_summary:
     $ref: ./OccupancySummary.yaml

--- a/docs/spec/src/components/schemas/property/UpdatePropertyRequest.yaml
+++ b/docs/spec/src/components/schemas/property/UpdatePropertyRequest.yaml
@@ -2,6 +2,9 @@ type: object
 properties:
   name:
     type: string
+  subtitle:
+    type: string
+    nullable: true
   address:
     type: string
   electricity_unit_price:
@@ -16,3 +19,17 @@ properties:
       - monthly
       - bimonthly
     description: 僅影響之後新建的 Lease，不回頭修改既有 Lease
+  contact_phone:
+    type: string
+    nullable: true
+  contact_email:
+    type: string
+    format: email
+    nullable: true
+  notes:
+    type: string
+    nullable: true
+  facilities:
+    type: object
+    additionalProperties: true
+    nullable: true

--- a/docs/spec/src/components/schemas/property/UpdateRoomRequest.yaml
+++ b/docs/spec/src/components/schemas/property/UpdateRoomRequest.yaml
@@ -2,3 +2,26 @@ type: object
 properties:
   name:
     type: string
+  size:
+    type: number
+    format: double
+    nullable: true
+  floor:
+    type: string
+    nullable: true
+  room_type:
+    type: string
+    nullable: true
+  facilities:
+    type: object
+    additionalProperties: true
+    nullable: true
+  default_rent_amount:
+    type: integer
+    nullable: true
+  notes:
+    type: string
+    nullable: true
+  zone:
+    type: string
+    nullable: true

--- a/docs/spec/src/components/schemas/tenancy/CreateLeaseRequest.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CreateLeaseRequest.yaml
@@ -43,3 +43,6 @@ properties:
     minimum: 0
     description: Move-in starting meter reading. Backend uses it as the previous reading baseline for the first electricity bill in this lease.
     x-go-type: '*int'
+  notes:
+    type: string
+    nullable: true

--- a/docs/spec/src/components/schemas/tenancy/CreateTenantRequest.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CreateTenantRequest.yaml
@@ -13,4 +13,17 @@ properties:
   contacts:
     type: array
     items:
-      type: object
+      $ref: ./TenantContact.yaml
+  birth_date:
+    type: string
+    format: date
+    nullable: true
+  national_id:
+    type: string
+    nullable: true
+  address:
+    type: string
+    nullable: true
+  occupation:
+    type: string
+    nullable: true

--- a/docs/spec/src/components/schemas/tenancy/TenantContact.yaml
+++ b/docs/spec/src/components/schemas/tenancy/TenantContact.yaml
@@ -1,0 +1,19 @@
+type: object
+additionalProperties: false
+properties:
+  name:
+    type: string
+    nullable: true
+  phone:
+    type: string
+    nullable: true
+  email:
+    type: string
+    format: email
+    nullable: true
+  relation:
+    type: string
+    nullable: true
+  notes:
+    type: string
+    nullable: true

--- a/docs/spec/src/components/schemas/tenancy/TenantResponse.yaml
+++ b/docs/spec/src/components/schemas/tenancy/TenantResponse.yaml
@@ -15,7 +15,7 @@ properties:
   contacts:
     type: array
     items:
-      type: object
+      $ref: ./TenantContact.yaml
   birth_date:
     type: string
     format: date

--- a/docs/spec/src/components/schemas/tenancy/UpdateLeaseRequest.yaml
+++ b/docs/spec/src/components/schemas/tenancy/UpdateLeaseRequest.yaml
@@ -2,14 +2,6 @@ type: object
 properties:
   rent_amount:
     type: integer
-  rent_billing_cadence:
-    type: string
-    enum:
-      - monthly
-      - quarterly
-      - semiannual
-      - annual
-    description: 不支援透過 PATCH 修改；若需更動 rent cadence，請使用 Lease replacement。
   end_date:
     type: string
     format: date

--- a/docs/spec/src/components/schemas/tenancy/UpdateTenantRequest.yaml
+++ b/docs/spec/src/components/schemas/tenancy/UpdateTenantRequest.yaml
@@ -10,4 +10,17 @@ properties:
   contacts:
     type: array
     items:
-      type: object
+      $ref: ./TenantContact.yaml
+  birth_date:
+    type: string
+    format: date
+    nullable: true
+  national_id:
+    type: string
+    nullable: true
+  address:
+    type: string
+    nullable: true
+  occupation:
+    type: string
+    nullable: true

--- a/internal/application/lease/create_lease.go
+++ b/internal/application/lease/create_lease.go
@@ -38,6 +38,7 @@ type CreateLeaseInput struct {
 	RentBillingCadence        string
 	ElectricityBillingCadence *string
 	StartingMeterReading      int
+	Notes                     *string
 }
 
 // CreateLeaseService creates a lease and pre-generates bills.
@@ -142,6 +143,7 @@ func (s *CreateLeaseService) Execute(ctx context.Context, input CreateLeaseInput
 			ElectricityBillingCadence: state.ElectricityBillingCadence,
 			StartingMeterReading:      input.StartingMeterReading,
 			DepositAmount:             state.DepositAmount,
+			Notes:                     trimmedOptionalString(input.Notes),
 		})
 		if err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)
@@ -191,6 +193,17 @@ func containsAssignedProperty(assignedPropertyIDs []string, propertyID string) b
 	}
 
 	return false
+}
+
+func trimmedOptionalString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
 }
 
 func buildBillSeeds(lease *Lease, rentPeriods []domainlease.BillingPeriod, electricityPeriods []domainlease.BillingPeriod) []CreateBillParams {

--- a/internal/application/property/create_property.go
+++ b/internal/application/property/create_property.go
@@ -15,10 +15,15 @@ import (
 // CreatePropertyInput is the command payload for creating a property.
 type CreatePropertyInput struct {
 	Name                             string
+	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+	ContactPhone                     *string
+	ContactEmail                     *string
+	Notes                            *string
+	Facilities                       *map[string]interface{}
 }
 
 // CreatePropertyService creates properties in a transaction and publishes the
@@ -44,10 +49,15 @@ func NewCreatePropertyService(propertyRepo Repository, propertyAccountRepo Prope
 func (s *CreatePropertyService) Execute(ctx context.Context, input CreatePropertyInput) (*Property, error) {
 	aggregate, err := domainproperty.New(domainproperty.State{
 		Name:                             input.Name,
+		Subtitle:                         input.Subtitle,
 		Address:                          input.Address,
 		ElectricityUnitPrice:             &input.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: input.DefaultElectricityBillingCadence,
 		OwnerID:                          input.OwnerID,
+		ContactPhone:                     input.ContactPhone,
+		ContactEmail:                     input.ContactEmail,
+		Notes:                            input.Notes,
+		Facilities:                       input.Facilities,
 	})
 	if err != nil {
 		switch {
@@ -67,10 +77,15 @@ func (s *CreatePropertyService) Execute(ctx context.Context, input CreatePropert
 		}
 		property, err := s.propertyRepo.Create(ctx, tx, CreatePropertyParams{
 			Name:                             state.Name,
+			Subtitle:                         state.Subtitle,
 			Address:                          state.Address,
 			ElectricityUnitPrice:             electricityUnitPrice,
 			DefaultElectricityBillingCadence: state.DefaultElectricityBillingCadence,
 			OwnerID:                          state.OwnerID,
+			ContactPhone:                     state.ContactPhone,
+			ContactEmail:                     state.ContactEmail,
+			Notes:                            state.Notes,
+			Facilities:                       state.Facilities,
 		})
 		if err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)

--- a/internal/application/property/create_property_test.go
+++ b/internal/application/property/create_property_test.go
@@ -23,10 +23,10 @@ func TestCreatePropertyServiceCreatesProperty(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("INSERT INTO properties").
-		WithArgs("Property A", "Address A", 4.5, "monthly", "owner-1").
+		WithArgs("Property A", nil, "Address A", 4.5, "monthly", "owner-1", nil, nil, nil, nil).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "name", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id", "created_at", "updated_at", "version",
-		}).AddRow("property-1", "Property A", "Address A", 4.5, "monthly", "owner-1", time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), 1))
+			"id", "name", "subtitle", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id", "contact_phone", "contact_email", "notes", "facilities", "created_at", "updated_at", "version",
+		}).AddRow("property-1", "Property A", nil, "Address A", 4.5, "monthly", "owner-1", nil, nil, nil, nil, time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), 1))
 	mock.ExpectExec("INSERT INTO property_accounts").
 		WithArgs("property-1").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -74,10 +74,15 @@ func (a sqlPropertyAccountRepositoryAdapter) CreatePropertyAccount(ctx context.C
 func (a sqlPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params CreatePropertyParams) (*Property, error) {
 	property, err := a.repo.Create(ctx, tx, dbproperties.CreatePropertyParams{
 		Name:                             params.Name,
+		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
 		OwnerID:                          params.OwnerID,
+		ContactPhone:                     params.ContactPhone,
+		ContactEmail:                     params.ContactEmail,
+		Notes:                            params.Notes,
+		Facilities:                       params.Facilities,
 	})
 	if err != nil {
 		return nil, err
@@ -86,10 +91,15 @@ func (a sqlPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, pa
 	return &Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
+		ContactPhone:                     property.ContactPhone,
+		ContactEmail:                     property.ContactEmail,
+		Notes:                            property.Notes,
+		Facilities:                       property.Facilities,
 		CreatedAt:                        property.CreatedAt,
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,

--- a/internal/application/property/create_room.go
+++ b/internal/application/property/create_room.go
@@ -13,8 +13,15 @@ import (
 
 // CreateRoomInput is the command payload for creating a room.
 type CreateRoomInput struct {
-	PropertyID string
-	Name       string
+	PropertyID        string
+	Name              string
+	Size              *float64
+	Floor             *string
+	RoomType          *string
+	Facilities        *map[string]interface{}
+	DefaultRentAmount *int
+	Notes             *string
+	Zone              *string
 }
 
 // CreateRoomService creates rooms within a property.
@@ -39,9 +46,16 @@ func (s *CreateRoomService) Execute(ctx context.Context, input CreateRoomInput) 
 	}
 
 	aggregate, err := domainproperty.NewRoom(domainproperty.RoomState{
-		PropertyID: propertyID,
-		Name:       input.Name,
-		Status:     domainproperty.RoomStatusVacant,
+		PropertyID:        propertyID,
+		Name:              input.Name,
+		Status:            domainproperty.RoomStatusVacant,
+		Size:              input.Size,
+		Floor:             input.Floor,
+		RoomType:          input.RoomType,
+		Facilities:        input.Facilities,
+		DefaultRentAmount: input.DefaultRentAmount,
+		Notes:             input.Notes,
+		Zone:              input.Zone,
 	})
 	if err != nil {
 		return nil, mapDomainError(err)
@@ -59,8 +73,15 @@ func (s *CreateRoomService) Execute(ctx context.Context, input CreateRoomInput) 
 		}
 
 		room, err := s.propertyRepo.CreateRoom(ctx, tx, CreateRoomParams{
-			PropertyID: propertyID,
-			Name:       aggregate.RoomState().Name,
+			PropertyID:        propertyID,
+			Name:              aggregate.RoomState().Name,
+			Size:              aggregate.RoomState().Size,
+			Floor:             aggregate.RoomState().Floor,
+			RoomType:          aggregate.RoomState().RoomType,
+			Facilities:        aggregate.RoomState().Facilities,
+			DefaultRentAmount: aggregate.RoomState().DefaultRentAmount,
+			Notes:             aggregate.RoomState().Notes,
+			Zone:              aggregate.RoomState().Zone,
 		})
 		if err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)

--- a/internal/application/property/repository.go
+++ b/internal/application/property/repository.go
@@ -14,10 +14,15 @@ var ErrPropertyNotFound = errors.New("property not found")
 type Property struct {
 	ID                               string
 	Name                             string
+	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+	ContactPhone                     *string
+	ContactEmail                     *string
+	Notes                            *string
+	Facilities                       *map[string]interface{}
 	CreatedAt                        time.Time
 	UpdatedAt                        time.Time
 	Version                          int
@@ -25,12 +30,19 @@ type Property struct {
 
 // Room is the application-facing room shape for room command use cases.
 type Room struct {
-	ID         string
-	PropertyID string
-	Name       string
-	Status     string
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	ID                string
+	PropertyID        string
+	Name              string
+	Status            string
+	Size              *float64
+	Floor             *string
+	RoomType          *string
+	Facilities        *map[string]interface{}
+	DefaultRentAmount *int
+	Notes             *string
+	Zone              *string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
 }
 
 // RepairRequest is the application-facing repair request shape for maintenance entry.
@@ -120,10 +132,15 @@ type DashboardRecentJournal struct {
 // property.
 type CreatePropertyParams struct {
 	Name                             string
+	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+	ContactPhone                     *string
+	ContactEmail                     *string
+	Notes                            *string
+	Facilities                       *map[string]interface{}
 }
 
 // CreatePropertyAccountParams contains the fields required to create the
@@ -137,24 +154,43 @@ type CreatePropertyAccountParams struct {
 type UpdatePropertyParams struct {
 	ID                               string
 	Name                             string
+	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+	ContactPhone                     *string
+	ContactEmail                     *string
+	Notes                            *string
+	Facilities                       *map[string]interface{}
 	Version                          int
 }
 
 // CreateRoomParams contains the writable fields required to create a room.
 type CreateRoomParams struct {
-	PropertyID string
-	Name       string
+	PropertyID        string
+	Name              string
+	Size              *float64
+	Floor             *string
+	RoomType          *string
+	Facilities        *map[string]interface{}
+	DefaultRentAmount *int
+	Notes             *string
+	Zone              *string
 }
 
 // UpdateRoomParams contains the writable fields required to persist a room update.
 type UpdateRoomParams struct {
-	ID     string
-	Name   string
-	Status *string
+	ID                string
+	Name              string
+	Status            *string
+	Size              *float64
+	Floor             *string
+	RoomType          *string
+	Facilities        *map[string]interface{}
+	DefaultRentAmount *int
+	Notes             *string
+	Zone              *string
 }
 
 // CreateRepairRequestParams contains the writable fields required to create a room-scoped repair request.

--- a/internal/application/property/update_property.go
+++ b/internal/application/property/update_property.go
@@ -16,9 +16,19 @@ type UpdatePropertyInput struct {
 	ID                               string
 	ActorRole                        string
 	Name                             *string
+	Subtitle                         *string
+	ClearSubtitle                    bool
 	Address                          *string
 	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence *string
+	ContactPhone                     *string
+	ClearContactPhone                bool
+	ContactEmail                     *string
+	ClearContactEmail                bool
+	Notes                            *string
+	ClearNotes                       bool
+	Facilities                       *map[string]interface{}
+	ClearFacilities                  bool
 }
 
 // UpdatePropertyService updates property fields while enforcing mutation rules.
@@ -47,7 +57,7 @@ func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropert
 	if strings.TrimSpace(input.ActorRole) == "" {
 		return nil, apperr.ErrUnauthorized
 	}
-	if input.Name == nil && input.Address == nil && input.ElectricityUnitPrice == nil && input.DefaultElectricityBillingCadence == nil {
+	if input.Name == nil && input.Subtitle == nil && !input.ClearSubtitle && input.Address == nil && input.ElectricityUnitPrice == nil && input.DefaultElectricityBillingCadence == nil && input.ContactPhone == nil && !input.ClearContactPhone && input.ContactEmail == nil && !input.ClearContactEmail && input.Notes == nil && !input.ClearNotes && input.Facilities == nil && !input.ClearFacilities {
 		return nil, apperr.ErrBadRequest
 	}
 
@@ -66,10 +76,15 @@ func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropert
 		aggregate, err := domainproperty.Rehydrate(domainproperty.State{
 			ID:                               current.ID,
 			Name:                             current.Name,
+			Subtitle:                         current.Subtitle,
 			Address:                          current.Address,
 			ElectricityUnitPrice:             current.ElectricityUnitPrice,
 			DefaultElectricityBillingCadence: current.DefaultElectricityBillingCadence,
 			OwnerID:                          current.OwnerID,
+			ContactPhone:                     current.ContactPhone,
+			ContactEmail:                     current.ContactEmail,
+			Notes:                            current.Notes,
+			Facilities:                       current.Facilities,
 			Version:                          current.Version,
 		})
 		if err != nil {
@@ -79,9 +94,19 @@ func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropert
 		if err := aggregate.Update(domainproperty.UpdateInput{
 			ActorRole:                        input.ActorRole,
 			Name:                             input.Name,
+			Subtitle:                         input.Subtitle,
+			ClearSubtitle:                    input.ClearSubtitle,
 			Address:                          input.Address,
 			ElectricityUnitPrice:             input.ElectricityUnitPrice,
 			DefaultElectricityBillingCadence: input.DefaultElectricityBillingCadence,
+			ContactPhone:                     input.ContactPhone,
+			ClearContactPhone:                input.ClearContactPhone,
+			ContactEmail:                     input.ContactEmail,
+			ClearContactEmail:                input.ClearContactEmail,
+			Notes:                            input.Notes,
+			ClearNotes:                       input.ClearNotes,
+			Facilities:                       input.Facilities,
+			ClearFacilities:                  input.ClearFacilities,
 		}); err != nil {
 			return mapDomainError(err)
 		}
@@ -90,10 +115,15 @@ func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropert
 		property, err := s.propertyRepo.Update(ctx, tx, UpdatePropertyParams{
 			ID:                               state.ID,
 			Name:                             state.Name,
+			Subtitle:                         state.Subtitle,
 			Address:                          state.Address,
 			ElectricityUnitPrice:             state.ElectricityUnitPrice,
 			DefaultElectricityBillingCadence: state.DefaultElectricityBillingCadence,
 			OwnerID:                          state.OwnerID,
+			ContactPhone:                     state.ContactPhone,
+			ContactEmail:                     state.ContactEmail,
+			Notes:                            state.Notes,
+			Facilities:                       state.Facilities,
 			Version:                          state.Version,
 		})
 		if err != nil {

--- a/internal/application/property/update_room.go
+++ b/internal/application/property/update_room.go
@@ -13,8 +13,22 @@ import (
 
 // UpdateRoomInput is the command payload for updating a room.
 type UpdateRoomInput struct {
-	ID   string
-	Name *string
+	ID                string
+	Name              *string
+	Size              *float64
+	ClearSize         bool
+	Floor             *string
+	ClearFloor        bool
+	RoomType          *string
+	ClearRoomType     bool
+	Facilities        *map[string]interface{}
+	ClearFacilities   bool
+	DefaultRentAmount *int
+	ClearDefaultRent  bool
+	Notes             *string
+	ClearNotes        bool
+	Zone              *string
+	ClearZone         bool
 }
 
 // UpdateRoomService updates room fields while enforcing mutation rules.
@@ -37,7 +51,7 @@ func (s *UpdateRoomService) Execute(ctx context.Context, input UpdateRoomInput) 
 	if roomID == "" {
 		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "id"})
 	}
-	if input.Name == nil {
+	if input.Name == nil && input.Size == nil && !input.ClearSize && input.Floor == nil && !input.ClearFloor && input.RoomType == nil && !input.ClearRoomType && input.Facilities == nil && !input.ClearFacilities && input.DefaultRentAmount == nil && !input.ClearDefaultRent && input.Notes == nil && !input.ClearNotes && input.Zone == nil && !input.ClearZone {
 		return nil, apperr.ErrBadRequest
 	}
 
@@ -54,24 +68,54 @@ func (s *UpdateRoomService) Execute(ctx context.Context, input UpdateRoomInput) 
 		}
 
 		aggregate, err := domainproperty.RehydrateRoom(domainproperty.RoomState{
-			ID:         current.ID,
-			PropertyID: current.PropertyID,
-			Name:       current.Name,
-			Status:     current.Status,
+			ID:                current.ID,
+			PropertyID:        current.PropertyID,
+			Name:              current.Name,
+			Status:            current.Status,
+			Size:              current.Size,
+			Floor:             current.Floor,
+			RoomType:          current.RoomType,
+			Facilities:        current.Facilities,
+			DefaultRentAmount: current.DefaultRentAmount,
+			Notes:             current.Notes,
+			Zone:              current.Zone,
 		})
 		if err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)
 		}
 
-		if err := aggregate.UpdateRoom(domainproperty.RoomUpdateInput{Name: input.Name}); err != nil {
+		if err := aggregate.UpdateRoom(domainproperty.RoomUpdateInput{
+			Name:              input.Name,
+			Size:              input.Size,
+			ClearSize:         input.ClearSize,
+			Floor:             input.Floor,
+			ClearFloor:        input.ClearFloor,
+			RoomType:          input.RoomType,
+			ClearRoomType:     input.ClearRoomType,
+			Facilities:        input.Facilities,
+			ClearFacilities:   input.ClearFacilities,
+			DefaultRentAmount: input.DefaultRentAmount,
+			ClearDefaultRent:  input.ClearDefaultRent,
+			Notes:             input.Notes,
+			ClearNotes:        input.ClearNotes,
+			Zone:              input.Zone,
+			ClearZone:         input.ClearZone,
+		}); err != nil {
 			return mapDomainError(err)
 		}
 
 		state := aggregate.RoomState()
 		room, err := s.propertyRepo.UpdateRoom(ctx, tx, UpdateRoomParams{
-			ID:     state.ID,
-			Name:   state.Name,
-			Status: nil,
+			ID:                state.ID,
+			Name:              state.Name,
+			Status:            nil,
+			Size:              state.Size,
+			Floor:             state.Floor,
+			RoomType:          state.RoomType,
+			Facilities:        state.Facilities,
+			DefaultRentAmount: state.DefaultRentAmount,
+			Notes:             state.Notes,
+			Zone:              state.Zone,
 		})
 		if err != nil {
 			switch {

--- a/internal/application/tenant/create_tenant.go
+++ b/internal/application/tenant/create_tenant.go
@@ -3,6 +3,7 @@ package tenant
 import (
 	"context"
 	"database/sql"
+	"time"
 
 	domaintenant "stds_backend/internal/domain/tenant"
 	"stds_backend/internal/platform/database/txrunner"
@@ -11,10 +12,14 @@ import (
 
 // CreateTenantInput is the command payload for creating a tenant.
 type CreateTenantInput struct {
-	Name     string
-	Email    string
-	Phone    *string
-	Contacts *[]map[string]interface{}
+	Name       string
+	Email      string
+	Phone      *string
+	Contacts   *[]map[string]interface{}
+	BirthDate  *time.Time
+	NationalID *string
+	Address    *string
+	Occupation *string
 }
 
 // CreateTenantService creates tenants in a transaction.
@@ -40,11 +45,15 @@ func (s *CreateTenantService) Execute(ctx context.Context, input CreateTenantInp
 	}
 
 	aggregate, err := domaintenant.New(domaintenant.State{
-		Name:     input.Name,
-		Email:    &email,
-		Phone:    input.Phone,
-		Contacts: contacts,
-		Status:   domaintenant.StatusActive,
+		Name:       input.Name,
+		Email:      &email,
+		Phone:      input.Phone,
+		Contacts:   contacts,
+		BirthDate:  input.BirthDate,
+		NationalID: input.NationalID,
+		Address:    input.Address,
+		Occupation: input.Occupation,
+		Status:     domaintenant.StatusActive,
 	})
 	if err != nil {
 		return nil, mapDomainError(err)
@@ -54,10 +63,14 @@ func (s *CreateTenantService) Execute(ctx context.Context, input CreateTenantInp
 	var created *Tenant
 	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
 		tenant, err := s.tenantRepo.Create(ctx, tx, CreateTenantParams{
-			Name:     state.Name,
-			Email:    state.Email,
-			Phone:    state.Phone,
-			Contacts: state.Contacts,
+			Name:       state.Name,
+			Email:      state.Email,
+			Phone:      state.Phone,
+			Contacts:   state.Contacts,
+			BirthDate:  state.BirthDate,
+			NationalID: state.NationalID,
+			Address:    state.Address,
+			Occupation: state.Occupation,
 		})
 		if err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)

--- a/internal/application/tenant/repository.go
+++ b/internal/application/tenant/repository.go
@@ -29,20 +29,28 @@ type Tenant struct {
 
 // CreateTenantParams contains the writable fields required to persist a tenant.
 type CreateTenantParams struct {
-	Name     string
-	Email    *string
-	Phone    *string
-	Contacts []map[string]interface{}
+	Name       string
+	Email      *string
+	Phone      *string
+	Contacts   []map[string]interface{}
+	BirthDate  *time.Time
+	NationalID *string
+	Address    *string
+	Occupation *string
 }
 
 // UpdateTenantParams contains the writable fields required to persist a tenant update.
 type UpdateTenantParams struct {
-	ID       string
-	Name     string
-	Email    *string
-	Phone    *string
-	Contacts []map[string]interface{}
-	Version  int
+	ID         string
+	Name       string
+	Email      *string
+	Phone      *string
+	Contacts   []map[string]interface{}
+	BirthDate  *time.Time
+	NationalID *string
+	Address    *string
+	Occupation *string
+	Version    int
 }
 
 // Repository defines persistence needed by tenant application services.

--- a/internal/application/tenant/update_tenant.go
+++ b/internal/application/tenant/update_tenant.go
@@ -15,11 +15,19 @@ import (
 
 // UpdateTenantInput is the command payload for updating a tenant.
 type UpdateTenantInput struct {
-	ID       string
-	Name     *string
-	Email    *string
-	Phone    *string
-	Contacts *[]map[string]interface{}
+	ID              string
+	Name            *string
+	Email           *string
+	Phone           *string
+	Contacts        *[]map[string]interface{}
+	BirthDate       *time.Time
+	ClearBirthDate  bool
+	NationalID      *string
+	ClearNationalID bool
+	Address         *string
+	ClearAddress    bool
+	Occupation      *string
+	ClearOccupation bool
 }
 
 // UpdateTenantService updates tenant fields and publishes TenantInfoUpdated after commit.
@@ -44,7 +52,7 @@ func (s *UpdateTenantService) Execute(ctx context.Context, input UpdateTenantInp
 	if tenantID == "" {
 		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "id"})
 	}
-	if input.Name == nil && input.Email == nil && input.Phone == nil && input.Contacts == nil {
+	if input.Name == nil && input.Email == nil && input.Phone == nil && input.Contacts == nil && input.BirthDate == nil && !input.ClearBirthDate && input.NationalID == nil && !input.ClearNationalID && input.Address == nil && !input.ClearAddress && input.Occupation == nil && !input.ClearOccupation {
 		return nil, apperr.ErrBadRequest
 	}
 
@@ -61,35 +69,51 @@ func (s *UpdateTenantService) Execute(ctx context.Context, input UpdateTenantInp
 		}
 
 		aggregate, err := domaintenant.Rehydrate(domaintenant.State{
-			ID:       current.ID,
-			Name:     current.Name,
-			Email:    current.Email,
-			Phone:    current.Phone,
-			Contacts: current.Contacts,
-			Status:   current.Status,
-			Version:  current.Version,
+			ID:         current.ID,
+			Name:       current.Name,
+			Email:      current.Email,
+			Phone:      current.Phone,
+			Contacts:   current.Contacts,
+			BirthDate:  current.BirthDate,
+			NationalID: current.NationalID,
+			Address:    current.Address,
+			Occupation: current.Occupation,
+			Status:     current.Status,
+			Version:    current.Version,
 		})
 		if err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)
 		}
 
 		if err := aggregate.Update(domaintenant.UpdateInput{
-			Name:     input.Name,
-			Email:    input.Email,
-			Phone:    input.Phone,
-			Contacts: input.Contacts,
+			Name:            input.Name,
+			Email:           input.Email,
+			Phone:           input.Phone,
+			Contacts:        input.Contacts,
+			BirthDate:       input.BirthDate,
+			ClearBirthDate:  input.ClearBirthDate,
+			NationalID:      input.NationalID,
+			ClearNationalID: input.ClearNationalID,
+			Address:         input.Address,
+			ClearAddress:    input.ClearAddress,
+			Occupation:      input.Occupation,
+			ClearOccupation: input.ClearOccupation,
 		}); err != nil {
 			return mapDomainError(err)
 		}
 
 		state := aggregate.State()
 		tenant, err := s.tenantRepo.Update(ctx, tx, UpdateTenantParams{
-			ID:       state.ID,
-			Name:     state.Name,
-			Email:    state.Email,
-			Phone:    state.Phone,
-			Contacts: state.Contacts,
-			Version:  state.Version,
+			ID:         state.ID,
+			Name:       state.Name,
+			Email:      state.Email,
+			Phone:      state.Phone,
+			Contacts:   state.Contacts,
+			BirthDate:  state.BirthDate,
+			NationalID: state.NationalID,
+			Address:    state.Address,
+			Occupation: state.Occupation,
+			Version:    state.Version,
 		})
 		if err != nil {
 			switch {

--- a/internal/domain/property/aggregate.go
+++ b/internal/domain/property/aggregate.go
@@ -1,6 +1,9 @@
 package property
 
-import "strings"
+import (
+	"reflect"
+	"strings"
+)
 
 const (
 	BillingCadenceMonthly   = "monthly"
@@ -14,24 +17,50 @@ const (
 type State struct {
 	ID                               string
 	Name                             string
+	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+	ContactPhone                     *string
+	ContactEmail                     *string
+	Notes                            *string
+	Facilities                       *map[string]interface{}
 	Version                          int
 }
 
 // RoomState is the persisted room state used by room command rules.
 type RoomState struct {
-	ID         string
-	PropertyID string
-	Name       string
-	Status     string
+	ID                string
+	PropertyID        string
+	Name              string
+	Status            string
+	Size              *float64
+	Floor             *string
+	RoomType          *string
+	Facilities        *map[string]interface{}
+	DefaultRentAmount *int
+	Notes             *string
+	Zone              *string
 }
 
 // RoomUpdateInput is the aggregate patch for room mutations.
 type RoomUpdateInput struct {
-	Name *string
+	Name              *string
+	Size              *float64
+	ClearSize         bool
+	Floor             *string
+	ClearFloor        bool
+	RoomType          *string
+	ClearRoomType     bool
+	Facilities        *map[string]interface{}
+	ClearFacilities   bool
+	DefaultRentAmount *int
+	ClearDefaultRent  bool
+	Notes             *string
+	ClearNotes        bool
+	Zone              *string
+	ClearZone         bool
 }
 
 // RoomAggregate owns room command rules.
@@ -43,9 +72,19 @@ type RoomAggregate struct {
 type UpdateInput struct {
 	ActorRole                        string
 	Name                             *string
+	Subtitle                         *string
+	ClearSubtitle                    bool
 	Address                          *string
 	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence *string
+	ContactPhone                     *string
+	ClearContactPhone                bool
+	ContactEmail                     *string
+	ClearContactEmail                bool
+	Notes                            *string
+	ClearNotes                       bool
+	Facilities                       *map[string]interface{}
+	ClearFacilities                  bool
 }
 
 // Aggregate owns property command business rules.
@@ -86,6 +125,11 @@ func (a *Aggregate) Update(input UpdateInput) error {
 		}
 		a.state.Name = name
 	}
+	if input.Subtitle != nil {
+		a.state.Subtitle = normalizeOptionalString(*input.Subtitle)
+	} else if input.ClearSubtitle {
+		a.state.Subtitle = nil
+	}
 
 	if input.Address != nil {
 		address := strings.TrimSpace(*input.Address)
@@ -112,6 +156,26 @@ func (a *Aggregate) Update(input UpdateInput) error {
 			return ErrInvalidBillingCadence
 		}
 		a.state.DefaultElectricityBillingCadence = cadence
+	}
+	if input.ContactPhone != nil {
+		a.state.ContactPhone = normalizeOptionalString(*input.ContactPhone)
+	} else if input.ClearContactPhone {
+		a.state.ContactPhone = nil
+	}
+	if input.ContactEmail != nil {
+		a.state.ContactEmail = normalizeOptionalString(*input.ContactEmail)
+	} else if input.ClearContactEmail {
+		a.state.ContactEmail = nil
+	}
+	if input.Notes != nil {
+		a.state.Notes = normalizeOptionalString(*input.Notes)
+	} else if input.ClearNotes {
+		a.state.Notes = nil
+	}
+	if input.Facilities != nil {
+		a.state.Facilities = cloneMapPtr(input.Facilities)
+	} else if input.ClearFacilities {
+		a.state.Facilities = nil
 	}
 
 	return nil
@@ -144,7 +208,14 @@ func (a *Aggregate) State() State {
 		return State{}
 	}
 
-	return a.state
+	snapshot := a.state
+	snapshot.Subtitle = cloneStringPtr(a.state.Subtitle)
+	snapshot.ElectricityUnitPrice = cloneFloat64Ptr(a.state.ElectricityUnitPrice)
+	snapshot.ContactPhone = cloneStringPtr(a.state.ContactPhone)
+	snapshot.ContactEmail = cloneStringPtr(a.state.ContactEmail)
+	snapshot.Notes = cloneStringPtr(a.state.Notes)
+	snapshot.Facilities = cloneMapPtr(a.state.Facilities)
+	return snapshot
 }
 
 func normalizeState(state State, requireElectricityPrice bool) (State, error) {
@@ -152,6 +223,7 @@ func normalizeState(state State, requireElectricityPrice bool) (State, error) {
 	if state.Name == "" {
 		return State{}, ErrNameRequired
 	}
+	state.Subtitle = normalizeOptionalStringPtr(state.Subtitle)
 
 	state.Address = strings.TrimSpace(state.Address)
 	if state.Address == "" {
@@ -175,6 +247,10 @@ func normalizeState(state State, requireElectricityPrice bool) (State, error) {
 	if state.OwnerID == "" {
 		return State{}, ErrOwnerIDRequired
 	}
+	state.ContactPhone = normalizeOptionalStringPtr(state.ContactPhone)
+	state.ContactEmail = normalizeOptionalStringPtr(state.ContactEmail)
+	state.Notes = normalizeOptionalStringPtr(state.Notes)
+	state.Facilities = cloneMapPtr(state.Facilities)
 
 	return state, nil
 }
@@ -214,7 +290,15 @@ func (a *RoomAggregate) RoomState() RoomState {
 		return RoomState{}
 	}
 
-	return a.state
+	snapshot := a.state
+	snapshot.Size = cloneFloat64Ptr(a.state.Size)
+	snapshot.Floor = cloneStringPtr(a.state.Floor)
+	snapshot.RoomType = cloneStringPtr(a.state.RoomType)
+	snapshot.Facilities = cloneMapPtr(a.state.Facilities)
+	snapshot.DefaultRentAmount = cloneIntPtr(a.state.DefaultRentAmount)
+	snapshot.Notes = cloneStringPtr(a.state.Notes)
+	snapshot.Zone = cloneStringPtr(a.state.Zone)
+	return snapshot
 }
 
 // UpdateRoom applies room mutation rules.
@@ -229,6 +313,43 @@ func (a *RoomAggregate) UpdateRoom(input RoomUpdateInput) error {
 			return ErrRoomNameRequired
 		}
 		a.state.Name = name
+	}
+	if input.Size != nil {
+		size := *input.Size
+		a.state.Size = &size
+	} else if input.ClearSize {
+		a.state.Size = nil
+	}
+	if input.Floor != nil {
+		a.state.Floor = normalizeOptionalString(*input.Floor)
+	} else if input.ClearFloor {
+		a.state.Floor = nil
+	}
+	if input.RoomType != nil {
+		a.state.RoomType = normalizeOptionalString(*input.RoomType)
+	} else if input.ClearRoomType {
+		a.state.RoomType = nil
+	}
+	if input.Facilities != nil {
+		a.state.Facilities = cloneMapPtr(input.Facilities)
+	} else if input.ClearFacilities {
+		a.state.Facilities = nil
+	}
+	if input.DefaultRentAmount != nil {
+		defaultRentAmount := *input.DefaultRentAmount
+		a.state.DefaultRentAmount = &defaultRentAmount
+	} else if input.ClearDefaultRent {
+		a.state.DefaultRentAmount = nil
+	}
+	if input.Notes != nil {
+		a.state.Notes = normalizeOptionalString(*input.Notes)
+	} else if input.ClearNotes {
+		a.state.Notes = nil
+	}
+	if input.Zone != nil {
+		a.state.Zone = normalizeOptionalString(*input.Zone)
+	} else if input.ClearZone {
+		a.state.Zone = nil
 	}
 
 	return nil
@@ -281,6 +402,11 @@ func normalizeRoomState(state RoomState, requireStatus bool) (RoomState, error) 
 	state.PropertyID = strings.TrimSpace(state.PropertyID)
 	state.Name = strings.TrimSpace(state.Name)
 	state.Status = strings.TrimSpace(state.Status)
+	state.Floor = normalizeOptionalStringPtr(state.Floor)
+	state.RoomType = normalizeOptionalStringPtr(state.RoomType)
+	state.Facilities = cloneMapPtr(state.Facilities)
+	state.Notes = normalizeOptionalStringPtr(state.Notes)
+	state.Zone = normalizeOptionalStringPtr(state.Zone)
 
 	if state.Name == "" {
 		return RoomState{}, ErrRoomNameRequired
@@ -298,5 +424,112 @@ func normalizeRoomState(state RoomState, requireStatus bool) (RoomState, error) 
 		return state, nil
 	default:
 		return RoomState{}, ErrBadRoomStatus
+	}
+}
+
+func normalizeOptionalStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	return normalizeOptionalString(*value)
+}
+
+func normalizeOptionalString(value string) *string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func cloneStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneIntPtr(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneFloat64Ptr(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneMapPtr(value *map[string]interface{}) *map[string]interface{} {
+	if value == nil {
+		return nil
+	}
+	cloned := make(map[string]interface{}, len(*value))
+	for key, item := range *value {
+		cloned[key] = deepCloneValue(item)
+	}
+	return &cloned
+}
+
+func deepCloneValue(value interface{}) interface{} {
+	if value == nil {
+		return nil
+	}
+	return deepCloneReflectValue(reflect.ValueOf(value)).Interface()
+}
+
+func deepCloneReflectValue(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return value
+	}
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := deepCloneReflectValue(value.Elem())
+		wrapped := reflect.New(value.Type()).Elem()
+		wrapped.Set(cloned)
+		return wrapped
+	case reflect.Ptr:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.New(value.Type().Elem())
+		cloned.Elem().Set(deepCloneReflectValue(value.Elem()))
+		return cloned
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iter := value.MapRange()
+		for iter.Next() {
+			cloned.SetMapIndex(deepCloneReflectValue(iter.Key()), deepCloneReflectValue(iter.Value()))
+		}
+		return cloned
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for index := 0; index < value.Len(); index++ {
+			cloned.Index(index).Set(deepCloneReflectValue(value.Index(index)))
+		}
+		return cloned
+	case reflect.Array:
+		cloned := reflect.New(value.Type()).Elem()
+		for index := 0; index < value.Len(); index++ {
+			cloned.Index(index).Set(deepCloneReflectValue(value.Index(index)))
+		}
+		return cloned
+	default:
+		return value
 	}
 }

--- a/internal/domain/property/aggregate_test.go
+++ b/internal/domain/property/aggregate_test.go
@@ -33,6 +33,32 @@ func TestNewNormalizesState(t *testing.T) {
 	}
 }
 
+func TestPropertyStateDefensivelyCopiesFacilities(t *testing.T) {
+	electricityUnitPrice := 4.5
+	facilities := map[string]interface{}{
+		"nested": map[string]interface{}{"elevator": true},
+	}
+	aggregate, err := New(State{
+		Name:                             "Property A",
+		Address:                          "Address A",
+		ElectricityUnitPrice:             &electricityUnitPrice,
+		DefaultElectricityBillingCadence: BillingCadenceMonthly,
+		OwnerID:                          "owner-1",
+		Facilities:                       &facilities,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	state := aggregate.State()
+	(*state.Facilities)["nested"].(map[string]interface{})["elevator"] = false
+
+	nextState := aggregate.State()
+	if (*nextState.Facilities)["nested"].(map[string]interface{})["elevator"] != true {
+		t.Fatalf("expected aggregate facilities to remain unchanged, got %#v", nextState.Facilities)
+	}
+}
+
 func TestUpdateRejectsStaffElectricityPriceMutation(t *testing.T) {
 	electricityUnitPrice := 4.0
 	aggregate, err := Rehydrate(State{

--- a/internal/domain/property/room_aggregate_test.go
+++ b/internal/domain/property/room_aggregate_test.go
@@ -23,6 +23,28 @@ func TestNewRoomNormalizesNameAndDefaultsVacant(t *testing.T) {
 	}
 }
 
+func TestRoomStateDefensivelyCopiesFacilities(t *testing.T) {
+	facilities := map[string]interface{}{
+		"nested": map[string]interface{}{"balcony": true},
+	}
+	aggregate, err := NewRoom(RoomState{
+		PropertyID: "property-1",
+		Name:       "101 Room",
+		Facilities: &facilities,
+	})
+	if err != nil {
+		t.Fatalf("NewRoom: %v", err)
+	}
+
+	state := aggregate.RoomState()
+	(*state.Facilities)["nested"].(map[string]interface{})["balcony"] = false
+
+	nextState := aggregate.RoomState()
+	if (*nextState.Facilities)["nested"].(map[string]interface{})["balcony"] != true {
+		t.Fatalf("expected room facilities to remain unchanged, got %#v", nextState.Facilities)
+	}
+}
+
 func TestRehydrateRoomRejectsMissingStatus(t *testing.T) {
 	_, err := RehydrateRoom(RoomState{
 		ID:         "room-1",

--- a/internal/domain/tenant/aggregate.go
+++ b/internal/domain/tenant/aggregate.go
@@ -4,6 +4,7 @@ import (
 	"net/mail"
 	"reflect"
 	"strings"
+	"time"
 	"unicode/utf8"
 )
 
@@ -14,21 +15,33 @@ const (
 
 // State is the persisted tenant aggregate state.
 type State struct {
-	ID       string
-	Name     string
-	Email    *string
-	Phone    *string
-	Contacts []map[string]interface{}
-	Status   string
-	Version  int
+	ID         string
+	Name       string
+	Email      *string
+	Phone      *string
+	Contacts   []map[string]interface{}
+	BirthDate  *time.Time
+	NationalID *string
+	Address    *string
+	Occupation *string
+	Status     string
+	Version    int
 }
 
 // UpdateInput is the aggregate patch for tenant mutations.
 type UpdateInput struct {
-	Name     *string
-	Email    *string
-	Phone    *string
-	Contacts *[]map[string]interface{}
+	Name            *string
+	Email           *string
+	Phone           *string
+	Contacts        *[]map[string]interface{}
+	BirthDate       *time.Time
+	ClearBirthDate  bool
+	NationalID      *string
+	ClearNationalID bool
+	Address         *string
+	ClearAddress    bool
+	Occupation      *string
+	ClearOccupation bool
 }
 
 // Aggregate owns tenant command validation and normalization.
@@ -85,6 +98,27 @@ func (a *Aggregate) Update(input UpdateInput) error {
 	if input.Contacts != nil {
 		a.state.Contacts = cloneContacts(*input.Contacts)
 	}
+	if input.BirthDate != nil {
+		birthDate := *input.BirthDate
+		a.state.BirthDate = &birthDate
+	} else if input.ClearBirthDate {
+		a.state.BirthDate = nil
+	}
+	if input.NationalID != nil {
+		a.state.NationalID = normalizeOptionalString(*input.NationalID)
+	} else if input.ClearNationalID {
+		a.state.NationalID = nil
+	}
+	if input.Address != nil {
+		a.state.Address = normalizeOptionalString(*input.Address)
+	} else if input.ClearAddress {
+		a.state.Address = nil
+	}
+	if input.Occupation != nil {
+		a.state.Occupation = normalizeOptionalString(*input.Occupation)
+	} else if input.ClearOccupation {
+		a.state.Occupation = nil
+	}
 
 	return nil
 }
@@ -99,6 +133,10 @@ func (a *Aggregate) State() State {
 	snapshot.Email = cloneStringPtr(a.state.Email)
 	snapshot.Phone = cloneStringPtr(a.state.Phone)
 	snapshot.Contacts = cloneContacts(a.state.Contacts)
+	snapshot.BirthDate = cloneTimePtr(a.state.BirthDate)
+	snapshot.NationalID = cloneStringPtr(a.state.NationalID)
+	snapshot.Address = cloneStringPtr(a.state.Address)
+	snapshot.Occupation = cloneStringPtr(a.state.Occupation)
 
 	return snapshot
 }
@@ -117,6 +155,10 @@ func normalizeState(state State, requireEmail bool) (State, error) {
 	state.Email = email
 	state.Phone = normalizeOptionalStringPtr(state.Phone)
 	state.Contacts = cloneContacts(state.Contacts)
+	state.BirthDate = cloneTimePtr(state.BirthDate)
+	state.NationalID = normalizeOptionalStringPtr(state.NationalID)
+	state.Address = normalizeOptionalStringPtr(state.Address)
+	state.Occupation = normalizeOptionalStringPtr(state.Occupation)
 	if state.Status == "" {
 		state.Status = StatusActive
 	} else {
@@ -180,6 +222,15 @@ func normalizeOptionalString(value string) *string {
 }
 
 func cloneStringPtr(value *string) *string {
+	if value == nil {
+		return nil
+	}
+
+	cloned := *value
+	return &cloned
+}
+
+func cloneTimePtr(value *time.Time) *time.Time {
 	if value == nil {
 		return nil
 	}

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -338,18 +338,10 @@ const (
 	TenantResponseStatusInactive TenantResponseStatus = "inactive"
 )
 
-// Defines values for UpdateLeaseRequestRentBillingCadence.
-const (
-	UpdateLeaseRequestRentBillingCadenceAnnual     UpdateLeaseRequestRentBillingCadence = "annual"
-	UpdateLeaseRequestRentBillingCadenceMonthly    UpdateLeaseRequestRentBillingCadence = "monthly"
-	UpdateLeaseRequestRentBillingCadenceQuarterly  UpdateLeaseRequestRentBillingCadence = "quarterly"
-	UpdateLeaseRequestRentBillingCadenceSemiannual UpdateLeaseRequestRentBillingCadence = "semiannual"
-)
-
 // Defines values for UpdatePropertyRequestDefaultElectricityBillingCadence.
 const (
-	UpdatePropertyRequestDefaultElectricityBillingCadenceBimonthly UpdatePropertyRequestDefaultElectricityBillingCadence = "bimonthly"
-	UpdatePropertyRequestDefaultElectricityBillingCadenceMonthly   UpdatePropertyRequestDefaultElectricityBillingCadence = "monthly"
+	Bimonthly UpdatePropertyRequestDefaultElectricityBillingCadence = "bimonthly"
+	Monthly   UpdatePropertyRequestDefaultElectricityBillingCadence = "monthly"
 )
 
 // Defines values for UpdateUserRequestRole.
@@ -719,6 +711,7 @@ type CreateLeaseRequest struct {
 	// ElectricityBillingCadence 可省略；若未提供則套用 Property 的 default_electricity_billing_cadence
 	ElectricityBillingCadence *CreateLeaseRequestElectricityBillingCadence `json:"electricity_billing_cadence,omitempty"`
 	EndDate                   openapi_types.Date                           `json:"end_date"`
+	Notes                     *string                                      `json:"notes"`
 	RentAmount                int                                          `json:"rent_amount"`
 
 	// RentBillingCadence 可省略；預設 monthly。rent_amount 為每個租金計費週期的金額。
@@ -739,15 +732,20 @@ type CreateLeaseRequestRentBillingCadence string
 
 // CreatePropertyRequest defines model for CreatePropertyRequest.
 type CreatePropertyRequest struct {
-	Address string `json:"address"`
+	Address      string               `json:"address"`
+	ContactEmail *openapi_types.Email `json:"contact_email"`
+	ContactPhone *string              `json:"contact_phone"`
 
 	// DefaultElectricityBillingCadence 物業預設電費計費 cadence，僅影響新建 Lease
 	DefaultElectricityBillingCadence CreatePropertyRequestDefaultElectricityBillingCadence `json:"default_electricity_billing_cadence"`
 
 	// ElectricityUnitPrice 台幣正數/度，可接受小數（例如 4.5）
-	ElectricityUnitPrice float64            `json:"electricity_unit_price"`
-	Name                 string             `json:"name"`
-	OwnerId              openapi_types.UUID `json:"owner_id"`
+	ElectricityUnitPrice float64                 `json:"electricity_unit_price"`
+	Facilities           *map[string]interface{} `json:"facilities"`
+	Name                 string                  `json:"name"`
+	Notes                *string                 `json:"notes"`
+	OwnerId              openapi_types.UUID      `json:"owner_id"`
+	Subtitle             *string                 `json:"subtitle"`
 }
 
 // CreatePropertyRequestDefaultElectricityBillingCadence 物業預設電費計費 cadence，僅影響新建 Lease
@@ -763,15 +761,26 @@ type CreateRepairRequestRequest struct {
 
 // CreateRoomRequest defines model for CreateRoomRequest.
 type CreateRoomRequest struct {
-	Name string `json:"name"`
+	DefaultRentAmount *int                    `json:"default_rent_amount"`
+	Facilities        *map[string]interface{} `json:"facilities"`
+	Floor             *string                 `json:"floor"`
+	Name              string                  `json:"name"`
+	Notes             *string                 `json:"notes"`
+	RoomType          *string                 `json:"room_type"`
+	Size              *float64                `json:"size"`
+	Zone              *string                 `json:"zone"`
 }
 
 // CreateTenantRequest defines model for CreateTenantRequest.
 type CreateTenantRequest struct {
-	Contacts *[]map[string]interface{} `json:"contacts,omitempty"`
-	Email    openapi_types.Email       `json:"email"`
-	Name     string                    `json:"name"`
-	Phone    *string                   `json:"phone,omitempty"`
+	Address    *string             `json:"address"`
+	BirthDate  *openapi_types.Date `json:"birth_date"`
+	Contacts   *[]TenantContact    `json:"contacts,omitempty"`
+	Email      openapi_types.Email `json:"email"`
+	Name       string              `json:"name"`
+	NationalId *string             `json:"national_id"`
+	Occupation *string             `json:"occupation"`
+	Phone      *string             `json:"phone,omitempty"`
 }
 
 // CreateUserRequest defines model for CreateUserRequest.
@@ -1201,16 +1210,16 @@ type PropertyResponse struct {
 	DefaultElectricityBillingCadence *PropertyResponseDefaultElectricityBillingCadence `json:"default_electricity_billing_cadence,omitempty"`
 
 	// ElectricityUnitPrice 台幣正數/度，可接受小數
-	ElectricityUnitPrice *float64            `json:"electricity_unit_price"`
-	Facilities           *[]interface{}      `json:"facilities"`
-	Id                   *openapi_types.UUID `json:"id,omitempty"`
-	Name                 *string             `json:"name,omitempty"`
-	Notes                *string             `json:"notes"`
-	OccupancySummary     *OccupancySummary   `json:"occupancy_summary,omitempty"`
-	OwnerId              *openapi_types.UUID `json:"owner_id,omitempty"`
-	Subtitle             *string             `json:"subtitle"`
-	UpdatedAt            *time.Time          `json:"updated_at,omitempty"`
-	Version              *int                `json:"version,omitempty"`
+	ElectricityUnitPrice *float64                `json:"electricity_unit_price"`
+	Facilities           *map[string]interface{} `json:"facilities"`
+	Id                   *openapi_types.UUID     `json:"id,omitempty"`
+	Name                 *string                 `json:"name,omitempty"`
+	Notes                *string                 `json:"notes"`
+	OccupancySummary     *OccupancySummary       `json:"occupancy_summary,omitempty"`
+	OwnerId              *openapi_types.UUID     `json:"owner_id,omitempty"`
+	Subtitle             *string                 `json:"subtitle"`
+	UpdatedAt            *time.Time              `json:"updated_at,omitempty"`
+	Version              *int                    `json:"version,omitempty"`
 }
 
 // PropertyResponseDefaultElectricityBillingCadence defines model for PropertyResponse.DefaultElectricityBillingCadence.
@@ -1372,6 +1381,15 @@ type SetMaintenanceResponse struct {
 	Room          RoomResponse          `json:"room"`
 }
 
+// TenantContact defines model for TenantContact.
+type TenantContact struct {
+	Email    *openapi_types.Email `json:"email"`
+	Name     *string              `json:"name"`
+	Notes    *string              `json:"notes"`
+	Phone    *string              `json:"phone"`
+	Relation *string              `json:"relation"`
+}
+
 // TenantListResponse defines model for TenantListResponse.
 type TenantListResponse struct {
 	Data       *[]TenantResponse   `json:"data,omitempty"`
@@ -1380,19 +1398,19 @@ type TenantListResponse struct {
 
 // TenantResponse defines model for TenantResponse.
 type TenantResponse struct {
-	Address    *string                   `json:"address"`
-	BirthDate  *openapi_types.Date       `json:"birth_date"`
-	Contacts   *[]map[string]interface{} `json:"contacts,omitempty"`
-	CreatedAt  *time.Time                `json:"created_at,omitempty"`
-	Email      *openapi_types.Email      `json:"email"`
-	Id         *openapi_types.UUID       `json:"id,omitempty"`
-	Name       *string                   `json:"name,omitempty"`
-	NationalId *string                   `json:"national_id"`
-	Occupation *string                   `json:"occupation"`
-	Phone      *string                   `json:"phone"`
-	Status     *TenantResponseStatus     `json:"status,omitempty"`
-	UpdatedAt  *time.Time                `json:"updated_at,omitempty"`
-	Version    *int                      `json:"version,omitempty"`
+	Address    *string               `json:"address"`
+	BirthDate  *openapi_types.Date   `json:"birth_date"`
+	Contacts   *[]TenantContact      `json:"contacts,omitempty"`
+	CreatedAt  *time.Time            `json:"created_at,omitempty"`
+	Email      *openapi_types.Email  `json:"email"`
+	Id         *openapi_types.UUID   `json:"id,omitempty"`
+	Name       *string               `json:"name,omitempty"`
+	NationalId *string               `json:"national_id"`
+	Occupation *string               `json:"occupation"`
+	Phone      *string               `json:"phone"`
+	Status     *TenantResponseStatus `json:"status,omitempty"`
+	UpdatedAt  *time.Time            `json:"updated_at,omitempty"`
+	Version    *int                  `json:"version,omitempty"`
 }
 
 // TenantResponseStatus defines model for TenantResponse.Status.
@@ -1439,24 +1457,23 @@ type UpdateJournalLogRequest struct {
 type UpdateLeaseRequest struct {
 	EndDate    *openapi_types.Date `json:"end_date,omitempty"`
 	RentAmount *int                `json:"rent_amount,omitempty"`
-
-	// RentBillingCadence 不支援透過 PATCH 修改；若需更動 rent cadence，請使用 Lease replacement。
-	RentBillingCadence *UpdateLeaseRequestRentBillingCadence `json:"rent_billing_cadence,omitempty"`
 }
-
-// UpdateLeaseRequestRentBillingCadence 不支援透過 PATCH 修改；若需更動 rent cadence，請使用 Lease replacement。
-type UpdateLeaseRequestRentBillingCadence string
 
 // UpdatePropertyRequest defines model for UpdatePropertyRequest.
 type UpdatePropertyRequest struct {
-	Address *string `json:"address,omitempty"`
+	Address      *string              `json:"address,omitempty"`
+	ContactEmail *openapi_types.Email `json:"contact_email"`
+	ContactPhone *string              `json:"contact_phone"`
 
 	// DefaultElectricityBillingCadence 僅影響之後新建的 Lease，不回頭修改既有 Lease
 	DefaultElectricityBillingCadence *UpdatePropertyRequestDefaultElectricityBillingCadence `json:"default_electricity_billing_cadence,omitempty"`
 
 	// ElectricityUnitPrice 台幣正數/度，可接受小數（例如 4.5）
-	ElectricityUnitPrice *float64 `json:"electricity_unit_price,omitempty"`
-	Name                 *string  `json:"name,omitempty"`
+	ElectricityUnitPrice *float64                `json:"electricity_unit_price,omitempty"`
+	Facilities           *map[string]interface{} `json:"facilities"`
+	Name                 *string                 `json:"name,omitempty"`
+	Notes                *string                 `json:"notes"`
+	Subtitle             *string                 `json:"subtitle"`
 }
 
 // UpdatePropertyRequestDefaultElectricityBillingCadence 僅影響之後新建的 Lease，不回頭修改既有 Lease
@@ -1470,15 +1487,26 @@ type UpdateRepairRequestRequest struct {
 
 // UpdateRoomRequest defines model for UpdateRoomRequest.
 type UpdateRoomRequest struct {
-	Name *string `json:"name,omitempty"`
+	DefaultRentAmount *int                    `json:"default_rent_amount"`
+	Facilities        *map[string]interface{} `json:"facilities"`
+	Floor             *string                 `json:"floor"`
+	Name              *string                 `json:"name,omitempty"`
+	Notes             *string                 `json:"notes"`
+	RoomType          *string                 `json:"room_type"`
+	Size              *float64                `json:"size"`
+	Zone              *string                 `json:"zone"`
 }
 
 // UpdateTenantRequest defines model for UpdateTenantRequest.
 type UpdateTenantRequest struct {
-	Contacts *[]map[string]interface{} `json:"contacts,omitempty"`
-	Email    *openapi_types.Email      `json:"email,omitempty"`
-	Name     *string                   `json:"name,omitempty"`
-	Phone    *string                   `json:"phone,omitempty"`
+	Address    *string              `json:"address"`
+	BirthDate  *openapi_types.Date  `json:"birth_date"`
+	Contacts   *[]TenantContact     `json:"contacts,omitempty"`
+	Email      *openapi_types.Email `json:"email,omitempty"`
+	Name       *string              `json:"name,omitempty"`
+	NationalId *string              `json:"national_id"`
+	Occupation *string              `json:"occupation"`
+	Phone      *string              `json:"phone,omitempty"`
 }
 
 // UpdateUserRequest defines model for UpdateUserRequest.

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -1209,6 +1210,7 @@ func (s *APIServer) CreateLease(c *gin.Context) {
 		RentBillingCadence:        rentCadence,
 		ElectricityBillingCadence: cadence,
 		StartingMeterReading:      *request.StartingMeterReading,
+		Notes:                     request.Notes,
 	})
 	if err != nil {
 		c.Error(err)
@@ -1269,19 +1271,12 @@ func (s *APIServer) UpdateLease(c *gin.Context, id string) {
 		value := request.EndDate.Time
 		endDate = &value
 	}
-	var rentCadence *string
-	if request.RentBillingCadence != nil {
-		value := string(*request.RentBillingCadence)
-		rentCadence = &value
-	}
-
 	lease, err := s.updateLeaseSvc.Execute(c.Request.Context(), applease.UpdateLeaseInput{
 		ActorRole:           principal.Role,
 		AssignedPropertyIDs: principal.AssignedPropertyIDs,
 		LeaseID:             id,
 		RentAmount:          request.RentAmount,
 		EndDate:             endDate,
-		RentBillingCadence:  rentCadence,
 	})
 	if err != nil {
 		c.Error(err)
@@ -1571,10 +1566,15 @@ func (s *APIServer) CreateProperty(c *gin.Context) {
 
 	property, err := s.createPropertySvc.Execute(c.Request.Context(), appproperty.CreatePropertyInput{
 		Name:                             request.Name,
+		Subtitle:                         request.Subtitle,
 		Address:                          request.Address,
 		ElectricityUnitPrice:             request.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: string(request.DefaultElectricityBillingCadence),
 		OwnerID:                          request.OwnerId.String(),
+		ContactPhone:                     request.ContactPhone,
+		ContactEmail:                     emailPtrToStringPtr(request.ContactEmail),
+		Notes:                            request.Notes,
+		Facilities:                       request.Facilities,
 	})
 	if err != nil {
 		c.Error(err)
@@ -1631,7 +1631,8 @@ func (s *APIServer) UpdateProperty(c *gin.Context, id string) {
 	}
 
 	var request api.UpdatePropertyRequest
-	if err := c.ShouldBindJSON(&request); err != nil {
+	fields, err := bindJSONWithFields(c, &request)
+	if err != nil {
 		c.Error(apperr.ErrBadRequest.WithCause(err))
 		return
 	}
@@ -1646,9 +1647,19 @@ func (s *APIServer) UpdateProperty(c *gin.Context, id string) {
 		ID:                               id,
 		ActorRole:                        principal.Role,
 		Name:                             request.Name,
+		Subtitle:                         request.Subtitle,
+		ClearSubtitle:                    jsonFieldIsNull(fields, "subtitle"),
 		Address:                          request.Address,
 		ElectricityUnitPrice:             request.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: cadence,
+		ContactPhone:                     request.ContactPhone,
+		ClearContactPhone:                jsonFieldIsNull(fields, "contact_phone"),
+		ContactEmail:                     emailPtrToStringPtr(request.ContactEmail),
+		ClearContactEmail:                jsonFieldIsNull(fields, "contact_email"),
+		Notes:                            request.Notes,
+		ClearNotes:                       jsonFieldIsNull(fields, "notes"),
+		Facilities:                       request.Facilities,
+		ClearFacilities:                  jsonFieldIsNull(fields, "facilities"),
 	})
 	if err != nil {
 		c.Error(err)
@@ -2094,8 +2105,15 @@ func (s *APIServer) CreatePropertyRoom(c *gin.Context, id string) {
 	}
 
 	room, err := s.createRoomSvc.Execute(c.Request.Context(), appproperty.CreateRoomInput{
-		PropertyID: id,
-		Name:       request.Name,
+		PropertyID:        id,
+		Name:              request.Name,
+		Size:              request.Size,
+		Floor:             request.Floor,
+		RoomType:          request.RoomType,
+		Facilities:        request.Facilities,
+		DefaultRentAmount: request.DefaultRentAmount,
+		Notes:             request.Notes,
+		Zone:              request.Zone,
 	})
 	if err != nil {
 		c.Error(err)
@@ -2387,14 +2405,29 @@ func (s *APIServer) CreateRoomAttachment(c *gin.Context, id openapi_types.UUID) 
 // UpdateRoom handles room updates.
 func (s *APIServer) UpdateRoom(c *gin.Context, id string) {
 	var request api.UpdateRoomRequest
-	if err := c.ShouldBindJSON(&request); err != nil {
+	fields, err := bindJSONWithFields(c, &request)
+	if err != nil {
 		c.Error(apperr.ErrBadRequest.WithCause(err))
 		return
 	}
 
 	room, err := s.updateRoomSvc.Execute(c.Request.Context(), appproperty.UpdateRoomInput{
-		ID:   id,
-		Name: request.Name,
+		ID:                id,
+		Name:              request.Name,
+		Size:              request.Size,
+		ClearSize:         jsonFieldIsNull(fields, "size"),
+		Floor:             request.Floor,
+		ClearFloor:        jsonFieldIsNull(fields, "floor"),
+		RoomType:          request.RoomType,
+		ClearRoomType:     jsonFieldIsNull(fields, "room_type"),
+		Facilities:        request.Facilities,
+		ClearFacilities:   jsonFieldIsNull(fields, "facilities"),
+		DefaultRentAmount: request.DefaultRentAmount,
+		ClearDefaultRent:  jsonFieldIsNull(fields, "default_rent_amount"),
+		Notes:             request.Notes,
+		ClearNotes:        jsonFieldIsNull(fields, "notes"),
+		Zone:              request.Zone,
+		ClearZone:         jsonFieldIsNull(fields, "zone"),
 	})
 	if err != nil {
 		c.Error(err)
@@ -2523,10 +2556,14 @@ func (s *APIServer) CreateTenant(c *gin.Context) {
 	}
 
 	tenant, err := s.createTenantSvc.Execute(c.Request.Context(), apptenant.CreateTenantInput{
-		Name:     request.Name,
-		Email:    string(request.Email),
-		Phone:    phone,
-		Contacts: request.Contacts,
+		Name:       request.Name,
+		Email:      string(request.Email),
+		Phone:      phone,
+		Contacts:   tenantContactsToMaps(request.Contacts),
+		BirthDate:  datePtrToTimePtr(request.BirthDate),
+		NationalID: request.NationalId,
+		Address:    request.Address,
+		Occupation: request.Occupation,
 	})
 	if err != nil {
 		c.Error(err)
@@ -2571,7 +2608,8 @@ func (s *APIServer) GetTenant(c *gin.Context, id string) {
 // UpdateTenant handles tenant updates.
 func (s *APIServer) UpdateTenant(c *gin.Context, id string) {
 	var request api.UpdateTenantRequest
-	if err := c.ShouldBindJSON(&request); err != nil {
+	fields, err := bindJSONWithFields(c, &request)
+	if err != nil {
 		c.Error(apperr.ErrBadRequest.WithCause(err))
 		return
 	}
@@ -2583,11 +2621,19 @@ func (s *APIServer) UpdateTenant(c *gin.Context, id string) {
 	}
 
 	tenant, err := s.updateTenantSvc.Execute(c.Request.Context(), apptenant.UpdateTenantInput{
-		ID:       id,
-		Name:     request.Name,
-		Email:    email,
-		Phone:    request.Phone,
-		Contacts: request.Contacts,
+		ID:              id,
+		Name:            request.Name,
+		Email:           email,
+		Phone:           request.Phone,
+		Contacts:        tenantContactsToMaps(request.Contacts),
+		BirthDate:       datePtrToTimePtr(request.BirthDate),
+		ClearBirthDate:  jsonFieldIsNull(fields, "birth_date"),
+		NationalID:      request.NationalId,
+		ClearNationalID: jsonFieldIsNull(fields, "national_id"),
+		Address:         request.Address,
+		ClearAddress:    jsonFieldIsNull(fields, "address"),
+		Occupation:      request.Occupation,
+		ClearOccupation: jsonFieldIsNull(fields, "occupation"),
 	})
 	if err != nil {
 		c.Error(err)
@@ -2966,6 +3012,104 @@ func parseUUID(value string) (openapi_types.UUID, bool) {
 	}
 
 	return parsed, true
+}
+
+func emailPtrToStringPtr(value *openapi_types.Email) *string {
+	if value == nil {
+		return nil
+	}
+	result := string(*value)
+	return &result
+}
+
+func bindJSONWithFields(c *gin.Context, target any) (map[string]json.RawMessage, error) {
+	body, err := c.GetRawData()
+	if err != nil {
+		return nil, err
+	}
+
+	fields := map[string]json.RawMessage{}
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(body, target); err != nil {
+		return nil, err
+	}
+
+	return fields, nil
+}
+
+func jsonFieldIsNull(fields map[string]json.RawMessage, name string) bool {
+	value, ok := fields[name]
+	if !ok {
+		return false
+	}
+
+	return strings.TrimSpace(string(value)) == "null"
+}
+
+func datePtrToTimePtr(value *openapi_types.Date) *time.Time {
+	if value == nil {
+		return nil
+	}
+	result := value.Time
+	return &result
+}
+
+func tenantContactsToMaps(value *[]api.TenantContact) *[]map[string]interface{} {
+	if value == nil {
+		return nil
+	}
+	contacts := make([]map[string]interface{}, 0, len(*value))
+	for _, contact := range *value {
+		item := map[string]interface{}{}
+		if contact.Name != nil {
+			item["name"] = *contact.Name
+		}
+		if contact.Phone != nil {
+			item["phone"] = *contact.Phone
+		}
+		if contact.Email != nil {
+			item["email"] = string(*contact.Email)
+		}
+		if contact.Relation != nil {
+			item["relation"] = *contact.Relation
+		}
+		if contact.Notes != nil {
+			item["notes"] = *contact.Notes
+		}
+		contacts = append(contacts, item)
+	}
+	return &contacts
+}
+
+func tenantMapsToContacts(value []map[string]interface{}) *[]api.TenantContact {
+	contacts := make([]api.TenantContact, 0, len(value))
+	for _, item := range value {
+		contact := api.TenantContact{}
+		contact.Name = optionalStringFromMap(item, "name")
+		contact.Phone = optionalStringFromMap(item, "phone")
+		if email := optionalStringFromMap(item, "email"); email != nil {
+			value := openapi_types.Email(*email)
+			contact.Email = &value
+		}
+		contact.Relation = optionalStringFromMap(item, "relation")
+		contact.Notes = optionalStringFromMap(item, "notes")
+		contacts = append(contacts, contact)
+	}
+	return &contacts
+}
+
+func optionalStringFromMap(values map[string]interface{}, key string) *string {
+	raw, ok := values[key]
+	if !ok || raw == nil {
+		return nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return nil
+	}
+	return &value
 }
 
 func isValidMonth(month int) bool {
@@ -3568,11 +3712,19 @@ func toPropertyResponse(property *dbpropertyquery.Property) api.PropertyResponse
 
 	response := api.PropertyResponse{
 		Address:          &address,
+		ContactPhone:     property.ContactPhone,
 		CreatedAt:        &createdAt,
 		Name:             &name,
+		Notes:            property.Notes,
 		OccupancySummary: toDBPropertyOccupancySummaryResponse(property.Occupancy),
+		Facilities:       property.Facilities,
+		Subtitle:         property.Subtitle,
 		UpdatedAt:        &updatedAt,
 		Version:          &version,
+	}
+	if property.ContactEmail != nil {
+		email := openapi_types.Email(*property.ContactEmail)
+		response.ContactEmail = &email
 	}
 	if property.DefaultElectricityBillingCadence != "" {
 		cadence := api.PropertyResponseDefaultElectricityBillingCadence(property.DefaultElectricityBillingCadence)
@@ -3627,10 +3779,15 @@ func toCreatedPropertyResponse(property *appproperty.Property) api.PropertyRespo
 	queryShape := &dbpropertyquery.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
+		ContactPhone:                     property.ContactPhone,
+		ContactEmail:                     property.ContactEmail,
+		Notes:                            property.Notes,
+		Facilities:                       property.Facilities,
 		CreatedAt:                        property.CreatedAt,
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,
@@ -3641,12 +3798,19 @@ func toCreatedPropertyResponse(property *appproperty.Property) api.PropertyRespo
 
 func toCreatedRoomResponse(room *appproperty.Room) api.RoomResponse {
 	queryShape := &dbpropertyquery.Room{
-		ID:         room.ID,
-		PropertyID: room.PropertyID,
-		Name:       room.Name,
-		Status:     room.Status,
-		CreatedAt:  room.CreatedAt,
-		UpdatedAt:  room.UpdatedAt,
+		ID:                room.ID,
+		PropertyID:        room.PropertyID,
+		Name:              room.Name,
+		Status:            room.Status,
+		Size:              room.Size,
+		Floor:             room.Floor,
+		RoomType:          room.RoomType,
+		Facilities:        room.Facilities,
+		DefaultRentAmount: room.DefaultRentAmount,
+		Notes:             room.Notes,
+		Zone:              room.Zone,
+		CreatedAt:         room.CreatedAt,
+		UpdatedAt:         room.UpdatedAt,
 	}
 
 	return toRoomResponse(queryShape)
@@ -3662,7 +3826,7 @@ func toTenantResponse(tenant *dbtenantquery.Tenant) api.TenantResponse {
 
 	response := api.TenantResponse{
 		Address:    tenant.Address,
-		Contacts:   &tenant.Contacts,
+		Contacts:   tenantMapsToContacts(tenant.Contacts),
 		CreatedAt:  &createdAt,
 		Name:       &name,
 		NationalId: tenant.NationalID,

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -55,6 +55,39 @@ func TestToPropertyResponseAllowsNilElectricityUnitPrice(t *testing.T) {
 	}
 }
 
+func TestToPropertyResponseIncludesWritableV1Fields(t *testing.T) {
+	subtitle := "North wing"
+	contactPhone := "02-1234-5678"
+	contactEmail := "owner@example.com"
+	notes := "Managed property"
+	facilities := map[string]interface{}{"elevator": true}
+
+	response := toPropertyResponse(&dbpropertyquery.Property{
+		ID:           "00000000-0000-0000-0000-000000000001",
+		Name:         "Property",
+		Subtitle:     &subtitle,
+		Address:      "Address",
+		OwnerID:      "00000000-0000-0000-0000-000000000002",
+		ContactPhone: &contactPhone,
+		ContactEmail: &contactEmail,
+		Notes:        &notes,
+		Facilities:   &facilities,
+		CreatedAt:    time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:    time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		Version:      1,
+	})
+
+	if response.Subtitle == nil || *response.Subtitle != subtitle {
+		t.Fatalf("subtitle = %v, want %s", response.Subtitle, subtitle)
+	}
+	if response.ContactEmail == nil || string(*response.ContactEmail) != contactEmail {
+		t.Fatalf("contact_email = %v, want %s", response.ContactEmail, contactEmail)
+	}
+	if response.Facilities == nil || (*response.Facilities)["elevator"] != true {
+		t.Fatalf("facilities = %#v, want elevator=true", response.Facilities)
+	}
+}
+
 func TestToRoomResponseAllowsNilOptionalFields(t *testing.T) {
 	response := toRoomResponse(&dbpropertyquery.Room{
 		ID:         "20000000-0000-0000-0000-000000000001",

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -706,6 +706,83 @@ func TestUpdateTenantReturnsUpdatedTenant(t *testing.T) {
 	}
 }
 
+func TestUpdateTenantClearsNullableFieldsWithExplicitNull(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	tenantID := "30000000-0000-0000-0000-000000000001"
+	birthDate := time.Date(1990, 1, 2, 0, 0, 0, 0, time.UTC)
+	nationalID := "A123456789"
+	address := "Address A"
+	occupation := "Engineer"
+	updateParams := apptenant.UpdateTenantParams{}
+	updateTenantRepo := fakeTenantRepo{
+		current: &apptenant.Tenant{
+			ID:         tenantID,
+			Name:       "Tenant A",
+			Contacts:   []map[string]interface{}{},
+			BirthDate:  &birthDate,
+			NationalID: &nationalID,
+			Address:    &address,
+			Occupation: &occupation,
+			Status:     "active",
+			Version:    1,
+		},
+		updateParams: &updateParams,
+	}
+
+	engine := newTestEngineWithTenantServices(
+		fakeUserRepo{role: "admin"},
+		fakeAuthenticator{role: "admin"},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeTenantQueryRepo{},
+		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(db, nil)),
+		apptenant.NewUpdateTenantService(updateTenantRepo, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/tenants/"+tenantID, strings.NewReader(`{
+		"birth_date":null,
+		"national_id":null,
+		"address":null,
+		"occupation":null
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if updateParams.BirthDate != nil {
+		t.Fatalf("expected birth_date to be cleared, got %v", updateParams.BirthDate)
+	}
+	if updateParams.NationalID != nil {
+		t.Fatalf("expected national_id to be cleared, got %v", *updateParams.NationalID)
+	}
+	if updateParams.Address != nil {
+		t.Fatalf("expected address to be cleared, got %v", *updateParams.Address)
+	}
+	if updateParams.Occupation != nil {
+		t.Fatalf("expected occupation to be cleared, got %v", *updateParams.Occupation)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func TestListTenantLeasesReturnsLeaseHistory(t *testing.T) {
 	leasesCall := &listTenantLeasesCall{}
 	engine := newTestEngineWithQueryRepos(
@@ -1505,7 +1582,7 @@ func TestExportLeaseCheckoutSettlementReturnsHTMLDocument(t *testing.T) {
 	}
 }
 
-func TestUpdateLeaseRejectsRentBillingCadencePatch(t *testing.T) {
+func TestUpdateLeaseRejectsPatchWithoutSupportedFields(t *testing.T) {
 	engine := newTestEngineWithAllQueryRepos(
 		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
 		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
@@ -1534,7 +1611,7 @@ func TestUpdateLeaseRejectsRentBillingCadencePatch(t *testing.T) {
 	if resp.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("expected 422, got %d: %s", resp.Code, resp.Body.String())
 	}
-	assertErrorField(t, resp.Body.Bytes(), "LEASE_UNSUPPORTED_UPDATE", "rent_billing_cadence")
+	assertErrorField(t, resp.Body.Bytes(), "LEASE_UNSUPPORTED_UPDATE", "rent_amount")
 }
 
 func TestListUsersReturnsActiveUsers(t *testing.T) {
@@ -2348,6 +2425,99 @@ func TestUpdateRoomReturnsUpdatedRoom(t *testing.T) {
 	}
 }
 
+func TestUpdateRoomClearsNullableFieldsWithExplicitNull(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	size := 12.5
+	floor := "2"
+	roomType := "suite"
+	facilities := map[string]interface{}{"bed": true}
+	defaultRent := 12000
+	notes := "Room note"
+	zone := "A"
+	updateParams := appproperty.UpdateRoomParams{}
+	propertyRepo := fakePropertyRepo{
+		roomByID: map[string]*appproperty.Room{
+			testRoomID1: {
+				ID:                testRoomID1,
+				PropertyID:        testPropertyID1,
+				Name:              "101 Room",
+				Status:            "vacant",
+				Size:              &size,
+				Floor:             &floor,
+				RoomType:          &roomType,
+				Facilities:        &facilities,
+				DefaultRentAmount: &defaultRent,
+				Notes:             &notes,
+				Zone:              &zone,
+			},
+		},
+		updateRoomParams: &updateParams,
+	}
+
+	repo := fakeUserRepo{role: "admin"}
+	engine := newTestEngineWithRoomServices(repo, fakeAuthenticator{role: "admin"}, propertyRepo, fakeResourceOwnershipRepo{propertyByRoomID: map[string]string{testRoomID1: testPropertyID1}}, "", fakeJobRunsRepo{}, fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(propertyRepo, fakePropertyAccountRepo{}, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeletePropertyService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewCreateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewUpdateRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewDeleteRoomService(propertyRepo, dbtxrunner.New(db, nil)),
+		appproperty.NewSetRoomMaintenanceService(propertyRepo, dbtxrunner.New(db, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/rooms/"+testRoomID1, strings.NewReader(`{
+		"size":null,
+		"floor":null,
+		"room_type":null,
+		"facilities":null,
+		"default_rent_amount":null,
+		"notes":null,
+		"zone":null
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if updateParams.Size != nil {
+		t.Fatalf("expected size to be cleared, got %v", *updateParams.Size)
+	}
+	if updateParams.Floor != nil {
+		t.Fatalf("expected floor to be cleared, got %v", *updateParams.Floor)
+	}
+	if updateParams.RoomType != nil {
+		t.Fatalf("expected room_type to be cleared, got %v", *updateParams.RoomType)
+	}
+	if updateParams.Facilities != nil {
+		t.Fatalf("expected facilities to be cleared, got %#v", *updateParams.Facilities)
+	}
+	if updateParams.DefaultRentAmount != nil {
+		t.Fatalf("expected default_rent_amount to be cleared, got %v", *updateParams.DefaultRentAmount)
+	}
+	if updateParams.Notes != nil {
+		t.Fatalf("expected notes to be cleared, got %v", *updateParams.Notes)
+	}
+	if updateParams.Zone != nil {
+		t.Fatalf("expected zone to be cleared, got %v", *updateParams.Zone)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func TestDeleteRoomRejectsMaintenanceRoom(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
@@ -2596,16 +2766,21 @@ func TestCreatePropertyAcceptsDecimalElectricityPrice(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("INSERT INTO properties").
-		WithArgs("Property A", "Address A", 4.5, "monthly", "00000000-0000-0000-0000-000000000010").
+		WithArgs("Property A", nil, "Address A", 4.5, "monthly", "00000000-0000-0000-0000-000000000010", nil, nil, nil, nil).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "name", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id", "created_at", "updated_at", "version",
+			"id", "name", "subtitle", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id", "contact_phone", "contact_email", "notes", "facilities", "created_at", "updated_at", "version",
 		}).AddRow(
 			"property-new",
 			"Property A",
+			nil,
 			"Address A",
 			4.5,
 			"monthly",
 			"00000000-0000-0000-0000-000000000010",
+			nil,
+			nil,
+			nil,
+			nil,
 			time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 			time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 			1,
@@ -2718,6 +2893,92 @@ func TestUpdatePropertyRejectsStaffElectricityPriceMutation(t *testing.T) {
 	}
 	if payload["error_code"] != "FORBIDDEN_ELECTRICITY_PRICE_UPDATE" {
 		t.Fatalf("expected FORBIDDEN_ELECTRICITY_PRICE_UPDATE, got %v", payload["error_code"])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestUpdatePropertyClearsNullableFieldsWithExplicitNull(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	subtitle := "Property subtitle"
+	contactPhone := "02-1234-5678"
+	contactEmail := "owner@example.com"
+	notes := "Property note"
+	facilities := map[string]interface{}{"parking": true}
+	updateParams := appproperty.UpdatePropertyParams{}
+	propertyRepo := fakePropertyRepo{
+		propertyByID: map[string]*appproperty.Property{
+			testPropertyID1: {
+				ID:                               testPropertyID1,
+				Name:                             "Property A",
+				Subtitle:                         &subtitle,
+				Address:                          "Address A",
+				ElectricityUnitPrice:             ptrFloat64(4.0),
+				DefaultElectricityBillingCadence: "monthly",
+				OwnerID:                          "owner-1",
+				ContactPhone:                     &contactPhone,
+				ContactEmail:                     &contactEmail,
+				Notes:                            &notes,
+				Facilities:                       &facilities,
+				Version:                          1,
+			},
+		},
+		updateParams: &updateParams,
+	}
+	updatePropertyService := appproperty.NewUpdatePropertyService(propertyRepo, dbtxrunner.New(db, nil))
+	engine := newTestEngineWithCreatePropertyService(
+		fakeUserRepo{role: "admin"},
+		fakeAuthenticator{role: "admin"},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		appproperty.NewCreatePropertyService(fakePropertyRepo{}, fakePropertyAccountRepo{}, dbtxrunner.New(nil, nil)),
+		updatePropertyService,
+		appproperty.NewDeletePropertyService(fakePropertyRepo{}, dbtxrunner.New(nil, nil)),
+	)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/properties/"+testPropertyID1, strings.NewReader(`{
+		"subtitle":null,
+		"contact_phone":null,
+		"contact_email":null,
+		"notes":null,
+		"facilities":null
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if updateParams.Subtitle != nil {
+		t.Fatalf("expected subtitle to be cleared, got %v", *updateParams.Subtitle)
+	}
+	if updateParams.ContactPhone != nil {
+		t.Fatalf("expected contact_phone to be cleared, got %v", *updateParams.ContactPhone)
+	}
+	if updateParams.ContactEmail != nil {
+		t.Fatalf("expected contact_email to be cleared, got %v", *updateParams.ContactEmail)
+	}
+	if updateParams.Notes != nil {
+		t.Fatalf("expected notes to be cleared, got %v", *updateParams.Notes)
+	}
+	if updateParams.Facilities != nil {
+		t.Fatalf("expected facilities to be cleared, got %#v", *updateParams.Facilities)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {
@@ -4322,6 +4583,8 @@ type fakePropertyRepo struct {
 	propertyByID      map[string]*appproperty.Property
 	occupiedRoomIDs   map[string][]string
 	roomByID          map[string]*appproperty.Room
+	updateParams      *appproperty.UpdatePropertyParams
+	updateRoomParams  *appproperty.UpdateRoomParams
 }
 
 type fakePropertyAccountRepo struct{}
@@ -4380,12 +4643,13 @@ func (r *fakeDashboardRepository) GetHomeDashboard(_ context.Context, scope appp
 }
 
 type fakeTenantRepo struct {
-	created   *apptenant.Tenant
-	current   *apptenant.Tenant
-	updated   *apptenant.Tenant
-	createErr error
-	findErr   error
-	updateErr error
+	created      *apptenant.Tenant
+	current      *apptenant.Tenant
+	updated      *apptenant.Tenant
+	updateParams *apptenant.UpdateTenantParams
+	createErr    error
+	findErr      error
+	updateErr    error
 }
 
 type fakeTenantQueryRepo struct {
@@ -5011,13 +5275,22 @@ func (f fakePropertyRepo) FindByID(_ context.Context, _ *sql.Tx, id string) (*ap
 }
 
 func (f fakePropertyRepo) Update(_ context.Context, _ *sql.Tx, params appproperty.UpdatePropertyParams) (*appproperty.Property, error) {
+	if f.updateParams != nil {
+		*f.updateParams = params
+	}
+
 	return &appproperty.Property{
 		ID:                               params.ID,
 		Name:                             params.Name,
+		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
 		OwnerID:                          params.OwnerID,
+		ContactPhone:                     params.ContactPhone,
+		ContactEmail:                     params.ContactEmail,
+		Notes:                            params.Notes,
+		Facilities:                       params.Facilities,
 		CreatedAt:                        time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
 		UpdatedAt:                        time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC),
 		Version:                          params.Version + 1,
@@ -5063,18 +5336,29 @@ func (f fakePropertyRepo) FindRoomByID(_ context.Context, _ *sql.Tx, id string) 
 }
 
 func (f fakePropertyRepo) UpdateRoom(_ context.Context, _ *sql.Tx, params appproperty.UpdateRoomParams) (*appproperty.Room, error) {
+	if f.updateRoomParams != nil {
+		*f.updateRoomParams = params
+	}
+
 	status := "vacant"
 	if params.Status != nil {
 		status = *params.Status
 	}
 
 	return &appproperty.Room{
-		ID:         params.ID,
-		PropertyID: testPropertyID1,
-		Name:       params.Name,
-		Status:     status,
-		CreatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
-		UpdatedAt:  time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC),
+		ID:                params.ID,
+		PropertyID:        testPropertyID1,
+		Name:              params.Name,
+		Status:            status,
+		Size:              params.Size,
+		Floor:             params.Floor,
+		RoomType:          params.RoomType,
+		Facilities:        params.Facilities,
+		DefaultRentAmount: params.DefaultRentAmount,
+		Notes:             params.Notes,
+		Zone:              params.Zone,
+		CreatedAt:         time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:         time.Date(2026, 4, 16, 11, 0, 0, 0, time.UTC),
 	}, nil
 }
 
@@ -5100,10 +5384,15 @@ func (f fakePropertyRepo) CreateRepairRequest(_ context.Context, _ *sql.Tx, para
 func (a testSQLPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params appproperty.CreatePropertyParams) (*appproperty.Property, error) {
 	property, err := a.repo.Create(ctx, tx, dbproperties.CreatePropertyParams{
 		Name:                             params.Name,
+		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
 		OwnerID:                          params.OwnerID,
+		ContactPhone:                     params.ContactPhone,
+		ContactEmail:                     params.ContactEmail,
+		Notes:                            params.Notes,
+		Facilities:                       params.Facilities,
 	})
 	if err != nil {
 		return nil, err
@@ -5112,10 +5401,15 @@ func (a testSQLPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx
 	return &appproperty.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
+		ContactPhone:                     property.ContactPhone,
+		ContactEmail:                     property.ContactEmail,
+		Notes:                            property.Notes,
+		Facilities:                       property.Facilities,
 		CreatedAt:                        property.CreatedAt,
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,
@@ -5135,10 +5429,15 @@ func (a testSQLPropertyRepositoryAdapter) FindByID(ctx context.Context, tx *sql.
 	return &appproperty.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
+		ContactPhone:                     property.ContactPhone,
+		ContactEmail:                     property.ContactEmail,
+		Notes:                            property.Notes,
+		Facilities:                       property.Facilities,
 		CreatedAt:                        property.CreatedAt,
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,
@@ -5149,10 +5448,15 @@ func (a testSQLPropertyRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx
 	property, err := a.repo.Update(ctx, tx, dbproperties.UpdatePropertyParams{
 		ID:                               params.ID,
 		Name:                             params.Name,
+		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
 		OwnerID:                          params.OwnerID,
+		ContactPhone:                     params.ContactPhone,
+		ContactEmail:                     params.ContactEmail,
+		Notes:                            params.Notes,
+		Facilities:                       params.Facilities,
 		Version:                          params.Version,
 	})
 	if err != nil {
@@ -5162,10 +5466,15 @@ func (a testSQLPropertyRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx
 	return &appproperty.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
+		ContactPhone:                     property.ContactPhone,
+		ContactEmail:                     property.ContactEmail,
+		Notes:                            property.Notes,
+		Facilities:                       property.Facilities,
 		CreatedAt:                        property.CreatedAt,
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,
@@ -5182,20 +5491,34 @@ func (a testSQLPropertyRepositoryAdapter) SoftDelete(ctx context.Context, tx *sq
 
 func (a testSQLPropertyRepositoryAdapter) CreateRoom(ctx context.Context, tx *sql.Tx, params appproperty.CreateRoomParams) (*appproperty.Room, error) {
 	room, err := a.repo.CreateRoom(ctx, tx, dbproperties.CreateRoomParams{
-		PropertyID: params.PropertyID,
-		Name:       params.Name,
+		PropertyID:        params.PropertyID,
+		Name:              params.Name,
+		Size:              params.Size,
+		Floor:             params.Floor,
+		RoomType:          params.RoomType,
+		Facilities:        params.Facilities,
+		DefaultRentAmount: params.DefaultRentAmount,
+		Notes:             params.Notes,
+		Zone:              params.Zone,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &appproperty.Room{
-		ID:         room.ID,
-		PropertyID: room.PropertyID,
-		Name:       room.Name,
-		Status:     room.Status,
-		CreatedAt:  room.CreatedAt,
-		UpdatedAt:  room.UpdatedAt,
+		ID:                room.ID,
+		PropertyID:        room.PropertyID,
+		Name:              room.Name,
+		Status:            room.Status,
+		Size:              room.Size,
+		Floor:             room.Floor,
+		RoomType:          room.RoomType,
+		Facilities:        room.Facilities,
+		DefaultRentAmount: room.DefaultRentAmount,
+		Notes:             room.Notes,
+		Zone:              room.Zone,
+		CreatedAt:         room.CreatedAt,
+		UpdatedAt:         room.UpdatedAt,
 	}, nil
 }
 
@@ -5206,32 +5529,53 @@ func (a testSQLPropertyRepositoryAdapter) FindRoomByID(ctx context.Context, tx *
 	}
 
 	return &appproperty.Room{
-		ID:         room.ID,
-		PropertyID: room.PropertyID,
-		Name:       room.Name,
-		Status:     room.Status,
-		CreatedAt:  room.CreatedAt,
-		UpdatedAt:  room.UpdatedAt,
+		ID:                room.ID,
+		PropertyID:        room.PropertyID,
+		Name:              room.Name,
+		Status:            room.Status,
+		Size:              room.Size,
+		Floor:             room.Floor,
+		RoomType:          room.RoomType,
+		Facilities:        room.Facilities,
+		DefaultRentAmount: room.DefaultRentAmount,
+		Notes:             room.Notes,
+		Zone:              room.Zone,
+		CreatedAt:         room.CreatedAt,
+		UpdatedAt:         room.UpdatedAt,
 	}, nil
 }
 
 func (a testSQLPropertyRepositoryAdapter) UpdateRoom(ctx context.Context, tx *sql.Tx, params appproperty.UpdateRoomParams) (*appproperty.Room, error) {
 	room, err := a.repo.UpdateRoom(ctx, tx, dbproperties.UpdateRoomParams{
-		ID:     params.ID,
-		Name:   params.Name,
-		Status: params.Status,
+		ID:                params.ID,
+		Name:              params.Name,
+		Status:            params.Status,
+		Size:              params.Size,
+		Floor:             params.Floor,
+		RoomType:          params.RoomType,
+		Facilities:        params.Facilities,
+		DefaultRentAmount: params.DefaultRentAmount,
+		Notes:             params.Notes,
+		Zone:              params.Zone,
 	})
 	if err != nil {
 		return nil, err
 	}
 
 	return &appproperty.Room{
-		ID:         room.ID,
-		PropertyID: room.PropertyID,
-		Name:       room.Name,
-		Status:     room.Status,
-		CreatedAt:  room.CreatedAt,
-		UpdatedAt:  room.UpdatedAt,
+		ID:                room.ID,
+		PropertyID:        room.PropertyID,
+		Name:              room.Name,
+		Status:            room.Status,
+		Size:              room.Size,
+		Floor:             room.Floor,
+		RoomType:          room.RoomType,
+		Facilities:        room.Facilities,
+		DefaultRentAmount: room.DefaultRentAmount,
+		Notes:             room.Notes,
+		Zone:              room.Zone,
+		CreatedAt:         room.CreatedAt,
+		UpdatedAt:         room.UpdatedAt,
 	}, nil
 }
 
@@ -5428,22 +5772,31 @@ func (f fakeTenantRepo) FindByID(_ context.Context, _ *sql.Tx, _ string) (*appte
 	}, nil
 }
 
-func (f fakeTenantRepo) Update(_ context.Context, _ *sql.Tx, _ apptenant.UpdateTenantParams) (*apptenant.Tenant, error) {
+func (f fakeTenantRepo) Update(_ context.Context, _ *sql.Tx, params apptenant.UpdateTenantParams) (*apptenant.Tenant, error) {
 	if f.updateErr != nil {
 		return nil, f.updateErr
+	}
+	if f.updateParams != nil {
+		*f.updateParams = params
 	}
 	if f.updated != nil {
 		return f.updated, nil
 	}
 
 	return &apptenant.Tenant{
-		ID:        "30000000-0000-0000-0000-000000000001",
-		Name:      "Tenant A",
-		Status:    "active",
-		Contacts:  []map[string]interface{}{},
-		Version:   2,
-		CreatedAt: time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
-		UpdatedAt: time.Date(2026, 4, 17, 10, 0, 0, 0, time.UTC),
+		ID:         params.ID,
+		Name:       params.Name,
+		Email:      params.Email,
+		Phone:      params.Phone,
+		Contacts:   params.Contacts,
+		BirthDate:  params.BirthDate,
+		NationalID: params.NationalID,
+		Address:    params.Address,
+		Occupation: params.Occupation,
+		Status:     "active",
+		Version:    2,
+		CreatedAt:  time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:  time.Date(2026, 4, 17, 10, 0, 0, 0, time.UTC),
 	}, nil
 }
 

--- a/internal/platform/database/properties/repository.go
+++ b/internal/platform/database/properties/repository.go
@@ -3,6 +3,7 @@ package properties
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -34,10 +35,15 @@ type CommandRepository interface {
 type Property struct {
 	ID                               string
 	Name                             string
+	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+	ContactPhone                     *string
+	ContactEmail                     *string
+	Notes                            *string
+	Facilities                       *map[string]interface{}
 	CreatedAt                        time.Time
 	UpdatedAt                        time.Time
 	Version                          int
@@ -45,12 +51,19 @@ type Property struct {
 
 // Room is the persisted room state used by write flows.
 type Room struct {
-	ID         string
-	PropertyID string
-	Name       string
-	Status     string
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	ID                string
+	PropertyID        string
+	Name              string
+	Status            string
+	Size              *float64
+	Floor             *string
+	RoomType          *string
+	Facilities        *map[string]interface{}
+	DefaultRentAmount *int
+	Notes             *string
+	Zone              *string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
 }
 
 // RepairRequest is the persisted repair request state used by write flows.
@@ -73,34 +86,58 @@ type RepairRequest struct {
 // CreatePropertyParams contains the writable fields required to persist a property.
 type CreatePropertyParams struct {
 	Name                             string
+	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+	ContactPhone                     *string
+	ContactEmail                     *string
+	Notes                            *string
+	Facilities                       *map[string]interface{}
 }
 
 // UpdatePropertyParams contains the writable fields required to persist a property update.
 type UpdatePropertyParams struct {
 	ID                               string
 	Name                             string
+	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+	ContactPhone                     *string
+	ContactEmail                     *string
+	Notes                            *string
+	Facilities                       *map[string]interface{}
 	Version                          int
 }
 
 // CreateRoomParams contains the writable fields required to persist a room.
 type CreateRoomParams struct {
-	PropertyID string
-	Name       string
+	PropertyID        string
+	Name              string
+	Size              *float64
+	Floor             *string
+	RoomType          *string
+	Facilities        *map[string]interface{}
+	DefaultRentAmount *int
+	Notes             *string
+	Zone              *string
 }
 
 // UpdateRoomParams contains the writable fields required to persist a room update.
 type UpdateRoomParams struct {
-	ID     string
-	Name   string
-	Status *string
+	ID                string
+	Name              string
+	Status            *string
+	Size              *float64
+	Floor             *string
+	RoomType          *string
+	Facilities        *map[string]interface{}
+	DefaultRentAmount *int
+	Notes             *string
+	Zone              *string
 }
 
 // CreateRepairRequestParams contains the writable fields required to persist a repair request.
@@ -146,27 +183,42 @@ LIMIT 1
 
 // Create persists a new property row within the provided transaction.
 func (r *SQLRepository) Create(ctx context.Context, tx *sql.Tx, params CreatePropertyParams) (*Property, error) {
+	facilitiesJSON, err := marshalJSONMap(params.Facilities)
+	if err != nil {
+		return nil, fmt.Errorf("marshal property facilities: %w", err)
+	}
+
 	const query = `
 INSERT INTO properties (
 	name,
-	address,
-	electricity_unit_price,
-	default_electricity_billing_cadence,
-	owner_id
-) VALUES ($1, $2, $3, $4, $5)
-RETURNING
-	id,
-	name,
+	subtitle,
 	address,
 	electricity_unit_price,
 	default_electricity_billing_cadence,
 	owner_id,
+	contact_phone,
+	contact_email,
+	notes,
+	facilities
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
+RETURNING
+	id,
+	name,
+	subtitle,
+	address,
+	electricity_unit_price,
+	default_electricity_billing_cadence,
+	owner_id,
+	contact_phone,
+	contact_email,
+	notes,
+	facilities::text,
 	created_at,
 	updated_at,
 	version
 `
 
-	property, err := scanProperty(tx.QueryRowContext(ctx, query, params.Name, params.Address, params.ElectricityUnitPrice, params.DefaultElectricityBillingCadence, params.OwnerID))
+	property, err := scanProperty(tx.QueryRowContext(ctx, query, params.Name, params.Subtitle, params.Address, params.ElectricityUnitPrice, params.DefaultElectricityBillingCadence, params.OwnerID, params.ContactPhone, params.ContactEmail, params.Notes, facilitiesJSON))
 	if err != nil {
 		return nil, fmt.Errorf("create property: %w", err)
 	}
@@ -180,10 +232,15 @@ func (r *SQLRepository) FindByID(ctx context.Context, tx *sql.Tx, id string) (*P
 SELECT
 	id,
 	name,
+	subtitle,
 	address,
 	electricity_unit_price,
 	default_electricity_billing_cadence,
 	owner_id,
+	contact_phone,
+	contact_email,
+	notes,
+	facilities::text,
 	created_at,
 	updated_at,
 	version
@@ -206,31 +263,46 @@ LIMIT 1
 
 // Update persists a property mutation inside the provided transaction.
 func (r *SQLRepository) Update(ctx context.Context, tx *sql.Tx, params UpdatePropertyParams) (*Property, error) {
+	facilitiesJSON, err := marshalJSONMap(params.Facilities)
+	if err != nil {
+		return nil, fmt.Errorf("marshal property facilities: %w", err)
+	}
+
 	const query = `
 UPDATE properties
 SET name = $2,
-	address = $3,
-	electricity_unit_price = $4,
-	default_electricity_billing_cadence = $5,
-	owner_id = $6,
+	subtitle = $3,
+	address = $4,
+	electricity_unit_price = $5,
+	default_electricity_billing_cadence = $6,
+	owner_id = $7,
+	contact_phone = $8,
+	contact_email = $9,
+	notes = $10,
+	facilities = $11::jsonb,
 	updated_at = now(),
 	version = version + 1
 WHERE id = $1
-  AND version = $7
+  AND version = $12
   AND deleted_at IS NULL
 RETURNING
 	id,
 	name,
+	subtitle,
 	address,
 	electricity_unit_price,
 	default_electricity_billing_cadence,
 	owner_id,
+	contact_phone,
+	contact_email,
+	notes,
+	facilities::text,
 	created_at,
 	updated_at,
 	version
 `
 
-	property, err := scanProperty(tx.QueryRowContext(ctx, query, params.ID, params.Name, params.Address, params.ElectricityUnitPrice, params.DefaultElectricityBillingCadence, params.OwnerID, params.Version))
+	property, err := scanProperty(tx.QueryRowContext(ctx, query, params.ID, params.Name, params.Subtitle, params.Address, params.ElectricityUnitPrice, params.DefaultElectricityBillingCadence, params.OwnerID, params.ContactPhone, params.ContactEmail, params.Notes, facilitiesJSON, params.Version))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -306,21 +378,40 @@ WHERE id = $1
 
 // CreateRoom persists a new room row within the provided transaction.
 func (r *SQLRepository) CreateRoom(ctx context.Context, tx *sql.Tx, params CreateRoomParams) (*Room, error) {
+	facilitiesJSON, err := marshalJSONMap(params.Facilities)
+	if err != nil {
+		return nil, fmt.Errorf("marshal room facilities: %w", err)
+	}
+
 	const query = `
 INSERT INTO rooms (
 	property_id,
-	name
-) VALUES ($1, $2)
+	name,
+	size,
+	floor,
+	room_type,
+	facilities,
+	default_rent_amount,
+	notes,
+	zone
+) VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9)
 RETURNING
 	id,
 	property_id,
 	name,
 	status,
+	size,
+	floor,
+	room_type,
+	facilities::text,
+	default_rent_amount,
+	notes,
+	zone,
 	created_at,
 	updated_at
 `
 
-	room, err := scanRoom(tx.QueryRowContext(ctx, query, params.PropertyID, params.Name))
+	room, err := scanRoom(tx.QueryRowContext(ctx, query, params.PropertyID, params.Name, params.Size, params.Floor, params.RoomType, facilitiesJSON, params.DefaultRentAmount, params.Notes, params.Zone))
 	if err != nil {
 		return nil, fmt.Errorf("create room: %w", err)
 	}
@@ -336,6 +427,13 @@ SELECT
 	property_id,
 	name,
 	status,
+	size,
+	floor,
+	room_type,
+	facilities::text,
+	default_rent_amount,
+	notes,
+	zone,
 	created_at,
 	updated_at
 FROM rooms
@@ -357,6 +455,11 @@ LIMIT 1
 
 // UpdateRoom persists a room mutation inside the provided transaction.
 func (r *SQLRepository) UpdateRoom(ctx context.Context, tx *sql.Tx, params UpdateRoomParams) (*Room, error) {
+	facilitiesJSON, err := marshalJSONMap(params.Facilities)
+	if err != nil {
+		return nil, fmt.Errorf("marshal room facilities: %w", err)
+	}
+
 	status := ""
 	if params.Status != nil {
 		status = *params.Status
@@ -366,6 +469,13 @@ func (r *SQLRepository) UpdateRoom(ctx context.Context, tx *sql.Tx, params Updat
 UPDATE rooms
 SET name = $2,
 	status = CASE WHEN $3 = '' THEN status ELSE $3 END,
+	size = $4,
+	floor = $5,
+	room_type = $6,
+	facilities = $7::jsonb,
+	default_rent_amount = $8,
+	notes = $9,
+	zone = $10,
 	updated_at = now()
 WHERE id = $1
   AND deleted_at IS NULL
@@ -374,11 +484,18 @@ RETURNING
 	property_id,
 	name,
 	status,
+	size,
+	floor,
+	room_type,
+	facilities::text,
+	default_rent_amount,
+	notes,
+	zone,
 	created_at,
 	updated_at
 `
 
-	room, err := scanRoom(tx.QueryRowContext(ctx, query, params.ID, params.Name, status))
+	room, err := scanRoom(tx.QueryRowContext(ctx, query, params.ID, params.Name, status, params.Size, params.Floor, params.RoomType, facilitiesJSON, params.DefaultRentAmount, params.Notes, params.Zone))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -455,22 +572,43 @@ type rowScanner interface {
 
 func scanProperty(row rowScanner) (*Property, error) {
 	var property Property
+	var subtitle sql.NullString
 	var electricityUnitPrice sql.NullFloat64
+	var contactPhone sql.NullString
+	var contactEmail sql.NullString
+	var notes sql.NullString
+	var facilities sql.NullString
 	if err := row.Scan(
 		&property.ID,
 		&property.Name,
+		&subtitle,
 		&property.Address,
 		&electricityUnitPrice,
 		&property.DefaultElectricityBillingCadence,
 		&property.OwnerID,
+		&contactPhone,
+		&contactEmail,
+		&notes,
+		&facilities,
 		&property.CreatedAt,
 		&property.UpdatedAt,
 		&property.Version,
 	); err != nil {
 		return nil, err
 	}
+	property.Subtitle = nullStringPtr(subtitle)
 	if electricityUnitPrice.Valid {
 		property.ElectricityUnitPrice = &electricityUnitPrice.Float64
+	}
+	property.ContactPhone = nullStringPtr(contactPhone)
+	property.ContactEmail = nullStringPtr(contactEmail)
+	property.Notes = nullStringPtr(notes)
+	if facilities.Valid {
+		decoded, err := unmarshalJSONMap(facilities.String)
+		if err != nil {
+			return nil, fmt.Errorf("decode property facilities: %w", err)
+		}
+		property.Facilities = decoded
 	}
 
 	return &property, nil
@@ -478,18 +616,85 @@ func scanProperty(row rowScanner) (*Property, error) {
 
 func scanRoom(row rowScanner) (*Room, error) {
 	var room Room
+	var size sql.NullFloat64
+	var floor sql.NullString
+	var roomType sql.NullString
+	var facilities sql.NullString
+	var defaultRentAmount sql.NullInt64
+	var notes sql.NullString
+	var zone sql.NullString
 	if err := row.Scan(
 		&room.ID,
 		&room.PropertyID,
 		&room.Name,
 		&room.Status,
+		&size,
+		&floor,
+		&roomType,
+		&facilities,
+		&defaultRentAmount,
+		&notes,
+		&zone,
 		&room.CreatedAt,
 		&room.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}
+	if size.Valid {
+		room.Size = &size.Float64
+	}
+	room.Floor = nullStringPtr(floor)
+	room.RoomType = nullStringPtr(roomType)
+	if facilities.Valid {
+		decoded, err := unmarshalJSONMap(facilities.String)
+		if err != nil {
+			return nil, fmt.Errorf("decode room facilities: %w", err)
+		}
+		room.Facilities = decoded
+	}
+	if defaultRentAmount.Valid {
+		value := int(defaultRentAmount.Int64)
+		room.DefaultRentAmount = &value
+	}
+	room.Notes = nullStringPtr(notes)
+	room.Zone = nullStringPtr(zone)
 
 	return &room, nil
+}
+
+func marshalJSONMap(value *map[string]interface{}) (*string, error) {
+	if value == nil {
+		return nil, nil
+	}
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	result := string(payload)
+	return &result, nil
+}
+
+func unmarshalJSONMap(raw string) (*map[string]interface{}, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return nil, err
+	}
+	objectValue, ok := decoded.(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+	return &objectValue, nil
+}
+
+func nullStringPtr(value sql.NullString) *string {
+	if !value.Valid {
+		return nil
+	}
+	result := value.String
+	return &result
 }
 
 func scanRepairRequest(row rowScanner) (*RepairRequest, error) {

--- a/internal/platform/database/properties/repository_test.go
+++ b/internal/platform/database/properties/repository_test.go
@@ -66,34 +66,26 @@ func TestCreatePersistsPropertyInTransaction(t *testing.T) {
 	tx := beginPropertyTx(t, db, mock)
 	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
 	updatedAt := createdAt.Add(time.Minute)
+	subtitle := "North wing"
+	contactPhone := "02-1234-5678"
+	contactEmail := "owner@example.com"
+	notes := "Managed property"
+	facilities := map[string]interface{}{"elevator": true}
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-INSERT INTO properties (
-	name,
-	address,
-	electricity_unit_price,
-	default_electricity_billing_cadence,
-	owner_id
-) VALUES ($1, $2, $3, $4, $5)
-RETURNING
-	id,
-	name,
-	address,
-	electricity_unit_price,
-	default_electricity_billing_cadence,
-	owner_id,
-	created_at,
-	updated_at,
-	version
-`)).
-		WithArgs("Green Villa", "Taipei", 4.5, "monthly", "owner-1").
+	mock.ExpectQuery("INSERT INTO properties").
+		WithArgs("Green Villa", &subtitle, "Taipei", 4.5, "monthly", "owner-1", &contactPhone, &contactEmail, &notes, `{"elevator":true}`).
 		WillReturnRows(propertyRows().AddRow(
 			"property-1",
 			"Green Villa",
+			subtitle,
 			"Taipei",
 			4.5,
 			"monthly",
 			"owner-1",
+			contactPhone,
+			contactEmail,
+			notes,
+			`{"elevator":true}`,
 			createdAt,
 			updatedAt,
 			1,
@@ -101,10 +93,15 @@ RETURNING
 
 	property, err := repo.Create(context.Background(), tx, CreatePropertyParams{
 		Name:                             "Green Villa",
+		Subtitle:                         &subtitle,
 		Address:                          "Taipei",
 		ElectricityUnitPrice:             4.5,
 		DefaultElectricityBillingCadence: "monthly",
 		OwnerID:                          "owner-1",
+		ContactPhone:                     &contactPhone,
+		ContactEmail:                     &contactEmail,
+		Notes:                            &notes,
+		Facilities:                       &facilities,
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -117,6 +114,12 @@ RETURNING
 	}
 	if property.DefaultElectricityBillingCadence != "monthly" {
 		t.Fatalf("DefaultElectricityBillingCadence = %q, want monthly", property.DefaultElectricityBillingCadence)
+	}
+	if property.Subtitle == nil || *property.Subtitle != subtitle || property.ContactEmail == nil || *property.ContactEmail != contactEmail {
+		t.Fatalf("unexpected optional fields: %+v", property)
+	}
+	if property.Facilities == nil || (*property.Facilities)["elevator"] != true {
+		t.Fatalf("unexpected facilities: %#v", property.Facilities)
 	}
 	if property.CreatedAt != createdAt || property.UpdatedAt != updatedAt || property.Version != 1 {
 		t.Fatalf("unexpected audit fields: %+v", property)
@@ -138,30 +141,20 @@ func TestFindByIDScansNullableElectricityUnitPrice(t *testing.T) {
 	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
 	updatedAt := createdAt.Add(time.Minute)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-SELECT
-	id,
-	name,
-	address,
-	electricity_unit_price,
-	default_electricity_billing_cadence,
-	owner_id,
-	created_at,
-	updated_at,
-	version
-FROM properties
-WHERE id = $1
-  AND deleted_at IS NULL
-LIMIT 1
-`)).
+	mock.ExpectQuery("SELECT").
 		WithArgs("property-1").
 		WillReturnRows(propertyRows().AddRow(
 			"property-1",
 			"Green Villa",
+			nil,
 			"Taipei",
 			nil,
 			"bimonthly",
 			"owner-1",
+			nil,
+			nil,
+			nil,
+			nil,
 			createdAt,
 			updatedAt,
 			3,
@@ -195,22 +188,7 @@ func TestFindByIDMapsNoRowsToNotFound(t *testing.T) {
 	defer closePropertyDB(t, db)
 	tx := beginPropertyTx(t, db, mock)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-SELECT
-	id,
-	name,
-	address,
-	electricity_unit_price,
-	default_electricity_billing_cadence,
-	owner_id,
-	created_at,
-	updated_at,
-	version
-FROM properties
-WHERE id = $1
-  AND deleted_at IS NULL
-LIMIT 1
-`)).
+	mock.ExpectQuery("SELECT").
 		WithArgs("property-404").
 		WillReturnError(sql.ErrNoRows)
 
@@ -235,37 +213,20 @@ func TestUpdatePersistsPropertyWithNullableElectricityUnitPrice(t *testing.T) {
 	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
 	updatedAt := createdAt.Add(time.Minute)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-UPDATE properties
-SET name = $2,
-	address = $3,
-	electricity_unit_price = $4,
-	default_electricity_billing_cadence = $5,
-	owner_id = $6,
-	updated_at = now(),
-	version = version + 1
-WHERE id = $1
-  AND version = $7
-  AND deleted_at IS NULL
-RETURNING
-	id,
-	name,
-	address,
-	electricity_unit_price,
-	default_electricity_billing_cadence,
-	owner_id,
-	created_at,
-	updated_at,
-	version
-`)).
-		WithArgs("property-1", "Green Villa Updated", "New Taipei", nil, "bimonthly", "owner-2", 3).
+	mock.ExpectQuery("UPDATE properties").
+		WithArgs("property-1", "Green Villa Updated", nil, "New Taipei", nil, "bimonthly", "owner-2", nil, nil, nil, nil, 3).
 		WillReturnRows(propertyRows().AddRow(
 			"property-1",
 			"Green Villa Updated",
+			nil,
 			"New Taipei",
 			nil,
 			"bimonthly",
 			"owner-2",
+			nil,
+			nil,
+			nil,
+			nil,
 			createdAt,
 			updatedAt,
 			4,
@@ -308,30 +269,8 @@ func TestUpdateMapsNoRowsToNotFound(t *testing.T) {
 	tx := beginPropertyTx(t, db, mock)
 	unitPrice := 5.25
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-UPDATE properties
-SET name = $2,
-	address = $3,
-	electricity_unit_price = $4,
-	default_electricity_billing_cadence = $5,
-	owner_id = $6,
-	updated_at = now(),
-	version = version + 1
-WHERE id = $1
-  AND version = $7
-  AND deleted_at IS NULL
-RETURNING
-	id,
-	name,
-	address,
-	electricity_unit_price,
-	default_electricity_billing_cadence,
-	owner_id,
-	created_at,
-	updated_at,
-	version
-`)).
-		WithArgs("property-404", "Green Villa", "Taipei", &unitPrice, "monthly", "owner-1", 9).
+	mock.ExpectQuery("UPDATE properties").
+		WithArgs("property-404", "Green Villa", nil, "Taipei", &unitPrice, "monthly", "owner-1", nil, nil, nil, nil, 9).
 		WillReturnError(sql.ErrNoRows)
 
 	_, err := repo.Update(context.Background(), tx, UpdatePropertyParams{
@@ -426,32 +365,40 @@ func TestCreateRoomPersistsRoomInTransaction(t *testing.T) {
 	tx := beginPropertyTx(t, db, mock)
 	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
 	updatedAt := createdAt.Add(time.Minute)
+	size := 12.5
+	floor := "2F"
+	roomType := "suite"
+	facilities := map[string]interface{}{"balcony": true}
+	defaultRent := 18000
+	notes := "Bright room"
+	zone := "A"
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-INSERT INTO rooms (
-	property_id,
-	name
-) VALUES ($1, $2)
-RETURNING
-	id,
-	property_id,
-	name,
-	status,
-	created_at,
-	updated_at
-`)).
-		WithArgs("property-1", "Room A").
-		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A", "vacant", createdAt, updatedAt))
+	mock.ExpectQuery("INSERT INTO rooms").
+		WithArgs("property-1", "Room A", &size, &floor, &roomType, `{"balcony":true}`, &defaultRent, &notes, &zone).
+		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A", "vacant", size, floor, roomType, `{"balcony":true}`, defaultRent, notes, zone, createdAt, updatedAt))
 
 	room, err := repo.CreateRoom(context.Background(), tx, CreateRoomParams{
-		PropertyID: "property-1",
-		Name:       "Room A",
+		PropertyID:        "property-1",
+		Name:              "Room A",
+		Size:              &size,
+		Floor:             &floor,
+		RoomType:          &roomType,
+		Facilities:        &facilities,
+		DefaultRentAmount: &defaultRent,
+		Notes:             &notes,
+		Zone:              &zone,
 	})
 	if err != nil {
 		t.Fatalf("CreateRoom: %v", err)
 	}
 	if room.ID != "room-1" || room.PropertyID != "property-1" || room.Name != "Room A" || room.Status != "vacant" {
 		t.Fatalf("unexpected room: %+v", room)
+	}
+	if room.Size == nil || *room.Size != size || room.DefaultRentAmount == nil || *room.DefaultRentAmount != defaultRent {
+		t.Fatalf("unexpected room writable fields: %+v", room)
+	}
+	if room.Facilities == nil || (*room.Facilities)["balcony"] != true {
+		t.Fatalf("unexpected room facilities: %#v", room.Facilities)
 	}
 
 	mock.ExpectCommit()
@@ -470,21 +417,9 @@ func TestFindRoomByIDReturnsRoom(t *testing.T) {
 	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
 	updatedAt := createdAt.Add(time.Minute)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-SELECT
-	id,
-	property_id,
-	name,
-	status,
-	created_at,
-	updated_at
-FROM rooms
-WHERE id = $1
-  AND deleted_at IS NULL
-LIMIT 1
-`)).
+	mock.ExpectQuery("SELECT").
 		WithArgs("room-1").
-		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A", "occupied", createdAt, updatedAt))
+		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A", "occupied", nil, nil, nil, nil, nil, nil, nil, createdAt, updatedAt))
 
 	room, err := repo.FindRoomByID(context.Background(), tx, "room-1")
 	if err != nil {
@@ -510,23 +445,9 @@ func TestUpdateRoomUsesEmptyStatusWhenStatusIsNil(t *testing.T) {
 	createdAt := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
 	updatedAt := createdAt.Add(time.Minute)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-UPDATE rooms
-SET name = $2,
-	status = CASE WHEN $3 = '' THEN status ELSE $3 END,
-	updated_at = now()
-WHERE id = $1
-  AND deleted_at IS NULL
-RETURNING
-	id,
-	property_id,
-	name,
-	status,
-	created_at,
-	updated_at
-`)).
-		WithArgs("room-1", "Room A Updated", "").
-		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A Updated", "occupied", createdAt, updatedAt))
+	mock.ExpectQuery("UPDATE rooms").
+		WithArgs("room-1", "Room A Updated", "", nil, nil, nil, nil, nil, nil, nil).
+		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A Updated", "occupied", nil, nil, nil, nil, nil, nil, nil, createdAt, updatedAt))
 
 	room, err := repo.UpdateRoom(context.Background(), tx, UpdateRoomParams{
 		ID:   "room-1",
@@ -556,23 +477,9 @@ func TestUpdateRoomUsesProvidedStatusWhenStatusIsNonNil(t *testing.T) {
 	updatedAt := createdAt.Add(time.Minute)
 	status := "maintenance"
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-UPDATE rooms
-SET name = $2,
-	status = CASE WHEN $3 = '' THEN status ELSE $3 END,
-	updated_at = now()
-WHERE id = $1
-  AND deleted_at IS NULL
-RETURNING
-	id,
-	property_id,
-	name,
-	status,
-	created_at,
-	updated_at
-`)).
-		WithArgs("room-1", "Room A", "maintenance").
-		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A", "maintenance", createdAt, updatedAt))
+	mock.ExpectQuery("UPDATE rooms").
+		WithArgs("room-1", "Room A", "maintenance", nil, nil, nil, nil, nil, nil, nil).
+		WillReturnRows(roomRows().AddRow("room-1", "property-1", "Room A", "maintenance", nil, nil, nil, nil, nil, nil, nil, createdAt, updatedAt))
 
 	room, err := repo.UpdateRoom(context.Background(), tx, UpdateRoomParams{
 		ID:     "room-1",
@@ -600,22 +507,8 @@ func TestUpdateRoomMapsNoRowsToNotFound(t *testing.T) {
 	defer closePropertyDB(t, db)
 	tx := beginPropertyTx(t, db, mock)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-UPDATE rooms
-SET name = $2,
-	status = CASE WHEN $3 = '' THEN status ELSE $3 END,
-	updated_at = now()
-WHERE id = $1
-  AND deleted_at IS NULL
-RETURNING
-	id,
-	property_id,
-	name,
-	status,
-	created_at,
-	updated_at
-`)).
-		WithArgs("room-404", "Room Missing", "").
+	mock.ExpectQuery("UPDATE rooms").
+		WithArgs("room-404", "Room Missing", "", nil, nil, nil, nil, nil, nil, nil).
 		WillReturnError(sql.ErrNoRows)
 
 	_, err := repo.UpdateRoom(context.Background(), tx, UpdateRoomParams{
@@ -836,10 +729,15 @@ func propertyRows() *sqlmock.Rows {
 	return sqlmock.NewRows([]string{
 		"id",
 		"name",
+		"subtitle",
 		"address",
 		"electricity_unit_price",
 		"default_electricity_billing_cadence",
 		"owner_id",
+		"contact_phone",
+		"contact_email",
+		"notes",
+		"facilities",
 		"created_at",
 		"updated_at",
 		"version",
@@ -852,6 +750,13 @@ func roomRows() *sqlmock.Rows {
 		"property_id",
 		"name",
 		"status",
+		"size",
+		"floor",
+		"room_type",
+		"facilities",
+		"default_rent_amount",
+		"notes",
+		"zone",
 		"created_at",
 		"updated_at",
 	})

--- a/internal/platform/database/propertyquery/repository.go
+++ b/internal/platform/database/propertyquery/repository.go
@@ -19,10 +19,15 @@ var ErrNotFound = errors.New("property query not found")
 type Property struct {
 	ID                               string
 	Name                             string
+	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
 	DefaultElectricityBillingCadence string
 	OwnerID                          string
+	ContactPhone                     *string
+	ContactEmail                     *string
+	Notes                            *string
+	Facilities                       *map[string]interface{}
 	Occupancy                        OccupancySummary
 	CreatedAt                        time.Time
 	UpdatedAt                        time.Time
@@ -85,10 +90,15 @@ func (r *SQLRepository) FindByID(ctx context.Context, propertyID string) (*Prope
 SELECT
 	p.id,
 	p.name,
+	p.subtitle,
 	p.address,
 	p.electricity_unit_price,
 	p.default_electricity_billing_cadence,
 	p.owner_id,
+	p.contact_phone,
+	p.contact_email,
+	p.notes,
+	p.facilities::text,
 	COUNT(rooms.id)::int AS total_rooms,
 	COUNT(rooms.id) FILTER (WHERE rooms.status = 'occupied')::int AS occupied_rooms,
 	COUNT(rooms.id) FILTER (WHERE rooms.status = 'vacant')::int AS vacant_rooms,
@@ -122,10 +132,15 @@ func (r *SQLRepository) ListAccessible(ctx context.Context, role string, userID 
 SELECT
 	p.id,
 	p.name,
+	p.subtitle,
 	p.address,
 	p.electricity_unit_price,
 	p.default_electricity_billing_cadence,
 	p.owner_id,
+	p.contact_phone,
+	p.contact_email,
+	p.notes,
+	p.facilities::text,
 	COUNT(rooms.id)::int AS total_rooms,
 	COUNT(rooms.id) FILTER (WHERE rooms.status = 'occupied')::int AS occupied_rooms,
 	COUNT(rooms.id) FILTER (WHERE rooms.status = 'vacant')::int AS vacant_rooms,
@@ -268,14 +283,24 @@ type rowScanner interface {
 
 func scanProperty(row rowScanner) (*Property, error) {
 	var property Property
+	var subtitle sql.NullString
 	var electricityUnitPrice sql.NullFloat64
+	var contactPhone sql.NullString
+	var contactEmail sql.NullString
+	var notes sql.NullString
+	var facilities sql.NullString
 	if err := row.Scan(
 		&property.ID,
 		&property.Name,
+		&subtitle,
 		&property.Address,
 		&electricityUnitPrice,
 		&property.DefaultElectricityBillingCadence,
 		&property.OwnerID,
+		&contactPhone,
+		&contactEmail,
+		&notes,
+		&facilities,
 		&property.Occupancy.TotalRooms,
 		&property.Occupancy.OccupiedRooms,
 		&property.Occupancy.VacantRooms,
@@ -289,6 +314,17 @@ func scanProperty(row rowScanner) (*Property, error) {
 	}
 	if electricityUnitPrice.Valid {
 		property.ElectricityUnitPrice = &electricityUnitPrice.Float64
+	}
+	property.Subtitle = nullStringPtr(subtitle)
+	property.ContactPhone = nullStringPtr(contactPhone)
+	property.ContactEmail = nullStringPtr(contactEmail)
+	property.Notes = nullStringPtr(notes)
+	if facilities.Valid {
+		decoded, err := unmarshalFacilities(facilities.String)
+		if err != nil {
+			return nil, fmt.Errorf("decode property facilities: %w", err)
+		}
+		property.Facilities = decoded
 	}
 
 	return &property, nil
@@ -352,4 +388,27 @@ func scanRoom(row rowScanner) (*Room, error) {
 	}
 
 	return &room, nil
+}
+
+func unmarshalFacilities(raw string) (*map[string]interface{}, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return nil, err
+	}
+	objectValue, ok := decoded.(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+	return &objectValue, nil
+}
+
+func nullStringPtr(value sql.NullString) *string {
+	if !value.Valid {
+		return nil
+	}
+	result := value.String
+	return &result
 }

--- a/internal/platform/database/propertyquery/repository_test.go
+++ b/internal/platform/database/propertyquery/repository_test.go
@@ -24,16 +24,22 @@ func TestListAccessibleReturnsOccupancySummary(t *testing.T) {
 
 	mock.ExpectQuery(`(?s)LEFT JOIN rooms ON rooms.property_id = p.id AND rooms.deleted_at IS NULL\s+WHERE p.deleted_at IS NULL\s+GROUP BY p.id ORDER BY p.created_at DESC`).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "name", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id",
+			"id", "name", "subtitle", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id",
+			"contact_phone", "contact_email", "notes", "facilities",
 			"total_rooms", "occupied_rooms", "vacant_rooms", "maintenance_rooms", "occupancy_rate",
 			"created_at", "updated_at", "version",
 		}).AddRow(
 			"10000000-0000-0000-0000-000000000001",
 			"Demo Property",
+			nil,
 			"Demo Address",
 			4.5,
 			"monthly",
 			"90000000-0000-0000-0000-000000000001",
+			nil,
+			nil,
+			nil,
+			nil,
 			4,
 			2,
 			1,

--- a/internal/platform/database/tenants/repository.go
+++ b/internal/platform/database/tenants/repository.go
@@ -38,20 +38,28 @@ type Tenant struct {
 
 // CreateTenantParams contains the writable fields required to persist a tenant.
 type CreateTenantParams struct {
-	Name     string
-	Email    *string
-	Phone    *string
-	Contacts []map[string]interface{}
+	Name       string
+	Email      *string
+	Phone      *string
+	Contacts   []map[string]interface{}
+	BirthDate  *time.Time
+	NationalID *string
+	Address    *string
+	Occupation *string
 }
 
 // UpdateTenantParams contains the writable fields required to persist a tenant update.
 type UpdateTenantParams struct {
-	ID       string
-	Name     string
-	Email    *string
-	Phone    *string
-	Contacts []map[string]interface{}
-	Version  int
+	ID         string
+	Name       string
+	Email      *string
+	Phone      *string
+	Contacts   []map[string]interface{}
+	BirthDate  *time.Time
+	NationalID *string
+	Address    *string
+	Occupation *string
+	Version    int
 }
 
 // SQLRepository reads and writes tenants from PostgreSQL.
@@ -76,8 +84,12 @@ INSERT INTO tenants (
 	name,
 	email,
 	phone,
-	contacts
-) VALUES ($1, $2, $3, $4::jsonb)
+	contacts,
+	birth_date,
+	national_id,
+	address,
+	occupation
+) VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7, $8)
 RETURNING
 	id,
 	name,
@@ -94,7 +106,7 @@ RETURNING
 	version
 `
 
-	tenant, err := scanTenant(tx.QueryRowContext(ctx, query, params.Name, params.Email, params.Phone, contactsJSON))
+	tenant, err := scanTenant(tx.QueryRowContext(ctx, query, params.Name, params.Email, params.Phone, contactsJSON, params.BirthDate, params.NationalID, params.Address, params.Occupation))
 	if err != nil {
 		return nil, fmt.Errorf("create tenant: %w", err)
 	}
@@ -149,10 +161,14 @@ SET name = $2,
 	email = $3,
 	phone = $4,
 	contacts = $5::jsonb,
+	birth_date = $6,
+	national_id = $7,
+	address = $8,
+	occupation = $9,
 	updated_at = now(),
 	version = version + 1
 WHERE id = $1
-  AND version = $6
+  AND version = $10
   AND deleted_at IS NULL
 RETURNING
 	id,
@@ -170,7 +186,7 @@ RETURNING
 	version
 `
 
-	tenant, err := scanTenant(tx.QueryRowContext(ctx, query, params.ID, params.Name, params.Email, params.Phone, contactsJSON, params.Version))
+	tenant, err := scanTenant(tx.QueryRowContext(ctx, query, params.ID, params.Name, params.Email, params.Phone, contactsJSON, params.BirthDate, params.NationalID, params.Address, params.Occupation, params.Version))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound

--- a/internal/platform/database/tenants/repository_test.go
+++ b/internal/platform/database/tenants/repository_test.go
@@ -19,29 +19,8 @@ func TestCreateUsesTransactionAndMarshalsNilContactsAsEmptyArray(t *testing.T) {
 	tx := beginTenantTx(t, db, mock)
 	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-INSERT INTO tenants (
-	name,
-	email,
-	phone,
-	contacts
-) VALUES ($1, $2, $3, $4::jsonb)
-RETURNING
-	id,
-	name,
-	email,
-	phone,
-	contacts::text,
-	birth_date,
-	national_id,
-	address,
-	occupation,
-	status,
-	created_at,
-	updated_at,
-	version
-`)).
-		WithArgs("Tenant A", nil, nil, "[]").
+	mock.ExpectQuery("INSERT INTO tenants").
+		WithArgs("Tenant A", nil, nil, "[]", nil, nil, nil, nil).
 		WillReturnRows(tenantRows().AddRow(
 			"tenant-1",
 			"Tenant A",
@@ -214,39 +193,22 @@ func TestUpdateUsesVersionConditionAndContactsJSON(t *testing.T) {
 	now := time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)
 	email := "tenant@example.com"
 	phone := "0912-345-678"
+	birthDate := time.Date(1992, 3, 4, 0, 0, 0, 0, time.UTC)
+	nationalID := "A123456789"
+	address := "Taipei"
+	occupation := "Engineer"
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-UPDATE tenants
-SET name = $2,
-	email = $3,
-	phone = $4,
-	contacts = $5::jsonb,
-	updated_at = now(),
-	version = version + 1
-WHERE id = $1
-  AND version = $6
-  AND deleted_at IS NULL
-RETURNING
-	id,
-	name,
-	email,
-	phone,
-	contacts::text,
-	birth_date,
-	national_id,
-	address,
-	occupation,
-	status,
-	created_at,
-	updated_at,
-	version
-`)).
+	mock.ExpectQuery("UPDATE tenants").
 		WithArgs(
 			"tenant-1",
 			"Tenant Updated",
 			&email,
 			&phone,
 			`[{"name":"Emergency","phone":"0987-654-321"}]`,
+			&birthDate,
+			&nationalID,
+			&address,
+			&occupation,
 			4,
 		).
 		WillReturnRows(tenantRows().AddRow(
@@ -255,10 +217,10 @@ RETURNING
 			email,
 			phone,
 			`[{"name":"Emergency","phone":"0987-654-321"}]`,
-			nil,
-			nil,
-			nil,
-			nil,
+			birthDate,
+			nationalID,
+			address,
+			occupation,
 			"active",
 			now,
 			now,
@@ -273,7 +235,11 @@ RETURNING
 		Contacts: []map[string]interface{}{
 			{"name": "Emergency", "phone": "0987-654-321"},
 		},
-		Version: 4,
+		BirthDate:  &birthDate,
+		NationalID: &nationalID,
+		Address:    &address,
+		Occupation: &occupation,
+		Version:    4,
 	})
 	if err != nil {
 		t.Fatalf("Update: %v", err)
@@ -283,6 +249,9 @@ RETURNING
 	}
 	if len(tenant.Contacts) != 1 || tenant.Contacts[0]["phone"] != "0987-654-321" {
 		t.Fatalf("expected decoded contacts, got %#v", tenant.Contacts)
+	}
+	if tenant.BirthDate == nil || !tenant.BirthDate.Equal(birthDate) || tenant.NationalID == nil || *tenant.NationalID != nationalID {
+		t.Fatalf("unexpected tenant v1 fields: %+v", tenant)
 	}
 
 	mock.ExpectCommit()
@@ -300,33 +269,8 @@ func TestUpdateMapsNoRowsToErrNotFound(t *testing.T) {
 
 	tx := beginTenantTx(t, db, mock)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`
-UPDATE tenants
-SET name = $2,
-	email = $3,
-	phone = $4,
-	contacts = $5::jsonb,
-	updated_at = now(),
-	version = version + 1
-WHERE id = $1
-  AND version = $6
-  AND deleted_at IS NULL
-RETURNING
-	id,
-	name,
-	email,
-	phone,
-	contacts::text,
-	birth_date,
-	national_id,
-	address,
-	occupation,
-	status,
-	created_at,
-	updated_at,
-	version
-`)).
-		WithArgs("missing-tenant", "Tenant Updated", nil, nil, "[]", 2).
+	mock.ExpectQuery("UPDATE tenants").
+		WithArgs("missing-tenant", "Tenant Updated", nil, nil, "[]", nil, nil, nil, nil, 2).
 		WillReturnError(sql.ErrNoRows)
 
 	_, err := repo.Update(context.Background(), tx, UpdateTenantParams{

--- a/internal/server/property_adapters.go
+++ b/internal/server/property_adapters.go
@@ -42,10 +42,15 @@ func (a propertyAccountRepositoryAdapter) CreatePropertyAccount(ctx context.Cont
 func (a propertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params appproperty.CreatePropertyParams) (*appproperty.Property, error) {
 	property, err := a.repo.Create(ctx, tx, dbproperties.CreatePropertyParams{
 		Name:                             params.Name,
+		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
 		OwnerID:                          params.OwnerID,
+		ContactPhone:                     params.ContactPhone,
+		ContactEmail:                     params.ContactEmail,
+		Notes:                            params.Notes,
+		Facilities:                       params.Facilities,
 	})
 	if err != nil {
 		return nil, err
@@ -70,10 +75,15 @@ func (a propertyRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx, param
 	property, err := a.repo.Update(ctx, tx, dbproperties.UpdatePropertyParams{
 		ID:                               params.ID,
 		Name:                             params.Name,
+		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
 		OwnerID:                          params.OwnerID,
+		ContactPhone:                     params.ContactPhone,
+		ContactEmail:                     params.ContactEmail,
+		Notes:                            params.Notes,
+		Facilities:                       params.Facilities,
 		Version:                          params.Version,
 	})
 	if err != nil {
@@ -100,8 +110,15 @@ func (a propertyRepositoryAdapter) SoftDelete(ctx context.Context, tx *sql.Tx, i
 
 func (a propertyRepositoryAdapter) CreateRoom(ctx context.Context, tx *sql.Tx, params appproperty.CreateRoomParams) (*appproperty.Room, error) {
 	room, err := a.repo.CreateRoom(ctx, tx, dbproperties.CreateRoomParams{
-		PropertyID: params.PropertyID,
-		Name:       params.Name,
+		PropertyID:        params.PropertyID,
+		Name:              params.Name,
+		Size:              params.Size,
+		Floor:             params.Floor,
+		RoomType:          params.RoomType,
+		Facilities:        params.Facilities,
+		DefaultRentAmount: params.DefaultRentAmount,
+		Notes:             params.Notes,
+		Zone:              params.Zone,
 	})
 	if err != nil {
 		return nil, err
@@ -124,9 +141,16 @@ func (a propertyRepositoryAdapter) FindRoomByID(ctx context.Context, tx *sql.Tx,
 
 func (a propertyRepositoryAdapter) UpdateRoom(ctx context.Context, tx *sql.Tx, params appproperty.UpdateRoomParams) (*appproperty.Room, error) {
 	room, err := a.repo.UpdateRoom(ctx, tx, dbproperties.UpdateRoomParams{
-		ID:     params.ID,
-		Name:   params.Name,
-		Status: params.Status,
+		ID:                params.ID,
+		Name:              params.Name,
+		Status:            params.Status,
+		Size:              params.Size,
+		Floor:             params.Floor,
+		RoomType:          params.RoomType,
+		Facilities:        params.Facilities,
+		DefaultRentAmount: params.DefaultRentAmount,
+		Notes:             params.Notes,
+		Zone:              params.Zone,
 	})
 	if err != nil {
 		if err == dbproperties.ErrNotFound {
@@ -165,10 +189,15 @@ func toApplicationProperty(property *dbproperties.Property) *appproperty.Propert
 	return &appproperty.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,
 		DefaultElectricityBillingCadence: property.DefaultElectricityBillingCadence,
 		OwnerID:                          property.OwnerID,
+		ContactPhone:                     property.ContactPhone,
+		ContactEmail:                     property.ContactEmail,
+		Notes:                            property.Notes,
+		Facilities:                       property.Facilities,
 		CreatedAt:                        property.CreatedAt,
 		UpdatedAt:                        property.UpdatedAt,
 		Version:                          property.Version,
@@ -177,12 +206,19 @@ func toApplicationProperty(property *dbproperties.Property) *appproperty.Propert
 
 func toApplicationRoom(room *dbproperties.Room) *appproperty.Room {
 	return &appproperty.Room{
-		ID:         room.ID,
-		PropertyID: room.PropertyID,
-		Name:       room.Name,
-		Status:     room.Status,
-		CreatedAt:  room.CreatedAt,
-		UpdatedAt:  room.UpdatedAt,
+		ID:                room.ID,
+		PropertyID:        room.PropertyID,
+		Name:              room.Name,
+		Status:            room.Status,
+		Size:              room.Size,
+		Floor:             room.Floor,
+		RoomType:          room.RoomType,
+		Facilities:        room.Facilities,
+		DefaultRentAmount: room.DefaultRentAmount,
+		Notes:             room.Notes,
+		Zone:              room.Zone,
+		CreatedAt:         room.CreatedAt,
+		UpdatedAt:         room.UpdatedAt,
 	}
 }
 

--- a/internal/server/tenant_adapters.go
+++ b/internal/server/tenant_adapters.go
@@ -14,10 +14,14 @@ type tenantRepositoryAdapter struct {
 
 func (a tenantRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params apptenant.CreateTenantParams) (*apptenant.Tenant, error) {
 	tenant, err := a.repo.Create(ctx, tx, dbtenants.CreateTenantParams{
-		Name:     params.Name,
-		Email:    params.Email,
-		Phone:    params.Phone,
-		Contacts: params.Contacts,
+		Name:       params.Name,
+		Email:      params.Email,
+		Phone:      params.Phone,
+		Contacts:   params.Contacts,
+		BirthDate:  params.BirthDate,
+		NationalID: params.NationalID,
+		Address:    params.Address,
+		Occupation: params.Occupation,
 	})
 	if err != nil {
 		return nil, err
@@ -40,12 +44,16 @@ func (a tenantRepositoryAdapter) FindByID(ctx context.Context, tx *sql.Tx, id st
 
 func (a tenantRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx, params apptenant.UpdateTenantParams) (*apptenant.Tenant, error) {
 	tenant, err := a.repo.Update(ctx, tx, dbtenants.UpdateTenantParams{
-		ID:       params.ID,
-		Name:     params.Name,
-		Email:    params.Email,
-		Phone:    params.Phone,
-		Contacts: params.Contacts,
-		Version:  params.Version,
+		ID:         params.ID,
+		Name:       params.Name,
+		Email:      params.Email,
+		Phone:      params.Phone,
+		Contacts:   params.Contacts,
+		BirthDate:  params.BirthDate,
+		NationalID: params.NationalID,
+		Address:    params.Address,
+		Occupation: params.Occupation,
+		Version:    params.Version,
 	})
 	if err != nil {
 		if err == dbtenants.ErrNotFound {

--- a/test/e2e/auth_master_data_test.go
+++ b/test/e2e/auth_master_data_test.go
@@ -95,6 +95,10 @@ func TestE2EAuthAndMasterDataAcceptance(t *testing.T) {
 		if readBack.PropertyID != assignedProperty.ID {
 			t.Fatalf("expected read-back room property_id %q, got %q", assignedProperty.ID, readBack.PropertyID)
 		}
+		if readBack.Facilities["balcony"] != true {
+			t.Fatalf("expected read-back room facilities balcony=true, got %#v", readBack.Facilities)
+		}
+		requireStringPtr(t, readBack.Notes, "E2E room notes", "read-back room notes")
 	})
 
 	t.Run("tenant can be created and read back through API", func(t *testing.T) {
@@ -112,32 +116,61 @@ func TestE2EAuthAndMasterDataAcceptance(t *testing.T) {
 		if readBack.Status != "active" {
 			t.Fatalf("expected tenant status %q, got %q", "active", readBack.Status)
 		}
+		requireStringPtr(t, readBack.NationalID, "A123456789", "read-back tenant national_id")
+		if len(readBack.Contacts) != 1 || readBack.Contacts[0].Relation == nil || *readBack.Contacts[0].Relation != "family" {
+			t.Fatalf("expected read-back typed tenant contact, got %#v", readBack.Contacts)
+		}
 	})
 }
 
 type e2ePropertyResponse struct {
 	ID                               string              `json:"id"`
 	Name                             string              `json:"name"`
+	Subtitle                         *string             `json:"subtitle"`
 	Address                          string              `json:"address"`
 	ElectricityUnitPrice             float64             `json:"electricity_unit_price"`
 	DefaultElectricityBillingCadence string              `json:"default_electricity_billing_cadence"`
 	OwnerID                          string              `json:"owner_id"`
+	ContactPhone                     *string             `json:"contact_phone"`
+	ContactEmail                     *string             `json:"contact_email"`
+	Notes                            *string             `json:"notes"`
+	Facilities                       map[string]any      `json:"facilities"`
 	OccupancySummary                 e2eOccupancySummary `json:"occupancy_summary"`
 }
 
 type e2eRoomResponse struct {
-	ID         string `json:"id"`
-	PropertyID string `json:"property_id"`
-	Name       string `json:"name"`
-	Status     string `json:"status"`
+	ID                string         `json:"id"`
+	PropertyID        string         `json:"property_id"`
+	Name              string         `json:"name"`
+	Status            string         `json:"status"`
+	Size              *float64       `json:"size"`
+	Floor             *string        `json:"floor"`
+	RoomType          *string        `json:"room_type"`
+	Facilities        map[string]any `json:"facilities"`
+	DefaultRentAmount *int           `json:"default_rent_amount"`
+	Notes             *string        `json:"notes"`
+	Zone              *string        `json:"zone"`
 }
 
 type e2eTenantResponse struct {
-	ID     string `json:"id"`
-	Name   string `json:"name"`
-	Email  string `json:"email"`
-	Phone  string `json:"phone"`
-	Status string `json:"status"`
+	ID         string             `json:"id"`
+	Name       string             `json:"name"`
+	Email      string             `json:"email"`
+	Phone      string             `json:"phone"`
+	Contacts   []e2eTenantContact `json:"contacts"`
+	BirthDate  *string            `json:"birth_date"`
+	NationalID *string            `json:"national_id"`
+	Address    *string            `json:"address"`
+	Occupation *string            `json:"occupation"`
+	Status     string             `json:"status"`
+}
+
+type e2eTenantContact struct {
+	Name     *string `json:"name"`
+	Phone    *string `json:"phone"`
+	Email    *string `json:"email"`
+	Relation *string `json:"relation"`
+	Notes    *string `json:"notes"`
 }
 
 func createProperty(t *testing.T, ctx context.Context, client apiClient, name string) e2ePropertyResponse {
@@ -145,10 +178,17 @@ func createProperty(t *testing.T, ctx context.Context, client apiClient, name st
 
 	request := map[string]any{
 		"name":                                name,
+		"subtitle":                            "E2E Sub Property",
 		"address":                             "100 E2E Acceptance Road",
 		"electricity_unit_price":              4.5,
 		"default_electricity_billing_cadence": "monthly",
 		"owner_id":                            seededAdminUserID,
+		"contact_phone":                       "02-1234-5678",
+		"contact_email":                       "property-contact@example.com",
+		"notes":                               "E2E property notes",
+		"facilities": map[string]any{
+			"elevator": true,
+		},
 	}
 	resp, body, err := client.postJSON(ctx, "/api/v1/properties", request)
 	if err != nil {
@@ -176,6 +216,13 @@ func createProperty(t *testing.T, ctx context.Context, client apiClient, name st
 	if property.OwnerID != seededAdminUserID {
 		t.Fatalf("expected owner_id %q, got %q", seededAdminUserID, property.OwnerID)
 	}
+	requireStringPtr(t, property.Subtitle, "E2E Sub Property", "property subtitle")
+	requireStringPtr(t, property.ContactPhone, "02-1234-5678", "property contact_phone")
+	requireStringPtr(t, property.ContactEmail, "property-contact@example.com", "property contact_email")
+	requireStringPtr(t, property.Notes, "E2E property notes", "property notes")
+	if property.Facilities["elevator"] != true {
+		t.Fatalf("expected property facilities elevator=true, got %#v", property.Facilities)
+	}
 
 	readBack := getProperty(t, ctx, client, property.ID)
 	if readBack.ID != property.ID {
@@ -183,6 +230,10 @@ func createProperty(t *testing.T, ctx context.Context, client apiClient, name st
 	}
 	if readBack.Name != property.Name {
 		t.Fatalf("expected read-back property name %q, got %q", property.Name, readBack.Name)
+	}
+	requireStringPtr(t, readBack.Subtitle, "E2E Sub Property", "read-back property subtitle")
+	if readBack.Facilities["elevator"] != true {
+		t.Fatalf("expected read-back property facilities elevator=true, got %#v", readBack.Facilities)
 	}
 
 	return property
@@ -205,9 +256,17 @@ func getProperty(t *testing.T, ctx context.Context, client apiClient, propertyID
 func createRoom(t *testing.T, ctx context.Context, client apiClient, propertyID string, name string) e2eRoomResponse {
 	t.Helper()
 
-	resp, body, err := client.postJSON(ctx, "/api/v1/properties/"+propertyID+"/rooms", map[string]any{
-		"name": name,
-	})
+	request := map[string]any{
+		"name":                name,
+		"size":                12.5,
+		"floor":               "2F",
+		"room_type":           "suite",
+		"facilities":          map[string]any{"balcony": true},
+		"default_rent_amount": 18000,
+		"notes":               "E2E room notes",
+		"zone":                "A",
+	}
+	resp, body, err := client.postJSON(ctx, "/api/v1/properties/"+propertyID+"/rooms", request)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,6 +280,13 @@ func createRoom(t *testing.T, ctx context.Context, client apiClient, propertyID 
 	if room.Name != name {
 		t.Fatalf("expected room name %q, got %q", name, room.Name)
 	}
+	if room.Size == nil || *room.Size != 12.5 {
+		t.Fatalf("expected room size %v, got %+v", request["size"], room.Size)
+	}
+	if room.Facilities["balcony"] != true {
+		t.Fatalf("expected room facilities balcony=true, got %#v", room.Facilities)
+	}
+	requireStringPtr(t, room.Notes, "E2E room notes", "room notes")
 
 	return room
 }
@@ -243,9 +309,22 @@ func createTenant(t *testing.T, ctx context.Context, client apiClient) e2eTenant
 	t.Helper()
 
 	request := map[string]any{
-		"name":  "E2E Tenant",
-		"email": "e2e.tenant@example.com",
-		"phone": "0912-345-678",
+		"name":        "E2E Tenant",
+		"email":       "e2e.tenant@example.com",
+		"phone":       "0912-345-678",
+		"birth_date":  "1990-05-01",
+		"national_id": "A123456789",
+		"address":     "E2E Tenant Address",
+		"occupation":  "Engineer",
+		"contacts": []map[string]any{
+			{
+				"name":     "Emergency Contact",
+				"phone":    "0987-654-321",
+				"email":    "emergency@example.com",
+				"relation": "family",
+				"notes":    "Call first",
+			},
+		},
 	}
 	resp, body, err := client.postJSON(ctx, "/api/v1/tenants", request)
 	if err != nil {
@@ -264,8 +343,22 @@ func createTenant(t *testing.T, ctx context.Context, client apiClient) e2eTenant
 	if tenant.Email != request["email"] {
 		t.Fatalf("expected tenant email %q, got %q", request["email"], tenant.Email)
 	}
+	requireStringPtr(t, tenant.BirthDate, "1990-05-01", "tenant birth_date")
+	requireStringPtr(t, tenant.NationalID, "A123456789", "tenant national_id")
+	requireStringPtr(t, tenant.Address, "E2E Tenant Address", "tenant address")
+	requireStringPtr(t, tenant.Occupation, "Engineer", "tenant occupation")
+	if len(tenant.Contacts) != 1 || tenant.Contacts[0].Name == nil || *tenant.Contacts[0].Name != "Emergency Contact" {
+		t.Fatalf("expected typed tenant contact, got %#v", tenant.Contacts)
+	}
 
 	return tenant
+}
+
+func requireStringPtr(t *testing.T, got *string, want string, label string) {
+	t.Helper()
+	if got == nil || *got != want {
+		t.Fatalf("expected %s %q, got %+v", label, want, got)
+	}
 }
 
 func getTenant(t *testing.T, ctx context.Context, client apiClient, tenantID string) e2eTenantResponse {

--- a/test/e2e/lease_billing_lifecycle_test.go
+++ b/test/e2e/lease_billing_lifecycle_test.go
@@ -49,6 +49,7 @@ func TestE2ELeaseCreationLifecycleAcceptance(t *testing.T) {
 		RentAmount: 18000,
 		Deposit:    36000,
 		Cadence:    "monthly",
+		Notes:      "E2E lease notes",
 	})
 
 	readRoom := getRoom(t, ctx, adminClient, room.ID)
@@ -71,6 +72,7 @@ func TestE2ELeaseCreationLifecycleAcceptance(t *testing.T) {
 		RentAmount: 18000,
 		Deposit:    36000,
 		Cadence:    "monthly",
+		Notes:      "E2E lease notes",
 	})
 
 	bills := leaseLifecycleE2EListBills(t, ctx, adminClient, lease.ID)
@@ -222,6 +224,7 @@ type leaseLifecycleE2ECreateLeaseParams struct {
 	RentCadence               string
 	ElectricityBillingCadence string
 	StartingMeterReading      int
+	Notes                     string
 }
 
 type leaseLifecycleE2ELeaseResponse struct {
@@ -319,6 +322,9 @@ func leaseLifecycleE2ECreateLease(t *testing.T, ctx context.Context, client apiC
 	}
 	if params.RentCadence != "" {
 		request["rent_billing_cadence"] = params.RentCadence
+	}
+	if params.Notes != "" {
+		request["notes"] = params.Notes
 	}
 
 	resp, body, err := client.postJSON(ctx, "/api/v1/leases", request)
@@ -487,6 +493,11 @@ func leaseLifecycleE2ERequireLease(t *testing.T, lease leaseLifecycleE2ELeaseRes
 	}
 	if lease.EndDate != expected.EndDate {
 		t.Fatalf("expected end_date %q, got %q", expected.EndDate, lease.EndDate)
+	}
+	if expected.Notes != "" {
+		if lease.Notes == nil || *lease.Notes != expected.Notes {
+			t.Fatalf("expected notes %q, got %+v", expected.Notes, lease.Notes)
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #133

## What changed
- Expanded writable OpenAPI schemas for property, room, tenant, and lease create/update paths needed by frontend v1.0.
- Aligned generated API types, handler mapping, application/domain inputs, repositories, and server adapters with the writable schema contract.
- Added typed tenant contacts and changed property/room facilities to DB-aligned object payloads.
- Removed `rent_billing_cadence` from lease PATCH; cadence changes stay in lease replacement.
- Fixed nullable PATCH handling so missing fields keep current values and explicit `null` clears nullable values.

## Frontend impact
- Frontend can use the backend OpenAPI contract directly for writable property, room, tenant, and lease create fields.
- Nullable PATCH fields now support explicit clear semantics for property, room, and tenant v1.0 editable fields.
- Lease PATCH no longer accepts rent cadence updates; use replacement flow for cadence changes.

## Validation
- `npm run openapi:lint`
- `GIN_MODE=release GOCACHE=/tmp/go-cache go test ./internal/http/router ./internal/application/property ./internal/application/tenant ./internal/domain/property ./internal/domain/tenant`
- `GOCACHE=/tmp/go-cache go test ./...`
- `GOCACHE=/tmp/go-cache go test -tags=e2e ./test/e2e -run 'TestE2EAuthAndMasterDataAcceptance|TestE2ELeaseCreationLifecycleAcceptance' -count=0`\n- runtime E2E: `GOCACHE=/tmp/go-cache ./scripts/e2e_test.sh`\n- `git diff --check`