### PR TITLE
[codex] Fix auth contract source of truth docs

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -10,13 +10,13 @@ info:
     產出依據：docs/design/domain-model.md v3.3
     授權模型：混合型（RBAC + Resource-based）
     - x-required-role：列出可呼叫的角色（RBAC）
-    - x-ownership-required：物業層級存取控制（resource-based），透過 Firebase ID token 內 Custom Claims 的 assigned_property_ids 驗證
+    - x-ownership-required：物業層級存取控制（resource-based），透過 Firebase ID token 解析出的 firebase_uid 載入 DB user principal，再以 DB 內 role / assigned_property_ids 驗證
     - 優先順序：先驗 RBAC role，再驗 property ownership（兩者皆須通過）
 
     認證機制（v3.2）：系統使用 Firebase Auth 管理使用者認證。
     - 登入流程：由前端 Firebase SDK 處理，後端不接受 email/password 登入
     - 後端驗證：每個 request 以 Firebase ID token（Bearer token）呼叫後端
-    - 後端 middleware 以 Firebase Admin SDK 驗證 token，從 Custom Claims 讀取 role 與 assigned_property_ids
+    - 後端 middleware 以 Firebase Admin SDK 驗證 token，使用 firebase_uid 查詢 DB user； DB user principal 才是 role 與 assigned_property_ids 的授權來源
     - 密碼重設：`POST /users` 建立帳號後由後端向 Firebase 產生 reset link，再透過 email 寄送；admin 可透過 `POST /users/{id}/password-reset` 重寄設定密碼信
     - users table 透過 firebase_uid 與 Firebase 帳號對應
 
@@ -49,7 +49,7 @@ paths:
         - Identity & Access
       responses:
         '200':
-          description: 同步成功，回傳使用者基本資料與 Custom Claims 資訊
+          description: 同步成功，回傳使用者基本資料與 DB 授權資訊
           content:
             application/json:
               schema:
@@ -549,7 +549,7 @@ paths:
         BR-11：指派對象必須為工作室成員（非業主）。
         x-required-role: admin
         指派成功後，後端呼叫 Firebase Admin SDK 更新該使用者的 Custom Claims（role 與 assigned_property_ids），
-        前端下次 refresh token 後新指派生效。
+        Backend authenticated requests 會於下次請求載入 DB user principal 後生效；Custom Claims 僅作為同步副本。
       tags:
         - Identity & Access
       x-required-role:
@@ -575,7 +575,7 @@ paths:
                     - 10000000-0000-0000-0000-000000000002
       responses:
         '200':
-          description: 指派成功（Firebase Custom Claims 已更新）
+          description: 指派成功（DB 授權資料已更新，Firebase Custom Claims 已同步）
           content:
             application/json:
               schema:
@@ -771,7 +771,7 @@ paths:
       description: |
         x-ownership-required: 依角色過濾：
         - admin：全部物業
-        - organizer/staff：Firebase Custom Claims 內 assigned_property_ids
+        - organizer/staff：DB user principal 內 assigned_property_ids
         - owner：自己名下（properties.owner_id = authenticated user id）
       tags:
         - Property
@@ -7022,7 +7022,7 @@ components:
       bearerFormat: JWT
       description: |
         Firebase ID token。前端以 Firebase SDK 登入後取得，每個 request 帶入 Authorization header。
-        後端以 Firebase Admin SDK 驗證，Custom Claims 包含 role 與 assigned_property_ids。
+        後端以 Firebase Admin SDK 驗證 token，並以 firebase_uid 載入 DB user principal 作為 role 與 assigned_property_ids 的授權來源。
     SchedulerKey:
       type: apiKey
       in: header

--- a/docs/spec/src/openapi.yaml
+++ b/docs/spec/src/openapi.yaml
@@ -14,8 +14,9 @@ info:
 
     - x-required-role：列出可呼叫的角色（RBAC）
 
-    - x-ownership-required：物業層級存取控制（resource-based），透過 Firebase ID token 內
-    Custom Claims 的 assigned_property_ids 驗證
+    - x-ownership-required：物業層級存取控制（resource-based），透過 Firebase ID token
+    解析出的 firebase_uid 載入 DB user principal，再以 DB 內 role / assigned_property_ids
+    驗證
 
     - 優先順序：先驗 RBAC role，再驗 property ownership（兩者皆須通過）
 
@@ -26,8 +27,8 @@ info:
 
     - 後端驗證：每個 request 以 Firebase ID token（Bearer token）呼叫後端
 
-    - 後端 middleware 以 Firebase Admin SDK 驗證 token，從 Custom Claims 讀取 role 與
-    assigned_property_ids
+    - 後端 middleware 以 Firebase Admin SDK 驗證 token，使用 firebase_uid 查詢 DB user；
+    DB user principal 才是 role 與 assigned_property_ids 的授權來源
 
     - 密碼重設：`POST /users` 建立帳號後由後端向 Firebase 產生 reset link，再透過 email 寄送；admin 可透過 `POST /users/{id}/password-reset` 重寄設定密碼信
 
@@ -65,7 +66,8 @@ components:
         Firebase ID token。前端以 Firebase SDK 登入後取得，每個 request 帶入 Authorization
         header。
 
-        後端以 Firebase Admin SDK 驗證，Custom Claims 包含 role 與 assigned_property_ids。
+        後端以 Firebase Admin SDK 驗證 token，並以 firebase_uid 載入 DB user principal
+        作為 role 與 assigned_property_ids 的授權來源。
     SchedulerKey:
       type: apiKey
       in: header

--- a/docs/spec/src/paths/iam/auth_sync.yaml
+++ b/docs/spec/src/paths/iam/auth_sync.yaml
@@ -10,7 +10,7 @@ post:
     - Identity & Access
   responses:
     '200':
-      description: 同步成功，回傳使用者基本資料與 Custom Claims 資訊
+      description: 同步成功，回傳使用者基本資料與 DB 授權資訊
       content:
         application/json:
           schema:

--- a/docs/spec/src/paths/iam/users_{id}_property-assignments.yaml
+++ b/docs/spec/src/paths/iam/users_{id}_property-assignments.yaml
@@ -11,7 +11,8 @@ post:
     指派成功後，後端呼叫 Firebase Admin SDK 更新該使用者的 Custom Claims（role 與
     assigned_property_ids），
 
-    前端下次 refresh token 後新指派生效。
+    Backend authenticated requests 會於下次請求載入 DB user principal 後生效；Custom Claims
+    僅作為同步副本。
   tags:
     - Identity & Access
   x-required-role:
@@ -37,7 +38,7 @@ post:
                 - 10000000-0000-0000-0000-000000000002
   responses:
     '200':
-      description: 指派成功（Firebase Custom Claims 已更新）
+      description: 指派成功（DB 授權資料已更新，Firebase Custom Claims 已同步）
       content:
         application/json:
           schema:

--- a/docs/spec/src/paths/property/properties.yaml
+++ b/docs/spec/src/paths/property/properties.yaml
@@ -4,7 +4,7 @@ get:
   description: |
     x-ownership-required: 依角色過濾：
     - admin：全部物業
-    - organizer/staff：Firebase Custom Claims 內 assigned_property_ids
+    - organizer/staff：DB user principal 內 assigned_property_ids
     - owner：自己名下（properties.owner_id = authenticated user id）
   tags:
     - Property

--- a/docs/spec/tasks.md
+++ b/docs/spec/tasks.md
@@ -213,9 +213,9 @@ T-14~T-19 ── T-20（整合測試）
   - [x] 所有查詢可自動加上 `deleted_at IS NULL` filter（middleware 或 ORM scope）
   - [x] `gen_random_uuid()` 可用（PostgreSQL uuid-ossp 或 pgcrypto extension 啟用）
   - [x] Firebase Admin SDK 初始化成功，可驗證 Firebase ID token
-  - [x] Auth middleware 完成：驗證 Firebase ID token、解析 Custom Claims、載入對應 DB user，並將 `user_id`、`firebase_uid`、`role`、`assigned_property_ids` 注入 request context
+  - [x] Auth middleware 完成：驗證 Firebase ID token、以 `firebase_uid` 載入對應 DB user，並將 DB principal 的 `user_id`、`firebase_uid`、`role`、`assigned_property_ids` 注入 request context
   - [x] Authorization middleware 拆分完成：RBAC（`x-required-role`）與 property ownership（`x-ownership-required`）分離實作，先驗 role 再驗 property access
-  - [x] Property ownership 檢查以 Firebase Custom Claims 的 `assigned_property_ids` 為主；設計上保留必要時 fallback DB 查詢的擴充點
+  - [x] Property ownership 檢查以 DB principal 的 `assigned_property_ids` 為主；owner 以 `properties.owner_id` 判斷
   - [x] 統一 error handling middleware 完成：handler / application service 回傳 domain/app error 時，可統一轉為 OpenAPI `ErrorResponse` 格式（`error_code`、`message`、`details`）
   - [x] `401` 與 `403` 錯誤可分別穩定回傳 `UNAUTHORIZED` 與 `FORBIDDEN` 類型 error code；`500` 由 recovery middleware 處理，回應內 `details` 含 `request_id`
   - [x] Request logging middleware 完成：使用 structured logging，至少記錄 `request_id`、`method`、`path`、`status`、`latency_ms`、`user_id`、`firebase_uid`、`role`、`property_id`、`error_code`
@@ -495,5 +495,5 @@ T-14~T-19 ── T-20（整合測試）
   - [ ] 強制終止路徑：建立 Lease → 模擬逾期帳單 → 觸發強制終止 → 補償排程執行 → 所有帳單 written_off → LeaseTerminated（forced:true）發出
   - [ ] 跨 BC side effect 正確：LeaseCreated 後 Room 改 occupied；Repair workflow 完成後 Room 改 vacant（所有 RepairRequest 完成後才轉換）
   - [ ] 樂觀鎖測試：兩個請求同時對同一帳單收款，只有一個成功，另一個回傳 409 `CONCURRENT_UPDATE_CONFLICT`
-  - [ ] Resource-based 存取控制：organizer 只能存取 Firebase Custom Claims 內 assigned_property_ids 的資源；嘗試存取未指派物業時回傳 403 `FORBIDDEN`
-  - [ ] Firebase Auth 整合：Firebase ID token 驗證正確，Custom Claims 更新（物業指派變更後）於下次 token refresh 生效
+  - [ ] Resource-based 存取控制：organizer 只能存取 DB principal 內 assigned_property_ids 的資源；嘗試存取未指派物業時回傳 403 `FORBIDDEN`
+  - [ ] Firebase Auth 整合：Firebase ID token 驗證正確，物業指派變更後 DB principal 於下次 request 生效，Custom Claims 仍同步最新授權副本

--- a/docs/spec/tech-stack.md
+++ b/docs/spec/tech-stack.md
@@ -62,10 +62,10 @@
 
 - **認證方式**：Firebase Auth（已確定於 schema）
 - **授權實作**：
-  - RBAC：role 欄位（admin/organizer/staff/owner）存於 Firebase Custom Claims，Go middleware 讀取 token 直接判斷，不需每次查 DB
-  - Resource-based：`assigned_property_ids` 存於 Custom Claims，middleware 驗證請求是否在允許的 property 範圍內
-- **Go 整合**：`firebase.google.com/go/v4` Admin SDK，middleware 驗證 ID Token → 解析 claims → 注入 context
-- **理由**：schema 已確定此方案，Custom Claims 避免每次 DB 查詢，符合低成本高效率需求
+  - RBAC：Go middleware 驗證 Firebase ID token 後，以 `firebase_uid` 載入 DB user principal，使用 DB role（admin/organizer/staff/owner）判斷
+  - Resource-based：middleware 使用 DB user principal 內的 `assigned_property_ids` 驗證請求是否在允許的 property 範圍內；owner 以 `properties.owner_id` 判斷
+- **Go 整合**：`firebase.google.com/go/v4` Admin SDK，middleware 驗證 ID Token → 載入 DB user principal → 注入 context
+- **理由**：Firebase Auth 負責身份驗證，DB user principal 作為授權 source of truth，避免 Custom Claims 與 DB drift 影響 runtime authorization
 - **放棄的選項**：JWT 自建（多餘複雜度，Firebase 已包含）、session-based（Cloud Run 無狀態不適合）
 
 ---


### PR DESCRIPTION
## Summary
- Update OpenAPI auth/ownership text to identify DB user principal as role and assigned_property_ids source of truth
- Clarify /auth/sync and property assignment Custom Claims sync as a secondary copy, not runtime authorization authority
- Refresh bundled docs/spec/openapi.yaml via npm run openapi:generate

## Validation
- npm run openapi:generate
- npm run openapi:lint
- git diff --check