### PR TITLE
[codex] fix property contact email response marshal

### DIFF
--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/mail"
 	"strings"
 	"time"
 
@@ -3712,8 +3713,10 @@ func toPropertyResponse(property *dbpropertyquery.Property) api.PropertyResponse
 		Version:          &version,
 	}
 	if property.ContactEmail != nil {
-		email := openapi_types.Email(*property.ContactEmail)
-		response.ContactEmail = &email
+		if parsed, err := mail.ParseAddress(*property.ContactEmail); err == nil {
+			email := openapi_types.Email(parsed.Address)
+			response.ContactEmail = &email
+		}
 	}
 	if property.DefaultElectricityBillingCadence != "" {
 		cadence := api.PropertyResponseDefaultElectricityBillingCadence(property.DefaultElectricityBillingCadence)

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -88,6 +88,35 @@ func TestToPropertyResponseIncludesWritableV1Fields(t *testing.T) {
 	}
 }
 
+func TestToPropertyResponseDropsInvalidContactEmail(t *testing.T) {
+	contactEmail := "not an email"
+
+	response := toPropertyResponse(&dbpropertyquery.Property{
+		ID:           "00000000-0000-0000-0000-000000000001",
+		Name:         "Property",
+		Address:      "Address",
+		OwnerID:      "00000000-0000-0000-0000-000000000002",
+		ContactEmail: &contactEmail,
+		CreatedAt:    time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:    time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		Version:      1,
+	})
+
+	body, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	if value, ok := payload["contact_email"]; !ok || value != nil {
+		t.Fatalf("expected contact_email null, got %v", payload["contact_email"])
+	}
+}
+
 func TestToRoomResponseAllowsNilOptionalFields(t *testing.T) {
 	response := toRoomResponse(&dbpropertyquery.Room{
 		ID:         "20000000-0000-0000-0000-000000000001",


### PR DESCRIPTION
## Summary

Fixes a runtime `GET /properties` failure when an existing property row contains an invalid `contact_email` value.

## Root Cause

`toPropertyResponse` cast DB `contact_email` directly to `openapi_types.Email`. The generated OpenAPI email type validates during JSON marshaling, so dirty legacy/dev data could make `c.JSON(...)` fail with `email: failed to pass regex validation` and return a 500.

## Changes

- Validate property `contact_email` with `net/mail.ParseAddress` before assigning it to the OpenAPI email response field.
- Return `null` for invalid existing contact email data instead of allowing response marshaling to fail.
- Add a focused regression test proving invalid DB email data no longer breaks JSON marshaling.

## Validation

- `GOCACHE=/tmp/go-cache go test ./internal/http/handler -run TestToPropertyResponse -count=1`
- `git diff --check`
