### PR TITLE
[codex] Add attachment download URL contract

### DIFF
--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -450,6 +450,7 @@ Operational lease lifecycle changes use terminate, force-terminate, or replaceme
 | `GET /journal-logs/{id}/attachments` | 日誌附件列表 |
 | `GET /repair-requests/{id}/attachments` | 維修單附件列表（依 sort_order 排序） |
 | `GET /bills/{id}/attachments` | 帳單附件列表 |
+| `POST /attachments/{id}/download-url` | 產生附件下載 Signed URL |
 | `DELETE /attachments/{id}` | 軟刪除附件 |
 
 ### 跨 BC 組合查詢
@@ -633,6 +634,8 @@ Step 3：POST /{resource}/{id}/attachments
   → 後端呼叫 GCS HEAD 確認物件存在，並以 metadata 再確認 content_type 與 size
   → 寫入對應 attachment table，刪除已用 nonce
 ```
+
+Download：`POST /attachments/{id}/download-url` 只對 authenticated caller 回傳 `{ download_url, expires_at }`。呼叫者必須符合附件宿主資源的 property access policy；missing 或已軟刪除附件不回傳可用 URL，且 response 不暴露 object_path、bucket 或 storage internals。
 
 Tenant attachment endpoints use the same tenant access model as tenant detail and lease-history flows. The tenant must exist, and non-admin management roles must have access to one of the tenant's associated properties.
 

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -6970,6 +6970,63 @@ paths:
                   value:
                     error_code: ATTACHMENT_FILE_TOO_LARGE
                     message: Attachment file size exceeds the 20MB limit.
+  /attachments/{id}/download-url:
+    post:
+      operationId: createAttachmentDownloadURL
+      summary: 產生附件下載 Signed URL
+      description: |
+        x-required-role: admin, organizer, staff; owner only for attachments whose host resource read/list policy allows owner (property, room, bill on own property)
+        依附件 id 產生短效讀取 Signed URL。呼叫者必須通過認證，並符合附件宿主資源的 property access policy；owner 只可下載其宿主資源 read/list policy 允許的附件（自己名下 property、room、bill attachments）。tenant attachments follow the same tenant to property access model as other tenant flows.
+        Missing 或已軟刪除的附件不回傳可用 URL。Response 不暴露 object_path、bucket、service account 或 storage internals。
+      tags:
+        - Attachments
+      x-required-role:
+        - admin
+        - organizer
+        - staff
+        - owner
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Signed URL 建立成功
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AttachmentDownloadURLResponse'
+              examples:
+                success:
+                  value:
+                    download_url: https://storage.googleapis.com/example-bucket/attachments/properties/10000000-0000-0000-0000-000000000001/abcd.jpg?signature=masked
+                    expires_at: '2026-04-17T10:15:00Z'
+        '401':
+          description: 未認證
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: 權限不足
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 附件不存在或已刪除
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                not_found:
+                  value:
+                    error_code: ATTACHMENT_NOT_FOUND
+                    message: Attachment not found.
   /attachments/{id}:
     delete:
       operationId: deleteAttachment
@@ -9083,6 +9140,18 @@ components:
           format: uri
         nonce:
           type: string
+        expires_at:
+          type: string
+          format: date-time
+    AttachmentDownloadURLResponse:
+      type: object
+      required:
+        - download_url
+        - expires_at
+      properties:
+        download_url:
+          type: string
+          format: uri
         expires_at:
           type: string
           format: date-time

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -6973,11 +6973,11 @@ paths:
   /attachments/{id}/download-url:
     post:
       operationId: createAttachmentDownloadURL
-      summary: 產生附件下載 Signed URL
+      summary: Generate attachment download signed URL
       description: |
-        x-required-role: admin, organizer, staff; owner only for attachments whose host resource read/list policy allows owner (property, room, bill on own property)
-        依附件 id 產生短效讀取 Signed URL。呼叫者必須通過認證，並符合附件宿主資源的 property access policy；owner 只可下載其宿主資源 read/list policy 允許的附件（自己名下 property、room、bill attachments）。tenant attachments follow the same tenant to property access model as other tenant flows.
-        Missing 或已軟刪除的附件不回傳可用 URL。Response 不暴露 object_path、bucket、service account 或 storage internals。
+        x-required-role: admin, organizer, staff; owner only for attachments whose host-resource read/list policy allows owner (property, room, bill on owned properties).
+        Generate a short-lived read signed URL by attachment id. Caller must be authenticated and satisfy host-resource property access policy. Owners may only download attachments allowed by host-resource read/list policy (property/room/bill on owned properties). Tenant attachments follow the same tenant-to-property access model as other tenant flows.
+        Missing or soft-deleted attachments must not return a usable URL. The response must not expose object_path, bucket, service account, or other storage internals.
       tags:
         - Attachments
       x-required-role:
@@ -7002,7 +7002,7 @@ paths:
               examples:
                 success:
                   value:
-                    download_url: https://storage.googleapis.com/example-bucket/attachments/properties/10000000-0000-0000-0000-000000000001/abcd.jpg?signature=masked
+                    download_url: https://files.example.com/attachments/dl/att_00000000-0000-0000-0000-000000000001?token=masked
                     expires_at: '2026-04-17T10:15:00Z'
         '401':
           description: 未認證

--- a/docs/spec/src/components/schemas/shared/AttachmentDownloadURLResponse.yaml
+++ b/docs/spec/src/components/schemas/shared/AttachmentDownloadURLResponse.yaml
@@ -1,0 +1,11 @@
+type: object
+required:
+  - download_url
+  - expires_at
+properties:
+  download_url:
+    type: string
+    format: uri
+  expires_at:
+    type: string
+    format: date-time

--- a/docs/spec/src/openapi.yaml
+++ b/docs/spec/src/openapi.yaml
@@ -209,5 +209,7 @@ paths:
     $ref: paths/scheduler/internal_jobs_force-terminations_compensate.yaml
   /attachments/upload-url:
     $ref: paths/shared/attachments_upload-url.yaml
+  /attachments/{id}/download-url:
+    $ref: paths/shared/attachments_{id}_download-url.yaml
   /attachments/{id}:
     $ref: paths/shared/attachments_{id}.yaml

--- a/docs/spec/src/paths/shared/attachments_{id}_download-url.yaml
+++ b/docs/spec/src/paths/shared/attachments_{id}_download-url.yaml
@@ -1,10 +1,10 @@
 post:
   operationId: createAttachmentDownloadURL
-  summary: 產生附件下載 Signed URL
+  summary: Generate attachment download signed URL
   description: |
-    x-required-role: admin, organizer, staff; owner only for attachments whose host resource read/list policy allows owner (property, room, bill on own property)
-    依附件 id 產生短效讀取 Signed URL。呼叫者必須通過認證，並符合附件宿主資源的 property access policy；owner 只可下載其宿主資源 read/list policy 允許的附件（自己名下 property、room、bill attachments）。tenant attachments follow the same tenant to property access model as other tenant flows.
-    Missing 或已軟刪除的附件不回傳可用 URL。Response 不暴露 object_path、bucket、service account 或 storage internals。
+    x-required-role: admin, organizer, staff; owner only for attachments whose host-resource read/list policy allows owner (property, room, bill on owned properties).
+    Generate a short-lived read signed URL by attachment id. Caller must be authenticated and satisfy host-resource property access policy. Owners may only download attachments allowed by host-resource read/list policy (property/room/bill on owned properties). Tenant attachments follow the same tenant-to-property access model as other tenant flows.
+    Missing or soft-deleted attachments must not return a usable URL. The response must not expose object_path, bucket, service account, or other storage internals.
   tags:
     - Attachments
   x-required-role:
@@ -29,7 +29,7 @@ post:
           examples:
             success:
               value:
-                download_url: https://storage.googleapis.com/example-bucket/attachments/properties/10000000-0000-0000-0000-000000000001/abcd.jpg?signature=masked
+                download_url: https://files.example.com/attachments/dl/att_00000000-0000-0000-0000-000000000001?token=masked
                 expires_at: '2026-04-17T10:15:00Z'
     '401':
       description: 未認證

--- a/docs/spec/src/paths/shared/attachments_{id}_download-url.yaml
+++ b/docs/spec/src/paths/shared/attachments_{id}_download-url.yaml
@@ -1,0 +1,56 @@
+post:
+  operationId: createAttachmentDownloadURL
+  summary: 產生附件下載 Signed URL
+  description: |
+    x-required-role: admin, organizer, staff; owner only for attachments whose host resource read/list policy allows owner (property, room, bill on own property)
+    依附件 id 產生短效讀取 Signed URL。呼叫者必須通過認證，並符合附件宿主資源的 property access policy；owner 只可下載其宿主資源 read/list policy 允許的附件（自己名下 property、room、bill attachments）。tenant attachments follow the same tenant to property access model as other tenant flows.
+    Missing 或已軟刪除的附件不回傳可用 URL。Response 不暴露 object_path、bucket、service account 或 storage internals。
+  tags:
+    - Attachments
+  x-required-role:
+    - admin
+    - organizer
+    - staff
+    - owner
+  parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    '200':
+      description: Signed URL 建立成功
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/AttachmentDownloadURLResponse.yaml
+          examples:
+            success:
+              value:
+                download_url: https://storage.googleapis.com/example-bucket/attachments/properties/10000000-0000-0000-0000-000000000001/abcd.jpg?signature=masked
+                expires_at: '2026-04-17T10:15:00Z'
+    '401':
+      description: 未認證
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+    '403':
+      description: 權限不足
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+    '404':
+      description: 附件不存在或已刪除
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+          examples:
+            not_found:
+              value:
+                error_code: ATTACHMENT_NOT_FOUND
+                message: Attachment not found.

--- a/internal/application/attachment/service.go
+++ b/internal/application/attachment/service.go
@@ -53,6 +53,19 @@ type RegisterAttachmentInput struct {
 	PhotoStage          *PhotoStage
 }
 
+// CreateDownloadURLInput contains the actor and attachment id for read URL creation.
+type CreateDownloadURLInput struct {
+	ActorRole           string
+	AssignedPropertyIDs []string
+	AttachmentID        string
+}
+
+// CreateDownloadURLOutput is returned to clients for short-lived attachment reads.
+type CreateDownloadURLOutput struct {
+	DownloadURL string
+	ExpiresAt   time.Time
+}
+
 // Service implements attachment upload, registration, listing, and delete flows.
 type Service struct {
 	repo           Repository
@@ -263,6 +276,49 @@ func (s *Service) ListAttachments(ctx context.Context, resourceType ResourceType
 	return attachments, nil
 }
 
+// CreateDownloadURL signs a short-lived read URL for an active attachment.
+func (s *Service) CreateDownloadURL(ctx context.Context, input CreateDownloadURLInput) (*CreateDownloadURLOutput, error) {
+	if err := s.ensureReady("attachment_download_url"); err != nil {
+		return nil, err
+	}
+	attachmentID, err := normalizeID(input.AttachmentID, "id")
+	if err != nil {
+		return nil, err
+	}
+
+	attachment, err := s.repo.FindActiveByID(ctx, attachmentID)
+	if err != nil {
+		return nil, mapAttachmentRepositoryError(err)
+	}
+	if attachment == nil {
+		return nil, apperr.ErrAttachmentNotFound
+	}
+	if err := ensureDownloadRole(input.ActorRole, attachment.ResourceType); err != nil {
+		return nil, err
+	}
+	if err := s.ensureResourceAccess(ctx, input.ActorRole, input.AssignedPropertyIDs, attachment.ResourceType, attachment.ResourceID); err != nil {
+		return nil, err
+	}
+
+	expiresAt := s.now().UTC().Add(s.uploadURLTTL)
+	if _, err := s.storage.GetObjectMetadata(ctx, attachment.ObjectPath); err != nil {
+		if errorsIsObjectMissing(err) {
+			return nil, ErrObjectNotFound
+		}
+		return nil, apperr.ErrInternalServerError.WithCause(err)
+	}
+
+	downloadURL, err := s.storage.GenerateDownloadURL(ctx, attachment.ObjectPath, expiresAt)
+	if err != nil {
+		return nil, apperr.ErrInternalServerError.WithCause(err)
+	}
+
+	return &CreateDownloadURLOutput{
+		DownloadURL: downloadURL,
+		ExpiresAt:   expiresAt,
+	}, nil
+}
+
 // DeleteAttachment soft-deletes one attachment row.
 func (s *Service) DeleteAttachment(ctx context.Context, attachmentID string) error {
 	if s.repo == nil || s.txRunner == nil {
@@ -343,6 +399,23 @@ func normalizeWriteRole(role string) (string, error) {
 	default:
 		return "", apperr.ErrForbidden
 	}
+}
+
+func ensureDownloadRole(role string, resourceType ResourceType) error {
+	normalized := strings.TrimSpace(role)
+	switch resourceType {
+	case ResourceTypeProperty, ResourceTypeRoom, ResourceTypeBill:
+		switch normalized {
+		case "admin", "organizer", "staff", "owner":
+			return nil
+		}
+	case ResourceTypeTenant, ResourceTypeLease, ResourceTypeJournalLog, ResourceTypeRepairRequest:
+		switch normalized {
+		case "admin", "organizer", "staff":
+			return nil
+		}
+	}
+	return apperr.ErrForbidden
 }
 
 func normalizeResourceType(resourceType ResourceType) (ResourceType, error) {

--- a/internal/application/attachment/service.go
+++ b/internal/application/attachment/service.go
@@ -301,11 +301,15 @@ func (s *Service) CreateDownloadURL(ctx context.Context, input CreateDownloadURL
 	}
 
 	expiresAt := s.now().UTC().Add(s.uploadURLTTL)
-	if _, err := s.storage.GetObjectMetadata(ctx, attachment.ObjectPath); err != nil {
+	metadata, err := s.storage.GetObjectMetadata(ctx, attachment.ObjectPath)
+	if err != nil {
 		if errorsIsObjectMissing(err) {
 			return nil, ErrObjectNotFound
 		}
 		return nil, apperr.ErrInternalServerError.WithCause(err)
+	}
+	if metadata == nil {
+		return nil, ErrObjectNotFound
 	}
 
 	downloadURL, err := s.storage.GenerateDownloadURL(ctx, attachment.ObjectPath, expiresAt)

--- a/internal/application/attachment/service_test.go
+++ b/internal/application/attachment/service_test.go
@@ -463,6 +463,96 @@ func TestDeleteAttachmentMapsRepositoryNotFoundToAttachmentNotFound(t *testing.T
 	assertAppErrorCode(t, err, apperr.CodeAttachmentNotFound)
 }
 
+func TestCreateAttachmentDownloadURLReturnsSignedURL(t *testing.T) {
+	now := time.Date(2026, 5, 11, 10, 0, 0, 0, time.UTC)
+	attachmentID := "10000000-0000-0000-0000-000000000011"
+	storage := &storageStub{downloadURL: "http://storage/download"}
+	service := newTestService(&attachmentRepoStub{
+		activeAttachment: &Attachment{
+			ID:           attachmentID,
+			ResourceType: ResourceTypeRoom,
+			ResourceID:   "10000000-0000-0000-0000-000000000004",
+			ObjectPath:   "attachments/room/object.pdf",
+			FileName:     "object.pdf",
+			CreatedAt:    now,
+		},
+	}, storage, &resourceAccessStub{
+		propertyByResource: map[ResourceType]string{ResourceTypeRoom: testPropertyID},
+	}, now)
+
+	result, err := service.CreateDownloadURL(context.Background(), CreateDownloadURLInput{
+		ActorRole:           "staff",
+		AssignedPropertyIDs: []string{testPropertyID},
+		AttachmentID:        attachmentID,
+	})
+	if err != nil {
+		t.Fatalf("CreateDownloadURL returned error: %v", err)
+	}
+	if result.DownloadURL != "http://storage/download" {
+		t.Fatalf("expected download URL, got %q", result.DownloadURL)
+	}
+	if result.ExpiresAt != now.Add(15*time.Minute) {
+		t.Fatalf("expected expiry %s, got %s", now.Add(15*time.Minute), result.ExpiresAt)
+	}
+	if storage.signedDownloadObjectPath != "attachments/room/object.pdf" {
+		t.Fatalf("expected storage to sign object path, got %q", storage.signedDownloadObjectPath)
+	}
+}
+
+func TestCreateAttachmentDownloadURLRejectsUnassignedPropertyBeforeSigning(t *testing.T) {
+	attachmentID := "10000000-0000-0000-0000-000000000011"
+	storage := &storageStub{downloadURL: "http://storage/download"}
+	service := newTestService(&attachmentRepoStub{
+		activeAttachment: &Attachment{
+			ID:           attachmentID,
+			ResourceType: ResourceTypeRoom,
+			ResourceID:   "10000000-0000-0000-0000-000000000004",
+			ObjectPath:   "attachments/room/object.pdf",
+		},
+	}, storage, &resourceAccessStub{
+		propertyByResource: map[ResourceType]string{ResourceTypeRoom: testPropertyID},
+	}, time.Now().UTC())
+
+	_, err := service.CreateDownloadURL(context.Background(), CreateDownloadURLInput{
+		ActorRole:           "staff",
+		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000099"},
+		AttachmentID:        attachmentID,
+	})
+	assertAppErrorCode(t, err, apperr.CodeForbidden)
+	if storage.downloadSignCalled {
+		t.Fatal("expected storage signing not to be called before access passes")
+	}
+}
+
+func TestCreateAttachmentDownloadURLMapsMissingAttachmentToNotFound(t *testing.T) {
+	service := newTestService(&attachmentRepoStub{findActiveErr: ErrNotFound}, &storageStub{}, &resourceAccessStub{}, time.Now().UTC())
+
+	_, err := service.CreateDownloadURL(context.Background(), CreateDownloadURLInput{
+		ActorRole:    "admin",
+		AttachmentID: "10000000-0000-0000-0000-000000000011",
+	})
+	assertAppErrorCode(t, err, apperr.CodeAttachmentNotFound)
+}
+
+func TestCreateAttachmentDownloadURLMapsStorageSigningFailureToInternal(t *testing.T) {
+	signErr := errors.New("storage signer unavailable")
+	service := newTestService(&attachmentRepoStub{
+		activeAttachment: &Attachment{
+			ID:           "10000000-0000-0000-0000-000000000011",
+			ResourceType: ResourceTypeProperty,
+			ResourceID:   testPropertyID,
+			ObjectPath:   "attachments/property/object.pdf",
+		},
+	}, &storageStub{downloadErr: signErr}, &resourceAccessStub{}, time.Now().UTC())
+
+	_, err := service.CreateDownloadURL(context.Background(), CreateDownloadURLInput{
+		ActorRole:           "staff",
+		AssignedPropertyIDs: []string{testPropertyID},
+		AttachmentID:        "10000000-0000-0000-0000-000000000011",
+	})
+	assertAppErrorCode(t, err, apperr.CodeInternalServerError)
+}
+
 func newTestService(repo *attachmentRepoStub, storage *storageStub, access *resourceAccessStub, now time.Time) *Service {
 	service := NewService(repo, storage, access, fakeTxRunner{}, 15*time.Minute)
 	service.now = func() time.Time { return now }
@@ -500,6 +590,8 @@ type attachmentRepoStub struct {
 	listErr                error
 	deletedAttachmentID    string
 	softDeleteErr          error
+	activeAttachment       *Attachment
+	findActiveErr          error
 }
 
 func (r *attachmentRepoStub) CreateUploadToken(_ context.Context, _ *sql.Tx, params CreateUploadTokenParams) (*UploadToken, error) {
@@ -567,12 +659,26 @@ func (r *attachmentRepoStub) SoftDeleteAttachmentByID(_ context.Context, _ *sql.
 	return nil
 }
 
+func (r *attachmentRepoStub) FindActiveByID(_ context.Context, attachmentID string) (*Attachment, error) {
+	if r.findActiveErr != nil {
+		return nil, r.findActiveErr
+	}
+	if r.activeAttachment == nil || r.activeAttachment.ID != attachmentID {
+		return nil, ErrNotFound
+	}
+	return r.activeAttachment, nil
+}
+
 type storageStub struct {
-	uploadURL         string
-	signCalled        bool
-	signedContentType string
-	metadata          *ObjectMetadata
-	metadataErr       error
+	uploadURL                string
+	signCalled               bool
+	signedContentType        string
+	downloadURL              string
+	downloadSignCalled       bool
+	signedDownloadObjectPath string
+	metadata                 *ObjectMetadata
+	metadataErr              error
+	downloadErr              error
 }
 
 func (s *storageStub) GenerateUploadURL(_ context.Context, _ string, contentType string, _ time.Time) (string, error) {
@@ -586,6 +692,15 @@ func (s *storageStub) GetObjectMetadata(_ context.Context, _ string) (*ObjectMet
 		return nil, s.metadataErr
 	}
 	return s.metadata, nil
+}
+
+func (s *storageStub) GenerateDownloadURL(_ context.Context, objectPath string, _ time.Time) (string, error) {
+	s.downloadSignCalled = true
+	s.signedDownloadObjectPath = objectPath
+	if s.downloadErr != nil {
+		return "", s.downloadErr
+	}
+	return s.downloadURL, nil
 }
 
 type resourceAccessStub struct {

--- a/internal/application/attachment/service_test.go
+++ b/internal/application/attachment/service_test.go
@@ -466,7 +466,10 @@ func TestDeleteAttachmentMapsRepositoryNotFoundToAttachmentNotFound(t *testing.T
 func TestCreateAttachmentDownloadURLReturnsSignedURL(t *testing.T) {
 	now := time.Date(2026, 5, 11, 10, 0, 0, 0, time.UTC)
 	attachmentID := "10000000-0000-0000-0000-000000000011"
-	storage := &storageStub{downloadURL: "http://storage/download"}
+	storage := &storageStub{
+		downloadURL: "http://storage/download",
+		metadata:    &ObjectMetadata{ContentType: "application/pdf", Size: 1024},
+	}
 	service := newTestService(&attachmentRepoStub{
 		activeAttachment: &Attachment{
 			ID:           attachmentID,
@@ -497,11 +500,17 @@ func TestCreateAttachmentDownloadURLReturnsSignedURL(t *testing.T) {
 	if storage.signedDownloadObjectPath != "attachments/room/object.pdf" {
 		t.Fatalf("expected storage to sign object path, got %q", storage.signedDownloadObjectPath)
 	}
+	if storage.signedDownloadExpiresAt != now.Add(15*time.Minute) {
+		t.Fatalf("expected signed expiry %s, got %s", now.Add(15*time.Minute), storage.signedDownloadExpiresAt)
+	}
 }
 
 func TestCreateAttachmentDownloadURLRejectsUnassignedPropertyBeforeSigning(t *testing.T) {
 	attachmentID := "10000000-0000-0000-0000-000000000011"
-	storage := &storageStub{downloadURL: "http://storage/download"}
+	storage := &storageStub{
+		downloadURL: "http://storage/download",
+		metadata:    &ObjectMetadata{ContentType: "application/pdf", Size: 1024},
+	}
 	service := newTestService(&attachmentRepoStub{
 		activeAttachment: &Attachment{
 			ID:           attachmentID,
@@ -534,6 +543,24 @@ func TestCreateAttachmentDownloadURLMapsMissingAttachmentToNotFound(t *testing.T
 	assertAppErrorCode(t, err, apperr.CodeAttachmentNotFound)
 }
 
+func TestCreateAttachmentDownloadURLRejectsNilStorageMetadata(t *testing.T) {
+	service := newTestService(&attachmentRepoStub{
+		activeAttachment: &Attachment{
+			ID:           "10000000-0000-0000-0000-000000000011",
+			ResourceType: ResourceTypeProperty,
+			ResourceID:   testPropertyID,
+			ObjectPath:   "attachments/property/object.pdf",
+		},
+	}, &storageStub{downloadURL: "http://storage/download"}, &resourceAccessStub{}, time.Now().UTC())
+
+	_, err := service.CreateDownloadURL(context.Background(), CreateDownloadURLInput{
+		ActorRole:           "staff",
+		AssignedPropertyIDs: []string{testPropertyID},
+		AttachmentID:        "10000000-0000-0000-0000-000000000011",
+	})
+	assertAppErrorCode(t, err, CodeObjectNotFound)
+}
+
 func TestCreateAttachmentDownloadURLMapsStorageSigningFailureToInternal(t *testing.T) {
 	signErr := errors.New("storage signer unavailable")
 	service := newTestService(&attachmentRepoStub{
@@ -543,7 +570,10 @@ func TestCreateAttachmentDownloadURLMapsStorageSigningFailureToInternal(t *testi
 			ResourceID:   testPropertyID,
 			ObjectPath:   "attachments/property/object.pdf",
 		},
-	}, &storageStub{downloadErr: signErr}, &resourceAccessStub{}, time.Now().UTC())
+	}, &storageStub{
+		metadata:    &ObjectMetadata{ContentType: "application/pdf", Size: 1024},
+		downloadErr: signErr,
+	}, &resourceAccessStub{}, time.Now().UTC())
 
 	_, err := service.CreateDownloadURL(context.Background(), CreateDownloadURLInput{
 		ActorRole:           "staff",
@@ -676,6 +706,7 @@ type storageStub struct {
 	downloadURL              string
 	downloadSignCalled       bool
 	signedDownloadObjectPath string
+	signedDownloadExpiresAt  time.Time
 	metadata                 *ObjectMetadata
 	metadataErr              error
 	downloadErr              error
@@ -694,9 +725,10 @@ func (s *storageStub) GetObjectMetadata(_ context.Context, _ string) (*ObjectMet
 	return s.metadata, nil
 }
 
-func (s *storageStub) GenerateDownloadURL(_ context.Context, objectPath string, _ time.Time) (string, error) {
+func (s *storageStub) GenerateDownloadURL(_ context.Context, objectPath string, expiresAt time.Time) (string, error) {
 	s.downloadSignCalled = true
 	s.signedDownloadObjectPath = objectPath
+	s.signedDownloadExpiresAt = expiresAt
 	if s.downloadErr != nil {
 		return "", s.downloadErr
 	}

--- a/internal/application/attachment/types.go
+++ b/internal/application/attachment/types.go
@@ -86,6 +86,7 @@ type Repository interface {
 	FindUploadTokenByNonce(ctx context.Context, nonce string) (*UploadToken, error)
 	DeleteUploadTokenByNonce(ctx context.Context, tx *sql.Tx, nonce string) error
 	ListByResource(ctx context.Context, resourceType ResourceType, resourceID string) ([]Attachment, error)
+	FindActiveByID(ctx context.Context, attachmentID string) (*Attachment, error)
 	CreateAttachment(ctx context.Context, tx *sql.Tx, params CreateAttachmentParams) (*Attachment, error)
 	SoftDeleteAttachmentByID(ctx context.Context, tx *sql.Tx, attachmentID string) error
 }
@@ -100,6 +101,7 @@ type ResourceAccess interface {
 // Storage signs upload URLs and verifies uploaded object metadata.
 type Storage interface {
 	GenerateUploadURL(ctx context.Context, objectPath string, contentType string, expiresAt time.Time) (string, error)
+	GenerateDownloadURL(ctx context.Context, objectPath string, expiresAt time.Time) (string, error)
 	GetObjectMetadata(ctx context.Context, objectPath string) (*ObjectMetadata, error)
 }
 

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -1893,7 +1893,7 @@ type ServerInterface interface {
 	// 軟刪除附件
 	// (DELETE /attachments/{id})
 	DeleteAttachment(c *gin.Context, id openapi_types.UUID)
-	// 產生附件下載 Signed URL
+	// Generate attachment download signed URL
 	// (POST /attachments/{id}/download-url)
 	CreateAttachmentDownloadURL(c *gin.Context, id openapi_types.UUID)
 	// 同步 Firebase 使用者至後端 DB（首次登入或 token 更新時呼叫）

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -487,6 +487,12 @@ type AssignRepairRequest struct {
 	AssignedTo openapi_types.UUID `json:"assigned_to"`
 }
 
+// AttachmentDownloadURLResponse defines model for AttachmentDownloadURLResponse.
+type AttachmentDownloadURLResponse struct {
+	DownloadUrl string    `json:"download_url"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
 // AttachmentListResponse defines model for AttachmentListResponse.
 type AttachmentListResponse struct {
 	Data *[]AttachmentResponse `json:"data,omitempty"`
@@ -1887,6 +1893,9 @@ type ServerInterface interface {
 	// 軟刪除附件
 	// (DELETE /attachments/{id})
 	DeleteAttachment(c *gin.Context, id openapi_types.UUID)
+	// 產生附件下載 Signed URL
+	// (POST /attachments/{id}/download-url)
+	CreateAttachmentDownloadURL(c *gin.Context, id openapi_types.UUID)
 	// 同步 Firebase 使用者至後端 DB（首次登入或 token 更新時呼叫）
 	// (POST /auth/sync)
 	SyncAuth(c *gin.Context)
@@ -2210,6 +2219,32 @@ func (siw *ServerInterfaceWrapper) DeleteAttachment(c *gin.Context) {
 	}
 
 	siw.Handler.DeleteAttachment(c, id)
+}
+
+// CreateAttachmentDownloadURL operation middleware
+func (siw *ServerInterfaceWrapper) CreateAttachmentDownloadURL(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id openapi_types.UUID
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", c.Param("id"), &id, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter id: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	c.Set(BearerAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.CreateAttachmentDownloadURL(c, id)
 }
 
 // SyncAuth operation middleware
@@ -5061,6 +5096,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 
 	router.POST(options.BaseURL+"/attachments/upload-url", wrapper.CreateAttachmentUploadURL)
 	router.DELETE(options.BaseURL+"/attachments/:id", wrapper.DeleteAttachment)
+	router.POST(options.BaseURL+"/attachments/:id/download-url", wrapper.CreateAttachmentDownloadURL)
 	router.POST(options.BaseURL+"/auth/sync", wrapper.SyncAuth)
 	router.GET(options.BaseURL+"/bills", wrapper.ListBills)
 	router.GET(options.BaseURL+"/bills/:id", wrapper.GetBill)

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -771,6 +771,36 @@ func (s *APIServer) DeleteAttachment(c *gin.Context, id openapi_types.UUID) {
 	c.Status(http.StatusNoContent)
 }
 
+// CreateAttachmentDownloadURL handles attachment download URL creation.
+func (s *APIServer) CreateAttachmentDownloadURL(c *gin.Context, id openapi_types.UUID) {
+	principal, ok := requestctx.GetPrincipal(c)
+	if !ok {
+		c.Error(apperr.ErrUnauthorized)
+		return
+	}
+	assignedPropertyIDs := principal.AssignedPropertyIDs
+	if principal.Role == "owner" {
+		if propertyID := requestctx.GetPropertyID(c); propertyID != "" {
+			assignedPropertyIDs = append(append([]string{}, assignedPropertyIDs...), propertyID)
+		}
+	}
+
+	result, err := s.attachment.CreateDownloadURL(c.Request.Context(), appattachment.CreateDownloadURLInput{
+		ActorRole:           principal.Role,
+		AssignedPropertyIDs: assignedPropertyIDs,
+		AttachmentID:        id.String(),
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, api.AttachmentDownloadURLResponse{
+		DownloadUrl: result.DownloadURL,
+		ExpiresAt:   result.ExpiresAt,
+	})
+}
+
 // ListBillAttachments handles bill attachment listing.
 func (s *APIServer) ListBillAttachments(c *gin.Context, id openapi_types.UUID) {
 	s.listAttachments(c, appattachment.ResourceTypeBill, id)

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -1025,6 +1025,57 @@ func TestCreateAttachmentDownloadURLReturnsOK(t *testing.T) {
 	}
 }
 
+func TestCreateAttachmentDownloadURLOwnerReturnsOK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	attachmentID := "10000000-0000-0000-0000-000000000011"
+	propertyID := "10000000-0000-0000-0000-000000000001"
+	repo := &handlerAttachmentRepoStub{
+		activeAttachment: &appattachment.Attachment{
+			ID:           attachmentID,
+			ResourceType: appattachment.ResourceTypeProperty,
+			ResourceID:   propertyID,
+			ObjectPath:   "attachments/property/object.pdf",
+			FileName:     "object.pdf",
+			CreatedAt:    time.Now().UTC(),
+		},
+	}
+	storage := &handlerAttachmentStorageStub{downloadURL: "http://storage/download"}
+	access := &handlerAttachmentResourceAccessStub{}
+	service := appattachment.NewService(repo, storage, access, handlerRepairTxRunner{}, 15*time.Minute)
+	server := &APIServer{attachment: service}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/attachments/"+attachmentID+"/download-url", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID: "00000000-0000-0000-0000-000000000001",
+		Role:   "owner",
+	})
+	requestctx.SetPropertyID(c, propertyID)
+
+	server.CreateAttachmentDownloadURL(c, openapi_types.UUID(googleuuid.MustParse(attachmentID)))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if repo.foundAttachmentID != attachmentID {
+		t.Fatalf("expected lookup for attachment id %q, got %q", attachmentID, repo.foundAttachmentID)
+	}
+	if storage.signedDownloadObjectPath != "attachments/property/object.pdf" {
+		t.Fatalf("expected download signing for object path, got %q", storage.signedDownloadObjectPath)
+	}
+	var response api.AttachmentDownloadURLResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.DownloadUrl != "http://storage/download" {
+		t.Fatalf("unexpected download URL response: %+v", response)
+	}
+	if response.ExpiresAt.IsZero() {
+		t.Fatalf("expected expires_at, got %+v", response)
+	}
+}
+
 func TestListRoomMeterHistoryForwardsYearMonthAndReturnsBillListResponse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -1740,7 +1791,7 @@ func (s *handlerAttachmentStorageStub) GenerateUploadURL(_ context.Context, _ st
 }
 
 func (s *handlerAttachmentStorageStub) GetObjectMetadata(context.Context, string) (*appattachment.ObjectMetadata, error) {
-	return nil, nil
+	return &appattachment.ObjectMetadata{ContentType: "application/pdf", Size: 1024}, nil
 }
 
 func (s *handlerAttachmentStorageStub) GenerateDownloadURL(_ context.Context, objectPath string, _ time.Time) (string, error) {

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -975,6 +975,56 @@ func TestCreateAttachmentUploadURLReturnsOK(t *testing.T) {
 	}
 }
 
+func TestCreateAttachmentDownloadURLReturnsOK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	attachmentID := "10000000-0000-0000-0000-000000000011"
+	repo := &handlerAttachmentRepoStub{
+		activeAttachment: &appattachment.Attachment{
+			ID:           attachmentID,
+			ResourceType: appattachment.ResourceTypeProperty,
+			ResourceID:   "10000000-0000-0000-0000-000000000001",
+			ObjectPath:   "attachments/property/object.pdf",
+			FileName:     "object.pdf",
+			CreatedAt:    time.Now().UTC(),
+		},
+	}
+	storage := &handlerAttachmentStorageStub{downloadURL: "http://storage/download"}
+	access := &handlerAttachmentResourceAccessStub{}
+	service := appattachment.NewService(repo, storage, access, handlerRepairTxRunner{}, 15*time.Minute)
+	server := &APIServer{attachment: service}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/attachments/"+attachmentID+"/download-url", nil)
+	requestctx.SetPrincipal(c, requestctx.Principal{
+		UserID:              "00000000-0000-0000-0000-000000000001",
+		Role:                "staff",
+		AssignedPropertyIDs: []string{"10000000-0000-0000-0000-000000000001"},
+	})
+
+	server.CreateAttachmentDownloadURL(c, openapi_types.UUID(googleuuid.MustParse(attachmentID)))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if repo.foundAttachmentID != attachmentID {
+		t.Fatalf("expected lookup for attachment id %q, got %q", attachmentID, repo.foundAttachmentID)
+	}
+	if storage.signedDownloadObjectPath != "attachments/property/object.pdf" {
+		t.Fatalf("expected download signing for object path, got %q", storage.signedDownloadObjectPath)
+	}
+	var response api.AttachmentDownloadURLResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.DownloadUrl != "http://storage/download" {
+		t.Fatalf("unexpected download URL response: %+v", response)
+	}
+	if response.ExpiresAt.IsZero() {
+		t.Fatalf("expected expires_at, got %+v", response)
+	}
+}
+
 func TestListRoomMeterHistoryForwardsYearMonthAndReturnsBillListResponse(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -1632,7 +1682,9 @@ func (handlerRepairTxRunner) WithinTransaction(ctx context.Context, fn func(cont
 }
 
 type handlerAttachmentRepoStub struct {
-	createdToken *appattachment.CreateUploadTokenParams
+	createdToken      *appattachment.CreateUploadTokenParams
+	activeAttachment  *appattachment.Attachment
+	foundAttachmentID string
 }
 
 func (r *handlerAttachmentRepoStub) CreateUploadToken(_ context.Context, _ *sql.Tx, params appattachment.CreateUploadTokenParams) (*appattachment.UploadToken, error) {
@@ -1659,6 +1711,14 @@ func (r *handlerAttachmentRepoStub) ListByResource(context.Context, appattachmen
 	return nil, nil
 }
 
+func (r *handlerAttachmentRepoStub) FindActiveByID(_ context.Context, attachmentID string) (*appattachment.Attachment, error) {
+	r.foundAttachmentID = attachmentID
+	if r.activeAttachment == nil || r.activeAttachment.ID != attachmentID {
+		return nil, appattachment.ErrNotFound
+	}
+	return r.activeAttachment, nil
+}
+
 func (r *handlerAttachmentRepoStub) CreateAttachment(context.Context, *sql.Tx, appattachment.CreateAttachmentParams) (*appattachment.Attachment, error) {
 	return nil, nil
 }
@@ -1668,8 +1728,10 @@ func (r *handlerAttachmentRepoStub) SoftDeleteAttachmentByID(context.Context, *s
 }
 
 type handlerAttachmentStorageStub struct {
-	uploadURL         string
-	signedContentType string
+	uploadURL                string
+	downloadURL              string
+	signedContentType        string
+	signedDownloadObjectPath string
 }
 
 func (s *handlerAttachmentStorageStub) GenerateUploadURL(_ context.Context, _ string, contentType string, _ time.Time) (string, error) {
@@ -1679,6 +1741,11 @@ func (s *handlerAttachmentStorageStub) GenerateUploadURL(_ context.Context, _ st
 
 func (s *handlerAttachmentStorageStub) GetObjectMetadata(context.Context, string) (*appattachment.ObjectMetadata, error) {
 	return nil, nil
+}
+
+func (s *handlerAttachmentStorageStub) GenerateDownloadURL(_ context.Context, objectPath string, _ time.Time) (string, error) {
+	s.signedDownloadObjectPath = objectPath
+	return s.downloadURL, nil
 }
 
 type handlerAttachmentResourceAccessStub struct{}

--- a/internal/http/middleware/authorization.go
+++ b/internal/http/middleware/authorization.go
@@ -57,8 +57,8 @@ func RequireRoles(allowedRoles ...string) gin.HandlerFunc {
 }
 
 // RequireAnyPropertyAccess rejects requests when none of the resolved
-// properties is assigned to the authenticated principal.
-func RequireAnyPropertyAccess(resolvePropertyIDs PropertyIDsResolver) gin.HandlerFunc {
+// properties is assigned to or owned by the authenticated principal.
+func RequireAnyPropertyAccess(resolvePropertyIDs PropertyIDsResolver, propertyRepo dbproperties.Repository) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		principal, ok := requestctx.GetPrincipal(c)
 		if !ok {
@@ -76,6 +76,26 @@ func RequireAnyPropertyAccess(resolvePropertyIDs PropertyIDsResolver) gin.Handle
 
 		if principal.Role == "admin" {
 			c.Next()
+			return
+		}
+
+		if principal.Role == "owner" {
+			for _, propertyID := range propertyIDs {
+				ownerID, err := propertyRepo.FindOwnerIDByPropertyID(c.Request.Context(), propertyID)
+				if err != nil {
+					c.Error(mapPropertyLookupError(err))
+					c.Abort()
+					return
+				}
+				if ownerID == principal.UserID {
+					requestctx.SetPropertyID(c, propertyID)
+					c.Next()
+					return
+				}
+			}
+
+			c.Error(apperr.ErrForbidden)
+			c.Abort()
 			return
 		}
 

--- a/internal/http/middleware/authorization.go
+++ b/internal/http/middleware/authorization.go
@@ -83,6 +83,9 @@ func RequireAnyPropertyAccess(resolvePropertyIDs PropertyIDsResolver, propertyRe
 			for _, propertyID := range propertyIDs {
 				ownerID, err := propertyRepo.FindOwnerIDByPropertyID(c.Request.Context(), propertyID)
 				if err != nil {
+					if errors.Is(err, dbproperties.ErrNotFound) {
+						continue
+					}
 					c.Error(mapPropertyLookupError(err))
 					c.Abort()
 					return

--- a/internal/http/middleware/middleware_test.go
+++ b/internal/http/middleware/middleware_test.go
@@ -460,7 +460,7 @@ func TestRequireAnyPropertyAccessAllowsNonAdminWhenAssignedPropertyMatchesAnyRes
 		}
 
 		return []string{testPropertyID1, testPropertyID2}, nil
-	}, apperr.ErrTenantNotFound)), func(c *gin.Context) {
+	}, apperr.ErrTenantNotFound), fakePropertyRepo{}), func(c *gin.Context) {
 		propertyID := requestctx.GetPropertyID(c)
 		if propertyID != testPropertyID2 {
 			t.Fatalf("propertyID = %q, want %q", propertyID, testPropertyID2)
@@ -494,7 +494,7 @@ func TestRequireAnyPropertyAccessReturnsForbiddenWhenNoResolvedPropertyIsAssigne
 		}
 
 		return []string{testPropertyID1, testPropertyID2}, nil
-	}, apperr.ErrTenantNotFound)), func(c *gin.Context) {
+	}, apperr.ErrTenantNotFound), fakePropertyRepo{}), func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
 
@@ -519,7 +519,7 @@ func TestRequireAnyPropertyAccessAllowsAdminWhenTenantExistsWithoutResolvedPrope
 		}
 
 		return []string{}, nil
-	}, apperr.ErrTenantNotFound)), func(c *gin.Context) {
+	}, apperr.ErrTenantNotFound), fakePropertyRepo{}), func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	})
 

--- a/internal/http/middleware/middleware_test.go
+++ b/internal/http/middleware/middleware_test.go
@@ -586,6 +586,40 @@ func TestRequirePropertyAccessRejectsOwnerForOtherProperty(t *testing.T) {
 	assertErrorCode(t, resp, http.StatusForbidden, "FORBIDDEN")
 }
 
+func TestRequireAnyPropertyAccessAllowsOwnerWhenLaterResolvedPropertyIsOwned(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	engine := gin.New()
+	engine.Use(RequestID(), ErrorHandler(testLoggerBuffer(nil)))
+	engine.GET("/attachments/:id/download-url", func(c *gin.Context) {
+		requestctx.SetPrincipal(c, requestctx.Principal{
+			UserID: "owner-1",
+			Role:   "owner",
+		})
+		c.Next()
+	}, RequireAnyPropertyAccess(func(*gin.Context) ([]string, error) {
+		return []string{testPropertyID1, testPropertyID2}, nil
+	}, fakePropertyRepo{
+		ownerByPropertyID: map[string]string{
+			testPropertyID2: "owner-1",
+		},
+	}), func(c *gin.Context) {
+		propertyID := requestctx.GetPropertyID(c)
+		if propertyID != testPropertyID2 {
+			t.Fatalf("propertyID = %q, want %q", propertyID, testPropertyID2)
+		}
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/attachments/10000000-0000-0000-0000-000000000099/download-url", nil)
+	resp := httptest.NewRecorder()
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
 func TestErrorHandlerLogsStructuredServerError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -139,7 +139,7 @@ func compileRoutePolicies(appCfg config.AppConfig, authenticator platformfirebas
 		case policy.propertyResolver != nil:
 			compiled.requirePropertyAccess = middleware.RequirePropertyAccess(policy.propertyResolver, authzRepos.Properties)
 		case policy.propertyIDsResolver != nil:
-			compiled.requirePropertyAccess = middleware.RequireAnyPropertyAccess(policy.propertyIDsResolver)
+			compiled.requirePropertyAccess = middleware.RequireAnyPropertyAccess(policy.propertyIDsResolver, authzRepos.Properties)
 		}
 
 		policies[routePolicyKey(policy.method, policy.path)] = compiled
@@ -158,7 +158,8 @@ func routePolicies(authzRepos AuthorizationRepositories) []routePolicy {
 	return []routePolicy{
 		{method: "POST", path: "/api/v1/auth/sync", authStrategy: authStrategyFirebaseTokenOnly},
 		{method: "POST", path: "/api/v1/attachments/upload-url", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
-		{method: "DELETE", path: "/api/v1/attachments/:id", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByAttachmentID, apperr.ErrAttachmentNotFound)},
+		{method: "DELETE", path: "/api/v1/attachments/:id", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyIDsResolver: middleware.ResourcePropertyIDsWithNotFound("id", ownership.FindPropertyIDsByAttachmentID, apperr.ErrAttachmentNotFound)},
+		{method: "POST", path: "/api/v1/attachments/:id/download-url", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}, propertyIDsResolver: middleware.ResourcePropertyIDsWithNotFound("id", ownership.FindPropertyIDsByAttachmentID, apperr.ErrAttachmentNotFound)},
 
 		{method: "GET", path: "/api/v1/bills", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}, propertyResolver: middleware.QueryPropertyID("property_id")},
 		{method: "GET", path: "/api/v1/bills/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByBillID, apperr.ErrBillNotFound)},

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -4338,6 +4338,120 @@ func TestDeleteAttachmentReturnsAttachmentNotFound(t *testing.T) {
 	}
 }
 
+func TestCreateAttachmentDownloadURLResolvesPropertyAccessThroughOwnershipQuery(t *testing.T) {
+	repo := fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}}
+	engine := newTestEngine(repo, fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}}, fakePropertyRepo{}, fakeResourceOwnershipRepo{
+		propertyByAttachmentID: map[string]string{
+			"10000000-0000-0000-0000-000000000099": testPropertyID1,
+		},
+	}, "", fakeJobRunsRepo{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/attachments/10000000-0000-0000-0000-000000000099/download-url", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestCreateAttachmentDownloadURLAllowsTenantAttachmentWhenAnyResolvedPropertyIsAssigned(t *testing.T) {
+	attachmentID := "10000000-0000-0000-0000-000000000099"
+	repo := fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}}
+	engine := newTestEngine(repo, fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID2}}, fakePropertyRepo{}, fakeResourceOwnershipRepo{
+		propertyIDsByAttachmentID: map[string][]string{
+			attachmentID: {testPropertyID1, testPropertyID2},
+		},
+	}, "", fakeJobRunsRepo{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/attachments/"+attachmentID+"/download-url", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("expected middleware to allow request through to handler, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestCreateAttachmentDownloadURLAllowsOwnerForOwnedResolvedProperty(t *testing.T) {
+	attachmentID := "10000000-0000-0000-0000-000000000099"
+	repo := fakeUserRepo{userID: "owner-1", role: "owner"}
+	engine := newTestEngine(repo, fakeAuthenticator{role: "owner"}, fakePropertyRepo{
+		ownerByPropertyID: map[string]string{
+			testPropertyID1: "owner-1",
+		},
+	}, fakeResourceOwnershipRepo{
+		propertyIDsByAttachmentID: map[string][]string{
+			attachmentID: {testPropertyID1},
+		},
+	}, "", fakeJobRunsRepo{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/attachments/"+attachmentID+"/download-url", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusInternalServerError {
+		t.Fatalf("expected middleware to allow owner request through to handler, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestCreateAttachmentDownloadURLRejectsUnauthorizedPropertyAccess(t *testing.T) {
+	repo := fakeUserRepo{assignedPropertyIDs: []string{testPropertyID2}}
+	engine := newTestEngine(repo, fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID2}}, fakePropertyRepo{
+		ownerByPropertyID: map[string]string{
+			testPropertyID1: "user-1",
+		},
+	}, fakeResourceOwnershipRepo{
+		propertyByAttachmentID: map[string]string{
+			"10000000-0000-0000-0000-000000000099": testPropertyID1,
+		},
+	}, "", fakeJobRunsRepo{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/attachments/10000000-0000-0000-0000-000000000099/download-url", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", resp.Code, resp.Body.String())
+	}
+}
+
+func TestCreateAttachmentDownloadURLReturnsAttachmentNotFound(t *testing.T) {
+	repo := fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}}
+	engine := newTestEngine(repo, fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}}, fakePropertyRepo{
+		ownerByPropertyID: map[string]string{
+			testPropertyID1: "user-1",
+		},
+	}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/attachments/10000000-0000-0000-0000-000000000099/download-url", nil)
+	req.Header.Set("Authorization", "Bearer valid-token")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if payload["error_code"] != apperr.CodeAttachmentNotFound {
+		t.Fatalf("expected error_code %s, got %v", apperr.CodeAttachmentNotFound, payload["error_code"])
+	}
+}
+
 func TestCompileRoutePoliciesRejectsConflictingPropertyResolvers(t *testing.T) {
 	defer func() {
 		if recovered := recover(); recovered == nil {
@@ -4738,6 +4852,7 @@ type fakeResourceOwnershipRepo struct {
 	propertyByRepairRequestID    map[string]string
 	propertyByForceTerminationID map[string]string
 	propertyByAttachmentID       map[string]string
+	propertyIDsByAttachmentID    map[string][]string
 	tenantExists                 map[string]bool
 }
 
@@ -6243,6 +6358,20 @@ func (f fakeResourceOwnershipRepo) FindPropertyIDByForceTerminationID(_ context.
 
 func (f fakeResourceOwnershipRepo) FindPropertyIDByAttachmentID(_ context.Context, attachmentID string) (string, error) {
 	return lookupPropertyID(f.propertyByAttachmentID, attachmentID)
+}
+
+func (f fakeResourceOwnershipRepo) FindPropertyIDsByAttachmentID(_ context.Context, attachmentID string) ([]string, error) {
+	if f.propertyIDsByAttachmentID != nil {
+		if propertyIDs, ok := f.propertyIDsByAttachmentID[attachmentID]; ok {
+			copied := make([]string, len(propertyIDs))
+			copy(copied, propertyIDs)
+			return copied, nil
+		}
+	}
+	if propertyID, ok := f.propertyByAttachmentID[attachmentID]; ok {
+		return []string{propertyID}, nil
+	}
+	return nil, dbresourceownership.ErrNotFound
 }
 
 func (f fakeResourceOwnershipRepo) EnsureTenantExists(_ context.Context, tenantID string) error {

--- a/internal/platform/database/attachments/repository.go
+++ b/internal/platform/database/attachments/repository.go
@@ -141,6 +141,7 @@ type Repository interface {
 	DeleteUploadTokenByNonce(ctx context.Context, tx *sql.Tx, nonce string) error
 	DeleteExpiredUploadTokens(ctx context.Context, tx *sql.Tx, before time.Time) (int64, error)
 	ListByResource(ctx context.Context, resourceType ResourceType, resourceID string) ([]Attachment, error)
+	FindActiveByID(ctx context.Context, attachmentID string) (*Attachment, error)
 	CreateAttachment(ctx context.Context, tx *sql.Tx, params CreateAttachmentParams) (*Attachment, error)
 	SoftDeleteAttachmentByID(ctx context.Context, tx *sql.Tx, attachmentID string) error
 }
@@ -316,6 +317,152 @@ ORDER BY %s
 	return attachments, nil
 }
 
+// FindActiveByID loads one active attachment across all resource attachment tables.
+func (r *SQLRepository) FindActiveByID(ctx context.Context, attachmentID string) (*Attachment, error) {
+	const query = `
+SELECT
+	id,
+	resource_type,
+	resource_id,
+	object_path,
+	file_name,
+	uploaded_by,
+	sort_order,
+	photo_stage,
+	created_at,
+	deleted_at
+FROM (
+	SELECT
+		id,
+		'property' AS resource_type,
+		property_id AS resource_id,
+		object_path,
+		file_name,
+		uploaded_by,
+		NULL AS sort_order,
+		NULL AS photo_stage,
+		created_at,
+		deleted_at
+	FROM property_attachments
+	WHERE id = $1
+	  AND deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT
+		id,
+		'room' AS resource_type,
+		room_id AS resource_id,
+		object_path,
+		file_name,
+		uploaded_by,
+		NULL AS sort_order,
+		NULL AS photo_stage,
+		created_at,
+		deleted_at
+	FROM room_attachments
+	WHERE id = $1
+	  AND deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT
+		id,
+		'tenant' AS resource_type,
+		tenant_id AS resource_id,
+		object_path,
+		file_name,
+		uploaded_by,
+		NULL AS sort_order,
+		NULL AS photo_stage,
+		created_at,
+		deleted_at
+	FROM tenant_attachments
+	WHERE id = $1
+	  AND deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT
+		id,
+		'lease' AS resource_type,
+		lease_id AS resource_id,
+		object_path,
+		file_name,
+		uploaded_by,
+		NULL AS sort_order,
+		NULL AS photo_stage,
+		created_at,
+		deleted_at
+	FROM lease_attachments
+	WHERE id = $1
+	  AND deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT
+		id,
+		'journal_log' AS resource_type,
+		journal_log_id AS resource_id,
+		object_path,
+		file_name,
+		uploaded_by,
+		NULL AS sort_order,
+		NULL AS photo_stage,
+		created_at,
+		deleted_at
+	FROM journal_log_attachments
+	WHERE id = $1
+	  AND deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT
+		id,
+		'repair_request' AS resource_type,
+		repair_request_id AS resource_id,
+		object_path,
+		file_name,
+		uploaded_by,
+		sort_order,
+		photo_stage,
+		created_at,
+		deleted_at
+	FROM repair_request_attachments
+	WHERE id = $1
+	  AND deleted_at IS NULL
+
+	UNION ALL
+
+	SELECT
+		id,
+		'bill' AS resource_type,
+		bill_id AS resource_id,
+		object_path,
+		file_name,
+		uploaded_by,
+		NULL AS sort_order,
+		NULL AS photo_stage,
+		created_at,
+		deleted_at
+	FROM bill_attachments
+	WHERE id = $1
+	  AND deleted_at IS NULL
+) AS active_attachments
+LIMIT 1
+`
+
+	attachment, err := scanAttachmentWithResourceType(r.db.QueryRowContext(ctx, query, attachmentID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find active attachment by id: %w", err)
+	}
+
+	return attachment, nil
+}
+
 // CreateAttachment registers a resource attachment row.
 func (r *SQLRepository) CreateAttachment(ctx context.Context, tx *sql.Tx, params CreateAttachmentParams) (*Attachment, error) {
 	if tx == nil {
@@ -477,6 +624,38 @@ func scanAttachment(row rowScanner, resourceType ResourceType) (*Attachment, err
 	}
 
 	attachment.ResourceType = resourceType
+	attachment.UploadedBy = stringPointer(uploadedBy)
+	attachment.SortOrder = intPointer(sortOrder)
+	attachment.PhotoStage = photoStagePointer(photoStage)
+	attachment.DeletedAt = timePointer(deletedAt)
+
+	return &attachment, nil
+}
+
+func scanAttachmentWithResourceType(row rowScanner) (*Attachment, error) {
+	var attachment Attachment
+	var resourceType string
+	var uploadedBy sql.NullString
+	var sortOrder sql.NullInt64
+	var photoStage sql.NullString
+	var deletedAt sql.NullTime
+
+	if err := row.Scan(
+		&attachment.ID,
+		&resourceType,
+		&attachment.ResourceID,
+		&attachment.ObjectPath,
+		&attachment.FileName,
+		&uploadedBy,
+		&sortOrder,
+		&photoStage,
+		&attachment.CreatedAt,
+		&deletedAt,
+	); err != nil {
+		return nil, err
+	}
+
+	attachment.ResourceType = ResourceType(resourceType)
 	attachment.UploadedBy = stringPointer(uploadedBy)
 	attachment.SortOrder = intPointer(sortOrder)
 	attachment.PhotoStage = photoStagePointer(photoStage)

--- a/internal/platform/database/attachments/repository_test.go
+++ b/internal/platform/database/attachments/repository_test.go
@@ -459,6 +459,58 @@ func TestListByResourceRejectsUnsupportedResourceType(t *testing.T) {
 	}
 }
 
+func TestFindActiveByIDReturnsAttachmentFromFirstMatchingResourceTable(t *testing.T) {
+	_, mock, repo := newAttachmentRepoTest(t)
+	now := time.Date(2026, 5, 11, 10, 0, 0, 0, time.UTC)
+	attachmentID := "80000000-0000-0000-0000-000000000001"
+
+	mock.ExpectQuery(findActiveByIDQueryPattern()).
+		WithArgs(attachmentID).
+		WillReturnRows(activeAttachmentRows().AddRow(
+			attachmentID,
+			"room",
+			"20000000-0000-0000-0000-000000000001",
+			"attachments/room/object.pdf",
+			"object.pdf",
+			nil,
+			nil,
+			nil,
+			now,
+			nil,
+		))
+
+	attachment, err := repo.FindActiveByID(context.Background(), attachmentID)
+	if err != nil {
+		t.Fatalf("FindActiveByID returned error: %v", err)
+	}
+	if attachment.ResourceType != ResourceTypeRoom || attachment.ResourceID != "20000000-0000-0000-0000-000000000001" {
+		t.Fatalf("unexpected attachment: %#v", attachment)
+	}
+	if attachment.ObjectPath != "attachments/room/object.pdf" {
+		t.Fatalf("unexpected object path: %q", attachment.ObjectPath)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+func TestFindActiveByIDMapsNoRowsToNotFound(t *testing.T) {
+	_, mock, repo := newAttachmentRepoTest(t)
+	attachmentID := "80000000-0000-0000-0000-000000000001"
+
+	mock.ExpectQuery(findActiveByIDQueryPattern()).
+		WithArgs(attachmentID).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err := repo.FindActiveByID(context.Background(), attachmentID)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sqlmock expectations: %v", err)
+	}
+}
+
 func TestSoftDeleteAttachmentByIDUsesDeterministicResourceOrder(t *testing.T) {
 	db, mock, repo := newAttachmentRepoTest(t)
 	tx := beginAttachmentTx(t, db, mock)
@@ -563,6 +615,32 @@ func attachmentRows(resourceIDColumn string) *sqlmock.Rows {
 		"created_at",
 		"deleted_at",
 	})
+}
+
+func activeAttachmentRows() *sqlmock.Rows {
+	return sqlmock.NewRows([]string{
+		"id",
+		"resource_type",
+		"resource_id",
+		"object_path",
+		"file_name",
+		"uploaded_by",
+		"sort_order",
+		"photo_stage",
+		"created_at",
+		"deleted_at",
+	})
+}
+
+func findActiveByIDQueryPattern() string {
+	return `(?s)FROM property_attachments\s+WHERE id = \$1\s+AND deleted_at IS NULL.*` +
+		`FROM room_attachments\s+WHERE id = \$1\s+AND deleted_at IS NULL.*` +
+		`FROM tenant_attachments\s+WHERE id = \$1\s+AND deleted_at IS NULL.*` +
+		`FROM lease_attachments\s+WHERE id = \$1\s+AND deleted_at IS NULL.*` +
+		`FROM journal_log_attachments\s+WHERE id = \$1\s+AND deleted_at IS NULL.*` +
+		`FROM repair_request_attachments\s+WHERE id = \$1\s+AND deleted_at IS NULL.*` +
+		`FROM bill_attachments\s+WHERE id = \$1\s+AND deleted_at IS NULL.*` +
+		`LIMIT 1`
 }
 
 func expectSoftDelete(mock sqlmock.Sqlmock, table string, attachmentID string, rowsAffected int64) {

--- a/internal/platform/database/resourceownership/repository.go
+++ b/internal/platform/database/resourceownership/repository.go
@@ -23,6 +23,7 @@ type Repository interface {
 	FindPropertyIDByRepairRequestID(ctx context.Context, repairRequestID string) (string, error)
 	FindPropertyIDByForceTerminationID(ctx context.Context, forceTerminationID string) (string, error)
 	FindPropertyIDByAttachmentID(ctx context.Context, attachmentID string) (string, error)
+	FindPropertyIDsByAttachmentID(ctx context.Context, attachmentID string) ([]string, error)
 	EnsureTenantExists(ctx context.Context, tenantID string) error
 }
 
@@ -238,6 +239,180 @@ LIMIT 1
 `
 
 	return r.findPropertyID(ctx, query, attachmentID, "query attachment property by id")
+}
+
+func (r *SQLRepository) FindPropertyIDsByAttachmentID(ctx context.Context, attachmentID string) ([]string, error) {
+	const query = `
+SELECT DISTINCT property_id
+FROM (
+    SELECT property_id AS property_id
+    FROM property_attachments
+    JOIN properties ON properties.id = property_attachments.property_id
+    WHERE property_attachments.id = $1
+      AND property_attachments.deleted_at IS NULL
+      AND properties.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT rooms.property_id AS property_id
+    FROM room_attachments
+    JOIN rooms ON rooms.id = room_attachments.room_id
+    WHERE room_attachments.id = $1
+      AND room_attachments.deleted_at IS NULL
+      AND rooms.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT leases.property_id AS property_id
+    FROM tenant_attachments
+    JOIN tenants ON tenants.id = tenant_attachments.tenant_id
+    JOIN leases ON leases.tenant_id = tenants.id
+    WHERE tenant_attachments.id = $1
+      AND tenant_attachments.deleted_at IS NULL
+      AND tenants.deleted_at IS NULL
+      AND leases.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT leases.property_id AS property_id
+    FROM lease_attachments
+    JOIN leases ON leases.id = lease_attachments.lease_id
+    WHERE lease_attachments.id = $1
+      AND lease_attachments.deleted_at IS NULL
+      AND leases.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT journal_logs.property_id AS property_id
+    FROM journal_log_attachments
+    JOIN journal_logs ON journal_logs.id = journal_log_attachments.journal_log_id
+    WHERE journal_log_attachments.id = $1
+      AND journal_log_attachments.deleted_at IS NULL
+      AND journal_logs.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT repair_requests.property_id AS property_id
+    FROM repair_request_attachments
+    JOIN repair_requests ON repair_requests.id = repair_request_attachments.repair_request_id
+    WHERE repair_request_attachments.id = $1
+      AND repair_request_attachments.deleted_at IS NULL
+      AND repair_requests.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT bills.property_id AS property_id
+    FROM bill_attachments
+    JOIN bills ON bills.id = bill_attachments.bill_id
+    WHERE bill_attachments.id = $1
+      AND bill_attachments.deleted_at IS NULL
+      AND bills.deleted_at IS NULL
+) AS attachment_properties
+ORDER BY property_id
+`
+
+	rows, err := r.db.QueryContext(ctx, query, attachmentID)
+	if err != nil {
+		return nil, fmt.Errorf("query attachment properties by id: %w", err)
+	}
+	defer rows.Close()
+
+	propertyIDs := []string{}
+	for rows.Next() {
+		var propertyID string
+		if err := rows.Scan(&propertyID); err != nil {
+			return nil, fmt.Errorf("scan attachment properties by id: %w", err)
+		}
+		propertyIDs = append(propertyIDs, propertyID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate attachment properties by id: %w", err)
+	}
+	if len(propertyIDs) == 0 {
+		exists, err := r.activeAttachmentHostExists(ctx, attachmentID)
+		if err != nil {
+			return nil, err
+		}
+		if exists {
+			return []string{}, nil
+		}
+		return nil, ErrNotFound
+	}
+
+	return propertyIDs, nil
+}
+
+func (r *SQLRepository) activeAttachmentHostExists(ctx context.Context, attachmentID string) (bool, error) {
+	const query = `
+SELECT EXISTS (
+    SELECT 1
+    FROM property_attachments
+    JOIN properties ON properties.id = property_attachments.property_id
+    WHERE property_attachments.id = $1
+      AND property_attachments.deleted_at IS NULL
+      AND properties.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT 1
+    FROM room_attachments
+    JOIN rooms ON rooms.id = room_attachments.room_id
+    WHERE room_attachments.id = $1
+      AND room_attachments.deleted_at IS NULL
+      AND rooms.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT 1
+    FROM tenant_attachments
+    JOIN tenants ON tenants.id = tenant_attachments.tenant_id
+    WHERE tenant_attachments.id = $1
+      AND tenant_attachments.deleted_at IS NULL
+      AND tenants.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT 1
+    FROM lease_attachments
+    JOIN leases ON leases.id = lease_attachments.lease_id
+    WHERE lease_attachments.id = $1
+      AND lease_attachments.deleted_at IS NULL
+      AND leases.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT 1
+    FROM journal_log_attachments
+    JOIN journal_logs ON journal_logs.id = journal_log_attachments.journal_log_id
+    WHERE journal_log_attachments.id = $1
+      AND journal_log_attachments.deleted_at IS NULL
+      AND journal_logs.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT 1
+    FROM repair_request_attachments
+    JOIN repair_requests ON repair_requests.id = repair_request_attachments.repair_request_id
+    WHERE repair_request_attachments.id = $1
+      AND repair_request_attachments.deleted_at IS NULL
+      AND repair_requests.deleted_at IS NULL
+
+    UNION ALL
+
+    SELECT 1
+    FROM bill_attachments
+    JOIN bills ON bills.id = bill_attachments.bill_id
+    WHERE bill_attachments.id = $1
+      AND bill_attachments.deleted_at IS NULL
+      AND bills.deleted_at IS NULL
+)
+`
+
+	var exists bool
+	if err := r.db.QueryRowContext(ctx, query, attachmentID).Scan(&exists); err != nil {
+		return false, fmt.Errorf("query active attachment host by id: %w", err)
+	}
+	return exists, nil
 }
 
 func (r *SQLRepository) EnsureTenantExists(ctx context.Context, tenantID string) error {

--- a/internal/platform/database/resourceownership/repository_test.go
+++ b/internal/platform/database/resourceownership/repository_test.go
@@ -347,6 +347,71 @@ func TestFindPropertyIDByAttachmentIDRequiresActiveAttachmentAndHostResource(t *
 	}
 }
 
+func TestFindPropertyIDsByAttachmentIDReturnsAllActiveAttachmentProperties(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	mock.ExpectQuery(attachmentPropertiesQueryPattern()).
+		WithArgs("attachment-1").
+		WillReturnRows(sqlmock.NewRows([]string{"property_id"}).
+			AddRow("property-1").
+			AddRow("property-2"))
+
+	propertyIDs, err := repo.FindPropertyIDsByAttachmentID(context.Background(), "attachment-1")
+	if err != nil {
+		t.Fatalf("FindPropertyIDsByAttachmentID: %v", err)
+	}
+	if len(propertyIDs) != 2 || propertyIDs[0] != "property-1" || propertyIDs[1] != "property-2" {
+		t.Fatalf("propertyIDs = %+v, want [property-1 property-2]", propertyIDs)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPropertyIDsByAttachmentIDMapsEmptyRowsToNotFound(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	mock.ExpectQuery(attachmentPropertiesQueryPattern()).
+		WithArgs("attachment-1").
+		WillReturnRows(sqlmock.NewRows([]string{"property_id"}))
+	mock.ExpectQuery(activeAttachmentHostExistsQueryPattern()).
+		WithArgs("attachment-1").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	_, err := repo.FindPropertyIDsByAttachmentID(context.Background(), "attachment-1")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFindPropertyIDsByAttachmentIDReturnsEmptyListForActiveHostWithoutProperties(t *testing.T) {
+	db, mock, repo := newResourceOwnershipRepoTest(t)
+	defer closeResourceOwnershipDB(t, db)
+
+	mock.ExpectQuery(attachmentPropertiesQueryPattern()).
+		WithArgs("attachment-1").
+		WillReturnRows(sqlmock.NewRows([]string{"property_id"}))
+	mock.ExpectQuery(activeAttachmentHostExistsQueryPattern()).
+		WithArgs("attachment-1").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	propertyIDs, err := repo.FindPropertyIDsByAttachmentID(context.Background(), "attachment-1")
+	if err != nil {
+		t.Fatalf("FindPropertyIDsByAttachmentID: %v", err)
+	}
+	if len(propertyIDs) != 0 {
+		t.Fatalf("propertyIDs = %+v, want empty list", propertyIDs)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
 func TestEnsureTenantExists(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -420,6 +485,31 @@ LIMIT 1
 `)).
 		WithArgs(tenantID).
 		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(tenantID))
+}
+
+func attachmentPropertiesQueryPattern() string {
+	return `(?s)` +
+		`SELECT DISTINCT property_id.*` +
+		`FROM property_attachments\s+JOIN properties ON properties.id = property_attachments.property_id\s+WHERE property_attachments.id = \$1\s+AND property_attachments.deleted_at IS NULL\s+AND properties.deleted_at IS NULL.*` +
+		`FROM room_attachments\s+JOIN rooms ON rooms.id = room_attachments.room_id\s+WHERE room_attachments.id = \$1\s+AND room_attachments.deleted_at IS NULL\s+AND rooms.deleted_at IS NULL.*` +
+		`FROM tenant_attachments\s+JOIN tenants ON tenants.id = tenant_attachments.tenant_id\s+JOIN leases ON leases.tenant_id = tenants.id\s+WHERE tenant_attachments.id = \$1\s+AND tenant_attachments.deleted_at IS NULL\s+AND tenants.deleted_at IS NULL\s+AND leases.deleted_at IS NULL.*` +
+		`FROM lease_attachments\s+JOIN leases ON leases.id = lease_attachments.lease_id\s+WHERE lease_attachments.id = \$1\s+AND lease_attachments.deleted_at IS NULL\s+AND leases.deleted_at IS NULL.*` +
+		`FROM journal_log_attachments\s+JOIN journal_logs ON journal_logs.id = journal_log_attachments.journal_log_id\s+WHERE journal_log_attachments.id = \$1\s+AND journal_log_attachments.deleted_at IS NULL\s+AND journal_logs.deleted_at IS NULL.*` +
+		`FROM repair_request_attachments\s+JOIN repair_requests ON repair_requests.id = repair_request_attachments.repair_request_id\s+WHERE repair_request_attachments.id = \$1\s+AND repair_request_attachments.deleted_at IS NULL\s+AND repair_requests.deleted_at IS NULL.*` +
+		`FROM bill_attachments\s+JOIN bills ON bills.id = bill_attachments.bill_id\s+WHERE bill_attachments.id = \$1\s+AND bill_attachments.deleted_at IS NULL\s+AND bills.deleted_at IS NULL.*` +
+		`ORDER BY property_id`
+}
+
+func activeAttachmentHostExistsQueryPattern() string {
+	return `(?s)` +
+		`SELECT EXISTS.*` +
+		`FROM property_attachments\s+JOIN properties ON properties.id = property_attachments.property_id\s+WHERE property_attachments.id = \$1\s+AND property_attachments.deleted_at IS NULL\s+AND properties.deleted_at IS NULL.*` +
+		`FROM room_attachments\s+JOIN rooms ON rooms.id = room_attachments.room_id\s+WHERE room_attachments.id = \$1\s+AND room_attachments.deleted_at IS NULL\s+AND rooms.deleted_at IS NULL.*` +
+		`FROM tenant_attachments\s+JOIN tenants ON tenants.id = tenant_attachments.tenant_id\s+WHERE tenant_attachments.id = \$1\s+AND tenant_attachments.deleted_at IS NULL\s+AND tenants.deleted_at IS NULL.*` +
+		`FROM lease_attachments\s+JOIN leases ON leases.id = lease_attachments.lease_id\s+WHERE lease_attachments.id = \$1\s+AND lease_attachments.deleted_at IS NULL\s+AND leases.deleted_at IS NULL.*` +
+		`FROM journal_log_attachments\s+JOIN journal_logs ON journal_logs.id = journal_log_attachments.journal_log_id\s+WHERE journal_log_attachments.id = \$1\s+AND journal_log_attachments.deleted_at IS NULL\s+AND journal_logs.deleted_at IS NULL.*` +
+		`FROM repair_request_attachments\s+JOIN repair_requests ON repair_requests.id = repair_request_attachments.repair_request_id\s+WHERE repair_request_attachments.id = \$1\s+AND repair_request_attachments.deleted_at IS NULL\s+AND repair_requests.deleted_at IS NULL.*` +
+		`FROM bill_attachments\s+JOIN bills ON bills.id = bill_attachments.bill_id\s+WHERE bill_attachments.id = \$1\s+AND bill_attachments.deleted_at IS NULL\s+AND bills.deleted_at IS NULL`
 }
 
 func newResourceOwnershipRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {

--- a/internal/platform/storage/attachment_storage_test.go
+++ b/internal/platform/storage/attachment_storage_test.go
@@ -34,6 +34,14 @@ func TestFakeMetadataStorageReturnsUploadURLAndMetadata(t *testing.T) {
 		t.Fatalf("unexpected upload URL %q", uploadURL)
 	}
 
+	downloadURL, err := storage.GenerateDownloadURL(context.Background(), "attachments/property/object.pdf", time.Now().Add(time.Minute))
+	if err != nil {
+		t.Fatalf("GenerateDownloadURL returned error: %v", err)
+	}
+	if downloadURL != "https://fake-storage.local/stds-e2e/attachments/property/object.pdf" {
+		t.Fatalf("unexpected download URL %q", downloadURL)
+	}
+
 	metadata, err := storage.GetObjectMetadata(context.Background(), "attachments/property/object.pdf")
 	if err != nil {
 		t.Fatalf("GetObjectMetadata returned error: %v", err)

--- a/internal/platform/storage/fake_metadata.go
+++ b/internal/platform/storage/fake_metadata.go
@@ -28,6 +28,15 @@ func (s *FakeMetadataStorage) GenerateUploadURL(_ context.Context, objectPath st
 	return url.JoinPath("https://fake-storage.local", bucketName, objectPath)
 }
 
+// GenerateDownloadURL returns a deterministic fake download URL.
+func (s *FakeMetadataStorage) GenerateDownloadURL(_ context.Context, objectPath string, _ time.Time) (string, error) {
+	bucketName := s.bucketName
+	if bucketName == "" {
+		bucketName = "fake-attachment-bucket"
+	}
+	return url.JoinPath("https://fake-storage.local", bucketName, objectPath)
+}
+
 // GetObjectMetadata returns valid attachment metadata without reading object storage.
 func (s *FakeMetadataStorage) GetObjectMetadata(_ context.Context, _ string) (*appattachment.ObjectMetadata, error) {
 	return &appattachment.ObjectMetadata{

--- a/internal/platform/storage/gcs.go
+++ b/internal/platform/storage/gcs.go
@@ -83,6 +83,27 @@ func (s *GCSStorage) GenerateUploadURL(ctx context.Context, objectPath string, c
 	return uploadURL, nil
 }
 
+// GenerateDownloadURL returns a GET URL for reading an existing object.
+func (s *GCSStorage) GenerateDownloadURL(ctx context.Context, objectPath string, expiresAt time.Time) (string, error) {
+	if s.emulatorHost != "" {
+		objectURL, err := url.JoinPath(s.emulatorHost, s.bucketName, objectPath)
+		if err != nil {
+			return "", fmt.Errorf("build emulator object url: %w", err)
+		}
+		return objectURL, nil
+	}
+
+	downloadURL, err := s.client.Bucket(s.bucketName).SignedURL(objectPath, &gcstorage.SignedURLOptions{
+		Method:  "GET",
+		Expires: expiresAt,
+	})
+	if err != nil {
+		return "", fmt.Errorf("sign gcs download url: %w", err)
+	}
+
+	return downloadURL, nil
+}
+
 // GetObjectMetadata returns metadata for an uploaded object.
 func (s *GCSStorage) GetObjectMetadata(ctx context.Context, objectPath string) (*appattachment.ObjectMetadata, error) {
 	attrsReader := s.attrsReader

--- a/internal/platform/storage/gcs_test.go
+++ b/internal/platform/storage/gcs_test.go
@@ -33,6 +33,27 @@ func TestGenerateUploadURLEmulatorDoesNotRequireSignedURL(t *testing.T) {
 	}
 }
 
+func TestGenerateDownloadURLEmulatorDoesNotRequireSignedURL(t *testing.T) {
+	storage := &GCSStorage{
+		bucketName:   "test-bucket",
+		emulatorHost: "http://127.0.0.1:9023",
+	}
+
+	downloadURL, err := storage.GenerateDownloadURL(
+		context.Background(),
+		"attachments/property/10000000-0000-0000-0000-000000000001/object.pdf",
+		time.Date(2026, 4, 28, 10, 15, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("GenerateDownloadURL returned error: %v", err)
+	}
+
+	want := "http://127.0.0.1:9023/test-bucket/attachments/property/10000000-0000-0000-0000-000000000001/object.pdf"
+	if downloadURL != want {
+		t.Fatalf("expected emulator download URL %q, got %q", want, downloadURL)
+	}
+}
+
 func TestGetObjectMetadataMapsAttrs(t *testing.T) {
 	reader := &fakeGCSAttrsReader{
 		attrs: &gcstorage.ObjectAttrs{

--- a/internal/server/attachment_adapters.go
+++ b/internal/server/attachment_adapters.go
@@ -56,6 +56,16 @@ func (a attachmentRepositoryAdapter) ListByResource(ctx context.Context, resourc
 	return attachments, nil
 }
 
+func (a attachmentRepositoryAdapter) FindActiveByID(ctx context.Context, attachmentID string) (*appattachment.Attachment, error) {
+	attachment, err := a.repo.FindActiveByID(ctx, attachmentID)
+	if err != nil {
+		return nil, mapAttachmentRepoError(err)
+	}
+
+	converted := toAppAttachment(attachment)
+	return &converted, nil
+}
+
 func (a attachmentRepositoryAdapter) CreateAttachment(ctx context.Context, tx *sql.Tx, params appattachment.CreateAttachmentParams) (*appattachment.Attachment, error) {
 	attachment, err := a.repo.CreateAttachment(ctx, tx, dbattachments.CreateAttachmentParams{
 		ResourceType: dbattachments.ResourceType(params.ResourceType),


### PR DESCRIPTION
Closes #163

## Summary

- Add `POST /attachments/{id}/download-url` for short-lived authenticated attachment read URLs.
- Generate and document `AttachmentDownloadURLResponse` without exposing storage internals.
- Add runtime support across attachment service, repository lookup, storage adapters, handler, and route policy.
- Fix attachment-id authorization to preserve tenant multi-property access and owner own-property download behavior.

## Validation

- `npm run openapi:lint`
- `npm run openapi:generate`
- `go test -count=1 ./internal/http/middleware ./internal/http/router ./internal/platform/database/resourceownership`
- `go test -count=1 ./internal/application/attachment ./internal/platform/database/attachments ./internal/platform/database/resourceownership ./internal/platform/storage ./internal/http/handler ./internal/http/middleware ./internal/http/router`
- `go test -count=1 ./...`
- `git diff --check`
