### PR TITLE
[codex] Clarify dashboard OpenAPI contract

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -7161,6 +7161,12 @@ components:
             format: uuid
     OccupancySummary:
       type: object
+      required:
+        - total_rooms
+        - occupied_rooms
+        - vacant_rooms
+        - maintenance_rooms
+        - occupancy_rate
       properties:
         total_rooms:
           type: integer
@@ -7177,6 +7183,10 @@ components:
           maximum: 1
     HomeDashboardBillingSummary:
       type: object
+      required:
+        - expected_rent
+        - collected_rent
+        - overdue_bill_count
       properties:
         expected_rent:
           type: integer
@@ -7186,6 +7196,11 @@ components:
           type: integer
     HomeDashboardPropertySummary:
       type: object
+      required:
+        - property_id
+        - property_name
+        - occupancy_summary
+        - monthly_billing_summary
       properties:
         property_id:
           type: string
@@ -7198,6 +7213,13 @@ components:
           $ref: '#/components/schemas/HomeDashboardBillingSummary'
     HomeDashboardRecentJournalItem:
       type: object
+      required:
+        - id
+        - property_id
+        - property_name
+        - type
+        - content
+        - created_at
       properties:
         id:
           type: string
@@ -7209,6 +7231,9 @@ components:
           type: string
         type:
           type: string
+          enum:
+            - journal_log
+            - repair_request
         content:
           type: string
         created_at:
@@ -7216,6 +7241,11 @@ components:
           format: date-time
     HomeDashboardResponse:
       type: object
+      required:
+        - portfolio_summary
+        - monthly_billing_summary
+        - property_summaries
+        - recent_journals
       properties:
         portfolio_summary:
           $ref: '#/components/schemas/OccupancySummary'

--- a/docs/spec/src/components/schemas/property/HomeDashboardBillingSummary.yaml
+++ b/docs/spec/src/components/schemas/property/HomeDashboardBillingSummary.yaml
@@ -1,4 +1,8 @@
 type: object
+required:
+  - expected_rent
+  - collected_rent
+  - overdue_bill_count
 properties:
   expected_rent:
     type: integer

--- a/docs/spec/src/components/schemas/property/HomeDashboardPropertySummary.yaml
+++ b/docs/spec/src/components/schemas/property/HomeDashboardPropertySummary.yaml
@@ -1,4 +1,9 @@
 type: object
+required:
+  - property_id
+  - property_name
+  - occupancy_summary
+  - monthly_billing_summary
 properties:
   property_id:
     type: string

--- a/docs/spec/src/components/schemas/property/HomeDashboardRecentJournalItem.yaml
+++ b/docs/spec/src/components/schemas/property/HomeDashboardRecentJournalItem.yaml
@@ -1,4 +1,11 @@
 type: object
+required:
+  - id
+  - property_id
+  - property_name
+  - type
+  - content
+  - created_at
 properties:
   id:
     type: string
@@ -10,6 +17,9 @@ properties:
     type: string
   type:
     type: string
+    enum:
+      - journal_log
+      - repair_request
   content:
     type: string
   created_at:

--- a/docs/spec/src/components/schemas/property/HomeDashboardResponse.yaml
+++ b/docs/spec/src/components/schemas/property/HomeDashboardResponse.yaml
@@ -1,4 +1,9 @@
 type: object
+required:
+  - portfolio_summary
+  - monthly_billing_summary
+  - property_summaries
+  - recent_journals
 properties:
   portfolio_summary:
     $ref: ./OccupancySummary.yaml

--- a/docs/spec/src/components/schemas/property/OccupancySummary.yaml
+++ b/docs/spec/src/components/schemas/property/OccupancySummary.yaml
@@ -1,4 +1,10 @@
 type: object
+required:
+  - total_rooms
+  - occupied_rooms
+  - vacant_rooms
+  - maintenance_rooms
+  - occupancy_rate
 properties:
   total_rooms:
     type: integer

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -196,6 +196,12 @@ const (
 	ForceTerminationResponseStatusInProgress ForceTerminationResponseStatus = "in_progress"
 )
 
+// Defines values for HomeDashboardRecentJournalItemType.
+const (
+	JournalLog    HomeDashboardRecentJournalItemType = "journal_log"
+	RepairRequest HomeDashboardRecentJournalItemType = "repair_request"
+)
+
 // Defines values for LeaseCheckoutReviewResponseDepositStatus.
 const (
 	LeaseCheckoutReviewResponseDepositStatusHeld       LeaseCheckoutReviewResponseDepositStatus = "held"
@@ -945,35 +951,38 @@ type ForceTerminationResponseStatus string
 
 // HomeDashboardBillingSummary defines model for HomeDashboardBillingSummary.
 type HomeDashboardBillingSummary struct {
-	CollectedRent    *int `json:"collected_rent,omitempty"`
-	ExpectedRent     *int `json:"expected_rent,omitempty"`
-	OverdueBillCount *int `json:"overdue_bill_count,omitempty"`
+	CollectedRent    int `json:"collected_rent"`
+	ExpectedRent     int `json:"expected_rent"`
+	OverdueBillCount int `json:"overdue_bill_count"`
 }
 
 // HomeDashboardPropertySummary defines model for HomeDashboardPropertySummary.
 type HomeDashboardPropertySummary struct {
-	MonthlyBillingSummary *HomeDashboardBillingSummary `json:"monthly_billing_summary,omitempty"`
-	OccupancySummary      *OccupancySummary            `json:"occupancy_summary,omitempty"`
-	PropertyId            *openapi_types.UUID          `json:"property_id,omitempty"`
-	PropertyName          *string                      `json:"property_name,omitempty"`
+	MonthlyBillingSummary HomeDashboardBillingSummary `json:"monthly_billing_summary"`
+	OccupancySummary      OccupancySummary            `json:"occupancy_summary"`
+	PropertyId            openapi_types.UUID          `json:"property_id"`
+	PropertyName          string                      `json:"property_name"`
 }
 
 // HomeDashboardRecentJournalItem defines model for HomeDashboardRecentJournalItem.
 type HomeDashboardRecentJournalItem struct {
-	Content      *string             `json:"content,omitempty"`
-	CreatedAt    *time.Time          `json:"created_at,omitempty"`
-	Id           *openapi_types.UUID `json:"id,omitempty"`
-	PropertyId   *openapi_types.UUID `json:"property_id,omitempty"`
-	PropertyName *string             `json:"property_name,omitempty"`
-	Type         *string             `json:"type,omitempty"`
+	Content      string                             `json:"content"`
+	CreatedAt    time.Time                          `json:"created_at"`
+	Id           openapi_types.UUID                 `json:"id"`
+	PropertyId   openapi_types.UUID                 `json:"property_id"`
+	PropertyName string                             `json:"property_name"`
+	Type         HomeDashboardRecentJournalItemType `json:"type"`
 }
+
+// HomeDashboardRecentJournalItemType defines model for HomeDashboardRecentJournalItem.Type.
+type HomeDashboardRecentJournalItemType string
 
 // HomeDashboardResponse defines model for HomeDashboardResponse.
 type HomeDashboardResponse struct {
-	MonthlyBillingSummary *HomeDashboardBillingSummary      `json:"monthly_billing_summary,omitempty"`
-	PortfolioSummary      *OccupancySummary                 `json:"portfolio_summary,omitempty"`
-	PropertySummaries     *[]HomeDashboardPropertySummary   `json:"property_summaries,omitempty"`
-	RecentJournals        *[]HomeDashboardRecentJournalItem `json:"recent_journals,omitempty"`
+	MonthlyBillingSummary HomeDashboardBillingSummary      `json:"monthly_billing_summary"`
+	PortfolioSummary      OccupancySummary                 `json:"portfolio_summary"`
+	PropertySummaries     []HomeDashboardPropertySummary   `json:"property_summaries"`
+	RecentJournals        []HomeDashboardRecentJournalItem `json:"recent_journals"`
 }
 
 // JournalLogListResponse defines model for JournalLogListResponse.
@@ -1136,11 +1145,11 @@ type LeaseResponseStatus string
 
 // OccupancySummary defines model for OccupancySummary.
 type OccupancySummary struct {
-	MaintenanceRooms *int     `json:"maintenance_rooms,omitempty"`
-	OccupancyRate    *float64 `json:"occupancy_rate,omitempty"`
-	OccupiedRooms    *int     `json:"occupied_rooms,omitempty"`
-	TotalRooms       *int     `json:"total_rooms,omitempty"`
-	VacantRooms      *int     `json:"vacant_rooms,omitempty"`
+	MaintenanceRooms int     `json:"maintenance_rooms"`
+	OccupancyRate    float64 `json:"occupancy_rate"`
+	OccupiedRooms    int     `json:"occupied_rooms"`
+	TotalRooms       int     `json:"total_rooms"`
+	VacantRooms      int     `json:"vacant_rooms"`
 }
 
 // PaginationResponse defines model for PaginationResponse.

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -3534,10 +3534,10 @@ func toHomeDashboardResponse(dashboard *appproperty.HomeDashboard) api.HomeDashb
 	}
 
 	return api.HomeDashboardResponse{
-		PortfolioSummary:      toOccupancySummaryResponse(dashboard.PortfolioSummary),
+		PortfolioSummary:      *toOccupancySummaryResponse(dashboard.PortfolioSummary),
 		MonthlyBillingSummary: toHomeDashboardBillingSummary(dashboard.MonthlyBillingSummary),
-		PropertySummaries:     &propertySummaries,
-		RecentJournals:        &recentJournals,
+		PropertySummaries:     propertySummaries,
+		RecentJournals:        recentJournals,
 	}
 }
 
@@ -3546,61 +3546,50 @@ func toHomeDashboardPropertySummary(summary appproperty.HomeDashboardPropertySum
 	propertyName := summary.PropertyName
 	response := api.HomeDashboardPropertySummary{
 		MonthlyBillingSummary: toHomeDashboardBillingSummary(summary.MonthlySummary),
-		OccupancySummary:      toOccupancySummaryResponse(summary.Occupancy),
-		PropertyName:          &propertyName,
+		OccupancySummary:      *toOccupancySummaryResponse(summary.Occupancy),
+		PropertyName:          propertyName,
 	}
 	if propertyOK {
-		response.PropertyId = &propertyID
+		response.PropertyId = propertyID
 	}
 	return response
 }
 
-func toHomeDashboardBillingSummary(summary appproperty.DashboardMonthlySummary) *api.HomeDashboardBillingSummary {
-	expectedRent := summary.ExpectedRent
-	collectedRent := summary.CollectedRent
-	overdueBillCount := summary.OverdueBillCount
-	return &api.HomeDashboardBillingSummary{
-		ExpectedRent:     &expectedRent,
-		CollectedRent:    &collectedRent,
-		OverdueBillCount: &overdueBillCount,
+func toHomeDashboardBillingSummary(summary appproperty.DashboardMonthlySummary) api.HomeDashboardBillingSummary {
+	return api.HomeDashboardBillingSummary{
+		ExpectedRent:     summary.ExpectedRent,
+		CollectedRent:    summary.CollectedRent,
+		OverdueBillCount: summary.OverdueBillCount,
 	}
 }
 
 func toHomeDashboardRecentJournalItem(journal appproperty.HomeDashboardRecentJournal) api.HomeDashboardRecentJournalItem {
 	id, idOK := parseUUID(journal.ID)
 	propertyID, propertyOK := parseUUID(journal.PropertyID)
-	propertyName := journal.PropertyName
-	content := journal.Content
 	createdAt := journal.CreatedAt
-	itemType := journal.Type
 
 	response := api.HomeDashboardRecentJournalItem{
-		Content:      &content,
-		CreatedAt:    &createdAt,
-		PropertyName: &propertyName,
-		Type:         &itemType,
+		Content:      journal.Content,
+		CreatedAt:    createdAt,
+		PropertyName: journal.PropertyName,
+		Type:         api.HomeDashboardRecentJournalItemType(journal.Type),
 	}
 	if idOK {
-		response.Id = &id
+		response.Id = id
 	}
 	if propertyOK {
-		response.PropertyId = &propertyID
+		response.PropertyId = propertyID
 	}
 	return response
 }
 
 func toOccupancySummaryResponse(summary appproperty.OccupancySummary) *api.OccupancySummary {
-	totalRooms := summary.TotalRooms
-	occupiedRooms := summary.OccupiedRooms
-	vacantRooms := summary.VacantRooms
-	maintenanceRooms := summary.MaintenanceRooms
-	occupancyRate := summary.OccupancyRate
 	return &api.OccupancySummary{
-		TotalRooms:       &totalRooms,
-		OccupiedRooms:    &occupiedRooms,
-		VacantRooms:      &vacantRooms,
-		MaintenanceRooms: &maintenanceRooms,
-		OccupancyRate:    &occupancyRate,
+		TotalRooms:       summary.TotalRooms,
+		OccupiedRooms:    summary.OccupiedRooms,
+		VacantRooms:      summary.VacantRooms,
+		MaintenanceRooms: summary.MaintenanceRooms,
+		OccupancyRate:    summary.OccupancyRate,
 	}
 }
 

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -239,7 +239,7 @@ func TestGetPropertyDashboardReturnsDashboardResponse(t *testing.T) {
 	if response.MonthlySummary == nil || response.MonthlySummary.ExpectedRent == nil || *response.MonthlySummary.ExpectedRent != 50000 {
 		t.Fatalf("unexpected monthly summary: %+v", response.MonthlySummary)
 	}
-	if response.OccupancySummary == nil || response.OccupancySummary.OccupancyRate == nil || *response.OccupancySummary.OccupancyRate != 0.5 {
+	if response.OccupancySummary == nil || response.OccupancySummary.OccupancyRate != 0.5 {
 		t.Fatalf("unexpected occupancy summary: %+v", response.OccupancySummary)
 	}
 	if response.Rooms == nil || len(*response.Rooms) != 1 || (*response.Rooms)[0].Status == nil || string(*(*response.Rooms)[0].Status) != "occupied" {
@@ -313,16 +313,16 @@ func TestGetDashboardReturnsHomeDashboardResponse(t *testing.T) {
 	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
-	if response.PortfolioSummary == nil || response.PortfolioSummary.TotalRooms == nil || *response.PortfolioSummary.TotalRooms != 2 {
+	if response.PortfolioSummary.TotalRooms != 2 {
 		t.Fatalf("unexpected portfolio summary: %+v", response.PortfolioSummary)
 	}
-	if response.MonthlyBillingSummary == nil || response.MonthlyBillingSummary.ExpectedRent == nil || *response.MonthlyBillingSummary.ExpectedRent != 50000 {
+	if response.MonthlyBillingSummary.ExpectedRent != 50000 {
 		t.Fatalf("unexpected billing summary: %+v", response.MonthlyBillingSummary)
 	}
-	if response.PropertySummaries == nil || len(*response.PropertySummaries) != 1 || (*response.PropertySummaries)[0].PropertyName == nil || *(*response.PropertySummaries)[0].PropertyName != "Demo Property" {
+	if len(response.PropertySummaries) != 1 || response.PropertySummaries[0].PropertyName != "Demo Property" {
 		t.Fatalf("unexpected property summaries: %+v", response.PropertySummaries)
 	}
-	if response.RecentJournals == nil || len(*response.RecentJournals) != 1 || (*response.RecentJournals)[0].PropertyName == nil || *(*response.RecentJournals)[0].PropertyName != "Demo Property" {
+	if len(response.RecentJournals) != 1 || response.RecentJournals[0].PropertyName != "Demo Property" || response.RecentJournals[0].Type != api.JournalLog {
 		t.Fatalf("unexpected recent journals: %+v", response.RecentJournals)
 	}
 }


### PR DESCRIPTION
## Summary

- Mark home dashboard summary objects, arrays, and nested response fields as required in OpenAPI.
- Add the `recent_journals[].type` enum: `journal_log` and `repair_request`.
- Regenerate OpenAPI bindings and update handler/test code for the required value types.

## Frontend impact

The home dashboard contract now documents the fields the backend already returns at runtime. Frontend can map `journal_log` to `一般日誌` and `repair_request` to `維修紀錄` without guessing string values.

## Validation

- `npm run openapi:generate`
- `npm run openapi:lint`
- `GOCACHE=/tmp/go-cache go test ./internal/http/handler ./internal/http/router ./internal/platform/database/propertydashboard ./internal/application/property`
- `GOCACHE=/tmp/go-cache go test ./...`
- `git diff --cached --check`
