### PR TITLE
[codex] Add force termination deposit accounting

### DIFF
--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -187,7 +187,7 @@ Lease 於建立時也決定 `electricityBillingCadence`（`monthly | bimonthly`�
 
 - **Root Entity**：PropertyAccount（一個物業一個）
 - **包含**：當月未結算的 AccountingEntry entities
-  - 來源：Bill payment command 直接寫入；Journal expense command 直接寫入並保留 `JournalExpenseRecorded` 作 trace/reserved event；DepositRefunded / DepositDeducted 由押金處理 command 直接寫入
+  - 來源：Bill payment command 直接寫入；Journal expense command 直接寫入並保留 `JournalExpenseRecorded` 作 trace/reserved event；DepositRefunded / DepositDeducted 由押金處理 command 直接寫入；強制終止 `deposit_handling=write_off` 由 force termination command 直接以 `deposit_deduction` 寫入全額押金沒收分錄
   - `category: rent_payment | electricity_payment | deposit_refund | deposit_deduction | journal_expense`（財報分類用）
   - `accounting_title_id` / `accounting_title_code` / `accounting_title_name`：穩定會計科目維度；`accounting_titles` 是 runtime master data，`category` 仍是既有財報 total classification，不以 `accounting_titles.kind` 取代收入/支出計算
   - `source_date` / `room_label` / `tenant_label` / `period_label` / `display_note`：報表列顯示事實；`source_date` 是顯示日期，不是新的 occurred-at domain model；labels/notes 由建立分錄當下保存
@@ -298,7 +298,7 @@ Lease 於建立時也決定 `electricityBillingCadence`（`monthly | bimonthly`�
 | BR-11 | 物業指派對象必須為工作室成員 | 指派對象角色為業主 | 拒絕指派 | 無 |
 | BR-12 | 建立租約時目標房間必須為 vacant，且需取得 Room 的悲觀鎖後才執行檢查 | 建立租約時 | 拒絕建立 | 無 |
 | BR-13 | 系統管理員不得降低自己的角色 | 修改自身角色時 | 拒絕操作 | 無 |
-| BR-14 | 強制終止租約需主辦以上角色執行並填寫原因 | 執行強制終止時 | 員工角色拒絕執行 | 無 |
+| BR-14 | 強制終止租約需主辦以上角色執行並填寫原因；`deposit_handling=write_off` 代表全額押金沒收，backend 必須在同一交易中以 `deposit_deduction` / accounting title `4601` 建立押金收入分錄，`source_ref` 保存 `type=ForceTerminationDepositWrittenOff`、`lease_id`、`force_termination_id`、`reason`；`keep_held` 不建立押金 accounting entry | 執行強制終止時 | 員工角色拒絕執行；write_off 任一核心寫入或押金 accounting 失敗則整筆 rollback | 歷史已強制終止且押金 written_off 的 backfill 另案處理，不在 runtime 行為變更內 |
 | BR-15 | 租金付款日固定為 rent billing period 的 `periodStart`；rent period 以租約起始日為 anchor，依 `rentBillingCadence` 前進 1 / 3 / 6 / 12 個月 | 租金帳單預產或租金調整重產時 | 自動計算，無需拒絕 | 最後短 rent period 仍收完整 period rent，不做 proration |
 | BR-16 | 電費帳單金額由系統計算：usage = currentReading - previousReading，rawAmount = usage × MeterReading.unitPrice，amount = round(rawAmount)；不由員工輸入金額 | 抄表送出時 | 系統自動計算並四捨五入為整數，拒絕員工直接輸入金額 | 無 |
 | BR-17 | 修改物業電價（electricityUnitPrice）需主辦以上角色，且電價僅接受大於 0 的數值，可接受小數 | 修改電價時 | 員工角色拒絕；零與負數拒絕 | 無 |

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -3369,8 +3369,9 @@ paths:
       summary: 強制終止租約（觸發 LeaseTerminated event，forced=true）
       description: |
         x-required-role: admin, organizer（BR-14：主辦以上）
-        流程：ForceTermination 記錄 → 未結清帳單同步標記 written_off → ForceTermination 標記 completed → LeaseTerminated（forced: true）
+        流程：ForceTermination 記錄 → 未結清帳單同步標記 written_off → ForceTermination 標記 completed → 若 deposit_handling=write_off，將全額押金以 deposit_deduction/4601 建立 accounting entry → LeaseTerminated（forced: true）
         強制終止完成後觸發 LeaseTerminated（forced: true）；Room/Tenant 後置處理由已確認的 runtime subscriber 執行。
+        deposit_handling=write_off 代表全額押金沒收，會進入既有押金扣款收入分類； deposit_handling=keep_held 不建立押金 accounting entry，押金仍保留待後續人工處理。
         BR-14：需主辦以上角色並填寫原因。
       tags:
         - Leasing
@@ -8466,7 +8467,7 @@ components:
           minLength: 1
         deposit_handling:
           type: string
-          description: Deposit handling decision during force termination; write_off marks the deposit as written_off, while keep_held leaves it held for later manual handling.
+          description: Deposit handling decision during force termination; write_off marks the deposit as written_off and records the full deposit amount as deposit_deduction accounting, while keep_held leaves it held for later manual handling without creating a deposit accounting entry.
           enum:
             - write_off
             - keep_held

--- a/docs/spec/src/components/schemas/tenancy/ForceTerminateRequest.yaml
+++ b/docs/spec/src/components/schemas/tenancy/ForceTerminateRequest.yaml
@@ -18,7 +18,7 @@ properties:
     minLength: 1
   deposit_handling:
     type: string
-    description: Deposit handling decision during force termination; write_off marks the deposit as written_off, while keep_held leaves it held for later manual handling.
+    description: Deposit handling decision during force termination; write_off marks the deposit as written_off and records the full deposit amount as deposit_deduction accounting, while keep_held leaves it held for later manual handling without creating a deposit accounting entry.
     enum:
       - write_off
       - keep_held

--- a/docs/spec/src/paths/tenancy/leases_{id}_force-terminate.yaml
+++ b/docs/spec/src/paths/tenancy/leases_{id}_force-terminate.yaml
@@ -5,9 +5,13 @@ post:
     x-required-role: admin, organizer（BR-14：主辦以上）
 
     流程：ForceTermination 記錄 → 未結清帳單同步標記 written_off → ForceTermination
-    標記 completed → LeaseTerminated（forced: true）
+    標記 completed → 若 deposit_handling=write_off，將全額押金以 deposit_deduction/4601
+    建立 accounting entry → LeaseTerminated（forced: true）
 
     強制終止完成後觸發 LeaseTerminated（forced: true）；Room/Tenant 後置處理由已確認的 runtime subscriber 執行。
+
+    deposit_handling=write_off 代表全額押金沒收，會進入既有押金扣款收入分類；
+    deposit_handling=keep_held 不建立押金 accounting entry，押金仍保留待後續人工處理。
 
     BR-14：需主辦以上角色並填寫原因。
   tags:

--- a/internal/application/lease/terminate_lease.go
+++ b/internal/application/lease/terminate_lease.go
@@ -174,13 +174,14 @@ type ForceTerminateLeaseInput struct {
 
 // ForceTerminateLeaseService force-terminates a lease and tracks bill write-off progress.
 type ForceTerminateLeaseService struct {
-	repo     Repository
-	txRunner *txrunner.Runner
+	repo           Repository
+	accountingRepo DepositAccountingRepository
+	txRunner       *txrunner.Runner
 }
 
 // NewForceTerminateLeaseService returns a ForceTerminateLeaseService.
-func NewForceTerminateLeaseService(repo Repository, txRunner *txrunner.Runner) *ForceTerminateLeaseService {
-	return &ForceTerminateLeaseService{repo: repo, txRunner: txRunner}
+func NewForceTerminateLeaseService(repo Repository, accountingRepo DepositAccountingRepository, txRunner *txrunner.Runner) *ForceTerminateLeaseService {
+	return &ForceTerminateLeaseService{repo: repo, accountingRepo: accountingRepo, txRunner: txRunner}
 }
 
 // Execute enforces BR-14, writes off unpaid bills, and records LeaseTerminated.
@@ -297,6 +298,11 @@ func (s *ForceTerminateLeaseService) Execute(ctx context.Context, input ForceTer
 		if err := s.repo.CompleteForceTermination(ctx, tx, created.ID); err != nil {
 			return apperr.ErrInternalServerError.WithCause(err)
 		}
+		if depositHandling == domainlease.ForceTerminationDepositWriteOff {
+			if err := recordForceTerminationDepositWriteOffAccountingEntry(ctx, tx, s.accountingRepo, terminatedLease, created.ID, reason, terminationDate); err != nil {
+				return err
+			}
+		}
 
 		detail, err := s.repo.FindForceTerminationByID(ctx, tx, created.ID)
 		if err != nil {
@@ -321,6 +327,41 @@ func (s *ForceTerminateLeaseService) Execute(ctx context.Context, input ForceTer
 	}
 
 	return forceTermination, nil
+}
+
+func recordForceTerminationDepositWriteOffAccountingEntry(ctx context.Context, tx *sql.Tx, repo DepositAccountingRepository, lease *Lease, forceTerminationID string, reason string, sourceDate time.Time) error {
+	if lease.DepositAmount == 0 {
+		return nil
+	}
+	if repo == nil {
+		return apperr.ErrInternalServerError.WithDetails(map[string]interface{}{"dependency": "deposit_accounting"})
+	}
+
+	accountingSourceDate := depositAccountingSourceDate(sourceDate)
+	description := "強制終止押金沒收"
+	if reason != "" {
+		description = description + "：" + reason
+	}
+	if err := repo.CreateDepositAccountingEntry(ctx, tx, DepositAccountingEntryParams{
+		PropertyID:          lease.PropertyID,
+		Category:            depositAccountingCategoryDeduction,
+		AccountingTitleCode: depositAccountingTitleCodeDeduction,
+		Amount:              lease.DepositAmount,
+		Description:         &description,
+		SourceRef: map[string]interface{}{
+			"type":                 "ForceTerminationDepositWrittenOff",
+			"lease_id":             lease.ID,
+			"force_termination_id": forceTerminationID,
+			"reason":               reason,
+		},
+		Year:        accountingSourceDate.Year(),
+		Month:       int(accountingSourceDate.Month()),
+		SourceDate:  &accountingSourceDate,
+		DisplayNote: &description,
+	}); err != nil {
+		return mapDepositAccountingError(err)
+	}
+	return nil
 }
 
 // GetForceTerminationInput is the query payload for force-termination detail.

--- a/internal/application/lease/terminate_lease_test.go
+++ b/internal/application/lease/terminate_lease_test.go
@@ -172,7 +172,8 @@ func TestForceTerminateLeaseServiceWritesOffBillsAndPublishesEvent(t *testing.T)
 		PeriodStart: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
 		PeriodEnd:   time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
 	})
-	service := NewForceTerminateLeaseService(repo, dbtxrunner.New(db, publisher))
+	accountingRepo := &depositAccountingRepositoryStub{}
+	service := NewForceTerminateLeaseService(repo, accountingRepo, dbtxrunner.New(db, publisher))
 
 	result, err := service.Execute(context.Background(), ForceTerminateLeaseInput{
 		ActorRole:           "organizer",
@@ -209,6 +210,22 @@ func TestForceTerminateLeaseServiceWritesOffBillsAndPublishesEvent(t *testing.T)
 	if repo.lease.DepositStatus != "written_off" {
 		t.Fatalf("deposit status = %q, want written_off", repo.lease.DepositStatus)
 	}
+	if len(accountingRepo.entries) != 1 {
+		t.Fatalf("accounting entries = %d, want 1", len(accountingRepo.entries))
+	}
+	entry := accountingRepo.entries[0]
+	if entry.Category != depositAccountingCategoryDeduction || entry.AccountingTitleCode != depositAccountingTitleCodeDeduction || entry.Amount != 20000 {
+		t.Fatalf("deposit write-off accounting entry = %+v", entry)
+	}
+	if entry.SourceRef["type"] != "ForceTerminationDepositWrittenOff" || entry.SourceRef["lease_id"] != terminateLeaseTestLeaseID || entry.SourceRef["force_termination_id"] != "80000000-0000-0000-0000-000000000001" || entry.SourceRef["reason"] != "tenant unreachable" {
+		t.Fatalf("deposit write-off source_ref = %+v", entry.SourceRef)
+	}
+	if entry.SourceDate == nil || entry.SourceDate.Year() != 2026 || entry.SourceDate.Month() != time.April || entry.Year != 2026 || entry.Month != 4 {
+		t.Fatalf("deposit write-off source date = %+v year=%d month=%d", entry.SourceDate, entry.Year, entry.Month)
+	}
+	if entry.Description == nil || *entry.Description != "強制終止押金沒收：tenant unreachable" || entry.DisplayNote == nil || *entry.DisplayNote != "強制終止押金沒收：tenant unreachable" {
+		t.Fatalf("deposit write-off note fields = description %+v display %+v", entry.Description, entry.DisplayNote)
+	}
 	if len(publisher.events) != 1 {
 		t.Fatalf("events = %d, want 1", len(publisher.events))
 	}
@@ -239,7 +256,8 @@ func TestForceTerminateLeaseServiceKeepsDepositHeld(t *testing.T) {
 		PeriodStart: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
 		PeriodEnd:   time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
 	})
-	service := NewForceTerminateLeaseService(repo, dbtxrunner.New(db, publisher))
+	accountingRepo := &depositAccountingRepositoryStub{}
+	service := NewForceTerminateLeaseService(repo, accountingRepo, dbtxrunner.New(db, publisher))
 
 	result, err := service.Execute(context.Background(), ForceTerminateLeaseInput{
 		ActorRole:           "admin",
@@ -275,6 +293,9 @@ func TestForceTerminateLeaseServiceKeepsDepositHeld(t *testing.T) {
 	if result.DepositHandling != "keep_held" {
 		t.Fatalf("deposit handling = %q, want keep_held", result.DepositHandling)
 	}
+	if len(accountingRepo.entries) != 0 {
+		t.Fatalf("accounting entries = %d, want 0", len(accountingRepo.entries))
+	}
 	if len(publisher.events) != 1 {
 		t.Fatalf("events = %d, want 1", len(publisher.events))
 	}
@@ -284,8 +305,45 @@ func TestForceTerminateLeaseServiceKeepsDepositHeld(t *testing.T) {
 	}
 }
 
+func TestForceTerminateLeaseServiceRollsBackWhenDepositAccountingFails(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer db.Close()
+	defer verifySQLMockExpectations(t, mock)
+
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	publisher := &recordingPublisher{}
+	repo := terminationRepoStub()
+	accountingRepo := &depositAccountingRepositoryStub{createErr: errors.New("accounting failed")}
+	service := NewForceTerminateLeaseService(repo, accountingRepo, dbtxrunner.New(db, publisher))
+
+	_, err = service.Execute(context.Background(), ForceTerminateLeaseInput{
+		ActorRole:           "admin",
+		ActorUserID:         "20000000-0000-0000-0000-000000000001",
+		AssignedPropertyIDs: []string{"property-1"},
+		LeaseID:             terminateLeaseTestLeaseID,
+		TerminationDate:     time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC),
+		Reason:              "tenant unreachable",
+		DepositHandling:     "write_off",
+	})
+	var appErr *apperr.Error
+	if !errors.As(err, &appErr) || appErr.Code != apperr.CodeInternalServerError {
+		t.Fatalf("expected internal server error, got %v", err)
+	}
+	if accountingRepo.createCalls != 1 {
+		t.Fatalf("CreateDepositAccountingEntry calls = %d, want 1", accountingRepo.createCalls)
+	}
+	if len(publisher.events) != 0 {
+		t.Fatalf("events should not publish on rollback: %+v", publisher.events)
+	}
+}
+
 func TestForceTerminateLeaseServiceRejectsLowPrivilegeRole(t *testing.T) {
-	service := NewForceTerminateLeaseService(nil, nil)
+	service := NewForceTerminateLeaseService(nil, nil, nil)
 
 	_, err := service.Execute(context.Background(), ForceTerminateLeaseInput{
 		ActorRole:       "staff",
@@ -300,7 +358,7 @@ func TestForceTerminateLeaseServiceRejectsLowPrivilegeRole(t *testing.T) {
 }
 
 func TestForceTerminateLeaseServiceRejectsMissingReason(t *testing.T) {
-	service := NewForceTerminateLeaseService(nil, nil)
+	service := NewForceTerminateLeaseService(nil, nil, nil)
 
 	_, err := service.Execute(context.Background(), ForceTerminateLeaseInput{
 		ActorRole:       "admin",
@@ -314,7 +372,7 @@ func TestForceTerminateLeaseServiceRejectsMissingReason(t *testing.T) {
 }
 
 func TestForceTerminateLeaseServiceRejectsMissingDepositHandling(t *testing.T) {
-	service := NewForceTerminateLeaseService(nil, nil)
+	service := NewForceTerminateLeaseService(nil, nil, nil)
 
 	_, err := service.Execute(context.Background(), ForceTerminateLeaseInput{
 		ActorRole:   "admin",
@@ -328,7 +386,7 @@ func TestForceTerminateLeaseServiceRejectsMissingDepositHandling(t *testing.T) {
 }
 
 func TestForceTerminateLeaseServiceRejectsMissingTerminationDate(t *testing.T) {
-	service := NewForceTerminateLeaseService(nil, nil)
+	service := NewForceTerminateLeaseService(nil, nil, nil)
 
 	_, err := service.Execute(context.Background(), ForceTerminateLeaseInput{
 		ActorRole:       "admin",
@@ -349,7 +407,7 @@ func TestForceTerminateLeaseServiceRejectsMissingTerminationDate(t *testing.T) {
 
 func TestForceTerminateLeaseServiceRejectsTerminationDateBeforeLeaseStart(t *testing.T) {
 	repo := terminationRepoStub()
-	service := NewForceTerminateLeaseService(repo, txRunnerForRollback(t))
+	service := NewForceTerminateLeaseService(repo, nil, txRunnerForRollback(t))
 
 	_, err := service.Execute(context.Background(), ForceTerminateLeaseInput{
 		ActorRole:           "admin",
@@ -375,7 +433,7 @@ func TestForceTerminateLeaseServiceRejectsTerminationDateBeforeLeaseStart(t *tes
 
 func TestForceTerminateLeaseServiceRejectsInvalidDepositHandling(t *testing.T) {
 	repo := terminationRepoStub()
-	service := NewForceTerminateLeaseService(repo, txRunnerForRollback(t))
+	service := NewForceTerminateLeaseService(repo, nil, txRunnerForRollback(t))
 
 	_, err := service.Execute(context.Background(), ForceTerminateLeaseInput{
 		ActorRole:           "admin",

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -955,7 +955,7 @@ type ForceTerminateRequest struct {
 	// ActualMoveOutDate Actual move-out or handover date. This is operational metadata only and does not affect write-off handling, deposit handling, or rent refund behavior.
 	ActualMoveOutDate *openapi_types.Date `json:"actual_move_out_date"`
 
-	// DepositHandling Deposit handling decision during force termination; write_off marks the deposit as written_off, while keep_held leaves it held for later manual handling.
+	// DepositHandling Deposit handling decision during force termination; write_off marks the deposit as written_off and records the full deposit amount as deposit_deduction accounting, while keep_held leaves it held for later manual handling without creating a deposit accounting entry.
 	DepositHandling ForceTerminateRequestDepositHandling `json:"deposit_handling"`
 	Reason          string                               `json:"reason"`
 
@@ -963,7 +963,7 @@ type ForceTerminateRequest struct {
 	TerminationDate openapi_types.Date `json:"termination_date"`
 }
 
-// ForceTerminateRequestDepositHandling Deposit handling decision during force termination; write_off marks the deposit as written_off, while keep_held leaves it held for later manual handling.
+// ForceTerminateRequestDepositHandling Deposit handling decision during force termination; write_off marks the deposit as written_off and records the full deposit amount as deposit_deduction accounting, while keep_held leaves it held for later manual handling without creating a deposit accounting entry.
 type ForceTerminateRequestDepositHandling string
 
 // ForceTerminationResponse defines model for ForceTerminationResponse.

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -1678,7 +1678,7 @@ func TestForceTerminateLeaseForwardsTerminationDates(t *testing.T) {
 		applease.NewCreateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
 		nil,
 		func(deps *handler.APIServerDeps) {
-			deps.Leases.ForceTerminateLease = applease.NewForceTerminateLeaseService(fakeLeaseRepo{forceTerminateParams: &forceTerminateParams}, dbtxrunner.New(db, nil))
+			deps.Leases.ForceTerminateLease = applease.NewForceTerminateLeaseService(fakeLeaseRepo{forceTerminateParams: &forceTerminateParams}, fakeDepositAccountingRepo{}, dbtxrunner.New(db, nil))
 		},
 	)
 
@@ -6854,7 +6854,7 @@ func defaultAPIServerDeps(userRepo *fakeUserRepo, authenticator fakeAuthenticato
 			PreviewCheckout:     applease.NewPreviewCheckoutSettlementService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
 			FinalizeCheckout:    applease.NewFinalizeCheckoutSettlementService(fakeLeaseRepo{}, nil, dbtxrunner.New(nil, nil)),
 			ExportCheckout:      applease.NewExportCheckoutSettlementService(fakeLeaseRepo{}, applease.MustNewCheckoutSettlementRenderer(), dbtxrunner.New(nil, nil)),
-			ForceTerminateLease: applease.NewForceTerminateLeaseService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
+			ForceTerminateLease: applease.NewForceTerminateLeaseService(fakeLeaseRepo{}, fakeDepositAccountingRepo{}, dbtxrunner.New(nil, nil)),
 			GetForceTermination: applease.NewGetForceTerminationService(fakeLeaseRepo{}, dbtxrunner.New(nil, nil)),
 		},
 		Billing: handler.BillingServices{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -130,7 +130,7 @@ func New(cfg *config.Config) (*Server, error) {
 	previewCheckoutService := applease.NewPreviewCheckoutSettlementService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	finalizeCheckoutService := applease.NewFinalizeCheckoutSettlementService(leaseRepositoryAdapter{repo: leaseRepo}, leaseDepositAccounting, txRunner)
 	exportCheckoutService := applease.NewExportCheckoutSettlementService(leaseRepositoryAdapter{repo: leaseRepo}, applease.MustNewCheckoutSettlementRenderer(), txRunner)
-	forceTerminateLeaseService := applease.NewForceTerminateLeaseService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
+	forceTerminateLeaseService := applease.NewForceTerminateLeaseService(leaseRepositoryAdapter{repo: leaseRepo}, leaseDepositAccounting, txRunner)
 	getForceTerminationService := applease.NewGetForceTerminationService(leaseRepositoryAdapter{repo: leaseRepo}, txRunner)
 	attachmentService := appattachment.NewService(
 		attachmentRepositoryAdapter{repo: attachmentRepo},


### PR DESCRIPTION
## Summary

- Closes #175.
- Records force-termination deposit write_off as a deposit_deduction / 4601 accounting entry in the same transaction.
- Keeps keep_held from creating a deposit accounting entry.
- Documents the reporting semantics in domain docs and OpenAPI, and regenerates the bundled spec and Go bindings.
- Opens #176 for historical backfill follow-up.

## Validation

- go test ./internal/application/lease
- go test ./internal/http/router
- go test ./...
- git diff --check
