### PR TITLE
Clarify checkout settlement dates and manual rent refund

### DIFF
--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -547,7 +547,7 @@ PropertyOwnerView
 
 ```
 主辦以上角色發起強制終止，填寫原因、termination_date，並可選填 actual_move_out_date
-  → 建立 ForceTermination 記錄（leaseId, billIds[], reason, deposit_handling）
+  → 建立 ForceTermination 記錄（leaseId, force_termination_bills, reason, deposit_handling）
   → 同步將未結清帳單標記為 written_off，每筆成功記錄進度
   → 將 leases.end_date 更新為 termination_date，若提供則保存 actual_move_out_date
   → 全部成功後將 ForceTermination 標記 completed

--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -69,7 +69,7 @@ Lease 於建立時也決定 `electricityBillingCadence`（`monthly | bimonthly`�
 
 **LeaseTerminated 後的處理**：目前沒有 Billing BC runtime subscriber。正常終止時帳單應已全清；強制終止時未結清帳單在 command 內同步標記 `written_off`、記錄 force termination progress，並完成 force termination。若未來需要處理剩餘預產帳單 void，應先確認是否需與 termination command 強一致。
 
-**強制終止租約**（呆帳情境）：由主辦以上角色執行，流程記錄於 `force_terminations` table（Billing BC），在同一 command 中同步將未結清帳單標記為 `written_off`、記錄 `deposit_handling` 決策、完成 ForceTermination，並發出 `LeaseTerminated`。
+**強制終止租約**（呆帳情境）：由主辦以上角色執行，流程記錄於 `force_terminations` table（Billing BC），在同一 command 中同步將未結清帳單標記為 `written_off`、記錄 `termination_date` 與 `deposit_handling` 決策、完成 ForceTermination，並發出 `LeaseTerminated`。`termination_date` 會寫入 `leases.end_date`；`actual_move_out_date` 為可選實際搬出 / 點交日 metadata，不影響 write-off、押金處理或租金退費。
 
 ### Journal
 
@@ -514,7 +514,7 @@ PropertyOwnerView
 | Tenant Index | `(status)` on tenants table |
 | 維修 Index | `(property_id, status)` on repair_requests table |
 | 日誌 Index | `(property_id, created_at)` on journal_logs table |
-| ForceTermination table | 欄位：`id, lease_id, initiated_by, reason, deposit_handling: write_off \| keep_held, status: completed, created_at`（bill_ids[] 移除，改用 force_termination_bills table；`in_progress` 為已棄用的補償流程歷史狀態） |
+| ForceTermination table | 欄位：`id, lease_id, initiated_by, reason, deposit_handling: write_off \| keep_held, status: completed, created_at`（bill_ids[] 移除，改用 force_termination_bills table；`in_progress` 為已棄用的補償流程歷史狀態）。強制終止生效日存於 `leases.end_date`；實際搬出 / 點交日可選存於 `leases.actual_move_out_date`。 |
 | PropertyAccount 架構 | 月結快照拆兩層：summary + entries |
 | accounting_titles table | 欄位：`id, code, name, kind: income \| expense, legacy_kind, is_active, created_at, updated_at`；runtime master data；`kind` 不取代 `category` 的財報 total classification |
 | legacy_accounting_title_mappings table | 欄位：`legacy_accounting_id, legacy_accounting_title_id, accounting_title_id, legacy_accounting_kind, legacy_accounting_title, source_table, created_at`；保存 legacy `xx_accounting_title` 對 canonical title 的 mapping |
@@ -546,9 +546,10 @@ PropertyOwnerView
 ### 強制終止（呆帳）
 
 ```
-主辦以上角色發起強制終止，填寫原因
+主辦以上角色發起強制終止，填寫原因、termination_date，並可選填 actual_move_out_date
   → 建立 ForceTermination 記錄（leaseId, billIds[], reason, deposit_handling）
   → 同步將未結清帳單標記為 written_off，每筆成功記錄進度
+  → 將 leases.end_date 更新為 termination_date，若提供則保存 actual_move_out_date
   → 全部成功後將 ForceTermination 標記 completed
   → 全部 written_off 完成 → 依 deposit_handling 人工決定將押金標記 written_off，或維持 held 等待後續押金處理
   → LeaseTerminated event（forced: true）

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -3393,6 +3393,8 @@ paths:
             examples:
               default:
                 value:
+                  termination_date: '2026-07-15'
+                  actual_move_out_date: '2026-07-10'
                   reason: 租客失聯，連續 3 個月未繳租金
                   deposit_handling: write_off
       responses:
@@ -7914,6 +7916,11 @@ components:
         end_date:
           type: string
           format: date
+        actual_move_out_date:
+          type: string
+          format: date
+          nullable: true
+          description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date 或帳務。
         electricity_billing_cadence:
           type: string
           enum:
@@ -8205,7 +8212,12 @@ components:
         checkout_date:
           type: string
           format: date
-          description: 實際退租日；backend 以此計算並保存結算快照。
+          description: 結算生效日 / 租約終止日；backend 以此更新 lease end_date 並保存結算快照，不代表實際搬出日。
+        actual_move_out_date:
+          type: string
+          format: date
+          nullable: true
+          description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date、帳務期間或自動租金計算。
         reason:
           type: string
           description: 退租原因。
@@ -8230,6 +8242,15 @@ components:
           type: string
           nullable: true
           description: other_fee 大於 0 時建議提供。
+        manual_rent_refund_amount:
+          type: integer
+          minimum: 0
+          default: 0
+          description: 人工決定的未到期租金退款金額；backend 不自動按比例計算。
+        manual_rent_refund_reason:
+          type: string
+          nullable: true
+          description: 人工租金退款決策原因；checkout_date 早於原租約 end_date 時必填，金額 0 加原因表示明確決定不退未到期租金。
         notes:
           type: string
           nullable: true
@@ -8247,6 +8268,7 @@ components:
       properties:
         kind:
           type: string
+          description: rent_refund 表示 backend 接收的人工租金退款決策，不代表自動按比例計算的未到期租金退款。
           enum:
             - deposit_refund
             - cleaning_fee
@@ -8286,7 +8308,7 @@ components:
             - lease_not_active
             - deposit_not_held
             - charge_exceeds_deposit
-            - rent_refund_not_calculated
+            - manual_rent_refund_decision_required
         message:
           type: string
         source_id:
@@ -8301,7 +8323,7 @@ components:
         code:
           type: string
           enum:
-            - rent_refund_not_calculated
+            - manual_rent_refund_recorded
             - final_meter_snapshot_only
         message:
           type: string
@@ -8348,6 +8370,12 @@ components:
         checkout_date:
           type: string
           format: date
+          description: 結算生效日 / 租約終止日，不代表實際搬出日。
+        actual_move_out_date:
+          type: string
+          format: date
+          nullable: true
+          description: 實際搬出 / 點交日；僅作為營運紀錄。
         reason:
           type: string
         final_meter_reading:
@@ -8356,6 +8384,14 @@ components:
         notes:
           type: string
           nullable: true
+        manual_rent_refund_amount:
+          type: integer
+          minimum: 0
+          description: 人工決定的未到期租金退款金額；0 加 reason 表示明確不退。
+        manual_rent_refund_reason:
+          type: string
+          nullable: true
+          description: 人工租金退款決策原因。
         lines:
           type: array
           items:
@@ -8406,9 +8442,19 @@ components:
     ForceTerminateRequest:
       type: object
       required:
+        - termination_date
         - reason
         - deposit_handling
       properties:
+        termination_date:
+          type: string
+          format: date
+          description: 強制終止生效日；backend 以此更新 lease end_date。
+        actual_move_out_date:
+          type: string
+          format: date
+          nullable: true
+          description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 write-off、deposit handling 或租金退款。
         reason:
           type: string
           minLength: 1
@@ -8732,6 +8778,7 @@ components:
             - journal_expense
             - deposit_refund
             - deposit_deduction
+            - rent_refund
     FinancialReportEntryItem:
       type: object
       properties:
@@ -8746,6 +8793,7 @@ components:
             - electricity_payment
             - deposit_refund
             - deposit_deduction
+            - rent_refund
             - journal_expense
         accounting_title_id:
           type: string

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -8308,6 +8308,7 @@ components:
             - lease_not_active
             - deposit_not_held
             - charge_exceeds_deposit
+            - checkout_date_before_lease_start
             - manual_rent_refund_decision_required
         message:
           type: string

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -7920,7 +7920,7 @@ components:
           type: string
           format: date
           nullable: true
-          description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date 或帳務。
+          description: Actual move-out or handover date. This is operational metadata only and does not affect lease end_date or accounting.
         electricity_billing_cadence:
           type: string
           enum:
@@ -8212,20 +8212,20 @@ components:
         checkout_date:
           type: string
           format: date
-          description: 結算生效日 / 租約終止日；backend 以此更新 lease end_date 並保存結算快照，不代表實際搬出日。
+          description: Settlement effective date and lease termination date. The backend writes this value to lease end_date and stores it in the finalized settlement snapshot. It is not the actual move-out date.
         actual_move_out_date:
           type: string
           format: date
           nullable: true
-          description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date、帳務期間或自動租金計算。
+          description: Actual move-out or handover date. This is operational metadata only and does not affect lease end_date, accounting periods, or automatic rent calculation.
         reason:
           type: string
-          description: 退租原因。
+          description: Checkout settlement reason.
         final_meter_reading:
           type: integer
           minimum: 0
           nullable: true
-          description: 退租電表讀數；v1 僅作為快照顯示輸入，不由 frontend 計算電費。
+          description: Final meter reading at checkout. In v1 this is stored for snapshot display only and must not be used by the frontend to calculate electricity fees.
         cleaning_fee:
           type: integer
           minimum: 0
@@ -8241,20 +8241,20 @@ components:
         other_fee_reason:
           type: string
           nullable: true
-          description: other_fee 大於 0 時建議提供。
+          description: Recommended when other_fee is greater than 0.
         manual_rent_refund_amount:
           type: integer
           minimum: 0
           default: 0
-          description: 人工決定的未到期租金退款金額；backend 不自動按比例計算。
+          description: Manually decided unexpired-rent refund amount. The backend never calculates a prorated rent refund automatically.
         manual_rent_refund_reason:
           type: string
           nullable: true
-          description: 人工租金退款決策原因；checkout_date 早於原租約 end_date 時必填，金額 0 加原因表示明確決定不退未到期租金。
+          description: Manual rent refund decision reason. Required when checkout_date is earlier than the original lease end_date or when manual_rent_refund_amount is greater than 0. Otherwise nullable. Amount 0 with a reason records an explicit decision not to refund unexpired rent.
         notes:
           type: string
           nullable: true
-          description: 退租結算備註。
+          description: Checkout settlement notes.
     CheckoutSettlementPreviewRequest:
       allOf:
         - $ref: '#/components/schemas/CheckoutSettlementInput'
@@ -8268,7 +8268,7 @@ components:
       properties:
         kind:
           type: string
-          description: rent_refund 表示 backend 接收的人工租金退款決策，不代表自動按比例計算的未到期租金退款。
+          description: rent_refund means a manual rent refund decision accepted by the backend. It does not represent an automatically prorated unexpired-rent refund.
           enum:
             - deposit_refund
             - cleaning_fee
@@ -8371,12 +8371,12 @@ components:
         checkout_date:
           type: string
           format: date
-          description: 結算生效日 / 租約終止日，不代表實際搬出日。
+          description: Settlement effective date and lease termination date. This is not the actual move-out date.
         actual_move_out_date:
           type: string
           format: date
           nullable: true
-          description: 實際搬出 / 點交日；僅作為營運紀錄。
+          description: Actual move-out or handover date. This is operational metadata only.
         reason:
           type: string
         final_meter_reading:
@@ -8388,11 +8388,11 @@ components:
         manual_rent_refund_amount:
           type: integer
           minimum: 0
-          description: 人工決定的未到期租金退款金額；0 加 reason 表示明確不退。
+          description: Manually decided unexpired-rent refund amount. Amount 0 with a reason records an explicit no-refund decision.
         manual_rent_refund_reason:
           type: string
           nullable: true
-          description: 人工租金退款決策原因。
+          description: Manual rent refund decision reason. Required when checkout_date is earlier than the original lease end_date or when manual_rent_refund_amount is greater than 0. Otherwise nullable.
         lines:
           type: array
           items:
@@ -8450,12 +8450,12 @@ components:
         termination_date:
           type: string
           format: date
-          description: 強制終止生效日；backend 以此更新 lease end_date。
+          description: Force-termination effective date. The backend writes this value to lease end_date.
         actual_move_out_date:
           type: string
           format: date
           nullable: true
-          description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 write-off、deposit handling 或租金退款。
+          description: Actual move-out or handover date. This is operational metadata only and does not affect write-off handling, deposit handling, or rent refund behavior.
         reason:
           type: string
           minLength: 1

--- a/docs/spec/schema.sql
+++ b/docs/spec/schema.sql
@@ -166,6 +166,7 @@ CREATE TABLE leases (
     rent_amount             INTEGER      NOT NULL CHECK (rent_amount > 0),  -- BR-02
     start_date              DATE         NOT NULL,
     end_date                DATE         NOT NULL,
+    actual_move_out_date    DATE,
     rent_billing_cadence     VARCHAR(20)  NOT NULL DEFAULT 'monthly' CHECK (rent_billing_cadence IN ('monthly', 'quarterly', 'semiannual', 'annual')),
     electricity_billing_cadence VARCHAR(20) NOT NULL DEFAULT 'monthly' CHECK (electricity_billing_cadence IN ('monthly', 'bimonthly')),
     starting_meter_reading  INTEGER CHECK (starting_meter_reading IS NULL OR starting_meter_reading >= 0),
@@ -337,7 +338,8 @@ CREATE TABLE accounting_entries (
     -- category：財報分類
     category            VARCHAR(50)  NOT NULL CHECK (category IN (
                             'rent_payment', 'electricity_payment',
-                            'deposit_refund', 'deposit_deduction', 'journal_expense'
+                            'deposit_refund', 'deposit_deduction',
+                            'journal_expense', 'rent_refund'
                         )),
     -- accounting_title_*：穩定會計科目維度；category 仍是財報 total classification
     accounting_title_id   UUID        REFERENCES accounting_titles(id),
@@ -398,7 +400,8 @@ CREATE TABLE monthly_snapshot_entries (
     snapshot_id     UUID        NOT NULL REFERENCES monthly_snapshots(id),
     category        VARCHAR(50)  NOT NULL CHECK (category IN (
                         'rent_payment', 'electricity_payment',
-                        'deposit_refund', 'deposit_deduction', 'journal_expense'
+                        'deposit_refund', 'deposit_deduction',
+                        'journal_expense', 'rent_refund'
                     )),
     -- snapshot copy 保護 finalized historical report 不受 accounting title rename 影響
     accounting_title_id   UUID        REFERENCES accounting_titles(id),

--- a/docs/spec/src/components/schemas/billing/FinancialReportEntryItem.yaml
+++ b/docs/spec/src/components/schemas/billing/FinancialReportEntryItem.yaml
@@ -11,6 +11,7 @@ properties:
       - electricity_payment
       - deposit_refund
       - deposit_deduction
+      - rent_refund
       - journal_expense
   accounting_title_id:
     type: string

--- a/docs/spec/src/components/schemas/billing/FinancialReportEntrySource.yaml
+++ b/docs/spec/src/components/schemas/billing/FinancialReportEntrySource.yaml
@@ -16,3 +16,4 @@ properties:
       - journal_expense
       - deposit_refund
       - deposit_deduction
+      - rent_refund

--- a/docs/spec/src/components/schemas/tenancy/CheckoutSettlementBlocker.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CheckoutSettlementBlocker.yaml
@@ -11,6 +11,7 @@ properties:
       - lease_not_active
       - deposit_not_held
       - charge_exceeds_deposit
+      - checkout_date_before_lease_start
       - manual_rent_refund_decision_required
   message:
     type: string

--- a/docs/spec/src/components/schemas/tenancy/CheckoutSettlementBlocker.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CheckoutSettlementBlocker.yaml
@@ -11,7 +11,7 @@ properties:
       - lease_not_active
       - deposit_not_held
       - charge_exceeds_deposit
-      - rent_refund_not_calculated
+      - manual_rent_refund_decision_required
   message:
     type: string
   source_id:

--- a/docs/spec/src/components/schemas/tenancy/CheckoutSettlementInput.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CheckoutSettlementInput.yaml
@@ -6,20 +6,20 @@ properties:
   checkout_date:
     type: string
     format: date
-    description: 結算生效日 / 租約終止日；backend 以此更新 lease end_date 並保存結算快照，不代表實際搬出日。
+    description: Settlement effective date and lease termination date. The backend writes this value to lease end_date and stores it in the finalized settlement snapshot. It is not the actual move-out date.
   actual_move_out_date:
     type: string
     format: date
     nullable: true
-    description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date、帳務期間或自動租金計算。
+    description: Actual move-out or handover date. This is operational metadata only and does not affect lease end_date, accounting periods, or automatic rent calculation.
   reason:
     type: string
-    description: 退租原因。
+    description: Checkout settlement reason.
   final_meter_reading:
     type: integer
     minimum: 0
     nullable: true
-    description: 退租電表讀數；v1 僅作為快照顯示輸入，不由 frontend 計算電費。
+    description: Final meter reading at checkout. In v1 this is stored for snapshot display only and must not be used by the frontend to calculate electricity fees.
   cleaning_fee:
     type: integer
     minimum: 0
@@ -35,17 +35,17 @@ properties:
   other_fee_reason:
     type: string
     nullable: true
-    description: other_fee 大於 0 時建議提供。
+    description: Recommended when other_fee is greater than 0.
   manual_rent_refund_amount:
     type: integer
     minimum: 0
     default: 0
-    description: 人工決定的未到期租金退款金額；backend 不自動按比例計算。
+    description: Manually decided unexpired-rent refund amount. The backend never calculates a prorated rent refund automatically.
   manual_rent_refund_reason:
     type: string
     nullable: true
-    description: 人工租金退款決策原因；checkout_date 早於原租約 end_date 時必填，金額 0 加原因表示明確決定不退未到期租金。
+    description: Manual rent refund decision reason. Required when checkout_date is earlier than the original lease end_date or when manual_rent_refund_amount is greater than 0. Otherwise nullable. Amount 0 with a reason records an explicit decision not to refund unexpired rent.
   notes:
     type: string
     nullable: true
-    description: 退租結算備註。
+    description: Checkout settlement notes.

--- a/docs/spec/src/components/schemas/tenancy/CheckoutSettlementInput.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CheckoutSettlementInput.yaml
@@ -6,7 +6,12 @@ properties:
   checkout_date:
     type: string
     format: date
-    description: 實際退租日；backend 以此計算並保存結算快照。
+    description: 結算生效日 / 租約終止日；backend 以此更新 lease end_date 並保存結算快照，不代表實際搬出日。
+  actual_move_out_date:
+    type: string
+    format: date
+    nullable: true
+    description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date、帳務期間或自動租金計算。
   reason:
     type: string
     description: 退租原因。
@@ -31,6 +36,15 @@ properties:
     type: string
     nullable: true
     description: other_fee 大於 0 時建議提供。
+  manual_rent_refund_amount:
+    type: integer
+    minimum: 0
+    default: 0
+    description: 人工決定的未到期租金退款金額；backend 不自動按比例計算。
+  manual_rent_refund_reason:
+    type: string
+    nullable: true
+    description: 人工租金退款決策原因；checkout_date 早於原租約 end_date 時必填，金額 0 加原因表示明確決定不退未到期租金。
   notes:
     type: string
     nullable: true

--- a/docs/spec/src/components/schemas/tenancy/CheckoutSettlementLine.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CheckoutSettlementLine.yaml
@@ -7,6 +7,7 @@ required:
 properties:
   kind:
     type: string
+    description: rent_refund 表示 backend 接收的人工租金退款決策，不代表自動按比例計算的未到期租金退款。
     enum:
       - deposit_refund
       - cleaning_fee

--- a/docs/spec/src/components/schemas/tenancy/CheckoutSettlementLine.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CheckoutSettlementLine.yaml
@@ -7,7 +7,7 @@ required:
 properties:
   kind:
     type: string
-    description: rent_refund 表示 backend 接收的人工租金退款決策，不代表自動按比例計算的未到期租金退款。
+    description: rent_refund means a manual rent refund decision accepted by the backend. It does not represent an automatically prorated unexpired-rent refund.
     enum:
       - deposit_refund
       - cleaning_fee

--- a/docs/spec/src/components/schemas/tenancy/CheckoutSettlementResponse.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CheckoutSettlementResponse.yaml
@@ -40,6 +40,12 @@ properties:
   checkout_date:
     type: string
     format: date
+    description: 結算生效日 / 租約終止日，不代表實際搬出日。
+  actual_move_out_date:
+    type: string
+    format: date
+    nullable: true
+    description: 實際搬出 / 點交日；僅作為營運紀錄。
   reason:
     type: string
   final_meter_reading:
@@ -48,6 +54,14 @@ properties:
   notes:
     type: string
     nullable: true
+  manual_rent_refund_amount:
+    type: integer
+    minimum: 0
+    description: 人工決定的未到期租金退款金額；0 加 reason 表示明確不退。
+  manual_rent_refund_reason:
+    type: string
+    nullable: true
+    description: 人工租金退款決策原因。
   lines:
     type: array
     items:

--- a/docs/spec/src/components/schemas/tenancy/CheckoutSettlementResponse.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CheckoutSettlementResponse.yaml
@@ -40,12 +40,12 @@ properties:
   checkout_date:
     type: string
     format: date
-    description: 結算生效日 / 租約終止日，不代表實際搬出日。
+    description: Settlement effective date and lease termination date. This is not the actual move-out date.
   actual_move_out_date:
     type: string
     format: date
     nullable: true
-    description: 實際搬出 / 點交日；僅作為營運紀錄。
+    description: Actual move-out or handover date. This is operational metadata only.
   reason:
     type: string
   final_meter_reading:
@@ -57,11 +57,11 @@ properties:
   manual_rent_refund_amount:
     type: integer
     minimum: 0
-    description: 人工決定的未到期租金退款金額；0 加 reason 表示明確不退。
+    description: Manually decided unexpired-rent refund amount. Amount 0 with a reason records an explicit no-refund decision.
   manual_rent_refund_reason:
     type: string
     nullable: true
-    description: 人工租金退款決策原因。
+    description: Manual rent refund decision reason. Required when checkout_date is earlier than the original lease end_date or when manual_rent_refund_amount is greater than 0. Otherwise nullable.
   lines:
     type: array
     items:

--- a/docs/spec/src/components/schemas/tenancy/CheckoutSettlementWarning.yaml
+++ b/docs/spec/src/components/schemas/tenancy/CheckoutSettlementWarning.yaml
@@ -6,7 +6,7 @@ properties:
   code:
     type: string
     enum:
-      - rent_refund_not_calculated
+      - manual_rent_refund_recorded
       - final_meter_snapshot_only
   message:
     type: string

--- a/docs/spec/src/components/schemas/tenancy/ForceTerminateRequest.yaml
+++ b/docs/spec/src/components/schemas/tenancy/ForceTerminateRequest.yaml
@@ -1,8 +1,18 @@
 type: object
 required:
+  - termination_date
   - reason
   - deposit_handling
 properties:
+  termination_date:
+    type: string
+    format: date
+    description: 強制終止生效日；backend 以此更新 lease end_date。
+  actual_move_out_date:
+    type: string
+    format: date
+    nullable: true
+    description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 write-off、deposit handling 或租金退款。
   reason:
     type: string
     minLength: 1

--- a/docs/spec/src/components/schemas/tenancy/ForceTerminateRequest.yaml
+++ b/docs/spec/src/components/schemas/tenancy/ForceTerminateRequest.yaml
@@ -7,12 +7,12 @@ properties:
   termination_date:
     type: string
     format: date
-    description: 強制終止生效日；backend 以此更新 lease end_date。
+    description: Force-termination effective date. The backend writes this value to lease end_date.
   actual_move_out_date:
     type: string
     format: date
     nullable: true
-    description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 write-off、deposit handling 或租金退款。
+    description: Actual move-out or handover date. This is operational metadata only and does not affect write-off handling, deposit handling, or rent refund behavior.
   reason:
     type: string
     minLength: 1

--- a/docs/spec/src/components/schemas/tenancy/LeaseResponse.yaml
+++ b/docs/spec/src/components/schemas/tenancy/LeaseResponse.yaml
@@ -33,6 +33,11 @@ properties:
   end_date:
     type: string
     format: date
+  actual_move_out_date:
+    type: string
+    format: date
+    nullable: true
+    description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date 或帳務。
   electricity_billing_cadence:
     type: string
     enum:

--- a/docs/spec/src/components/schemas/tenancy/LeaseResponse.yaml
+++ b/docs/spec/src/components/schemas/tenancy/LeaseResponse.yaml
@@ -37,7 +37,7 @@ properties:
     type: string
     format: date
     nullable: true
-    description: 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date 或帳務。
+    description: Actual move-out or handover date. This is operational metadata only and does not affect lease end_date or accounting.
   electricity_billing_cadence:
     type: string
     enum:

--- a/docs/spec/src/paths/tenancy/leases_{id}_force-terminate.yaml
+++ b/docs/spec/src/paths/tenancy/leases_{id}_force-terminate.yaml
@@ -31,6 +31,8 @@ post:
         examples:
           default:
             value:
+              termination_date: '2026-07-15'
+              actual_move_out_date: '2026-07-10'
               reason: 租客失聯，連續 3 個月未繳租金
               deposit_handling: write_off
   responses:

--- a/internal/application/billing/reports.go
+++ b/internal/application/billing/reports.go
@@ -1521,7 +1521,7 @@ func cashflowIncomeExpense(category string, amount int) (int, int) {
 	switch category {
 	case "rent_payment", "electricity_payment", "deposit_deduction":
 		return absValue(amount), 0
-	case "deposit_refund", "journal_expense":
+	case "deposit_refund", "rent_refund", "journal_expense":
 		return 0, absValue(amount)
 	default:
 		return 0, 0
@@ -1545,6 +1545,8 @@ func cashflowCategoryLabel(category string) string {
 		return "押金扣抵收入"
 	case "deposit_refund":
 		return "押金退還"
+	case "rent_refund":
+		return "租金退回"
 	case "journal_expense":
 		return "支出"
 	default:
@@ -1666,6 +1668,9 @@ func depositSourceDetail(category string, sourceType string) *string {
 	switch {
 	case category == "deposit_refund" || sourceType == "DepositRefunded":
 		detail := "deposit_refund"
+		return &detail
+	case category == "rent_refund" || sourceType == "RentRefunded":
+		detail := "rent_refund"
 		return &detail
 	case category == "deposit_deduction" || sourceType == "DepositDeducted":
 		detail := "deposit_deduction"

--- a/internal/application/billing/reports_test.go
+++ b/internal/application/billing/reports_test.go
@@ -729,6 +729,14 @@ func TestExportMonthlyCashflowUsesCurrentMonthLiveRowsAndRunningBalance(t *testi
 					SourceRef:           []byte(`{"journal_log_id":"journal-1"}`),
 					CreatedAt:           time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC),
 				},
+				{
+					Category:            "rent_refund",
+					AccountingTitleCode: stringPtr("4604"),
+					AccountingTitleName: stringPtr("租金退回(減項)"),
+					Amount:              -3000,
+					SourceRef:           []byte(`{"type":"RentRefunded","lease_id":"lease-1","reason":"提前退租租金退回"}`),
+					CreatedAt:           time.Date(2026, 5, 6, 10, 0, 0, 0, time.UTC),
+				},
 			},
 		},
 		openingBalance: 1000,
@@ -764,10 +772,10 @@ func TestExportMonthlyCashflowUsesCurrentMonthLiveRowsAndRunningBalance(t *testi
 	if view.Title != "Demo Property收支表 (2026/05)" || view.PeriodLabel != "2026-05" {
 		t.Fatalf("unexpected view metadata: %+v", view)
 	}
-	if view.OpeningBalanceLabel != "NT$ 1,000" || view.MonthlyIncomeTotalLabel != "NT$ 18,000" || view.MonthlyExpenseTotalLabel != "NT$ 2,500" || view.EndingBalanceLabel != "NT$ 16,500" {
+	if view.OpeningBalanceLabel != "NT$ 1,000" || view.MonthlyIncomeTotalLabel != "NT$ 18,000" || view.MonthlyExpenseTotalLabel != "NT$ 5,500" || view.EndingBalanceLabel != "NT$ 13,500" {
 		t.Fatalf("unexpected totals: %+v", view)
 	}
-	if len(view.Rows) != 2 || view.Rows[0].BalanceLabel != "NT$ 19,000" || view.Rows[1].BalanceLabel != "NT$ 16,500" {
+	if len(view.Rows) != 3 || view.Rows[0].BalanceLabel != "NT$ 19,000" || view.Rows[1].BalanceLabel != "NT$ 16,500" || view.Rows[2].BalanceLabel != "NT$ 13,500" {
 		t.Fatalf("unexpected rows: %+v", view.Rows)
 	}
 	if view.Rows[0].DateLabel != "05/02" || view.Rows[0].SubjectLabel != "租金收入" || view.Rows[0].Note != "101 王小明 2026-05 租金" {
@@ -778,6 +786,9 @@ func TestExportMonthlyCashflowUsesCurrentMonthLiveRowsAndRunningBalance(t *testi
 	}
 	if view.Rows[1].Note != "" {
 		t.Fatalf("second row note = %q, want empty note without raw source_ref JSON", view.Rows[1].Note)
+	}
+	if view.Rows[2].SubjectLabel != "租金退回(減項)" || view.Rows[2].ExpenseLabel != "NT$ 3,000" || view.Rows[2].Note != "提前退租租金退回" {
+		t.Fatalf("rent refund row = %+v", view.Rows[2])
 	}
 	if document.Filename != "monthly-cashflow-demo-property-2026-05.html" {
 		t.Fatalf("filename = %q", document.Filename)
@@ -907,6 +918,14 @@ func TestFinancialReportEntrySourceFromRefNormalizesKnownSourceRefs(t *testing.T
 			wantType:   "lease",
 			wantID:     "10000000-0000-0000-0000-000000000013",
 			wantDetail: "deposit_refund",
+		},
+		{
+			name:       "rent refund",
+			category:   "rent_refund",
+			sourceRef:  []byte(`{"type":"RentRefunded","lease_id":"10000000-0000-0000-0000-000000000015"}`),
+			wantType:   "lease",
+			wantID:     "10000000-0000-0000-0000-000000000015",
+			wantDetail: "rent_refund",
 		},
 		{
 			name:       "deposit deduction",

--- a/internal/application/lease/checkout_settlement.go
+++ b/internal/application/lease/checkout_settlement.go
@@ -36,23 +36,28 @@ const (
 	checkoutBlockerLeaseNotActive   = "lease_not_active"
 	checkoutBlockerDepositNotHeld   = "deposit_not_held"
 	checkoutBlockerChargeExceedsDep = "charge_exceeds_deposit"
-	checkoutBlockerRentRefund       = "rent_refund_not_calculated"
+	checkoutBlockerRentRefund       = "manual_rent_refund_decision_required"
+	rentRefundAccountingCategory    = "rent_refund"
+	rentRefundAccountingTitleCode   = "4604"
 )
 
 // CheckoutSettlementInput is the shared input for preview and finalize.
 type CheckoutSettlementInput struct {
-	ActorRole           string
-	AssignedPropertyIDs []string
-	LeaseID             string
-	CheckoutDate        time.Time
-	Reason              string
-	FinalMeterReading   *int
-	CleaningFee         int
-	KeyCardLossFee      int
-	OtherFee            int
-	OtherFeeReason      *string
-	Notes               *string
-	PreviewToken        string
+	ActorRole              string
+	AssignedPropertyIDs    []string
+	LeaseID                string
+	CheckoutDate           time.Time
+	ActualMoveOutDate      *time.Time
+	Reason                 string
+	FinalMeterReading      *int
+	CleaningFee            int
+	KeyCardLossFee         int
+	OtherFee               int
+	OtherFeeReason         *string
+	ManualRentRefundAmount int
+	ManualRentRefundReason *string
+	Notes                  *string
+	PreviewToken           string
 }
 
 // CheckoutSettlementLine is one typed settlement item.
@@ -80,28 +85,31 @@ type CheckoutSettlementWarning struct {
 
 // CheckoutSettlement is the backend-owned checkout settlement snapshot.
 type CheckoutSettlement struct {
-	LeaseID           string                      `json:"lease_id"`
-	PropertyID        string                      `json:"property_id"`
-	TenantID          string                      `json:"tenant_id"`
-	RoomID            string                      `json:"room_id"`
-	PropertyLabel     string                      `json:"property_label"`
-	TenantLabel       string                      `json:"tenant_label"`
-	RoomLabel         string                      `json:"room_label"`
-	CheckoutDate      time.Time                   `json:"checkout_date"`
-	Reason            string                      `json:"reason"`
-	FinalMeterReading *int                        `json:"final_meter_reading,omitempty"`
-	Notes             *string                     `json:"notes,omitempty"`
-	Lines             []CheckoutSettlementLine    `json:"lines"`
-	Blockers          []CheckoutSettlementBlocker `json:"blockers"`
-	Warnings          []CheckoutSettlementWarning `json:"warnings"`
-	DepositAmount     int                         `json:"deposit_amount"`
-	TotalRefund       int                         `json:"total_refund"`
-	TotalCharge       int                         `json:"total_charge"`
-	NetAmount         int                         `json:"net_amount"`
-	NetDirection      string                      `json:"net_direction"`
-	PreviewToken      *string                     `json:"preview_token,omitempty"`
-	ExportAvailable   bool                        `json:"export_available"`
-	FinalizedAt       *time.Time                  `json:"finalized_at,omitempty"`
+	LeaseID                string                      `json:"lease_id"`
+	PropertyID             string                      `json:"property_id"`
+	TenantID               string                      `json:"tenant_id"`
+	RoomID                 string                      `json:"room_id"`
+	PropertyLabel          string                      `json:"property_label"`
+	TenantLabel            string                      `json:"tenant_label"`
+	RoomLabel              string                      `json:"room_label"`
+	CheckoutDate           time.Time                   `json:"checkout_date"`
+	ActualMoveOutDate      *time.Time                  `json:"actual_move_out_date,omitempty"`
+	Reason                 string                      `json:"reason"`
+	FinalMeterReading      *int                        `json:"final_meter_reading,omitempty"`
+	ManualRentRefundAmount int                         `json:"manual_rent_refund_amount"`
+	ManualRentRefundReason *string                     `json:"manual_rent_refund_reason,omitempty"`
+	Notes                  *string                     `json:"notes,omitempty"`
+	Lines                  []CheckoutSettlementLine    `json:"lines"`
+	Blockers               []CheckoutSettlementBlocker `json:"blockers"`
+	Warnings               []CheckoutSettlementWarning `json:"warnings"`
+	DepositAmount          int                         `json:"deposit_amount"`
+	TotalRefund            int                         `json:"total_refund"`
+	TotalCharge            int                         `json:"total_charge"`
+	NetAmount              int                         `json:"net_amount"`
+	NetDirection           string                      `json:"net_direction"`
+	PreviewToken           *string                     `json:"preview_token,omitempty"`
+	ExportAvailable        bool                        `json:"export_available"`
+	FinalizedAt            *time.Time                  `json:"finalized_at,omitempty"`
 }
 
 // PreviewCheckoutSettlementService calculates checkout settlement without mutation.
@@ -261,6 +269,7 @@ func (s *FinalizeCheckoutSettlementService) Execute(ctx context.Context, input C
 		terminatedLease, err := s.repo.TerminateLease(ctx, tx, TerminateLeaseParams{
 			LeaseID:           leaseID,
 			EndDate:           normalizeDate(normalized.CheckoutDate),
+			ActualMoveOutDate: normalized.ActualMoveOutDate,
 			TerminationReason: normalized.Reason,
 			SettlementDetail:  detail,
 		})
@@ -269,6 +278,9 @@ func (s *FinalizeCheckoutSettlementService) Execute(ctx context.Context, input C
 		}
 
 		if err := recordDepositAccountingEntries(ctx, tx, s.accountingRepo, settled, refundAmount, deductionAmount, depositReasonValue(deductionReason), occurredAt); err != nil {
+			return err
+		}
+		if err := recordRentRefundAccountingEntry(ctx, tx, s.accountingRepo, settled, proposal); err != nil {
 			return err
 		}
 		if refundAmount > 0 {
@@ -387,7 +399,15 @@ func normalizeCheckoutSettlementInput(input CheckoutSettlementInput) (CheckoutSe
 	if input.CleaningFee < 0 || input.KeyCardLossFee < 0 || input.OtherFee < 0 {
 		return input, errSettlementNegative
 	}
+	if input.ManualRentRefundAmount < 0 {
+		return input, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "manual_rent_refund_amount"})
+	}
 	input.OtherFeeReason = trimmedStringPtr(input.OtherFeeReason)
+	input.ManualRentRefundReason = trimmedStringPtr(input.ManualRentRefundReason)
+	if input.ManualRentRefundAmount > 0 && input.ManualRentRefundReason == nil {
+		return input, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "manual_rent_refund_reason"})
+	}
+	input.ActualMoveOutDate = normalizedDatePtr(input.ActualMoveOutDate)
 	input.Notes = trimmedStringPtr(input.Notes)
 	return input, nil
 }
@@ -424,6 +444,20 @@ func buildCheckoutSettlement(current CheckoutSettlementContext, bills []Bill, in
 	if input.OtherFee > 0 {
 		lines = append(lines, CheckoutSettlementLine{Kind: checkoutLineOtherFee, Label: "其他費用", Direction: checkoutDirectionCharge, Amount: input.OtherFee, Description: input.OtherFeeReason})
 	}
+	if input.ManualRentRefundAmount > 0 {
+		lines = append(lines, CheckoutSettlementLine{
+			Kind:        checkoutLineRentRefund,
+			Label:       "未到期租金手動退回",
+			Direction:   checkoutDirectionRefund,
+			Amount:      input.ManualRentRefundAmount,
+			Description: input.ManualRentRefundReason,
+			SourceRef: map[string]interface{}{
+				"type":     "manual_rent_refund",
+				"lease_id": current.Lease.ID,
+				"reason":   stringValue(input.ManualRentRefundReason),
+			},
+		})
+	}
 	if input.FinalMeterReading != nil {
 		lines = append(lines, CheckoutSettlementLine{
 			Kind:        checkoutLineElectricSettlement,
@@ -441,27 +475,30 @@ func buildCheckoutSettlement(current CheckoutSettlementContext, bills []Bill, in
 	netDirection, netAmount := checkoutSettlementNet(totalRefund, totalCharge)
 
 	settlement := &CheckoutSettlement{
-		LeaseID:           current.Lease.ID,
-		PropertyID:        current.Lease.PropertyID,
-		TenantID:          current.Lease.TenantID,
-		RoomID:            current.Lease.RoomID,
-		PropertyLabel:     current.PropertyName,
-		TenantLabel:       current.TenantName,
-		RoomLabel:         current.RoomName,
-		CheckoutDate:      normalizeDate(input.CheckoutDate),
-		Reason:            input.Reason,
-		FinalMeterReading: input.FinalMeterReading,
-		Notes:             input.Notes,
-		Lines:             lines,
-		Blockers:          blockers,
-		Warnings:          warnings,
-		DepositAmount:     current.Lease.DepositAmount,
-		TotalRefund:       totalRefund,
-		TotalCharge:       totalCharge,
-		NetAmount:         netAmount,
-		NetDirection:      netDirection,
-		ExportAvailable:   finalizedAt != nil,
-		FinalizedAt:       finalizedAt,
+		LeaseID:                current.Lease.ID,
+		PropertyID:             current.Lease.PropertyID,
+		TenantID:               current.Lease.TenantID,
+		RoomID:                 current.Lease.RoomID,
+		PropertyLabel:          current.PropertyName,
+		TenantLabel:            current.TenantName,
+		RoomLabel:              current.RoomName,
+		CheckoutDate:           normalizeDate(input.CheckoutDate),
+		ActualMoveOutDate:      input.ActualMoveOutDate,
+		Reason:                 input.Reason,
+		FinalMeterReading:      input.FinalMeterReading,
+		ManualRentRefundAmount: input.ManualRentRefundAmount,
+		ManualRentRefundReason: input.ManualRentRefundReason,
+		Notes:                  input.Notes,
+		Lines:                  lines,
+		Blockers:               blockers,
+		Warnings:               warnings,
+		DepositAmount:          current.Lease.DepositAmount,
+		TotalRefund:            totalRefund,
+		TotalCharge:            totalCharge,
+		NetAmount:              netAmount,
+		NetDirection:           netDirection,
+		ExportAvailable:        finalizedAt != nil,
+		FinalizedAt:            finalizedAt,
 	}
 	if len(blockers) == 0 && finalizedAt == nil {
 		token := checkoutSettlementToken(current.Lease, bills, input, lines, totalRefund, totalCharge)
@@ -479,7 +516,9 @@ func checkoutSettlementBlockers(lease Lease, bills []Bill, input CheckoutSettlem
 		blockers = append(blockers, CheckoutSettlementBlocker{Code: checkoutBlockerDepositNotHeld, Message: "押金狀態不是 held，無法執行退租結算。"})
 	}
 	if normalizeDate(input.CheckoutDate).Before(normalizeDate(lease.EndDate)) {
-		blockers = append(blockers, CheckoutSettlementBlocker{Code: checkoutBlockerRentRefund, Message: "v1 尚未自動計算未到期租金退款，不能定稿退租結算。"})
+		if input.ManualRentRefundReason == nil {
+			blockers = append(blockers, CheckoutSettlementBlocker{Code: checkoutBlockerRentRefund, Message: "提前退租必須填寫手動租金退回決策原因；金額可為 0。"})
+		}
 	}
 	for _, bill := range bills {
 		switch bill.Status {
@@ -533,21 +572,24 @@ func checkoutSettlementNet(totalRefund int, totalCharge int) (string, int) {
 
 func checkoutSettlementToken(lease Lease, bills []Bill, input CheckoutSettlementInput, lines []CheckoutSettlementLine, totalRefund int, totalCharge int) string {
 	payload := map[string]interface{}{
-		"lease_id":       lease.ID,
-		"lease_version":  lease.Version,
-		"checkout_date":  normalizeDate(input.CheckoutDate).Format("2006-01-02"),
-		"reason":         input.Reason,
-		"final_meter":    input.FinalMeterReading,
-		"cleaning_fee":   input.CleaningFee,
-		"key_card_fee":   input.KeyCardLossFee,
-		"other_fee":      input.OtherFee,
-		"other_reason":   stringValue(input.OtherFeeReason),
-		"notes":          stringValue(input.Notes),
-		"bills":          bills,
-		"lines":          lines,
-		"total_refund":   totalRefund,
-		"total_charge":   totalCharge,
-		"deposit_amount": lease.DepositAmount,
+		"lease_id":                  lease.ID,
+		"lease_version":             lease.Version,
+		"checkout_date":             normalizeDate(input.CheckoutDate).Format("2006-01-02"),
+		"actual_move_out_date":      dateStringValue(input.ActualMoveOutDate),
+		"reason":                    input.Reason,
+		"final_meter":               input.FinalMeterReading,
+		"cleaning_fee":              input.CleaningFee,
+		"key_card_fee":              input.KeyCardLossFee,
+		"other_fee":                 input.OtherFee,
+		"other_reason":              stringValue(input.OtherFeeReason),
+		"manual_rent_refund_amount": input.ManualRentRefundAmount,
+		"manual_rent_refund_reason": stringValue(input.ManualRentRefundReason),
+		"notes":                     stringValue(input.Notes),
+		"bills":                     bills,
+		"lines":                     lines,
+		"total_refund":              totalRefund,
+		"total_charge":              totalCharge,
+		"deposit_amount":            lease.DepositAmount,
 	}
 	data, _ := json.Marshal(payload)
 	sum := sha256.Sum256(data)
@@ -597,6 +639,43 @@ func checkoutSettlementFromDetailMap(detail map[string]interface{}) (*CheckoutSe
 	return &settlement, nil
 }
 
+func recordRentRefundAccountingEntry(ctx context.Context, tx *sql.Tx, repo DepositAccountingRepository, lease *Lease, settlement *CheckoutSettlement) error {
+	if settlement.ManualRentRefundAmount == 0 {
+		return nil
+	}
+	if repo == nil {
+		return apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "rent_refund_accounting"})
+	}
+
+	sourceDate := normalizeDate(settlement.CheckoutDate)
+	description := stringValue(settlement.ManualRentRefundReason)
+	displayNote := "租金退回"
+	if settlement.ManualRentRefundReason != nil {
+		displayNote = *settlement.ManualRentRefundReason
+	}
+	if err := repo.CreateDepositAccountingEntry(ctx, tx, DepositAccountingEntryParams{
+		PropertyID:          lease.PropertyID,
+		Category:            rentRefundAccountingCategory,
+		AccountingTitleCode: rentRefundAccountingTitleCode,
+		Amount:              -settlement.ManualRentRefundAmount,
+		Description:         &description,
+		SourceRef: map[string]interface{}{
+			"type":          "RentRefunded",
+			"lease_id":      lease.ID,
+			"checkout_date": sourceDate.Format("2006-01-02"),
+			"reason":        description,
+		},
+		Year:        sourceDate.Year(),
+		Month:       int(sourceDate.Month()),
+		SourceDate:  &sourceDate,
+		TenantLabel: &settlement.TenantLabel,
+		DisplayNote: &displayNote,
+	}); err != nil {
+		return mapDepositAccountingError(err)
+	}
+	return nil
+}
+
 func stringPtr(value string) *string {
 	return &value
 }
@@ -612,9 +691,24 @@ func trimmedStringPtr(value *string) *string {
 	return &trimmed
 }
 
+func normalizedDatePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	normalized := normalizeDate(*value)
+	return &normalized
+}
+
 func stringValue(value *string) string {
 	if value == nil {
 		return ""
 	}
 	return *value
+}
+
+func dateStringValue(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return normalizeDate(*value).Format("2006-01-02")
 }

--- a/internal/application/lease/checkout_settlement.go
+++ b/internal/application/lease/checkout_settlement.go
@@ -17,28 +17,29 @@ import (
 )
 
 const (
-	checkoutLineDepositRefund       = "deposit_refund"
-	checkoutLineCleaningFee         = "cleaning_fee"
-	checkoutLineKeyCardLoss         = "key_card_loss"
-	checkoutLineOtherFee            = "other_fee"
-	checkoutLineElectricSettlement  = "electricity_settlement"
-	checkoutLineRentRefund          = "rent_refund"
-	checkoutDirectionRefund         = "refund"
-	checkoutDirectionCharge         = "charge"
-	checkoutDirectionInfo           = "info"
-	checkoutNetRefund               = "refund"
-	checkoutNetPayable              = "payable"
-	checkoutNetZero                 = "zero"
-	checkoutWarningRentRefund       = "rent_refund_not_calculated"
-	checkoutWarningFinalMeter       = "final_meter_snapshot_only"
-	checkoutBlockerUnpaidBill       = "unpaid_bill"
-	checkoutBlockerPendingMeter     = "pending_meter"
-	checkoutBlockerLeaseNotActive   = "lease_not_active"
-	checkoutBlockerDepositNotHeld   = "deposit_not_held"
-	checkoutBlockerChargeExceedsDep = "charge_exceeds_deposit"
-	checkoutBlockerRentRefund       = "manual_rent_refund_decision_required"
-	rentRefundAccountingCategory    = "rent_refund"
-	rentRefundAccountingTitleCode   = "4604"
+	checkoutLineDepositRefund          = "deposit_refund"
+	checkoutLineCleaningFee            = "cleaning_fee"
+	checkoutLineKeyCardLoss            = "key_card_loss"
+	checkoutLineOtherFee               = "other_fee"
+	checkoutLineElectricSettlement     = "electricity_settlement"
+	checkoutLineRentRefund             = "rent_refund"
+	checkoutDirectionRefund            = "refund"
+	checkoutDirectionCharge            = "charge"
+	checkoutDirectionInfo              = "info"
+	checkoutNetRefund                  = "refund"
+	checkoutNetPayable                 = "payable"
+	checkoutNetZero                    = "zero"
+	checkoutWarningRentRefund          = "rent_refund_not_calculated"
+	checkoutWarningFinalMeter          = "final_meter_snapshot_only"
+	checkoutBlockerUnpaidBill          = "unpaid_bill"
+	checkoutBlockerPendingMeter        = "pending_meter"
+	checkoutBlockerLeaseNotActive      = "lease_not_active"
+	checkoutBlockerDepositNotHeld      = "deposit_not_held"
+	checkoutBlockerChargeExceedsDep    = "charge_exceeds_deposit"
+	checkoutBlockerRentRefund          = "manual_rent_refund_decision_required"
+	checkoutBlockerCheckoutBeforeStart = "checkout_date_before_lease_start"
+	rentRefundAccountingCategory       = "rent_refund"
+	rentRefundAccountingTitleCode      = "4604"
 )
 
 // CheckoutSettlementInput is the shared input for preview and finalize.
@@ -514,6 +515,9 @@ func checkoutSettlementBlockers(lease Lease, bills []Bill, input CheckoutSettlem
 	}
 	if lease.DepositStatus != domainlease.DepositStatusHeld {
 		blockers = append(blockers, CheckoutSettlementBlocker{Code: checkoutBlockerDepositNotHeld, Message: "押金狀態不是 held，無法執行退租結算。"})
+	}
+	if normalizeDate(input.CheckoutDate).Before(normalizeDate(lease.StartDate)) {
+		blockers = append(blockers, CheckoutSettlementBlocker{Code: checkoutBlockerCheckoutBeforeStart, Message: "結算生效日不可早於租約起始日。"})
 	}
 	if normalizeDate(input.CheckoutDate).Before(normalizeDate(lease.EndDate)) {
 		if input.ManualRentRefundReason == nil {

--- a/internal/application/lease/checkout_settlement.go
+++ b/internal/application/lease/checkout_settlement.go
@@ -517,11 +517,11 @@ func checkoutSettlementBlockers(lease Lease, bills []Bill, input CheckoutSettlem
 		blockers = append(blockers, CheckoutSettlementBlocker{Code: checkoutBlockerDepositNotHeld, Message: "押金狀態不是 held，無法執行退租結算。"})
 	}
 	if normalizeDate(input.CheckoutDate).Before(normalizeDate(lease.StartDate)) {
-		blockers = append(blockers, CheckoutSettlementBlocker{Code: checkoutBlockerCheckoutBeforeStart, Message: "結算生效日不可早於租約起始日。"})
+		blockers = append(blockers, CheckoutSettlementBlocker{Code: checkoutBlockerCheckoutBeforeStart, Message: "Checkout effective date cannot be before the lease start date."})
 	}
 	if normalizeDate(input.CheckoutDate).Before(normalizeDate(lease.EndDate)) {
 		if input.ManualRentRefundReason == nil {
-			blockers = append(blockers, CheckoutSettlementBlocker{Code: checkoutBlockerRentRefund, Message: "提前退租必須填寫手動租金退回決策原因；金額可為 0。"})
+			blockers = append(blockers, CheckoutSettlementBlocker{Code: checkoutBlockerRentRefund, Message: "Early checkout requires an explicit manual rent refund decision reason; the amount may be 0."})
 		}
 	}
 	for _, bill := range bills {

--- a/internal/application/lease/checkout_settlement_view.go
+++ b/internal/application/lease/checkout_settlement_view.go
@@ -6,19 +6,21 @@ import (
 )
 
 type checkoutSettlementView struct {
-	PropertyLabel     string
-	TenantLabel       string
-	RoomLabel         string
-	CheckoutDateLabel string
-	Reason            string
-	FinalMeterReading *int
-	Notes             *string
-	Lines             []checkoutSettlementLineView
-	TotalRefundLabel  string
-	TotalChargeLabel  string
-	NetLabel          string
-	NetDirectionLabel string
-	FinalizedAtLabel  string
+	PropertyLabel          string
+	TenantLabel            string
+	RoomLabel              string
+	CheckoutDateLabel      string
+	ActualMoveOutDateLabel string
+	Reason                 string
+	FinalMeterReading      *int
+	ManualRentRefundReason *string
+	Notes                  *string
+	Lines                  []checkoutSettlementLineView
+	TotalRefundLabel       string
+	TotalChargeLabel       string
+	NetLabel               string
+	NetDirectionLabel      string
+	FinalizedAtLabel       string
 }
 
 type checkoutSettlementLineView struct {
@@ -45,20 +47,29 @@ func newCheckoutSettlementView(settlement *CheckoutSettlement) checkoutSettlemen
 	}
 
 	return checkoutSettlementView{
-		PropertyLabel:     settlement.PropertyLabel,
-		TenantLabel:       settlement.TenantLabel,
-		RoomLabel:         settlement.RoomLabel,
-		CheckoutDateLabel: settlement.CheckoutDate.Format("2006-01-02"),
-		Reason:            settlement.Reason,
-		FinalMeterReading: settlement.FinalMeterReading,
-		Notes:             settlement.Notes,
-		Lines:             lines,
-		TotalRefundLabel:  formatCheckoutAmount(settlement.TotalRefund),
-		TotalChargeLabel:  formatCheckoutAmount(settlement.TotalCharge),
-		NetLabel:          formatCheckoutAmount(settlement.NetAmount),
-		NetDirectionLabel: checkoutNetDirectionLabel(settlement.NetDirection),
-		FinalizedAtLabel:  finalizedAt,
+		PropertyLabel:          settlement.PropertyLabel,
+		TenantLabel:            settlement.TenantLabel,
+		RoomLabel:              settlement.RoomLabel,
+		CheckoutDateLabel:      settlement.CheckoutDate.Format("2006-01-02"),
+		ActualMoveOutDateLabel: checkoutDatePtrLabel(settlement.ActualMoveOutDate),
+		Reason:                 settlement.Reason,
+		FinalMeterReading:      settlement.FinalMeterReading,
+		ManualRentRefundReason: settlement.ManualRentRefundReason,
+		Notes:                  settlement.Notes,
+		Lines:                  lines,
+		TotalRefundLabel:       formatCheckoutAmount(settlement.TotalRefund),
+		TotalChargeLabel:       formatCheckoutAmount(settlement.TotalCharge),
+		NetLabel:               formatCheckoutAmount(settlement.NetAmount),
+		NetDirectionLabel:      checkoutNetDirectionLabel(settlement.NetDirection),
+		FinalizedAtLabel:       finalizedAt,
 	}
+}
+
+func checkoutDatePtrLabel(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return value.Format("2006-01-02")
 }
 
 func checkoutDirectionLabel(direction string) string {

--- a/internal/application/lease/create_lease_test.go
+++ b/internal/application/lease/create_lease_test.go
@@ -478,15 +478,21 @@ type leaseRepositoryStub struct {
 }
 
 type depositAccountingRepositoryStub struct {
-	entries     []DepositAccountingEntryParams
-	createErr   error
-	createCalls int
+	entries             []DepositAccountingEntryParams
+	createErr           error
+	createErrByCategory map[string]error
+	createCalls         int
 }
 
 func (s *depositAccountingRepositoryStub) CreateDepositAccountingEntry(_ context.Context, _ *sql.Tx, params DepositAccountingEntryParams) error {
 	s.createCalls++
 	if s.createErr != nil {
 		return s.createErr
+	}
+	if s.createErrByCategory != nil {
+		if err := s.createErrByCategory[params.Category]; err != nil {
+			return err
+		}
 	}
 	s.entries = append(s.entries, params)
 	return nil
@@ -584,6 +590,7 @@ func (s *leaseRepositoryStub) TerminateLease(_ context.Context, _ *sql.Tx, param
 	}
 	s.lease.Status = "terminated"
 	s.lease.EndDate = params.EndDate
+	s.lease.ActualMoveOutDate = params.ActualMoveOutDate
 	s.lease.TerminationReason = &params.TerminationReason
 	if params.SettlementDetail != nil {
 		s.lease.SettlementDetail = &params.SettlementDetail
@@ -597,6 +604,8 @@ func (s *leaseRepositoryStub) ForceTerminateLease(_ context.Context, _ *sql.Tx, 
 		return nil, ErrLeaseNotFound
 	}
 	s.lease.Status = "force_terminated"
+	s.lease.EndDate = params.TerminationDate
+	s.lease.ActualMoveOutDate = params.ActualMoveOutDate
 	s.lease.TerminationReason = &params.TerminationReason
 	s.lease.DepositStatus = params.DepositStatus
 	return s.lease, nil

--- a/internal/application/lease/replace_lease_test.go
+++ b/internal/application/lease/replace_lease_test.go
@@ -48,6 +48,13 @@ func TestReplaceLeaseServiceCreatesSuccessorAndPublishesEvents(t *testing.T) {
 	if result.OldLease.Status != "terminated" {
 		t.Fatalf("old status = %q, want terminated", result.OldLease.Status)
 	}
+	expectedOldEndDate := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
+	if !result.OldLease.EndDate.Equal(expectedOldEndDate) {
+		t.Fatalf("old end date = %v, want %v", result.OldLease.EndDate, expectedOldEndDate)
+	}
+	if result.OldLease.ActualMoveOutDate != nil {
+		t.Fatalf("old actual move-out date = %v, want nil", result.OldLease.ActualMoveOutDate)
+	}
 	if repo.createLeaseParams == nil || repo.createLeaseParams.TenantID != repo.lease.TenantID || repo.createLeaseParams.RoomID != repo.lease.RoomID {
 		t.Fatalf("successor did not inherit scope: %+v", repo.createLeaseParams)
 	}

--- a/internal/application/lease/repository.go
+++ b/internal/application/lease/repository.go
@@ -24,6 +24,7 @@ type Lease struct {
 	RentAmount                int
 	StartDate                 time.Time
 	EndDate                   time.Time
+	ActualMoveOutDate         *time.Time
 	RentBillingCadence        string
 	ElectricityBillingCadence string
 	StartingMeterReading      *int
@@ -164,6 +165,7 @@ type DepositAccountingEntryParams struct {
 type TerminateLeaseParams struct {
 	LeaseID           string
 	EndDate           time.Time
+	ActualMoveOutDate *time.Time
 	TerminationReason string
 	SettlementDetail  map[string]interface{}
 }
@@ -171,6 +173,8 @@ type TerminateLeaseParams struct {
 // ForceTerminateLeaseParams contains fields for forced termination.
 type ForceTerminateLeaseParams struct {
 	LeaseID           string
+	TerminationDate   time.Time
+	ActualMoveOutDate *time.Time
 	TerminationReason string
 	DepositStatus     string
 }

--- a/internal/application/lease/templates/checkout_settlement.html
+++ b/internal/application/lease/templates/checkout_settlement.html
@@ -25,8 +25,14 @@
     <div class="label">物業</div><div>{{.PropertyLabel}}</div>
     <div class="label">房號</div><div>{{.RoomLabel}}</div>
     <div class="label">租客</div><div>{{.TenantLabel}}</div>
-    <div class="label">退租日</div><div>{{.CheckoutDateLabel}}</div>
+    <div class="label">結算生效日 / 租約終止日</div><div>{{.CheckoutDateLabel}}</div>
+    {{if .ActualMoveOutDateLabel}}
+    <div class="label">實際搬出日 / 點交日</div><div>{{.ActualMoveOutDateLabel}}</div>
+    {{end}}
     <div class="label">退租原因</div><div>{{.Reason}}</div>
+    {{if .ManualRentRefundReason}}
+    <div class="label">租金退回決策</div><div>{{.ManualRentRefundReason}}</div>
+    {{end}}
     <div class="label">完成時間</div><div>{{.FinalizedAtLabel}}</div>
     {{if .FinalMeterReading}}
     <div class="label">退租電表</div><div>{{.FinalMeterReading}}</div>

--- a/internal/application/lease/terminate_lease.go
+++ b/internal/application/lease/terminate_lease.go
@@ -166,6 +166,8 @@ type ForceTerminateLeaseInput struct {
 	ActorUserID         string
 	AssignedPropertyIDs []string
 	LeaseID             string
+	TerminationDate     time.Time
+	ActualMoveOutDate   *time.Time
 	Reason              string
 	DepositHandling     string
 }
@@ -210,6 +212,15 @@ func (s *ForceTerminateLeaseService) Execute(ctx context.Context, input ForceTer
 	if depositHandling == "" {
 		return nil, errForceTerminationDepositHandlingRequired
 	}
+	terminationDate := normalizeDate(input.TerminationDate)
+	if terminationDate.IsZero() {
+		return nil, apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "termination_date"})
+	}
+	var actualMoveOutDate *time.Time
+	if input.ActualMoveOutDate != nil {
+		normalizedActualMoveOutDate := normalizeDate(*input.ActualMoveOutDate)
+		actualMoveOutDate = &normalizedActualMoveOutDate
+	}
 
 	var forceTermination *ForceTermination
 	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, recorder *txrunner.EventRecorder) error {
@@ -219,6 +230,9 @@ func (s *ForceTerminateLeaseService) Execute(ctx context.Context, input ForceTer
 		}
 		if actorRole == "organizer" && !containsAssignedProperty(input.AssignedPropertyIDs, current.PropertyID) {
 			return apperr.ErrForbidden
+		}
+		if terminationDate.Before(normalizeDate(current.StartDate)) {
+			return apperr.ErrBadRequest.WithDetails(map[string]interface{}{"field": "termination_date"})
 		}
 		aggregate, err := domainlease.Rehydrate(domainlease.State{
 			ID:                        current.ID,
@@ -272,6 +286,8 @@ func (s *ForceTerminateLeaseService) Execute(ctx context.Context, input ForceTer
 
 		terminatedLease, err := s.repo.ForceTerminateLease(ctx, tx, ForceTerminateLeaseParams{
 			LeaseID:           leaseID,
+			TerminationDate:   terminationDate,
+			ActualMoveOutDate: actualMoveOutDate,
 			TerminationReason: reason,
 			DepositStatus:     state.DepositStatus,
 		})

--- a/internal/application/lease/terminate_lease_test.go
+++ b/internal/application/lease/terminate_lease_test.go
@@ -162,6 +162,8 @@ func TestForceTerminateLeaseServiceWritesOffBillsAndPublishesEvent(t *testing.T)
 
 	publisher := &recordingPublisher{}
 	repo := terminationRepoStub()
+	terminationDate := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	actualMoveOutDate := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
 	repo.replacementBills = append(repo.replacementBills, Bill{
 		ID:          "50000000-0000-0000-0000-000000000010",
 		Type:        "rent",
@@ -176,6 +178,8 @@ func TestForceTerminateLeaseServiceWritesOffBillsAndPublishesEvent(t *testing.T)
 		ActorUserID:         "20000000-0000-0000-0000-000000000001",
 		AssignedPropertyIDs: []string{"property-1"},
 		LeaseID:             terminateLeaseTestLeaseID,
+		TerminationDate:     terminationDate,
+		ActualMoveOutDate:   &actualMoveOutDate,
 		Reason:              "tenant unreachable",
 		DepositHandling:     "write_off",
 	})
@@ -194,6 +198,12 @@ func TestForceTerminateLeaseServiceWritesOffBillsAndPublishesEvent(t *testing.T)
 	}
 	if repo.forceTerminateCalls != 1 {
 		t.Fatalf("forceTerminateCalls = %d, want 1", repo.forceTerminateCalls)
+	}
+	if !repo.lease.EndDate.Equal(terminationDate) {
+		t.Fatalf("end date = %v, want %v", repo.lease.EndDate, terminationDate)
+	}
+	if repo.lease.ActualMoveOutDate == nil || !repo.lease.ActualMoveOutDate.Equal(actualMoveOutDate) {
+		t.Fatalf("actual move-out date = %v, want %v", repo.lease.ActualMoveOutDate, actualMoveOutDate)
 	}
 	if repo.lease.DepositStatus != "written_off" {
 		t.Fatalf("deposit status = %q, want written_off", repo.lease.DepositStatus)
@@ -220,6 +230,7 @@ func TestForceTerminateLeaseServiceKeepsDepositHeld(t *testing.T) {
 
 	publisher := &recordingPublisher{}
 	repo := terminationRepoStub()
+	terminationDate := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
 	repo.replacementBills = append(repo.replacementBills, Bill{
 		ID:          "50000000-0000-0000-0000-000000000010",
 		Type:        "rent",
@@ -234,6 +245,7 @@ func TestForceTerminateLeaseServiceKeepsDepositHeld(t *testing.T) {
 		ActorUserID:         "20000000-0000-0000-0000-000000000001",
 		AssignedPropertyIDs: []string{"property-1"},
 		LeaseID:             terminateLeaseTestLeaseID,
+		TerminationDate:     terminationDate,
 		Reason:              "tenant unreachable",
 		DepositHandling:     "keep_held",
 	})
@@ -249,6 +261,12 @@ func TestForceTerminateLeaseServiceKeepsDepositHeld(t *testing.T) {
 	}
 	if repo.forceTerminateCalls != 1 {
 		t.Fatalf("forceTerminateCalls = %d, want 1", repo.forceTerminateCalls)
+	}
+	if !repo.lease.EndDate.Equal(terminationDate) {
+		t.Fatalf("end date = %v, want %v", repo.lease.EndDate, terminationDate)
+	}
+	if repo.lease.ActualMoveOutDate != nil {
+		t.Fatalf("actual move-out date = %v, want nil", repo.lease.ActualMoveOutDate)
 	}
 	if repo.lease.DepositStatus != "held" {
 		t.Fatalf("deposit status = %q, want held", repo.lease.DepositStatus)
@@ -308,6 +326,52 @@ func TestForceTerminateLeaseServiceRejectsMissingDepositHandling(t *testing.T) {
 	}
 }
 
+func TestForceTerminateLeaseServiceRejectsMissingTerminationDate(t *testing.T) {
+	service := NewForceTerminateLeaseService(nil, nil)
+
+	_, err := service.Execute(context.Background(), ForceTerminateLeaseInput{
+		ActorRole:       "admin",
+		ActorUserID:     "20000000-0000-0000-0000-000000000001",
+		LeaseID:         terminateLeaseTestLeaseID,
+		Reason:          "tenant unreachable",
+		DepositHandling: "write_off",
+	})
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) || appErr.Code != apperr.CodeBadRequest {
+		t.Fatalf("expected BAD_REQUEST, got %v", err)
+	}
+	details, ok := appErr.Details.(map[string]interface{})
+	if !ok || details["field"] != "termination_date" {
+		t.Fatalf("expected termination_date field detail, got %+v", appErr.Details)
+	}
+}
+
+func TestForceTerminateLeaseServiceRejectsTerminationDateBeforeLeaseStart(t *testing.T) {
+	repo := terminationRepoStub()
+	service := NewForceTerminateLeaseService(repo, txRunnerForRollback(t))
+
+	_, err := service.Execute(context.Background(), ForceTerminateLeaseInput{
+		ActorRole:           "admin",
+		ActorUserID:         "20000000-0000-0000-0000-000000000001",
+		AssignedPropertyIDs: []string{"property-1"},
+		LeaseID:             terminateLeaseTestLeaseID,
+		TerminationDate:     time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC),
+		Reason:              "tenant unreachable",
+		DepositHandling:     "write_off",
+	})
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) || appErr.Code != apperr.CodeBadRequest {
+		t.Fatalf("expected BAD_REQUEST, got %v", err)
+	}
+	details, ok := appErr.Details.(map[string]interface{})
+	if !ok || details["field"] != "termination_date" {
+		t.Fatalf("expected termination_date field detail, got %+v", appErr.Details)
+	}
+	if repo.forceTerminateCalls != 0 {
+		t.Fatalf("forceTerminateCalls = %d, want 0", repo.forceTerminateCalls)
+	}
+}
+
 func TestForceTerminateLeaseServiceRejectsInvalidDepositHandling(t *testing.T) {
 	repo := terminationRepoStub()
 	service := NewForceTerminateLeaseService(repo, txRunnerForRollback(t))
@@ -317,6 +381,7 @@ func TestForceTerminateLeaseServiceRejectsInvalidDepositHandling(t *testing.T) {
 		ActorUserID:         "20000000-0000-0000-0000-000000000001",
 		AssignedPropertyIDs: []string{"property-1"},
 		LeaseID:             terminateLeaseTestLeaseID,
+		TerminationDate:     time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
 		Reason:              "tenant unreachable",
 		DepositHandling:     "refund",
 	})
@@ -407,7 +472,7 @@ func TestPreviewCheckoutSettlementReturnsTokenAndNoWrites(t *testing.T) {
 	}
 }
 
-func TestPreviewCheckoutSettlementBlocksEarlyCheckoutUntilRentRefundIsSupported(t *testing.T) {
+func TestPreviewCheckoutSettlementBlocksEarlyCheckoutWithoutManualRentRefundDecision(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
@@ -438,6 +503,98 @@ func TestPreviewCheckoutSettlementBlocksEarlyCheckoutUntilRentRefundIsSupported(
 	}
 }
 
+func TestPreviewCheckoutSettlementAllowsEarlyCheckoutWithNoRentRefundDecision(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	defer verifySQLMockExpectations(t, mock)
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := terminationRepoStub()
+	service := NewPreviewCheckoutSettlementService(repo, dbtxrunner.New(db, nil))
+	reason := "雙方協議不退未到期租金"
+
+	result, err := service.Execute(context.Background(), CheckoutSettlementInput{
+		ActorRole:              "admin",
+		AssignedPropertyIDs:    []string{"property-1"},
+		LeaseID:                terminateLeaseTestLeaseID,
+		CheckoutDate:           time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
+		Reason:                 "tenant requested",
+		ManualRentRefundReason: &reason,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.PreviewToken == nil || *result.PreviewToken == "" {
+		t.Fatalf("expected preview token, got %+v", result.PreviewToken)
+	}
+	if len(result.Blockers) != 0 {
+		t.Fatalf("unexpected blockers: %+v", result.Blockers)
+	}
+	if result.ManualRentRefundAmount != 0 || result.ManualRentRefundReason == nil || *result.ManualRentRefundReason != reason {
+		t.Fatalf("manual rent refund fields = amount %d reason %+v", result.ManualRentRefundAmount, result.ManualRentRefundReason)
+	}
+	for _, line := range result.Lines {
+		if line.Kind == checkoutLineRentRefund {
+			t.Fatalf("did not expect rent refund line for amount 0: %+v", line)
+		}
+	}
+}
+
+func TestPreviewCheckoutSettlementManualRentRefundAffectsTotalsButNotDepositInvariant(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	defer verifySQLMockExpectations(t, mock)
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := terminationRepoStub()
+	service := NewPreviewCheckoutSettlementService(repo, dbtxrunner.New(db, nil))
+	reason := "退還 6 月未使用租金"
+	actualMoveOut := time.Date(2026, 6, 15, 13, 0, 0, 0, time.UTC)
+
+	result, err := service.Execute(context.Background(), CheckoutSettlementInput{
+		ActorRole:              "admin",
+		AssignedPropertyIDs:    []string{"property-1"},
+		LeaseID:                terminateLeaseTestLeaseID,
+		CheckoutDate:           time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
+		ActualMoveOutDate:      &actualMoveOut,
+		Reason:                 "tenant requested",
+		CleaningFee:            3000,
+		ManualRentRefundAmount: 5000,
+		ManualRentRefundReason: &reason,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var rentRefundLine *CheckoutSettlementLine
+	for i := range result.Lines {
+		if result.Lines[i].Kind == checkoutLineRentRefund {
+			rentRefundLine = &result.Lines[i]
+		}
+	}
+	if rentRefundLine == nil || rentRefundLine.Direction != checkoutDirectionRefund || rentRefundLine.Amount != 5000 {
+		t.Fatalf("rent refund line = %+v", rentRefundLine)
+	}
+	if result.TotalRefund != 25000 || result.TotalCharge != 3000 || result.NetDirection != checkoutNetRefund || result.NetAmount != 22000 {
+		t.Fatalf("unexpected totals: refund=%d charge=%d net=%s/%d", result.TotalRefund, result.TotalCharge, result.NetDirection, result.NetAmount)
+	}
+	depositRefund := result.DepositAmount - result.TotalCharge
+	depositDeduction := result.TotalCharge
+	if depositRefund+depositDeduction != result.DepositAmount {
+		t.Fatalf("deposit invariant failed: refund=%d deduction=%d deposit=%d", depositRefund, depositDeduction, result.DepositAmount)
+	}
+	if result.ActualMoveOutDate == nil || !result.ActualMoveOutDate.Equal(time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("ActualMoveOutDate = %+v", result.ActualMoveOutDate)
+	}
+}
+
 func TestPreviewCheckoutSettlementRejectsNegativeFinalMeterReading(t *testing.T) {
 	repo := terminationRepoStub()
 	service := NewPreviewCheckoutSettlementService(repo, nil)
@@ -458,6 +615,55 @@ func TestPreviewCheckoutSettlementRejectsNegativeFinalMeterReading(t *testing.T)
 	details, ok := appErr.Details.(map[string]interface{})
 	if !ok || details["field"] != "final_meter_reading" {
 		t.Fatalf("expected final_meter_reading field detail, got %+v", appErr.Details)
+	}
+}
+
+func TestPreviewCheckoutSettlementValidatesManualRentRefund(t *testing.T) {
+	service := NewPreviewCheckoutSettlementService(terminationRepoStub(), nil)
+	reason := "tenant requested"
+
+	tests := []struct {
+		name  string
+		input CheckoutSettlementInput
+		field string
+	}{
+		{
+			name: "negative amount",
+			input: CheckoutSettlementInput{
+				ActorRole:              "admin",
+				LeaseID:                terminateLeaseTestLeaseID,
+				CheckoutDate:           time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+				Reason:                 reason,
+				ManualRentRefundAmount: -1,
+				ManualRentRefundReason: &reason,
+			},
+			field: "manual_rent_refund_amount",
+		},
+		{
+			name: "positive amount blank reason",
+			input: CheckoutSettlementInput{
+				ActorRole:              "admin",
+				LeaseID:                terminateLeaseTestLeaseID,
+				CheckoutDate:           time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC),
+				Reason:                 reason,
+				ManualRentRefundAmount: 1,
+			},
+			field: "manual_rent_refund_reason",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := service.Execute(context.Background(), tc.input)
+			var appErr *apperr.Error
+			if !errors.As(err, &appErr) || appErr.Code != apperr.CodeBadRequest {
+				t.Fatalf("expected BAD_REQUEST, got %v", err)
+			}
+			details, ok := appErr.Details.(map[string]interface{})
+			if !ok || details["field"] != tc.field {
+				t.Fatalf("expected %s field detail, got %+v", tc.field, appErr.Details)
+			}
+		})
 	}
 }
 
@@ -511,6 +717,56 @@ func TestFinalizeCheckoutSettlementRejectsStalePreviewToken(t *testing.T) {
 		Reason:              "tenant requested",
 		CleaningFee:         3000,
 		PreviewToken:        "stale",
+	})
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) || appErr.Code != codeCheckoutSettlementStale {
+		t.Fatalf("expected stale checkout error, got %v", err)
+	}
+	if repo.settleDepositCalls != 0 || repo.terminateCalls != 0 {
+		t.Fatalf("stale finalize should not write, settle=%d terminate=%d", repo.settleDepositCalls, repo.terminateCalls)
+	}
+}
+
+func TestFinalizeCheckoutSettlementRejectsStalePreviewTokenWhenManualRefundFieldsChange(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	defer verifySQLMockExpectations(t, mock)
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := terminationRepoStub()
+	previewService := NewPreviewCheckoutSettlementService(repo, dbtxrunner.New(db, nil))
+	reason := "退還未使用租金"
+	actualMoveOut := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	preview, err := previewService.Execute(context.Background(), CheckoutSettlementInput{
+		ActorRole:              "admin",
+		AssignedPropertyIDs:    []string{"property-1"},
+		LeaseID:                terminateLeaseTestLeaseID,
+		CheckoutDate:           time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
+		ActualMoveOutDate:      &actualMoveOut,
+		Reason:                 "tenant requested",
+		ManualRentRefundAmount: 5000,
+		ManualRentRefundReason: &reason,
+	})
+	if err != nil {
+		t.Fatalf("preview Execute: %v", err)
+	}
+	changedReason := "改為不退租金"
+	service := NewFinalizeCheckoutSettlementService(repo, &depositAccountingRepositoryStub{}, txRunnerForRollback(t))
+
+	_, err = service.Execute(context.Background(), CheckoutSettlementInput{
+		ActorRole:              "admin",
+		AssignedPropertyIDs:    []string{"property-1"},
+		LeaseID:                terminateLeaseTestLeaseID,
+		CheckoutDate:           time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
+		ActualMoveOutDate:      &actualMoveOut,
+		Reason:                 "tenant requested",
+		ManualRentRefundAmount: 0,
+		ManualRentRefundReason: &changedReason,
+		PreviewToken:           *preview.PreviewToken,
 	})
 	var appErr *apperr.Error
 	if !errors.As(err, &appErr) || appErr.Code != codeCheckoutSettlementStale {
@@ -584,6 +840,137 @@ func TestFinalizeCheckoutSettlementPersistsSnapshotAndPublishesEvent(t *testing.
 	}
 	if len(publisher.events) != 3 {
 		t.Fatalf("events = %d, want deposit refund, deduction, termination", len(publisher.events))
+	}
+}
+
+func TestFinalizeCheckoutSettlementPersistsManualRentRefundAndAccounting(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	defer verifySQLMockExpectations(t, mock)
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := terminationRepoStub()
+	previewService := NewPreviewCheckoutSettlementService(repo, dbtxrunner.New(db, nil))
+	reason := "退還 6 月未使用租金"
+	actualMoveOut := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)
+	input := CheckoutSettlementInput{
+		ActorRole:              "admin",
+		AssignedPropertyIDs:    []string{"property-1"},
+		LeaseID:                terminateLeaseTestLeaseID,
+		CheckoutDate:           time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
+		ActualMoveOutDate:      &actualMoveOut,
+		Reason:                 "tenant requested",
+		CleaningFee:            3000,
+		ManualRentRefundAmount: 5000,
+		ManualRentRefundReason: &reason,
+	}
+	preview, err := previewService.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("preview Execute: %v", err)
+	}
+
+	db2, mock2, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db2.Close()
+	defer verifySQLMockExpectations(t, mock2)
+	mock2.ExpectBegin()
+	mock2.ExpectCommit()
+
+	publisher := &recordingPublisher{}
+	accountingRepo := &depositAccountingRepositoryStub{}
+	finalizeService := NewFinalizeCheckoutSettlementService(repo, accountingRepo, dbtxrunner.New(db2, publisher))
+	input.PreviewToken = *preview.PreviewToken
+	finalized, err := finalizeService.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("finalize Execute: %v", err)
+	}
+	if finalized.ActualMoveOutDate == nil || finalized.ManualRentRefundReason == nil || finalized.ManualRentRefundAmount != 5000 {
+		t.Fatalf("finalized manual refund fields = %+v", finalized)
+	}
+	if len(accountingRepo.entries) != 3 {
+		t.Fatalf("accounting entries = %d, want 3", len(accountingRepo.entries))
+	}
+	entry := accountingRepo.entries[2]
+	if entry.Category != rentRefundAccountingCategory || entry.AccountingTitleCode != rentRefundAccountingTitleCode || entry.Amount != -5000 {
+		t.Fatalf("rent refund accounting entry = %+v", entry)
+	}
+	if entry.Year != 2026 || entry.Month != 6 || entry.SourceDate == nil || !entry.SourceDate.Equal(time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("rent refund source period = year %d month %d date %+v", entry.Year, entry.Month, entry.SourceDate)
+	}
+	if entry.Description == nil || *entry.Description != reason || entry.DisplayNote == nil || *entry.DisplayNote != reason {
+		t.Fatalf("rent refund description/display = %+v/%+v", entry.Description, entry.DisplayNote)
+	}
+	if repo.lease.SettlementDetail == nil {
+		t.Fatal("expected settlement detail to be persisted")
+	}
+	decoded, err := checkoutSettlementFromDetailMap(*repo.lease.SettlementDetail)
+	if err != nil {
+		t.Fatalf("decode settlement detail: %v", err)
+	}
+	if decoded.ActualMoveOutDate == nil || decoded.ManualRentRefundReason == nil || decoded.ManualRentRefundAmount != 5000 {
+		t.Fatalf("decoded snapshot fields = %+v", decoded)
+	}
+	if decoded.DepositAmount != 20000 || repo.lease.DepositRefundAmount == nil || repo.lease.DepositDeductionAmount == nil || *repo.lease.DepositRefundAmount+*repo.lease.DepositDeductionAmount != decoded.DepositAmount {
+		t.Fatalf("deposit invariant failed: lease=%+v decoded=%+v", repo.lease, decoded)
+	}
+	if len(publisher.events) != 3 {
+		t.Fatalf("events = %d, want deposit refund, deduction, termination", len(publisher.events))
+	}
+}
+
+func TestFinalizeCheckoutSettlementRollsBackWhenRentRefundAccountingFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	defer verifySQLMockExpectations(t, mock)
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := terminationRepoStub()
+	previewService := NewPreviewCheckoutSettlementService(repo, dbtxrunner.New(db, nil))
+	reason := "退還未使用租金"
+	input := CheckoutSettlementInput{
+		ActorRole:              "admin",
+		AssignedPropertyIDs:    []string{"property-1"},
+		LeaseID:                terminateLeaseTestLeaseID,
+		CheckoutDate:           time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC),
+		Reason:                 "tenant requested",
+		ManualRentRefundAmount: 5000,
+		ManualRentRefundReason: &reason,
+	}
+	preview, err := previewService.Execute(context.Background(), input)
+	if err != nil {
+		t.Fatalf("preview Execute: %v", err)
+	}
+
+	db2, mock2, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db2.Close()
+	defer verifySQLMockExpectations(t, mock2)
+	mock2.ExpectBegin()
+	mock2.ExpectRollback()
+
+	publisher := &recordingPublisher{}
+	accountingRepo := &depositAccountingRepositoryStub{createErrByCategory: map[string]error{rentRefundAccountingCategory: errors.New("insert failed")}}
+	finalizeService := NewFinalizeCheckoutSettlementService(repo, accountingRepo, dbtxrunner.New(db2, publisher))
+	input.PreviewToken = *preview.PreviewToken
+	_, err = finalizeService.Execute(context.Background(), input)
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) || appErr.Code != apperr.CodeInternalServerError {
+		t.Fatalf("expected internal server error, got %v", err)
+	}
+	if len(publisher.events) != 0 {
+		t.Fatalf("events should not publish on rollback: %+v", publisher.events)
 	}
 }
 

--- a/internal/application/lease/terminate_lease_test.go
+++ b/internal/application/lease/terminate_lease_test.go
@@ -544,6 +544,39 @@ func TestPreviewCheckoutSettlementAllowsEarlyCheckoutWithNoRentRefundDecision(t 
 	}
 }
 
+func TestPreviewCheckoutSettlementBlocksCheckoutDateBeforeLeaseStart(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	defer verifySQLMockExpectations(t, mock)
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := terminationRepoStub()
+	service := NewPreviewCheckoutSettlementService(repo, dbtxrunner.New(db, nil))
+	reason := "雙方協議不退未到期租金"
+
+	result, err := service.Execute(context.Background(), CheckoutSettlementInput{
+		ActorRole:              "admin",
+		AssignedPropertyIDs:    []string{"property-1"},
+		LeaseID:                terminateLeaseTestLeaseID,
+		CheckoutDate:           time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC),
+		Reason:                 "tenant requested",
+		ManualRentRefundReason: &reason,
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if result.PreviewToken != nil {
+		t.Fatalf("expected no token for checkout before lease start, got %q", *result.PreviewToken)
+	}
+	if len(result.Blockers) != 1 || result.Blockers[0].Code != checkoutBlockerCheckoutBeforeStart {
+		t.Fatalf("unexpected blockers: %+v", result.Blockers)
+	}
+}
+
 func TestPreviewCheckoutSettlementManualRentRefundAffectsTotalsButNotDepositInvariant(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {

--- a/internal/application/lease/terminate_lease_test.go
+++ b/internal/application/lease/terminate_lease_test.go
@@ -839,7 +839,7 @@ func TestFinalizeCheckoutSettlementPersistsSnapshotAndPublishesEvent(t *testing.
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db2.Close()
+	defer func() { _ = db2.Close() }()
 	defer verifySQLMockExpectations(t, mock2)
 	mock2.ExpectBegin()
 	mock2.ExpectCommit()
@@ -910,7 +910,7 @@ func TestFinalizeCheckoutSettlementPersistsManualRentRefundAndAccounting(t *test
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db2.Close()
+	defer func() { _ = db2.Close() }()
 	defer verifySQLMockExpectations(t, mock2)
 	mock2.ExpectBegin()
 	mock2.ExpectCommit()
@@ -988,7 +988,7 @@ func TestFinalizeCheckoutSettlementRollsBackWhenRentRefundAccountingFails(t *tes
 	if err != nil {
 		t.Fatalf("sqlmock.New: %v", err)
 	}
-	defer db2.Close()
+	defer func() { _ = db2.Close() }()
 	defer verifySQLMockExpectations(t, mock2)
 	mock2.ExpectBegin()
 	mock2.ExpectRollback()

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -602,64 +602,64 @@ type CheckoutSettlementBlockerCode string
 
 // CheckoutSettlementFinalizeRequest defines model for CheckoutSettlementFinalizeRequest.
 type CheckoutSettlementFinalizeRequest struct {
-	// ActualMoveOutDate 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date、帳務期間或自動租金計算。
+	// ActualMoveOutDate Actual move-out or handover date. This is operational metadata only and does not affect lease end_date, accounting periods, or automatic rent calculation.
 	ActualMoveOutDate *openapi_types.Date `json:"actual_move_out_date"`
 
-	// CheckoutDate 結算生效日 / 租約終止日；backend 以此更新 lease end_date 並保存結算快照，不代表實際搬出日。
+	// CheckoutDate Settlement effective date and lease termination date. The backend writes this value to lease end_date and stores it in the finalized settlement snapshot. It is not the actual move-out date.
 	CheckoutDate openapi_types.Date `json:"checkout_date"`
 	CleaningFee  *int               `json:"cleaning_fee,omitempty"`
 
-	// FinalMeterReading 退租電表讀數；v1 僅作為快照顯示輸入，不由 frontend 計算電費。
+	// FinalMeterReading Final meter reading at checkout. In v1 this is stored for snapshot display only and must not be used by the frontend to calculate electricity fees.
 	FinalMeterReading *int `json:"final_meter_reading"`
 	KeyCardLossFee    *int `json:"key_card_loss_fee,omitempty"`
 
-	// ManualRentRefundAmount 人工決定的未到期租金退款金額；backend 不自動按比例計算。
+	// ManualRentRefundAmount Manually decided unexpired-rent refund amount. The backend never calculates a prorated rent refund automatically.
 	ManualRentRefundAmount *int `json:"manual_rent_refund_amount,omitempty"`
 
-	// ManualRentRefundReason 人工租金退款決策原因；checkout_date 早於原租約 end_date 時必填，金額 0 加原因表示明確決定不退未到期租金。
+	// ManualRentRefundReason Manual rent refund decision reason. Required when checkout_date is earlier than the original lease end_date or when manual_rent_refund_amount is greater than 0. Otherwise nullable. Amount 0 with a reason records an explicit decision not to refund unexpired rent.
 	ManualRentRefundReason *string `json:"manual_rent_refund_reason"`
 
-	// Notes 退租結算備註。
+	// Notes Checkout settlement notes.
 	Notes    *string `json:"notes"`
 	OtherFee *int    `json:"other_fee,omitempty"`
 
-	// OtherFeeReason other_fee 大於 0 時建議提供。
+	// OtherFeeReason Recommended when other_fee is greater than 0.
 	OtherFeeReason *string `json:"other_fee_reason"`
 
 	// PreviewToken Preview response token. Finalize rejects mismatched or stale tokens.
 	PreviewToken string `json:"preview_token"`
 
-	// Reason 退租原因。
+	// Reason Checkout settlement reason.
 	Reason string `json:"reason"`
 }
 
 // CheckoutSettlementInput defines model for CheckoutSettlementInput.
 type CheckoutSettlementInput struct {
-	// ActualMoveOutDate 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date、帳務期間或自動租金計算。
+	// ActualMoveOutDate Actual move-out or handover date. This is operational metadata only and does not affect lease end_date, accounting periods, or automatic rent calculation.
 	ActualMoveOutDate *openapi_types.Date `json:"actual_move_out_date"`
 
-	// CheckoutDate 結算生效日 / 租約終止日；backend 以此更新 lease end_date 並保存結算快照，不代表實際搬出日。
+	// CheckoutDate Settlement effective date and lease termination date. The backend writes this value to lease end_date and stores it in the finalized settlement snapshot. It is not the actual move-out date.
 	CheckoutDate openapi_types.Date `json:"checkout_date"`
 	CleaningFee  *int               `json:"cleaning_fee,omitempty"`
 
-	// FinalMeterReading 退租電表讀數；v1 僅作為快照顯示輸入，不由 frontend 計算電費。
+	// FinalMeterReading Final meter reading at checkout. In v1 this is stored for snapshot display only and must not be used by the frontend to calculate electricity fees.
 	FinalMeterReading *int `json:"final_meter_reading"`
 	KeyCardLossFee    *int `json:"key_card_loss_fee,omitempty"`
 
-	// ManualRentRefundAmount 人工決定的未到期租金退款金額；backend 不自動按比例計算。
+	// ManualRentRefundAmount Manually decided unexpired-rent refund amount. The backend never calculates a prorated rent refund automatically.
 	ManualRentRefundAmount *int `json:"manual_rent_refund_amount,omitempty"`
 
-	// ManualRentRefundReason 人工租金退款決策原因；checkout_date 早於原租約 end_date 時必填，金額 0 加原因表示明確決定不退未到期租金。
+	// ManualRentRefundReason Manual rent refund decision reason. Required when checkout_date is earlier than the original lease end_date or when manual_rent_refund_amount is greater than 0. Otherwise nullable. Amount 0 with a reason records an explicit decision not to refund unexpired rent.
 	ManualRentRefundReason *string `json:"manual_rent_refund_reason"`
 
-	// Notes 退租結算備註。
+	// Notes Checkout settlement notes.
 	Notes    *string `json:"notes"`
 	OtherFee *int    `json:"other_fee,omitempty"`
 
-	// OtherFeeReason other_fee 大於 0 時建議提供。
+	// OtherFeeReason Recommended when other_fee is greater than 0.
 	OtherFeeReason *string `json:"other_fee_reason"`
 
-	// Reason 退租原因。
+	// Reason Checkout settlement reason.
 	Reason string `json:"reason"`
 }
 
@@ -670,7 +670,7 @@ type CheckoutSettlementLine struct {
 	Description *string                         `json:"description"`
 	Direction   CheckoutSettlementLineDirection `json:"direction"`
 
-	// Kind rent_refund 表示 backend 接收的人工租金退款決策，不代表自動按比例計算的未到期租金退款。
+	// Kind rent_refund means a manual rent refund decision accepted by the backend. It does not represent an automatically prorated unexpired-rent refund.
 	Kind      CheckoutSettlementLineKind `json:"kind"`
 	Label     string                     `json:"label"`
 	SourceRef *map[string]interface{}    `json:"source_ref"`
@@ -679,7 +679,7 @@ type CheckoutSettlementLine struct {
 // CheckoutSettlementLineDirection defines model for CheckoutSettlementLine.Direction.
 type CheckoutSettlementLineDirection string
 
-// CheckoutSettlementLineKind rent_refund 表示 backend 接收的人工租金退款決策，不代表自動按比例計算的未到期租金退款。
+// CheckoutSettlementLineKind rent_refund means a manual rent refund decision accepted by the backend. It does not represent an automatically prorated unexpired-rent refund.
 type CheckoutSettlementLineKind string
 
 // CheckoutSettlementPreviewRequest defines model for CheckoutSettlementPreviewRequest.
@@ -687,11 +687,11 @@ type CheckoutSettlementPreviewRequest = CheckoutSettlementInput
 
 // CheckoutSettlementResponse defines model for CheckoutSettlementResponse.
 type CheckoutSettlementResponse struct {
-	// ActualMoveOutDate 實際搬出 / 點交日；僅作為營運紀錄。
+	// ActualMoveOutDate Actual move-out or handover date. This is operational metadata only.
 	ActualMoveOutDate *openapi_types.Date         `json:"actual_move_out_date"`
 	Blockers          []CheckoutSettlementBlocker `json:"blockers"`
 
-	// CheckoutDate 結算生效日 / 租約終止日，不代表實際搬出日。
+	// CheckoutDate Settlement effective date and lease termination date. This is not the actual move-out date.
 	CheckoutDate      openapi_types.Date       `json:"checkout_date"`
 	DepositAmount     int                      `json:"deposit_amount"`
 	ExportAvailable   bool                     `json:"export_available"`
@@ -700,10 +700,10 @@ type CheckoutSettlementResponse struct {
 	LeaseId           openapi_types.UUID       `json:"lease_id"`
 	Lines             []CheckoutSettlementLine `json:"lines"`
 
-	// ManualRentRefundAmount 人工決定的未到期租金退款金額；0 加 reason 表示明確不退。
+	// ManualRentRefundAmount Manually decided unexpired-rent refund amount. Amount 0 with a reason records an explicit no-refund decision.
 	ManualRentRefundAmount *int `json:"manual_rent_refund_amount,omitempty"`
 
-	// ManualRentRefundReason 人工租金退款決策原因。
+	// ManualRentRefundReason Manual rent refund decision reason. Required when checkout_date is earlier than the original lease end_date or when manual_rent_refund_amount is greater than 0. Otherwise nullable.
 	ManualRentRefundReason *string `json:"manual_rent_refund_reason"`
 
 	// NetAmount Absolute net amount after refund and charge lines are balanced.
@@ -944,14 +944,14 @@ type FinancialReportSummaryItem struct {
 
 // ForceTerminateRequest defines model for ForceTerminateRequest.
 type ForceTerminateRequest struct {
-	// ActualMoveOutDate 實際搬出 / 點交日；僅作為營運紀錄，不影響 write-off、deposit handling 或租金退款。
+	// ActualMoveOutDate Actual move-out or handover date. This is operational metadata only and does not affect write-off handling, deposit handling, or rent refund behavior.
 	ActualMoveOutDate *openapi_types.Date `json:"actual_move_out_date"`
 
 	// DepositHandling Deposit handling decision during force termination; write_off marks the deposit as written_off, while keep_held leaves it held for later manual handling.
 	DepositHandling ForceTerminateRequestDepositHandling `json:"deposit_handling"`
 	Reason          string                               `json:"reason"`
 
-	// TerminationDate 強制終止生效日；backend 以此更新 lease end_date。
+	// TerminationDate Force-termination effective date. The backend writes this value to lease end_date.
 	TerminationDate openapi_types.Date `json:"termination_date"`
 }
 
@@ -1147,7 +1147,7 @@ type LeaseReplaceResponseReplacementDepositHandling string
 
 // LeaseResponse defines model for LeaseResponse.
 type LeaseResponse struct {
-	// ActualMoveOutDate 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date 或帳務。
+	// ActualMoveOutDate Actual move-out or handover date. This is operational metadata only and does not affect lease end_date or accounting.
 	ActualMoveOutDate         *openapi_types.Date                     `json:"actual_move_out_date"`
 	CreatedAt                 *time.Time                              `json:"created_at,omitempty"`
 	DepositAmount             *int                                    `json:"deposit_amount,omitempty"`

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -76,6 +76,7 @@ const (
 // Defines values for CheckoutSettlementBlockerCode.
 const (
 	CheckoutSettlementBlockerCodeChargeExceedsDeposit             CheckoutSettlementBlockerCode = "charge_exceeds_deposit"
+	CheckoutSettlementBlockerCodeCheckoutDateBeforeLeaseStart     CheckoutSettlementBlockerCode = "checkout_date_before_lease_start"
 	CheckoutSettlementBlockerCodeDepositNotHeld                   CheckoutSettlementBlockerCode = "deposit_not_held"
 	CheckoutSettlementBlockerCodeLeaseNotActive                   CheckoutSettlementBlockerCode = "lease_not_active"
 	CheckoutSettlementBlockerCodeManualRentRefundDecisionRequired CheckoutSettlementBlockerCode = "manual_rent_refund_decision_required"

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -75,12 +75,12 @@ const (
 
 // Defines values for CheckoutSettlementBlockerCode.
 const (
-	CheckoutSettlementBlockerCodeChargeExceedsDeposit    CheckoutSettlementBlockerCode = "charge_exceeds_deposit"
-	CheckoutSettlementBlockerCodeDepositNotHeld          CheckoutSettlementBlockerCode = "deposit_not_held"
-	CheckoutSettlementBlockerCodeLeaseNotActive          CheckoutSettlementBlockerCode = "lease_not_active"
-	CheckoutSettlementBlockerCodePendingMeter            CheckoutSettlementBlockerCode = "pending_meter"
-	CheckoutSettlementBlockerCodeRentRefundNotCalculated CheckoutSettlementBlockerCode = "rent_refund_not_calculated"
-	CheckoutSettlementBlockerCodeUnpaidBill              CheckoutSettlementBlockerCode = "unpaid_bill"
+	CheckoutSettlementBlockerCodeChargeExceedsDeposit             CheckoutSettlementBlockerCode = "charge_exceeds_deposit"
+	CheckoutSettlementBlockerCodeDepositNotHeld                   CheckoutSettlementBlockerCode = "deposit_not_held"
+	CheckoutSettlementBlockerCodeLeaseNotActive                   CheckoutSettlementBlockerCode = "lease_not_active"
+	CheckoutSettlementBlockerCodeManualRentRefundDecisionRequired CheckoutSettlementBlockerCode = "manual_rent_refund_decision_required"
+	CheckoutSettlementBlockerCodePendingMeter                     CheckoutSettlementBlockerCode = "pending_meter"
+	CheckoutSettlementBlockerCodeUnpaidBill                       CheckoutSettlementBlockerCode = "unpaid_bill"
 )
 
 // Defines values for CheckoutSettlementLineDirection.
@@ -109,8 +109,8 @@ const (
 
 // Defines values for CheckoutSettlementWarningCode.
 const (
-	FinalMeterSnapshotOnly  CheckoutSettlementWarningCode = "final_meter_snapshot_only"
-	RentRefundNotCalculated CheckoutSettlementWarningCode = "rent_refund_not_calculated"
+	FinalMeterSnapshotOnly   CheckoutSettlementWarningCode = "final_meter_snapshot_only"
+	ManualRentRefundRecorded CheckoutSettlementWarningCode = "manual_rent_refund_recorded"
 )
 
 // Defines values for CreateLeaseRequestElectricityBillingCadence.
@@ -155,6 +155,7 @@ const (
 	FinancialReportEntryItemCategoryElectricityPayment FinancialReportEntryItemCategory = "electricity_payment"
 	FinancialReportEntryItemCategoryJournalExpense     FinancialReportEntryItemCategory = "journal_expense"
 	FinancialReportEntryItemCategoryRentPayment        FinancialReportEntryItemCategory = "rent_payment"
+	FinancialReportEntryItemCategoryRentRefund         FinancialReportEntryItemCategory = "rent_refund"
 )
 
 // Defines values for FinancialReportEntrySourceDetail.
@@ -163,6 +164,7 @@ const (
 	DepositRefund    FinancialReportEntrySourceDetail = "deposit_refund"
 	JournalExpense   FinancialReportEntrySourceDetail = "journal_expense"
 	Payment          FinancialReportEntrySourceDetail = "payment"
+	RentRefund       FinancialReportEntrySourceDetail = "rent_refund"
 )
 
 // Defines values for FinancialReportEntrySourceType.
@@ -599,13 +601,22 @@ type CheckoutSettlementBlockerCode string
 
 // CheckoutSettlementFinalizeRequest defines model for CheckoutSettlementFinalizeRequest.
 type CheckoutSettlementFinalizeRequest struct {
-	// CheckoutDate 實際退租日；backend 以此計算並保存結算快照。
+	// ActualMoveOutDate 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date、帳務期間或自動租金計算。
+	ActualMoveOutDate *openapi_types.Date `json:"actual_move_out_date"`
+
+	// CheckoutDate 結算生效日 / 租約終止日；backend 以此更新 lease end_date 並保存結算快照，不代表實際搬出日。
 	CheckoutDate openapi_types.Date `json:"checkout_date"`
 	CleaningFee  *int               `json:"cleaning_fee,omitempty"`
 
 	// FinalMeterReading 退租電表讀數；v1 僅作為快照顯示輸入，不由 frontend 計算電費。
 	FinalMeterReading *int `json:"final_meter_reading"`
 	KeyCardLossFee    *int `json:"key_card_loss_fee,omitempty"`
+
+	// ManualRentRefundAmount 人工決定的未到期租金退款金額；backend 不自動按比例計算。
+	ManualRentRefundAmount *int `json:"manual_rent_refund_amount,omitempty"`
+
+	// ManualRentRefundReason 人工租金退款決策原因；checkout_date 早於原租約 end_date 時必填，金額 0 加原因表示明確決定不退未到期租金。
+	ManualRentRefundReason *string `json:"manual_rent_refund_reason"`
 
 	// Notes 退租結算備註。
 	Notes    *string `json:"notes"`
@@ -623,13 +634,22 @@ type CheckoutSettlementFinalizeRequest struct {
 
 // CheckoutSettlementInput defines model for CheckoutSettlementInput.
 type CheckoutSettlementInput struct {
-	// CheckoutDate 實際退租日；backend 以此計算並保存結算快照。
+	// ActualMoveOutDate 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date、帳務期間或自動租金計算。
+	ActualMoveOutDate *openapi_types.Date `json:"actual_move_out_date"`
+
+	// CheckoutDate 結算生效日 / 租約終止日；backend 以此更新 lease end_date 並保存結算快照，不代表實際搬出日。
 	CheckoutDate openapi_types.Date `json:"checkout_date"`
 	CleaningFee  *int               `json:"cleaning_fee,omitempty"`
 
 	// FinalMeterReading 退租電表讀數；v1 僅作為快照顯示輸入，不由 frontend 計算電費。
 	FinalMeterReading *int `json:"final_meter_reading"`
 	KeyCardLossFee    *int `json:"key_card_loss_fee,omitempty"`
+
+	// ManualRentRefundAmount 人工決定的未到期租金退款金額；backend 不自動按比例計算。
+	ManualRentRefundAmount *int `json:"manual_rent_refund_amount,omitempty"`
+
+	// ManualRentRefundReason 人工租金退款決策原因；checkout_date 早於原租約 end_date 時必填，金額 0 加原因表示明確決定不退未到期租金。
+	ManualRentRefundReason *string `json:"manual_rent_refund_reason"`
 
 	// Notes 退租結算備註。
 	Notes    *string `json:"notes"`
@@ -648,15 +668,17 @@ type CheckoutSettlementLine struct {
 	Amount      int                             `json:"amount"`
 	Description *string                         `json:"description"`
 	Direction   CheckoutSettlementLineDirection `json:"direction"`
-	Kind        CheckoutSettlementLineKind      `json:"kind"`
-	Label       string                          `json:"label"`
-	SourceRef   *map[string]interface{}         `json:"source_ref"`
+
+	// Kind rent_refund 表示 backend 接收的人工租金退款決策，不代表自動按比例計算的未到期租金退款。
+	Kind      CheckoutSettlementLineKind `json:"kind"`
+	Label     string                     `json:"label"`
+	SourceRef *map[string]interface{}    `json:"source_ref"`
 }
 
 // CheckoutSettlementLineDirection defines model for CheckoutSettlementLine.Direction.
 type CheckoutSettlementLineDirection string
 
-// CheckoutSettlementLineKind defines model for CheckoutSettlementLine.Kind.
+// CheckoutSettlementLineKind rent_refund 表示 backend 接收的人工租金退款決策，不代表自動按比例計算的未到期租金退款。
 type CheckoutSettlementLineKind string
 
 // CheckoutSettlementPreviewRequest defines model for CheckoutSettlementPreviewRequest.
@@ -664,14 +686,24 @@ type CheckoutSettlementPreviewRequest = CheckoutSettlementInput
 
 // CheckoutSettlementResponse defines model for CheckoutSettlementResponse.
 type CheckoutSettlementResponse struct {
+	// ActualMoveOutDate 實際搬出 / 點交日；僅作為營運紀錄。
+	ActualMoveOutDate *openapi_types.Date         `json:"actual_move_out_date"`
 	Blockers          []CheckoutSettlementBlocker `json:"blockers"`
-	CheckoutDate      openapi_types.Date          `json:"checkout_date"`
-	DepositAmount     int                         `json:"deposit_amount"`
-	ExportAvailable   bool                        `json:"export_available"`
-	FinalMeterReading *int                        `json:"final_meter_reading"`
-	FinalizedAt       *time.Time                  `json:"finalized_at"`
-	LeaseId           openapi_types.UUID          `json:"lease_id"`
-	Lines             []CheckoutSettlementLine    `json:"lines"`
+
+	// CheckoutDate 結算生效日 / 租約終止日，不代表實際搬出日。
+	CheckoutDate      openapi_types.Date       `json:"checkout_date"`
+	DepositAmount     int                      `json:"deposit_amount"`
+	ExportAvailable   bool                     `json:"export_available"`
+	FinalMeterReading *int                     `json:"final_meter_reading"`
+	FinalizedAt       *time.Time               `json:"finalized_at"`
+	LeaseId           openapi_types.UUID       `json:"lease_id"`
+	Lines             []CheckoutSettlementLine `json:"lines"`
+
+	// ManualRentRefundAmount 人工決定的未到期租金退款金額；0 加 reason 表示明確不退。
+	ManualRentRefundAmount *int `json:"manual_rent_refund_amount,omitempty"`
+
+	// ManualRentRefundReason 人工租金退款決策原因。
+	ManualRentRefundReason *string `json:"manual_rent_refund_reason"`
 
 	// NetAmount Absolute net amount after refund and charge lines are balanced.
 	NetAmount    int                                    `json:"net_amount"`
@@ -911,9 +943,15 @@ type FinancialReportSummaryItem struct {
 
 // ForceTerminateRequest defines model for ForceTerminateRequest.
 type ForceTerminateRequest struct {
+	// ActualMoveOutDate 實際搬出 / 點交日；僅作為營運紀錄，不影響 write-off、deposit handling 或租金退款。
+	ActualMoveOutDate *openapi_types.Date `json:"actual_move_out_date"`
+
 	// DepositHandling Deposit handling decision during force termination; write_off marks the deposit as written_off, while keep_held leaves it held for later manual handling.
 	DepositHandling ForceTerminateRequestDepositHandling `json:"deposit_handling"`
 	Reason          string                               `json:"reason"`
+
+	// TerminationDate 強制終止生效日；backend 以此更新 lease end_date。
+	TerminationDate openapi_types.Date `json:"termination_date"`
 }
 
 // ForceTerminateRequestDepositHandling Deposit handling decision during force termination; write_off marks the deposit as written_off, while keep_held leaves it held for later manual handling.
@@ -1108,6 +1146,8 @@ type LeaseReplaceResponseReplacementDepositHandling string
 
 // LeaseResponse defines model for LeaseResponse.
 type LeaseResponse struct {
+	// ActualMoveOutDate 實際搬出 / 點交日；僅作為營運紀錄，不影響 lease end_date 或帳務。
+	ActualMoveOutDate         *openapi_types.Date                     `json:"actual_move_out_date"`
 	CreatedAt                 *time.Time                              `json:"created_at,omitempty"`
 	DepositAmount             *int                                    `json:"deposit_amount,omitempty"`
 	DepositDeductionAmount    *int                                    `json:"deposit_deduction_amount"`

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -1403,6 +1403,8 @@ func (s *APIServer) ForceTerminateLease(c *gin.Context, id string) {
 		ActorUserID:         principal.UserID,
 		AssignedPropertyIDs: principal.AssignedPropertyIDs,
 		LeaseID:             id,
+		TerminationDate:     request.TerminationDate.Time,
+		ActualMoveOutDate:   datePtrToTimePtr(request.ActualMoveOutDate),
 		Reason:              request.Reason,
 		DepositHandling:     string(request.DepositHandling),
 	})
@@ -1487,14 +1489,17 @@ func (s *APIServer) FinalizeLeaseCheckoutSettlement(c *gin.Context, id string) {
 	}
 
 	settlement, err := s.finalizeCheckout.Execute(c.Request.Context(), toCheckoutSettlementInput(principal, id, api.CheckoutSettlementInput{
-		CheckoutDate:      request.CheckoutDate,
-		CleaningFee:       request.CleaningFee,
-		FinalMeterReading: request.FinalMeterReading,
-		KeyCardLossFee:    request.KeyCardLossFee,
-		Notes:             request.Notes,
-		OtherFee:          request.OtherFee,
-		OtherFeeReason:    request.OtherFeeReason,
-		Reason:            request.Reason,
+		ActualMoveOutDate:      request.ActualMoveOutDate,
+		CheckoutDate:           request.CheckoutDate,
+		CleaningFee:            request.CleaningFee,
+		FinalMeterReading:      request.FinalMeterReading,
+		KeyCardLossFee:         request.KeyCardLossFee,
+		ManualRentRefundAmount: request.ManualRentRefundAmount,
+		ManualRentRefundReason: request.ManualRentRefundReason,
+		Notes:                  request.Notes,
+		OtherFee:               request.OtherFee,
+		OtherFeeReason:         request.OtherFeeReason,
+		Reason:                 request.Reason,
 	}, request.PreviewToken))
 	if err != nil {
 		c.Error(err)
@@ -3894,6 +3899,10 @@ func toTenantLeaseResponse(lease *dbtenantquery.Lease) api.LeaseResponse {
 	roomID, roomOK := parseUUID(lease.RoomID)
 	startDate := openapi_types.Date{Time: lease.StartDate}
 	endDate := openapi_types.Date{Time: lease.EndDate}
+	var actualMoveOutDate *openapi_types.Date
+	if lease.ActualMoveOutDate != nil {
+		actualMoveOutDate = &openapi_types.Date{Time: *lease.ActualMoveOutDate}
+	}
 	status := api.LeaseResponseStatus(lease.Status)
 	depositStatus := api.LeaseResponseDepositStatus(lease.DepositStatus)
 	rentCadence := api.LeaseResponseRentBillingCadence(lease.RentBillingCadence)
@@ -3907,6 +3916,7 @@ func toTenantLeaseResponse(lease *dbtenantquery.Lease) api.LeaseResponse {
 	response := api.LeaseResponse{
 		CreatedAt:                 &createdAt,
 		DepositAmount:             &depositAmount,
+		ActualMoveOutDate:         actualMoveOutDate,
 		DepositDeductionAmount:    lease.DepositDeductionAmount,
 		DepositDeductionReason:    lease.DepositDeductionReason,
 		DepositRefundAmount:       lease.DepositRefundAmount,
@@ -3949,6 +3959,7 @@ func toLeaseResponse(lease *dbleasequery.Lease) api.LeaseResponse {
 		RentAmount:                lease.RentAmount,
 		StartDate:                 lease.StartDate,
 		EndDate:                   lease.EndDate,
+		ActualMoveOutDate:         lease.ActualMoveOutDate,
 		RentBillingCadence:        lease.RentBillingCadence,
 		ElectricityBillingCadence: lease.ElectricityBillingCadence,
 		StartingMeterReading:      lease.StartingMeterReading,
@@ -4040,6 +4051,7 @@ func toCreatedLeaseResponse(lease *applease.Lease) api.LeaseResponse {
 		RentAmount:                lease.RentAmount,
 		StartDate:                 lease.StartDate,
 		EndDate:                   lease.EndDate,
+		ActualMoveOutDate:         lease.ActualMoveOutDate,
 		RentBillingCadence:        lease.RentBillingCadence,
 		ElectricityBillingCadence: lease.ElectricityBillingCadence,
 		StartingMeterReading:      lease.StartingMeterReading,
@@ -4141,18 +4153,21 @@ func toForceTerminationResponse(forceTermination *applease.ForceTermination) api
 
 func toCheckoutSettlementInput(principal requestctx.Principal, leaseID string, request api.CheckoutSettlementInput, previewToken string) applease.CheckoutSettlementInput {
 	return applease.CheckoutSettlementInput{
-		ActorRole:           principal.Role,
-		AssignedPropertyIDs: principal.AssignedPropertyIDs,
-		LeaseID:             leaseID,
-		CheckoutDate:        request.CheckoutDate.Time,
-		Reason:              request.Reason,
-		FinalMeterReading:   request.FinalMeterReading,
-		CleaningFee:         intValuePtr(request.CleaningFee),
-		KeyCardLossFee:      intValuePtr(request.KeyCardLossFee),
-		OtherFee:            intValuePtr(request.OtherFee),
-		OtherFeeReason:      request.OtherFeeReason,
-		Notes:               request.Notes,
-		PreviewToken:        previewToken,
+		ActorRole:              principal.Role,
+		AssignedPropertyIDs:    principal.AssignedPropertyIDs,
+		LeaseID:                leaseID,
+		CheckoutDate:           request.CheckoutDate.Time,
+		ActualMoveOutDate:      datePtrToTimePtr(request.ActualMoveOutDate),
+		Reason:                 request.Reason,
+		FinalMeterReading:      request.FinalMeterReading,
+		CleaningFee:            intValuePtr(request.CleaningFee),
+		KeyCardLossFee:         intValuePtr(request.KeyCardLossFee),
+		OtherFee:               intValuePtr(request.OtherFee),
+		OtherFeeReason:         request.OtherFeeReason,
+		ManualRentRefundAmount: intValuePtr(request.ManualRentRefundAmount),
+		ManualRentRefundReason: request.ManualRentRefundReason,
+		Notes:                  request.Notes,
+		PreviewToken:           previewToken,
 	}
 }
 
@@ -4207,29 +4222,37 @@ func toCheckoutSettlementResponse(settlement *applease.CheckoutSettlement) (api.
 		})
 	}
 
+	var actualMoveOutDate *openapi_types.Date
+	if settlement.ActualMoveOutDate != nil {
+		actualMoveOutDate = &openapi_types.Date{Time: *settlement.ActualMoveOutDate}
+	}
+
 	return api.CheckoutSettlementResponse{
-		Blockers:          blockers,
-		CheckoutDate:      openapi_types.Date{Time: settlement.CheckoutDate},
-		DepositAmount:     settlement.DepositAmount,
-		ExportAvailable:   settlement.ExportAvailable,
-		FinalMeterReading: settlement.FinalMeterReading,
-		FinalizedAt:       settlement.FinalizedAt,
-		LeaseId:           leaseID,
-		Lines:             lines,
-		NetAmount:         settlement.NetAmount,
-		NetDirection:      api.CheckoutSettlementResponseNetDirection(settlement.NetDirection),
-		Notes:             settlement.Notes,
-		PreviewToken:      settlement.PreviewToken,
-		PropertyId:        propertyID,
-		PropertyLabel:     settlement.PropertyLabel,
-		Reason:            settlement.Reason,
-		RoomId:            roomID,
-		RoomLabel:         settlement.RoomLabel,
-		TenantId:          tenantID,
-		TenantLabel:       settlement.TenantLabel,
-		TotalCharge:       settlement.TotalCharge,
-		TotalRefund:       settlement.TotalRefund,
-		Warnings:          warnings,
+		ActualMoveOutDate:      actualMoveOutDate,
+		Blockers:               blockers,
+		CheckoutDate:           openapi_types.Date{Time: settlement.CheckoutDate},
+		DepositAmount:          settlement.DepositAmount,
+		ExportAvailable:        settlement.ExportAvailable,
+		FinalMeterReading:      settlement.FinalMeterReading,
+		FinalizedAt:            settlement.FinalizedAt,
+		LeaseId:                leaseID,
+		Lines:                  lines,
+		ManualRentRefundAmount: &settlement.ManualRentRefundAmount,
+		ManualRentRefundReason: settlement.ManualRentRefundReason,
+		NetAmount:              settlement.NetAmount,
+		NetDirection:           api.CheckoutSettlementResponseNetDirection(settlement.NetDirection),
+		Notes:                  settlement.Notes,
+		PreviewToken:           settlement.PreviewToken,
+		PropertyId:             propertyID,
+		PropertyLabel:          settlement.PropertyLabel,
+		Reason:                 settlement.Reason,
+		RoomId:                 roomID,
+		RoomLabel:              settlement.RoomLabel,
+		TenantId:               tenantID,
+		TenantLabel:            settlement.TenantLabel,
+		TotalCharge:            settlement.TotalCharge,
+		TotalRefund:            settlement.TotalRefund,
+		Warnings:               warnings,
 	}, nil
 }
 

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -1579,8 +1579,8 @@ func TestFinalizeLeaseCheckoutSettlementForwardsNewContractFields(t *testing.T) 
 		"reason":"tenant requested",
 		"cleaning_fee":3000,
 		"key_card_loss_fee":1000,
-		"manual_rent_refund_amount":0,
-		"manual_rent_refund_reason":"no rent refund by agreement"
+		"manual_rent_refund_amount":1000,
+		"manual_rent_refund_reason":"manual rent refund approved"
 	}`
 	previewReq := httptest.NewRequest(http.MethodPost, "/api/v1/leases/40000000-0000-0000-0000-000000000001/checkout-settlement/preview", strings.NewReader(body))
 	previewReq.Header.Set("Authorization", "Bearer valid-token")
@@ -1605,8 +1605,8 @@ func TestFinalizeLeaseCheckoutSettlementForwardsNewContractFields(t *testing.T) 
 		"reason":"tenant requested",
 		"cleaning_fee":3000,
 		"key_card_loss_fee":1000,
-		"manual_rent_refund_amount":0,
-		"manual_rent_refund_reason":"no rent refund by agreement",
+		"manual_rent_refund_amount":1000,
+		"manual_rent_refund_reason":"manual rent refund approved",
 		"preview_token":` + strconv.Quote(token) + `
 	}`
 	finalizeReq := httptest.NewRequest(http.MethodPost, "/api/v1/leases/40000000-0000-0000-0000-000000000001/checkout-settlement/finalize", strings.NewReader(finalizeBody))
@@ -1624,8 +1624,25 @@ func TestFinalizeLeaseCheckoutSettlementForwardsNewContractFields(t *testing.T) 
 	if finalizePayload["actual_move_out_date"] != "2026-12-20" {
 		t.Fatalf("actual_move_out_date = %v, want 2026-12-20", finalizePayload["actual_move_out_date"])
 	}
-	if finalizePayload["manual_rent_refund_amount"] != float64(0) || finalizePayload["manual_rent_refund_reason"] != "no rent refund by agreement" {
+	if finalizePayload["manual_rent_refund_amount"] != float64(1000) || finalizePayload["manual_rent_refund_reason"] != "manual rent refund approved" {
 		t.Fatalf("unexpected manual rent refund fields: %+v", finalizePayload)
+	}
+	lines, ok := finalizePayload["lines"].([]any)
+	if !ok {
+		t.Fatalf("lines = %T, want array", finalizePayload["lines"])
+	}
+	hasRentRefundLine := false
+	for _, rawLine := range lines {
+		line, ok := rawLine.(map[string]any)
+		if !ok {
+			continue
+		}
+		if line["kind"] == "rent_refund" && line["amount"] == float64(1000) && line["direction"] == "refund" {
+			hasRentRefundLine = true
+		}
+	}
+	if !hasRentRefundLine {
+		t.Fatalf("expected finalized rent_refund line, got %+v", lines)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1479,9 +1480,12 @@ func TestPreviewLeaseCheckoutSettlementReturnsTokenAndForwardsScope(t *testing.T
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/leases/40000000-0000-0000-0000-000000000001/checkout-settlement/preview", strings.NewReader(`{
 		"checkout_date":"2026-12-31",
+		"actual_move_out_date":"2026-12-20",
 		"reason":"tenant requested",
 		"cleaning_fee":3000,
-		"key_card_loss_fee":1000
+		"key_card_loss_fee":1000,
+		"manual_rent_refund_amount":500,
+		"manual_rent_refund_reason":"manual refund approved"
 	}`))
 	req.Header.Set("Authorization", "Bearer valid-token")
 	req.Header.Set("Content-Type", "application/json")
@@ -1499,11 +1503,238 @@ func TestPreviewLeaseCheckoutSettlementReturnsTokenAndForwardsScope(t *testing.T
 	if payload["preview_token"] == nil || payload["net_direction"] != "refund" {
 		t.Fatalf("unexpected checkout preview response: %+v", payload)
 	}
+	if payload["actual_move_out_date"] != "2026-12-20" {
+		t.Fatalf("actual_move_out_date = %v, want 2026-12-20", payload["actual_move_out_date"])
+	}
+	if payload["manual_rent_refund_amount"] != float64(500) || payload["manual_rent_refund_reason"] != "manual refund approved" {
+		t.Fatalf("unexpected manual rent refund fields: %+v", payload)
+	}
+	lines, ok := payload["lines"].([]any)
+	if !ok {
+		t.Fatalf("lines has unexpected shape: %+v", payload["lines"])
+	}
+	hasRentRefundLine := false
+	for _, item := range lines {
+		line, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("line has unexpected shape: %+v", item)
+		}
+		if line["kind"] == "rent_refund" && line["direction"] == "refund" && line["amount"] == float64(500) {
+			hasRentRefundLine = true
+		}
+	}
+	if !hasRentRefundLine {
+		t.Fatalf("expected rent_refund line in response: %+v", lines)
+	}
+	if payload["total_refund"] != float64(36500) {
+		t.Fatalf("total_refund = %v, want 36500", payload["total_refund"])
+	}
 	if payload["total_charge"] != float64(4000) {
 		t.Fatalf("total_charge = %v, want 4000", payload["total_charge"])
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestFinalizeLeaseCheckoutSettlementForwardsNewContractFields(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	engine := newTestEngineWithAllServices(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{
+			propertyByLeaseID: map[string]string{
+				"40000000-0000-0000-0000-000000000001": testPropertyID1,
+			},
+		},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
+		fakeTenantQueryRepo{},
+		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		nil,
+		func(deps *handler.APIServerDeps) {
+			repo := fakeLeaseRepo{}
+			deps.Leases.PreviewCheckout = applease.NewPreviewCheckoutSettlementService(repo, dbtxrunner.New(db, nil))
+			deps.Leases.FinalizeCheckout = applease.NewFinalizeCheckoutSettlementService(repo, fakeDepositAccountingRepo{}, dbtxrunner.New(db, nil))
+		},
+	)
+
+	body := `{
+		"checkout_date":"2026-12-31",
+		"actual_move_out_date":"2026-12-20",
+		"reason":"tenant requested",
+		"cleaning_fee":3000,
+		"key_card_loss_fee":1000,
+		"manual_rent_refund_amount":0,
+		"manual_rent_refund_reason":"no rent refund by agreement"
+	}`
+	previewReq := httptest.NewRequest(http.MethodPost, "/api/v1/leases/40000000-0000-0000-0000-000000000001/checkout-settlement/preview", strings.NewReader(body))
+	previewReq.Header.Set("Authorization", "Bearer valid-token")
+	previewReq.Header.Set("Content-Type", "application/json")
+	previewResp := httptest.NewRecorder()
+	engine.ServeHTTP(previewResp, previewReq)
+	if previewResp.Code != http.StatusOK {
+		t.Fatalf("expected preview 200, got %d: %s", previewResp.Code, previewResp.Body.String())
+	}
+	previewPayload := map[string]any{}
+	if err := json.Unmarshal(previewResp.Body.Bytes(), &previewPayload); err != nil {
+		t.Fatalf("unmarshal preview response: %v", err)
+	}
+	token, ok := previewPayload["preview_token"].(string)
+	if !ok || token == "" {
+		t.Fatalf("expected preview token, got %+v", previewPayload)
+	}
+
+	finalizeBody := `{
+		"checkout_date":"2026-12-31",
+		"actual_move_out_date":"2026-12-20",
+		"reason":"tenant requested",
+		"cleaning_fee":3000,
+		"key_card_loss_fee":1000,
+		"manual_rent_refund_amount":0,
+		"manual_rent_refund_reason":"no rent refund by agreement",
+		"preview_token":` + strconv.Quote(token) + `
+	}`
+	finalizeReq := httptest.NewRequest(http.MethodPost, "/api/v1/leases/40000000-0000-0000-0000-000000000001/checkout-settlement/finalize", strings.NewReader(finalizeBody))
+	finalizeReq.Header.Set("Authorization", "Bearer valid-token")
+	finalizeReq.Header.Set("Content-Type", "application/json")
+	finalizeResp := httptest.NewRecorder()
+	engine.ServeHTTP(finalizeResp, finalizeReq)
+	if finalizeResp.Code != http.StatusOK {
+		t.Fatalf("expected finalize 200, got %d: %s", finalizeResp.Code, finalizeResp.Body.String())
+	}
+	finalizePayload := map[string]any{}
+	if err := json.Unmarshal(finalizeResp.Body.Bytes(), &finalizePayload); err != nil {
+		t.Fatalf("unmarshal finalize response: %v", err)
+	}
+	if finalizePayload["actual_move_out_date"] != "2026-12-20" {
+		t.Fatalf("actual_move_out_date = %v, want 2026-12-20", finalizePayload["actual_move_out_date"])
+	}
+	if finalizePayload["manual_rent_refund_amount"] != float64(0) || finalizePayload["manual_rent_refund_reason"] != "no rent refund by agreement" {
+		t.Fatalf("unexpected manual rent refund fields: %+v", finalizePayload)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestForceTerminateLeaseForwardsTerminationDates(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	var forceTerminateParams applease.ForceTerminateLeaseParams
+	engine := newTestEngineWithAllServices(
+		fakeUserRepo{userID: "20000000-0000-0000-0000-000000000001", assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{
+			propertyByLeaseID: map[string]string{
+				"40000000-0000-0000-0000-000000000001": testPropertyID1,
+			},
+		},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
+		fakeTenantQueryRepo{},
+		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		nil,
+		func(deps *handler.APIServerDeps) {
+			deps.Leases.ForceTerminateLease = applease.NewForceTerminateLeaseService(fakeLeaseRepo{forceTerminateParams: &forceTerminateParams}, dbtxrunner.New(db, nil))
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/leases/40000000-0000-0000-0000-000000000001/force-terminate", strings.NewReader(`{
+		"termination_date":"2026-07-15",
+		"actual_move_out_date":"2026-07-10",
+		"reason":"tenant unreachable",
+		"deposit_handling":"write_off"
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+	if got := forceTerminateParams.TerminationDate.Format("2006-01-02"); got != "2026-07-15" {
+		t.Fatalf("termination date = %q, want 2026-07-15", got)
+	}
+	if forceTerminateParams.ActualMoveOutDate == nil || forceTerminateParams.ActualMoveOutDate.Format("2006-01-02") != "2026-07-10" {
+		t.Fatalf("actual move-out date = %v, want 2026-07-10", forceTerminateParams.ActualMoveOutDate)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestForceTerminateLeaseBadDateUsesSharedAPIErrorShape(t *testing.T) {
+	engine := newTestEngineWithAllServices(
+		fakeUserRepo{assignedPropertyIDs: []string{testPropertyID1}},
+		fakeAuthenticator{assignedPropertyIDs: []string{testPropertyID1}},
+		fakePropertyRepo{},
+		fakeResourceOwnershipRepo{
+			propertyByLeaseID: map[string]string{
+				"40000000-0000-0000-0000-000000000001": testPropertyID1,
+			},
+		},
+		"",
+		fakeJobRunsRepo{},
+		fakePropertyQueryRepo{},
+		fakeLeaseQueryRepo{},
+		fakeTenantQueryRepo{},
+		apptenant.NewCreateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		apptenant.NewUpdateTenantService(fakeTenantRepo{}, dbtxrunner.New(nil, nil)),
+		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+		nil,
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/leases/40000000-0000-0000-0000-000000000001/force-terminate", strings.NewReader(`{
+		"termination_date":"not-a-date",
+		"reason":"tenant unreachable",
+		"deposit_handling":"write_off"
+	}`))
+	req.Header.Set("Authorization", "Bearer valid-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if payload["error_code"] != "BAD_REQUEST" {
+		t.Fatalf("expected BAD_REQUEST, got %v", payload["error_code"])
+	}
+	if _, ok := payload["details"].(map[string]any); !ok {
+		t.Fatalf("expected shared error details object, got %#v", payload["details"])
 	}
 }
 
@@ -4788,9 +5019,16 @@ type fakeLeaseRepo struct {
 	createErr                  error
 	billsErr                   error
 	settlementDetail           map[string]interface{}
+	forceTerminateParams       *applease.ForceTerminateLeaseParams
 	findForceTerminationIDSink *string
 	forceTerminationID         string
 	forceTerminationErr        error
+}
+
+type fakeDepositAccountingRepo struct{}
+
+func (fakeDepositAccountingRepo) CreateDepositAccountingEntry(context.Context, *sql.Tx, applease.DepositAccountingEntryParams) error {
+	return nil
 }
 
 type fakeLeaseQueryRepo struct {
@@ -6051,6 +6289,7 @@ func (f fakeLeaseRepo) TerminateLease(_ context.Context, _ *sql.Tx, params apple
 	}
 	lease.Status = "terminated"
 	lease.EndDate = params.EndDate
+	lease.ActualMoveOutDate = params.ActualMoveOutDate
 	lease.TerminationReason = &params.TerminationReason
 	if params.SettlementDetail != nil {
 		lease.SettlementDetail = &params.SettlementDetail
@@ -6059,11 +6298,16 @@ func (f fakeLeaseRepo) TerminateLease(_ context.Context, _ *sql.Tx, params apple
 }
 
 func (f fakeLeaseRepo) ForceTerminateLease(_ context.Context, _ *sql.Tx, params applease.ForceTerminateLeaseParams) (*applease.Lease, error) {
+	if f.forceTerminateParams != nil {
+		*f.forceTerminateParams = params
+	}
 	lease, err := f.FindLeaseByIDForUpdate(context.Background(), nil, params.LeaseID)
 	if err != nil {
 		return nil, err
 	}
 	lease.Status = "force_terminated"
+	lease.EndDate = params.TerminationDate
+	lease.ActualMoveOutDate = params.ActualMoveOutDate
 	lease.TerminationReason = &params.TerminationReason
 	lease.DepositStatus = params.DepositStatus
 	return lease, nil

--- a/internal/platform/database/billing/repository.go
+++ b/internal/platform/database/billing/repository.go
@@ -585,9 +585,9 @@ SELECT
 	$2,
 	$3,
 	COALESCE(SUM(CASE WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_income,
-	COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_expense,
+	COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'rent_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_expense,
 	COALESCE(SUM(CASE WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount) ELSE 0 END), 0)
-		- COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS net
+		- COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'rent_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS net
 FROM property_accounts pa
 JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL
 LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id
@@ -1415,9 +1415,9 @@ SELECT
 	$2::int AS year,
 	$3::int AS month,
 	COALESCE(SUM(CASE WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_income,
-	COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_expense,
+	COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'rent_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS total_expense,
 	COALESCE(SUM(CASE WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount) ELSE 0 END), 0)
-		- COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS net
+		- COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'rent_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0) AS net
 FROM property_accounts pa
 JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL
 LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id
@@ -1538,7 +1538,7 @@ SELECT
 	$2::int AS year,
 	$3::int AS month,
 	COALESCE(SUM(CASE WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount) ELSE 0 END), 0)::int AS total_income,
-	COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0)::int AS total_expense
+	COALESCE(SUM(CASE WHEN ae.category IN ('deposit_refund', 'rent_refund', 'journal_expense') THEN ABS(ae.amount) ELSE 0 END), 0)::int AS total_expense
 FROM property_accounts pa
 JOIN properties p ON p.id = pa.property_id AND p.deleted_at IS NULL
 LEFT JOIN accounting_entries ae ON ae.property_account_id = pa.id
@@ -2462,6 +2462,7 @@ func profitLossCategoryCodeSQL(categoryExpr string) string {
 		WHEN 'rent_payment' THEN '4603'
 		WHEN 'electricity_payment' THEN '4605'
 		WHEN 'deposit_refund' THEN '4602'
+		WHEN 'rent_refund' THEN '4604'
 		WHEN 'deposit_deduction' THEN '4601'
 		WHEN 'journal_expense' THEN '6681'
 		ELSE NULL
@@ -2473,6 +2474,7 @@ func profitLossCategoryNameSQL(categoryExpr string) string {
 		WHEN 'rent_payment' THEN '租金收入'
 		WHEN 'electricity_payment' THEN '房客電費收入'
 		WHEN 'deposit_refund' THEN '押金退回(減項)'
+		WHEN 'rent_refund' THEN '租金退回(減項)'
 		WHEN 'deposit_deduction' THEN '押金收入(暫收款)'
 		WHEN 'journal_expense' THEN '其他支出'
 		ELSE NULL
@@ -2482,7 +2484,7 @@ func profitLossCategoryNameSQL(categoryExpr string) string {
 func profitLossSignedAmountSQL(categoryExpr string, amountExpr string) string {
 	return `CASE
 		WHEN ` + categoryExpr + ` IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(` + amountExpr + `)
-		WHEN ` + categoryExpr + ` IN ('deposit_refund', 'journal_expense') THEN -ABS(` + amountExpr + `)
+		WHEN ` + categoryExpr + ` IN ('deposit_refund', 'rent_refund', 'journal_expense') THEN -ABS(` + amountExpr + `)
 		ELSE ` + amountExpr + `
 	END`
 }
@@ -3182,7 +3184,7 @@ func addFinancialReportAmount(report *FinancialReport, category string, amount i
 	switch category {
 	case "rent_payment", "electricity_payment", "deposit_deduction":
 		report.TotalIncome += absInt(amount)
-	case "deposit_refund", "journal_expense":
+	case "deposit_refund", "rent_refund", "journal_expense":
 		report.TotalExpense += absInt(amount)
 	}
 }

--- a/internal/platform/database/billing/repository_test.go
+++ b/internal/platform/database/billing/repository_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -821,6 +822,32 @@ func TestGetFinancialReportLiveMapsAccountingEntriesAndAggregatesTotals(t *testi
 	}
 }
 
+func TestFinancialReportAmountTreatsRentRefundAsExpense(t *testing.T) {
+	report := &FinancialReport{}
+
+	addFinancialReportAmount(report, "rent_refund", -5000)
+
+	if report.TotalIncome != 0 || report.TotalExpense != 5000 {
+		t.Fatalf("report totals = income %d expense %d, want 0 5000", report.TotalIncome, report.TotalExpense)
+	}
+}
+
+func TestProfitLossFallbackMapsRentRefundToTitleAndNegativeAmount(t *testing.T) {
+	codeSQL := profitLossCategoryCodeSQL("'rent_refund'")
+	nameSQL := profitLossCategoryNameSQL("'rent_refund'")
+	amountSQL := profitLossSignedAmountSQL("'rent_refund'", "-5000")
+
+	if !strings.Contains(codeSQL, "WHEN 'rent_refund' THEN '4604'") {
+		t.Fatalf("rent_refund title code fallback missing from %s", codeSQL)
+	}
+	if !strings.Contains(nameSQL, "WHEN 'rent_refund' THEN '租金退回(減項)'") {
+		t.Fatalf("rent_refund title name fallback missing from %s", nameSQL)
+	}
+	if !strings.Contains(amountSQL, "'rent_refund'") || !strings.Contains(amountSQL, "THEN -ABS(-5000)") {
+		t.Fatalf("rent_refund negative amount mapping missing from %s", amountSQL)
+	}
+}
+
 func TestGetFinancialReportFinalizedAllowsEmptyEntries(t *testing.T) {
 	db, mock, repo := newBillingRepoTest(t)
 	defer closeBillingDB(t, db)
@@ -1131,10 +1158,11 @@ func TestGetProfitLossPeriodLiveSQLDefinesFixedMappingSignedAmountAndUnsupported
 		"WHEN 'rent_payment' THEN '4603'",
 		"WHEN 'electricity_payment' THEN '4605'",
 		"WHEN 'deposit_refund' THEN '4602'",
+		"WHEN 'rent_refund' THEN '4604'",
 		"WHEN 'deposit_deduction' THEN '4601'",
 		"WHEN 'journal_expense' THEN '6681'",
 		"WHEN ae.category IN ('rent_payment', 'electricity_payment', 'deposit_deduction') THEN ABS(ae.amount)",
-		"WHEN ae.category IN ('deposit_refund', 'journal_expense') THEN -ABS(ae.amount)",
+		"WHEN ae.category IN ('deposit_refund', 'rent_refund', 'journal_expense') THEN -ABS(ae.amount)",
 		"ELSE ae.amount",
 		"WHEN ae.accounting_title_code IS NULL AND CASE ae.category",
 		"THEN '未支援會計分類：' || ae.category",

--- a/internal/platform/database/leasequery/repository.go
+++ b/internal/platform/database/leasequery/repository.go
@@ -25,6 +25,7 @@ type Lease struct {
 	RentAmount                int
 	StartDate                 time.Time
 	EndDate                   time.Time
+	ActualMoveOutDate         *time.Time
 	RentBillingCadence        string
 	ElectricityBillingCadence string
 	StartingMeterReading      *int
@@ -161,6 +162,7 @@ SELECT
 	l.rent_amount,
 	l.start_date,
 	l.end_date,
+	l.actual_move_out_date,
 	l.rent_billing_cadence,
 	l.electricity_billing_cadence,
 	l.starting_meter_reading,
@@ -247,6 +249,7 @@ SELECT
 	l.rent_amount,
 	l.start_date,
 	l.end_date,
+	l.actual_move_out_date,
 	l.rent_billing_cadence,
 	l.electricity_billing_cadence,
 	l.starting_meter_reading,
@@ -419,6 +422,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 	var depositRefundAmount sql.NullInt64
 	var depositDeductionAmount sql.NullInt64
 	var startingMeterReading sql.NullInt64
+	var actualMoveOutDate sql.NullTime
 	var depositDeductionReason sql.NullString
 	var notes sql.NullString
 	var terminationReason sql.NullString
@@ -435,6 +439,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 		&lease.RentAmount,
 		&lease.StartDate,
 		&lease.EndDate,
+		&actualMoveOutDate,
 		&lease.RentBillingCadence,
 		&lease.ElectricityBillingCadence,
 		&startingMeterReading,
@@ -457,6 +462,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 	lease.DepositRefundAmount = nullIntPtr(depositRefundAmount)
 	lease.DepositDeductionAmount = nullIntPtr(depositDeductionAmount)
 	lease.StartingMeterReading = nullIntPtr(startingMeterReading)
+	lease.ActualMoveOutDate = nullTimePtr(actualMoveOutDate)
 	lease.DepositDeductionReason = nullStringPtr(depositDeductionReason)
 	lease.Notes = nullStringPtr(notes)
 	lease.TerminationReason = nullStringPtr(terminationReason)
@@ -534,5 +540,13 @@ func nullIntPtr(value sql.NullInt64) *int {
 		return nil
 	}
 	result := int(value.Int64)
+	return &result
+}
+
+func nullTimePtr(value sql.NullTime) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	result := value.Time
 	return &result
 }

--- a/internal/platform/database/leasequery/repository_test.go
+++ b/internal/platform/database/leasequery/repository_test.go
@@ -28,7 +28,7 @@ WHERE l.deleted_at IS NULL
 	mock.ExpectQuery(`(?s)SELECT.*property_label.*tenant_label.*room_label.*FROM leases l.*WHERE l\.deleted_at IS NULL\s+ORDER BY l\.created_at DESC LIMIT \$1 OFFSET \$2`).
 		WithArgs(10, 20).
 		WillReturnRows(leaseQueryRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate,
+			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate, nil,
 			"monthly", "monthly", nil, "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 		))
 
@@ -173,12 +173,12 @@ func TestListAccessibleScansNullableFieldsAndSettlementDetail(t *testing.T) {
 		WithArgs(10, 0).
 		WillReturnRows(leaseQueryRows().
 			AddRow(
-				"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate,
+				"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate, nil,
 				"monthly", "monthly", nil, "terminated", 24000, 18000, 6000, "refunded", "cleaning",
 				"tenant note", "early termination", `{"refund_method":"bank","deduction":6000}`, now, now, 2,
 			).
 			AddRow(
-				"lease-2", "tenant-2", "property-2", "room-2", "Property 2", "Tenant 2", "Room 2", 15000, startDate, endDate,
+				"lease-2", "tenant-2", "property-2", "room-2", "Property 2", "Tenant 2", "Room 2", 15000, startDate, endDate, nil,
 				"monthly", "bi_monthly", nil, "active", 30000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 			))
 
@@ -323,7 +323,7 @@ func TestFindByIDAccessibleAdminSuccess(t *testing.T) {
 	mock.ExpectQuery(`(?s)SELECT.*property_label.*tenant_label.*room_label.*FROM leases l.*WHERE l\.id = \$1\s+AND l\.deleted_at IS NULL\s+LIMIT 1`).
 		WithArgs("lease-1").
 		WillReturnRows(leaseQueryRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate,
+			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate, nil,
 			"monthly", "monthly", nil, "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 		))
 
@@ -359,7 +359,7 @@ func TestFindByIDAccessibleOrganizerAndStaffApplyAssignedPropertyScope(t *testin
 			mock.ExpectQuery(`(?s)WHERE l\.id = \$1\s+AND l\.deleted_at IS NULL\s+AND l\.property_id IN \(\$2, \$3\)\s+LIMIT 1`).
 				WithArgs("lease-1", "property-1", "property-2").
 				WillReturnRows(leaseQueryRows().AddRow(
-					"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate,
+					"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate, nil,
 					"monthly", "monthly", nil, "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 				))
 
@@ -439,7 +439,7 @@ func TestFindByIDAccessibleInvalidSettlementDetailReturnsError(t *testing.T) {
 	mock.ExpectQuery(`(?s)WHERE l\.id = \$1\s+AND l\.deleted_at IS NULL\s+LIMIT 1`).
 		WithArgs("lease-1").
 		WillReturnRows(leaseQueryRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate,
+			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 12000, startDate, endDate, nil,
 			"monthly", "monthly", nil, "terminated", 24000, nil, nil, "held", nil, nil, nil, `{"broken"`, now, now, 1,
 		))
 
@@ -470,7 +470,7 @@ func TestFindByIDAccessibleScansRentBillingCadence(t *testing.T) {
 	mock.ExpectQuery(`(?s)SELECT.*property_label.*tenant_label.*room_label.*FROM leases l.*WHERE l\.id = \$1\s+AND l\.deleted_at IS NULL\s+LIMIT 1`).
 		WithArgs("lease-1").
 		WillReturnRows(leaseQueryRowsWithRentCadence().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 54000, startDate, endDate,
+			"lease-1", "tenant-1", "property-1", "room-1", "Property 1", "Tenant 1", "Room 1", 54000, startDate, endDate, nil,
 			"quarterly", "monthly", 1250, "active", 24000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 		))
 
@@ -519,6 +519,7 @@ func leaseQueryRows() *sqlmock.Rows {
 		"rent_amount",
 		"start_date",
 		"end_date",
+		"actual_move_out_date",
 		"rent_billing_cadence",
 		"electricity_billing_cadence",
 		"starting_meter_reading",
@@ -549,6 +550,7 @@ func leaseQueryRowsWithRentCadence() *sqlmock.Rows {
 		"rent_amount",
 		"start_date",
 		"end_date",
+		"actual_move_out_date",
 		"rent_billing_cadence",
 		"electricity_billing_cadence",
 		"starting_meter_reading",

--- a/internal/platform/database/leases/repository.go
+++ b/internal/platform/database/leases/repository.go
@@ -55,6 +55,7 @@ type Lease struct {
 	RentAmount                int
 	StartDate                 time.Time
 	EndDate                   time.Time
+	ActualMoveOutDate         *time.Time
 	RentBillingCadence        string
 	ElectricityBillingCadence string
 	StartingMeterReading      *int
@@ -201,6 +202,7 @@ type SettleDepositParams struct {
 type TerminateLeaseParams struct {
 	LeaseID           string
 	EndDate           time.Time
+	ActualMoveOutDate *time.Time
 	TerminationReason string
 	SettlementDetail  map[string]interface{}
 }
@@ -208,6 +210,8 @@ type TerminateLeaseParams struct {
 // ForceTerminateLeaseParams contains fields for forced termination.
 type ForceTerminateLeaseParams struct {
 	LeaseID           string
+	TerminationDate   time.Time
+	ActualMoveOutDate *time.Time
 	TerminationReason string
 	DepositStatus     string
 }
@@ -461,6 +465,7 @@ SELECT
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -511,6 +516,7 @@ SELECT
 	l.rent_amount,
 	l.start_date,
 	l.end_date,
+	l.actual_move_out_date,
 	l.rent_billing_cadence,
 	l.electricity_billing_cadence,
 	l.starting_meter_reading,
@@ -583,6 +589,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -627,6 +634,7 @@ SET status = 'terminated',
 	end_date = $2,
 	termination_reason = $3,
 	settlement_detail = COALESCE($4::jsonb, settlement_detail),
+	actual_move_out_date = COALESCE($5, actual_move_out_date),
 	updated_at = now(),
 	version = version + 1
 WHERE id = $1
@@ -639,6 +647,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -664,7 +673,7 @@ RETURNING
 			return nil, fmt.Errorf("marshal settlement detail: %w", marshalErr)
 		}
 	}
-	lease, err := scanLease(tx.QueryRowContext(ctx, query, params.LeaseID, params.EndDate, params.TerminationReason, nullableJSON(settlementDetail)))
+	lease, err := scanLease(tx.QueryRowContext(ctx, query, params.LeaseID, params.EndDate, params.TerminationReason, nullableJSON(settlementDetail), params.ActualMoveOutDate))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrLeaseNotFound
@@ -679,8 +688,10 @@ func (r *SQLRepository) ForceTerminateLease(ctx context.Context, tx *sql.Tx, par
 	const query = `
 UPDATE leases
 SET status = 'force_terminated',
-	termination_reason = $2,
-	deposit_status = $3,
+	end_date = $2,
+	termination_reason = $3,
+	deposit_status = $4,
+	actual_move_out_date = COALESCE($5, actual_move_out_date),
 	updated_at = now(),
 	version = version + 1
 WHERE id = $1
@@ -693,6 +704,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -710,7 +722,7 @@ RETURNING
 	version
 `
 
-	lease, err := scanLease(tx.QueryRowContext(ctx, query, params.LeaseID, params.TerminationReason, params.DepositStatus))
+	lease, err := scanLease(tx.QueryRowContext(ctx, query, params.LeaseID, params.TerminationDate, params.TerminationReason, params.DepositStatus, params.ActualMoveOutDate))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrLeaseNotFound
@@ -968,6 +980,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -1015,6 +1028,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -1249,6 +1263,7 @@ func scanLeaseWithExtra(row rowScanner, extras ...interface{}) (*Lease, error) {
 	var depositRefundAmount sql.NullInt64
 	var depositDeductionAmount sql.NullInt64
 	var startingMeterReading sql.NullInt64
+	var actualMoveOutDate sql.NullTime
 	var depositDeductionReason sql.NullString
 	var notes sql.NullString
 	var terminationReason sql.NullString
@@ -1262,6 +1277,7 @@ func scanLeaseWithExtra(row rowScanner, extras ...interface{}) (*Lease, error) {
 		&lease.RentAmount,
 		&lease.StartDate,
 		&lease.EndDate,
+		&actualMoveOutDate,
 		&lease.RentBillingCadence,
 		&lease.ElectricityBillingCadence,
 		&startingMeterReading,
@@ -1286,6 +1302,7 @@ func scanLeaseWithExtra(row rowScanner, extras ...interface{}) (*Lease, error) {
 	lease.DepositRefundAmount = nullIntPtr(depositRefundAmount)
 	lease.DepositDeductionAmount = nullIntPtr(depositDeductionAmount)
 	lease.StartingMeterReading = nullIntPtr(startingMeterReading)
+	lease.ActualMoveOutDate = nullTimePtr(actualMoveOutDate)
 	lease.DepositDeductionReason = nullStringPtr(depositDeductionReason)
 	lease.Notes = nullStringPtr(notes)
 	lease.TerminationReason = nullStringPtr(terminationReason)
@@ -1367,6 +1384,14 @@ func nullIntPtr(value sql.NullInt64) *int {
 		return nil
 	}
 	result := int(value.Int64)
+	return &result
+}
+
+func nullTimePtr(value sql.NullTime) *time.Time {
+	if !value.Valid {
+		return nil
+	}
+	result := value.Time
 	return &result
 }
 

--- a/internal/platform/database/leases/repository_test.go
+++ b/internal/platform/database/leases/repository_test.go
@@ -92,6 +92,7 @@ func TestFindLeaseByIDForUpdateScansNullableFieldsAndSettlementDetail(t *testing
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -113,7 +114,7 @@ WHERE id = $1
 FOR UPDATE`)).
 		WithArgs("lease-1").
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", nil,
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, nil, "monthly", "monthly", nil,
 			"terminated", 50000, 30000, 20000, "settled", "cleaning", "renewal candidate",
 			"tenant requested move-out", `{"deductions":[{"type":"cleaning","amount":20000}],"refund":30000}`,
 			now, now, 7,
@@ -182,6 +183,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -199,7 +201,7 @@ RETURNING
 	version`)).
 		WithArgs("tenant-1", "room-1", "property-1", 25000, startDate, endDate, "monthly", "monthly", 1250, 50000, &notes).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", 1250,
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, nil, "monthly", "monthly", 1250,
 			"active", 50000, nil, nil, "held", nil, notes, nil, nil, now, now, 1,
 		))
 
@@ -265,6 +267,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -282,7 +285,7 @@ RETURNING
 	version`)).
 		WithArgs("tenant-1", "room-1", "property-1", 54000, startDate, endDate, "quarterly", "monthly", 1300, 50000, nil).
 		WillReturnRows(newLeaseRowsWithRentCadence().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 54000, startDate, endDate, "quarterly", "monthly", 1300,
+			"lease-1", "tenant-1", "property-1", "room-1", 54000, startDate, endDate, nil, "quarterly", "monthly", 1300,
 			"active", 50000, nil, nil, "held", nil, nil, nil, nil, now, now, 1,
 		))
 
@@ -336,8 +339,10 @@ func TestLeaseReturningCommandsMapNoRowsToNotFound(t *testing.T) {
 		{
 			name: "ForceTerminateLease",
 			run: func(ctx context.Context, repo *SQLRepository, tx *sql.Tx) (*Lease, error) {
+				terminationDate := time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC)
 				return repo.ForceTerminateLease(ctx, tx, ForceTerminateLeaseParams{
 					LeaseID:           "lease-1",
+					TerminationDate:   terminationDate,
 					TerminationReason: "breach",
 					DepositStatus:     "forfeited",
 				})
@@ -404,6 +409,7 @@ SET status = 'terminated',
 	end_date = $2,
 	termination_reason = $3,
 	settlement_detail = COALESCE($4::jsonb, settlement_detail),
+	actual_move_out_date = COALESCE($5, actual_move_out_date),
 	updated_at = now(),
 	version = version + 1
 WHERE id = $1
@@ -416,6 +422,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -431,9 +438,9 @@ RETURNING
 	created_at,
 	updated_at,
 	version`)).
-		WithArgs("lease-1", endDate, "tenant requested", nil).
+		WithArgs("lease-1", endDate, "tenant requested", nil, nil).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", nil,
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, nil, "monthly", "monthly", nil,
 			"terminated", 50000, nil, nil, "held", nil, nil, "tenant requested", nil, now, now, 2,
 		))
 
@@ -477,6 +484,7 @@ SET status = 'terminated',
 	end_date = $2,
 	termination_reason = $3,
 	settlement_detail = COALESCE($4::jsonb, settlement_detail),
+	actual_move_out_date = COALESCE($5, actual_move_out_date),
 	updated_at = now(),
 	version = version + 1
 WHERE id = $1
@@ -489,6 +497,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -504,9 +513,9 @@ RETURNING
 	created_at,
 	updated_at,
 	version`)).
-		WithArgs("lease-1", endDate, "tenant requested", `{"ExportAvailable":true,"LeaseID":"lease-1","NetAmount":45000,"NetDirection":"refund"}`).
+		WithArgs("lease-1", endDate, "tenant requested", `{"ExportAvailable":true,"LeaseID":"lease-1","NetAmount":45000,"NetDirection":"refund"}`, nil).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", nil,
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, nil, "monthly", "monthly", nil,
 			"terminated", 50000, nil, nil, "held", nil, nil, "tenant requested",
 			`{"ExportAvailable":true,"LeaseID":"lease-1","NetAmount":45000,"NetDirection":"refund"}`,
 			now, now, 2,
@@ -531,18 +540,21 @@ RETURNING
 	}
 }
 
-func TestForceTerminateLeaseUpdatesReasonAndDepositStatus(t *testing.T) {
+func TestTerminateLeasePersistsActualMoveOutDateWhenProvided(t *testing.T) {
 	db, mock, repo := newLeaseRepoTest(t)
 	defer closeLeaseDB(t, db)
 	tx := beginLeaseTx(t, db, mock)
 	now := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
 	startDate := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
-	endDate := time.Date(2027, 4, 30, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2026, 9, 30, 0, 0, 0, 0, time.UTC)
+	actualMoveOutDate := time.Date(2026, 9, 25, 0, 0, 0, 0, time.UTC)
 
 	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE leases
-SET status = 'force_terminated',
-	termination_reason = $2,
-	deposit_status = $3,
+SET status = 'terminated',
+	end_date = $2,
+	termination_reason = $3,
+	settlement_detail = COALESCE($4::jsonb, settlement_detail),
+	actual_move_out_date = COALESCE($5, actual_move_out_date),
 	updated_at = now(),
 	version = version + 1
 WHERE id = $1
@@ -555,6 +567,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -570,21 +583,94 @@ RETURNING
 	created_at,
 	updated_at,
 	version`)).
-		WithArgs("lease-1", "breach", "forfeited").
+		WithArgs("lease-1", endDate, "tenant requested", nil, &actualMoveOutDate).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", nil,
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, actualMoveOutDate, "monthly", "monthly", nil,
+			"terminated", 50000, nil, nil, "held", nil, nil, "tenant requested", nil, now, now, 2,
+		))
+
+	lease, err := repo.TerminateLease(context.Background(), tx, TerminateLeaseParams{
+		LeaseID:           "lease-1",
+		EndDate:           endDate,
+		ActualMoveOutDate: &actualMoveOutDate,
+		TerminationReason: "tenant requested",
+	})
+	if err != nil {
+		t.Fatalf("TerminateLease: %v", err)
+	}
+	if lease.ActualMoveOutDate == nil || !lease.ActualMoveOutDate.Equal(actualMoveOutDate) {
+		t.Fatalf("actual move-out date = %v, want %v", lease.ActualMoveOutDate, actualMoveOutDate)
+	}
+
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("ExpectationsWereMet: %v", err)
+	}
+}
+
+func TestForceTerminateLeaseUpdatesReasonAndDepositStatus(t *testing.T) {
+	db, mock, repo := newLeaseRepoTest(t)
+	defer closeLeaseDB(t, db)
+	tx := beginLeaseTx(t, db, mock)
+	now := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	startDate := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	endDate := time.Date(2027, 4, 30, 0, 0, 0, 0, time.UTC)
+	actualMoveOutDate := time.Date(2026, 4, 25, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery(regexp.QuoteMeta(`UPDATE leases
+SET status = 'force_terminated',
+	end_date = $2,
+	termination_reason = $3,
+	deposit_status = $4,
+	actual_move_out_date = COALESCE($5, actual_move_out_date),
+	updated_at = now(),
+	version = version + 1
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING
+	id,
+	tenant_id,
+	property_id,
+	room_id,
+	rent_amount,
+	start_date,
+	end_date,
+	actual_move_out_date,
+	rent_billing_cadence,
+	electricity_billing_cadence,
+	starting_meter_reading,
+	status,
+	deposit_amount,
+	deposit_refund_amount,
+	deposit_deduction_amount,
+	deposit_status,
+	deposit_deduction_reason,
+	notes,
+	termination_reason,
+	settlement_detail::text,
+	created_at,
+	updated_at,
+	version`)).
+		WithArgs("lease-1", endDate, "breach", "forfeited", &actualMoveOutDate).
+		WillReturnRows(newLeaseRows().AddRow(
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, actualMoveOutDate, "monthly", "monthly", nil,
 			"force_terminated", 50000, nil, nil, "forfeited", nil, nil, "breach", nil, now, now, 3,
 		))
 
 	lease, err := repo.ForceTerminateLease(context.Background(), tx, ForceTerminateLeaseParams{
 		LeaseID:           "lease-1",
+		TerminationDate:   endDate,
+		ActualMoveOutDate: &actualMoveOutDate,
 		TerminationReason: "breach",
 		DepositStatus:     "forfeited",
 	})
 	if err != nil {
 		t.Fatalf("ForceTerminateLease: %v", err)
 	}
-	if lease.Status != "force_terminated" || lease.DepositStatus != "forfeited" {
+	if lease.Status != "force_terminated" || lease.DepositStatus != "forfeited" || lease.ActualMoveOutDate == nil || !lease.ActualMoveOutDate.Equal(actualMoveOutDate) {
 		t.Fatalf("unexpected lease: %+v", lease)
 	}
 
@@ -619,6 +705,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -636,7 +723,7 @@ RETURNING
 	version`)).
 		WithArgs("lease-1", 28000).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 28000, startDate, endDate, "monthly", "monthly", nil,
+			"lease-1", "tenant-1", "property-1", "room-1", 28000, startDate, endDate, nil, "monthly", "monthly", nil,
 			"active", 50000, nil, nil, "held", nil, nil, nil, nil, now, now, 4,
 		))
 
@@ -686,6 +773,7 @@ RETURNING
 	rent_amount,
 	start_date,
 	end_date,
+	actual_move_out_date,
 	rent_billing_cadence,
 	electricity_billing_cadence,
 	starting_meter_reading,
@@ -703,7 +791,7 @@ RETURNING
 	version`)).
 		WithArgs("lease-1", 30000, 20000, reason).
 		WillReturnRows(newLeaseRows().AddRow(
-			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, "monthly", "monthly", nil,
+			"lease-1", "tenant-1", "property-1", "room-1", 25000, startDate, endDate, nil, "monthly", "monthly", nil,
 			"terminated", 50000, 30000, 20000, "settled", reason, nil, nil, nil, now, now, 5,
 		))
 
@@ -1207,6 +1295,7 @@ func newLeaseRows() *sqlmock.Rows {
 		"rent_amount",
 		"start_date",
 		"end_date",
+		"actual_move_out_date",
 		"rent_billing_cadence",
 		"electricity_billing_cadence",
 		"starting_meter_reading",
@@ -1234,6 +1323,7 @@ func newLeaseRowsWithRentCadence() *sqlmock.Rows {
 		"rent_amount",
 		"start_date",
 		"end_date",
+		"actual_move_out_date",
 		"rent_billing_cadence",
 		"electricity_billing_cadence",
 		"starting_meter_reading",

--- a/internal/platform/database/migrate/migrations/000020_checkout_dates_and_rent_refund.down.sql
+++ b/internal/platform/database/migrate/migrations/000020_checkout_dates_and_rent_refund.down.sql
@@ -1,0 +1,10 @@
+ALTER TABLE leases
+    DROP COLUMN IF EXISTS actual_move_out_date;
+
+ALTER TABLE accounting_entries
+    DROP CONSTRAINT IF EXISTS accounting_entries_category_check,
+    ADD CONSTRAINT accounting_entries_category_check CHECK (category IN ('rent_payment', 'electricity_payment', 'deposit_refund', 'deposit_deduction', 'journal_expense'));
+
+ALTER TABLE monthly_snapshot_entries
+    DROP CONSTRAINT IF EXISTS monthly_snapshot_entries_category_check,
+    ADD CONSTRAINT monthly_snapshot_entries_category_check CHECK (category IN ('rent_payment', 'electricity_payment', 'deposit_refund', 'deposit_deduction', 'journal_expense'));

--- a/internal/platform/database/migrate/migrations/000020_checkout_dates_and_rent_refund.up.sql
+++ b/internal/platform/database/migrate/migrations/000020_checkout_dates_and_rent_refund.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE leases
+    ADD COLUMN IF NOT EXISTS actual_move_out_date DATE;
+
+ALTER TABLE accounting_entries
+    DROP CONSTRAINT IF EXISTS accounting_entries_category_check,
+    ADD CONSTRAINT accounting_entries_category_check CHECK (category IN ('rent_payment', 'electricity_payment', 'deposit_refund', 'deposit_deduction', 'journal_expense', 'rent_refund'));
+
+ALTER TABLE monthly_snapshot_entries
+    DROP CONSTRAINT IF EXISTS monthly_snapshot_entries_category_check,
+    ADD CONSTRAINT monthly_snapshot_entries_category_check CHECK (category IN ('rent_payment', 'electricity_payment', 'deposit_refund', 'deposit_deduction', 'journal_expense', 'rent_refund'));

--- a/internal/platform/database/migrate/runner_test.go
+++ b/internal/platform/database/migrate/runner_test.go
@@ -81,8 +81,8 @@ func TestRunnerDownRollsBackAppliedMigrationsInDescendingOrder(t *testing.T) {
 	defer db.Close()
 
 	migrations := migrationsByVersion(t, "down")
-	appliedVersions := []string{"000012", "000013", "000014", "000015", "000016", "000017", "000018", "000019"}
-	expectedRollbackOrder := []string{"000019", "000018", "000017", "000016", "000015", "000014", "000013", "000012"}
+	appliedVersions := []string{"000012", "000013", "000014", "000015", "000016", "000017", "000018", "000019", "000020"}
+	expectedRollbackOrder := []string{"000020", "000019", "000018", "000017", "000016", "000015", "000014", "000013", "000012"}
 
 	expectSchemaMigrationsQuery(mock, appliedVersions)
 	for _, version := range expectedRollbackOrder {

--- a/internal/platform/database/migrate/runner_test.go
+++ b/internal/platform/database/migrate/runner_test.go
@@ -35,6 +35,7 @@ var expectedMigrationVersions = []string{
 	"000017",
 	"000018",
 	"000019",
+	"000020",
 }
 
 func TestRunnerUpAppliesMigrationsAndRecordsVersions(t *testing.T) {
@@ -187,6 +188,40 @@ func TestAccountingEntryDisplayFieldsMigrationAddsNullableFields(t *testing.T) {
 		if !strings.Contains(downSQL, snippet) {
 			t.Fatalf("000017 down migration missing %q", snippet)
 		}
+	}
+}
+
+func TestCheckoutDatesAndRentRefundMigrationAddsNullableColumnAndCategories(t *testing.T) {
+	migrations := migrationsByVersion(t, "up")
+	sql := migrations["000020"].SQL
+
+	requiredSnippets := []string{
+		"ALTER TABLE leases",
+		"ADD COLUMN IF NOT EXISTS actual_move_out_date DATE",
+		"accounting_entries_category_check",
+		"monthly_snapshot_entries_category_check",
+		"'rent_refund'",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(sql, snippet) {
+			t.Fatalf("000020 migration missing %q", snippet)
+		}
+	}
+	forbiddenSnippets := []string{
+		"UPDATE leases",
+		"COALESCE",
+		"end_date",
+		"checkout_date",
+	}
+	for _, snippet := range forbiddenSnippets {
+		if strings.Contains(sql, snippet) {
+			t.Fatalf("000020 migration should not backfill actual_move_out_date using %q", snippet)
+		}
+	}
+
+	downSQL := migrationsByVersion(t, "down")["000020"].SQL
+	if !strings.Contains(downSQL, "DROP COLUMN IF EXISTS actual_move_out_date") {
+		t.Fatal("000020 down migration missing actual_move_out_date drop")
 	}
 }
 

--- a/internal/platform/database/tenantquery/repository.go
+++ b/internal/platform/database/tenantquery/repository.go
@@ -45,6 +45,7 @@ type Lease struct {
 	RentAmount                int
 	StartDate                 time.Time
 	EndDate                   time.Time
+	ActualMoveOutDate         *time.Time
 	RentBillingCadence        string
 	ElectricityBillingCadence string
 	StartingMeterReading      *int
@@ -261,6 +262,7 @@ SELECT
 	l.rent_amount,
 	l.start_date,
 	l.end_date,
+	l.actual_move_out_date,
 	l.rent_billing_cadence,
 	l.electricity_billing_cadence,
 	l.starting_meter_reading,
@@ -380,6 +382,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 	var depositRefundAmount sql.NullInt64
 	var depositDeductionAmount sql.NullInt64
 	var startingMeterReading sql.NullInt64
+	var actualMoveOutDate sql.NullTime
 	var depositDeductionReason sql.NullString
 	var notes sql.NullString
 	var terminationReason sql.NullString
@@ -393,6 +396,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 		&lease.RentAmount,
 		&lease.StartDate,
 		&lease.EndDate,
+		&actualMoveOutDate,
 		&lease.RentBillingCadence,
 		&lease.ElectricityBillingCadence,
 		&startingMeterReading,
@@ -415,6 +419,7 @@ func scanLease(row rowScanner) (*Lease, error) {
 	lease.DepositRefundAmount = nullIntPtr(depositRefundAmount)
 	lease.DepositDeductionAmount = nullIntPtr(depositDeductionAmount)
 	lease.StartingMeterReading = nullIntPtr(startingMeterReading)
+	lease.ActualMoveOutDate = nullTimePtr(actualMoveOutDate)
 	lease.DepositDeductionReason = nullStringPtr(depositDeductionReason)
 	lease.Notes = nullStringPtr(notes)
 	lease.TerminationReason = nullStringPtr(terminationReason)

--- a/internal/platform/database/tenantquery/repository_test.go
+++ b/internal/platform/database/tenantquery/repository_test.go
@@ -199,6 +199,7 @@ LIMIT 1`)).
 	l.rent_amount,
 	l.start_date,
 	l.end_date,
+	l.actual_move_out_date,
 	l.rent_billing_cadence,
 	l.electricity_billing_cadence,
 	l.starting_meter_reading,
@@ -222,7 +223,7 @@ WHERE l.tenant_id = $1
 ORDER BY l.created_at DESC`)).
 		WithArgs("30000000-0000-0000-0000-000000000001", "10000000-0000-0000-0000-000000000001", "active").
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "tenant_id", "property_id", "room_id", "rent_amount", "start_date", "end_date", "rent_billing_cadence", "electricity_billing_cadence", "starting_meter_reading", "status", "deposit_amount", "deposit_refund_amount", "deposit_deduction_amount", "deposit_status", "deposit_deduction_reason", "notes", "termination_reason", "settlement_detail", "created_at", "updated_at", "version",
+			"id", "tenant_id", "property_id", "room_id", "rent_amount", "start_date", "end_date", "actual_move_out_date", "rent_billing_cadence", "electricity_billing_cadence", "starting_meter_reading", "status", "deposit_amount", "deposit_refund_amount", "deposit_deduction_amount", "deposit_status", "deposit_deduction_reason", "notes", "termination_reason", "settlement_detail", "created_at", "updated_at", "version",
 		}).AddRow(
 			"40000000-0000-0000-0000-000000000001",
 			"30000000-0000-0000-0000-000000000001",
@@ -231,6 +232,7 @@ ORDER BY l.created_at DESC`)).
 			12000,
 			startDate,
 			endDate,
+			nil,
 			"quarterly",
 			"monthly",
 			1250,

--- a/internal/server/lease_adapters.go
+++ b/internal/server/lease_adapters.go
@@ -147,6 +147,7 @@ func (a leaseRepositoryAdapter) TerminateLease(ctx context.Context, tx *sql.Tx, 
 	lease, err := a.repo.TerminateLease(ctx, tx, dbleases.TerminateLeaseParams{
 		LeaseID:           params.LeaseID,
 		EndDate:           params.EndDate,
+		ActualMoveOutDate: params.ActualMoveOutDate,
 		TerminationReason: params.TerminationReason,
 		SettlementDetail:  params.SettlementDetail,
 	})
@@ -165,6 +166,8 @@ func (a leaseRepositoryAdapter) TerminateLease(ctx context.Context, tx *sql.Tx, 
 func (a leaseRepositoryAdapter) ForceTerminateLease(ctx context.Context, tx *sql.Tx, params applease.ForceTerminateLeaseParams) (*applease.Lease, error) {
 	lease, err := a.repo.ForceTerminateLease(ctx, tx, dbleases.ForceTerminateLeaseParams{
 		LeaseID:           params.LeaseID,
+		TerminationDate:   params.TerminationDate,
+		ActualMoveOutDate: params.ActualMoveOutDate,
 		TerminationReason: params.TerminationReason,
 		DepositStatus:     params.DepositStatus,
 	})
@@ -382,6 +385,7 @@ func toApplicationLease(lease *dbleases.Lease) *applease.Lease {
 		RentAmount:                lease.RentAmount,
 		StartDate:                 lease.StartDate,
 		EndDate:                   lease.EndDate,
+		ActualMoveOutDate:        lease.ActualMoveOutDate,
 		RentBillingCadence:        lease.RentBillingCadence,
 		ElectricityBillingCadence: lease.ElectricityBillingCadence,
 		StartingMeterReading:      lease.StartingMeterReading,

--- a/test/e2e/checkout_settlement_acceptance_test.go
+++ b/test/e2e/checkout_settlement_acceptance_test.go
@@ -54,7 +54,8 @@ func TestE2ELeaseCheckoutSettlementAcceptance(t *testing.T) {
 	if preview.NetDirection != "refund" || preview.NetAmount != 33000 {
 		t.Fatalf("unexpected preview net result: %+v", preview)
 	}
-	if preview.ActualMoveOutDate != "2026-08-20" || preview.ManualRentRefundAmount != 0 || preview.ManualRentRefundReason == nil {
+	expectedManualReason := "no rent refund for e2e normal checkout"
+	if preview.ActualMoveOutDate != "2026-08-20" || preview.ManualRentRefundAmount != 0 || preview.ManualRentRefundReason == nil || *preview.ManualRentRefundReason != expectedManualReason {
 		t.Fatalf("unexpected checkout date/refund contract fields: %+v", preview)
 	}
 
@@ -68,7 +69,7 @@ func TestE2ELeaseCheckoutSettlementAcceptance(t *testing.T) {
 	if finalized.FinalizedAt == nil {
 		t.Fatalf("expected finalized_at: %+v", finalized)
 	}
-	if finalized.ActualMoveOutDate != "2026-08-20" || finalized.ManualRentRefundAmount != 0 || finalized.ManualRentRefundReason == nil {
+	if finalized.ActualMoveOutDate != "2026-08-20" || finalized.ManualRentRefundAmount != 0 || finalized.ManualRentRefundReason == nil || *finalized.ManualRentRefundReason != expectedManualReason {
 		t.Fatalf("unexpected finalized checkout date/refund contract fields: %+v", finalized)
 	}
 

--- a/test/e2e/checkout_settlement_acceptance_test.go
+++ b/test/e2e/checkout_settlement_acceptance_test.go
@@ -54,6 +54,9 @@ func TestE2ELeaseCheckoutSettlementAcceptance(t *testing.T) {
 	if preview.NetDirection != "refund" || preview.NetAmount != 33000 {
 		t.Fatalf("unexpected preview net result: %+v", preview)
 	}
+	if preview.ActualMoveOutDate != "2026-08-20" || preview.ManualRentRefundAmount != 0 || preview.ManualRentRefundReason == nil {
+		t.Fatalf("unexpected checkout date/refund contract fields: %+v", preview)
+	}
 
 	finalized := checkoutE2EFinalize(t, ctx, adminClient, lease.ID, *preview.PreviewToken)
 	if finalized.PreviewToken != nil {
@@ -64,6 +67,9 @@ func TestE2ELeaseCheckoutSettlementAcceptance(t *testing.T) {
 	}
 	if finalized.FinalizedAt == nil {
 		t.Fatalf("expected finalized_at: %+v", finalized)
+	}
+	if finalized.ActualMoveOutDate != "2026-08-20" || finalized.ManualRentRefundAmount != 0 || finalized.ManualRentRefundReason == nil {
+		t.Fatalf("unexpected finalized checkout date/refund contract fields: %+v", finalized)
 	}
 
 	reviews := checkoutE2EListReviews(t, ctx, adminClient, property.ID)
@@ -102,16 +108,19 @@ func TestE2ELeaseCheckoutSettlementAcceptance(t *testing.T) {
 }
 
 type checkoutE2ESettlementResponse struct {
-	LeaseID         string                      `json:"lease_id"`
-	PreviewToken    *string                     `json:"preview_token"`
-	Blockers        []checkoutE2EBlocker        `json:"blockers"`
-	Lines           []checkoutE2ESettlementLine `json:"lines"`
-	TotalRefund     int                         `json:"total_refund"`
-	TotalCharge     int                         `json:"total_charge"`
-	NetAmount       int                         `json:"net_amount"`
-	NetDirection    string                      `json:"net_direction"`
-	ExportAvailable bool                        `json:"export_available"`
-	FinalizedAt     *string                     `json:"finalized_at"`
+	LeaseID                string                      `json:"lease_id"`
+	ActualMoveOutDate      string                      `json:"actual_move_out_date"`
+	ManualRentRefundAmount int                         `json:"manual_rent_refund_amount"`
+	ManualRentRefundReason *string                     `json:"manual_rent_refund_reason"`
+	PreviewToken           *string                     `json:"preview_token"`
+	Blockers               []checkoutE2EBlocker        `json:"blockers"`
+	Lines                  []checkoutE2ESettlementLine `json:"lines"`
+	TotalRefund            int                         `json:"total_refund"`
+	TotalCharge            int                         `json:"total_charge"`
+	NetAmount              int                         `json:"net_amount"`
+	NetDirection           string                      `json:"net_direction"`
+	ExportAvailable        bool                        `json:"export_available"`
+	FinalizedAt            *string                     `json:"finalized_at"`
 }
 
 type checkoutE2EBlocker struct {
@@ -207,13 +216,16 @@ func checkoutE2EListReviews(t *testing.T, ctx context.Context, client apiClient,
 
 func checkoutE2ERequest(previewToken string) map[string]any {
 	request := map[string]any{
-		"checkout_date":       "2026-08-31",
-		"reason":              "E2E normal checkout",
-		"cleaning_fee":        3000,
-		"key_card_loss_fee":   0,
-		"other_fee":           0,
-		"final_meter_reading": 120,
-		"notes":               "E2E checkout settlement",
+		"checkout_date":             "2026-08-31",
+		"actual_move_out_date":      "2026-08-20",
+		"reason":                    "E2E normal checkout",
+		"cleaning_fee":              3000,
+		"key_card_loss_fee":         0,
+		"other_fee":                 0,
+		"manual_rent_refund_amount": 0,
+		"manual_rent_refund_reason": "no rent refund for e2e normal checkout",
+		"final_meter_reading":       120,
+		"notes":                     "E2E checkout settlement",
 	}
 	if previewToken != "" {
 		request["preview_token"] = previewToken

--- a/test/e2e/lease_termination_acceptance_test.go
+++ b/test/e2e/lease_termination_acceptance_test.go
@@ -73,8 +73,10 @@ func TestE2ELeaseTerminationAcceptance(t *testing.T) {
 		}
 
 		resp, body, err := adminClient.postJSON(ctx, "/api/v1/leases/"+fixture.Lease.ID+"/force-terminate", map[string]any{
-			"reason":           "E2E forced termination for unpaid bills",
-			"deposit_handling": "write_off",
+			"termination_date":     "2026-07-15",
+			"actual_move_out_date": "2026-07-10",
+			"reason":               "E2E forced termination for unpaid bills",
+			"deposit_handling":     "write_off",
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -130,6 +132,9 @@ func TestE2ELeaseTerminationAcceptance(t *testing.T) {
 		if readBack.Status != "force_terminated" {
 			t.Fatalf("expected lease status %q, got %q", "force_terminated", readBack.Status)
 		}
+		if readBack.EndDate != "2026-07-15" || readBack.ActualMoveOutDate == nil || *readBack.ActualMoveOutDate != "2026-07-10" {
+			t.Fatalf("unexpected force termination lifecycle dates: %+v", readBack)
+		}
 		if readBack.DepositStatus != "written_off" {
 			t.Fatalf("expected lease deposit_status %q, got %q", "written_off", readBack.DepositStatus)
 		}
@@ -178,18 +183,19 @@ type terminationE2ELeaseFixture struct {
 }
 
 type terminationE2ELeaseResponse struct {
-	ID                        string `json:"id"`
-	TenantID                  string `json:"tenant_id"`
-	RoomID                    string `json:"room_id"`
-	PropertyID                string `json:"property_id"`
-	RentAmount                int    `json:"rent_amount"`
-	StartDate                 string `json:"start_date"`
-	EndDate                   string `json:"end_date"`
-	ElectricityBillingCadence string `json:"electricity_billing_cadence"`
-	StartingMeterReading      *int   `json:"starting_meter_reading"`
-	Status                    string `json:"status"`
-	DepositAmount             int    `json:"deposit_amount"`
-	DepositStatus             string `json:"deposit_status"`
+	ID                        string  `json:"id"`
+	TenantID                  string  `json:"tenant_id"`
+	RoomID                    string  `json:"room_id"`
+	PropertyID                string  `json:"property_id"`
+	RentAmount                int     `json:"rent_amount"`
+	StartDate                 string  `json:"start_date"`
+	EndDate                   string  `json:"end_date"`
+	ActualMoveOutDate         *string `json:"actual_move_out_date"`
+	ElectricityBillingCadence string  `json:"electricity_billing_cadence"`
+	StartingMeterReading      *int    `json:"starting_meter_reading"`
+	Status                    string  `json:"status"`
+	DepositAmount             int     `json:"deposit_amount"`
+	DepositStatus             string  `json:"deposit_status"`
 }
 
 type terminationE2EForceTerminationResponse struct {


### PR DESCRIPTION
Closes #170

## Summary
- Clarify checkout_date as settlement effective / lease termination date and add actual_move_out_date as nullable operational metadata.
- Add manual rent refund amount/reason contract, settlement line, accounting entry, report/cashflow mappings, and checkout export/readback support.
- Add force termination termination_date plus optional actual_move_out_date while keeping replacement semantics unchanged.
- Add migration support for lease actual_move_out_date and rent_refund accounting categories.

## Validation
- npm run openapi:generate
- npm run openapi:lint
- GOCACHE=/tmp/go-cache go test ./internal/application/lease -count=1
- GOCACHE=/tmp/go-cache go test ./internal/http/router -count=1
- GOCACHE=/tmp/go-cache go test ./internal/platform/database/leases ./internal/platform/database/leasequery ./internal/platform/database/tenantquery ./internal/platform/database/billing ./internal/platform/database/migrate -count=1
- GOCACHE=/tmp/go-cache go test ./internal/application/billing ./internal/server -count=1
- GOCACHE=/tmp/go-cache go test -tags=e2e ./test/e2e -run '^$'
- GOCACHE=/tmp/go-cache go test ./...
- GOCACHE=/tmp/go-cache ./scripts/e2e_test.sh -run 'TestE2ELeaseCheckoutSettlementAcceptance|TestE2ELeaseTerminationAcceptance' -count=1
- GOCACHE=/tmp/go-cache ./scripts/e2e_test.sh -count=1
- git diff --check