### PR TITLE
[codex] Add property_public_name to property contract

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -7328,6 +7328,9 @@ components:
           format: uuid
         name:
           type: string
+        property_public_name:
+          type: string
+          description: Public brand-page display name. Internal management name remains name.
         address:
           type: string
         subtitle:
@@ -7390,6 +7393,9 @@ components:
       properties:
         name:
           type: string
+        property_public_name:
+          type: string
+          description: Public brand-page display name. Defaults from name when omitted.
         subtitle:
           type: string
           nullable: true
@@ -7429,6 +7435,9 @@ components:
       properties:
         name:
           type: string
+        property_public_name:
+          type: string
+          description: Public brand-page display name. Can be updated independently from name.
         subtitle:
           type: string
           nullable: true

--- a/docs/spec/schema.sql
+++ b/docs/spec/schema.sql
@@ -61,6 +61,7 @@ CREATE INDEX idx_users_role ON users (role) WHERE deleted_at IS NULL;
 CREATE TABLE properties (
     id                      UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
     name                    VARCHAR(200) NOT NULL,
+    property_public_name    VARCHAR(200) NOT NULL CHECK (btrim(property_public_name) <> ''),
     address                 TEXT         NOT NULL,
     -- electricityUnitPrice：台幣正數/度，物業層級電價，可接受小數
     electricity_unit_price  NUMERIC(10,4) CHECK (electricity_unit_price > 0),

--- a/docs/spec/src/components/schemas/property/CreatePropertyRequest.yaml
+++ b/docs/spec/src/components/schemas/property/CreatePropertyRequest.yaml
@@ -8,6 +8,9 @@ required:
 properties:
   name:
     type: string
+  property_public_name:
+    type: string
+    description: Public brand-page display name. Defaults from name when omitted.
   subtitle:
     type: string
     nullable: true

--- a/docs/spec/src/components/schemas/property/PropertyResponse.yaml
+++ b/docs/spec/src/components/schemas/property/PropertyResponse.yaml
@@ -5,6 +5,9 @@ properties:
     format: uuid
   name:
     type: string
+  property_public_name:
+    type: string
+    description: Public brand-page display name. Internal management name remains name.
   address:
     type: string
   subtitle:

--- a/docs/spec/src/components/schemas/property/UpdatePropertyRequest.yaml
+++ b/docs/spec/src/components/schemas/property/UpdatePropertyRequest.yaml
@@ -2,6 +2,9 @@ type: object
 properties:
   name:
     type: string
+  property_public_name:
+    type: string
+    description: Public brand-page display name. Can be updated independently from name.
   subtitle:
     type: string
     nullable: true

--- a/internal/application/property/create_property.go
+++ b/internal/application/property/create_property.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"time"
 
 	domainevents "stds_backend/internal/domain/events"
@@ -15,6 +16,7 @@ import (
 // CreatePropertyInput is the command payload for creating a property.
 type CreatePropertyInput struct {
 	Name                             string
+	PropertyPublicName               *string
 	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             float64
@@ -47,8 +49,16 @@ func NewCreatePropertyService(propertyRepo Repository, propertyAccountRepo Prope
 
 // Execute validates input and persists a new property.
 func (s *CreatePropertyService) Execute(ctx context.Context, input CreatePropertyInput) (*Property, error) {
+	propertyPublicName := ""
+	if input.PropertyPublicName != nil {
+		propertyPublicName = *input.PropertyPublicName
+		if strings.TrimSpace(propertyPublicName) == "" {
+			return nil, mapDomainError(domainproperty.ErrPropertyPublicNameRequired)
+		}
+	}
 	aggregate, err := domainproperty.New(domainproperty.State{
 		Name:                             input.Name,
+		PropertyPublicName:               propertyPublicName,
 		Subtitle:                         input.Subtitle,
 		Address:                          input.Address,
 		ElectricityUnitPrice:             &input.ElectricityUnitPrice,
@@ -77,6 +87,7 @@ func (s *CreatePropertyService) Execute(ctx context.Context, input CreatePropert
 		}
 		property, err := s.propertyRepo.Create(ctx, tx, CreatePropertyParams{
 			Name:                             state.Name,
+			PropertyPublicName:               state.PropertyPublicName,
 			Subtitle:                         state.Subtitle,
 			Address:                          state.Address,
 			ElectricityUnitPrice:             electricityUnitPrice,

--- a/internal/application/property/create_property_test.go
+++ b/internal/application/property/create_property_test.go
@@ -23,10 +23,10 @@ func TestCreatePropertyServiceCreatesProperty(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("INSERT INTO properties").
-		WithArgs("Property A", nil, "Address A", 4.5, "monthly", "owner-1", nil, nil, nil, nil).
+		WithArgs("Property A", "Property A", nil, "Address A", 4.5, "monthly", "owner-1", nil, nil, nil, nil).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "name", "subtitle", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id", "contact_phone", "contact_email", "notes", "facilities", "created_at", "updated_at", "version",
-		}).AddRow("property-1", "Property A", nil, "Address A", 4.5, "monthly", "owner-1", nil, nil, nil, nil, time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), 1))
+			"id", "name", "property_public_name", "subtitle", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id", "contact_phone", "contact_email", "notes", "facilities", "created_at", "updated_at", "version",
+		}).AddRow("property-1", "Property A", "Property A", nil, "Address A", 4.5, "monthly", "owner-1", nil, nil, nil, nil, time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC), 1))
 	mock.ExpectExec("INSERT INTO property_accounts").
 		WithArgs("property-1").
 		WillReturnResult(sqlmock.NewResult(1, 1))
@@ -46,6 +46,9 @@ func TestCreatePropertyServiceCreatesProperty(t *testing.T) {
 
 	if property.ID != "property-1" {
 		t.Fatalf("expected property-1, got %q", property.ID)
+	}
+	if property.PropertyPublicName != "Property A" {
+		t.Fatalf("expected property_public_name default Property A, got %q", property.PropertyPublicName)
 	}
 	if property.ElectricityUnitPrice == nil || *property.ElectricityUnitPrice != 4.5 {
 		t.Fatalf("expected electricity_unit_price 4.5, got %v", property.ElectricityUnitPrice)
@@ -74,6 +77,7 @@ func (a sqlPropertyAccountRepositoryAdapter) CreatePropertyAccount(ctx context.C
 func (a sqlPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params CreatePropertyParams) (*Property, error) {
 	property, err := a.repo.Create(ctx, tx, dbproperties.CreatePropertyParams{
 		Name:                             params.Name,
+		PropertyPublicName:               params.PropertyPublicName,
 		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
@@ -91,6 +95,7 @@ func (a sqlPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, pa
 	return &Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		PropertyPublicName:               property.PropertyPublicName,
 		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,
@@ -110,6 +115,23 @@ func TestCreatePropertyServiceValidatesInput(t *testing.T) {
 	service := NewCreatePropertyService(nil, nil, nil)
 
 	if _, err := service.Execute(context.Background(), CreatePropertyInput{}); err == nil {
+		t.Fatal("expected validation error, got nil")
+	}
+}
+
+func TestCreatePropertyServiceRejectsBlankPropertyPublicName(t *testing.T) {
+	service := NewCreatePropertyService(nil, nil, nil)
+	propertyPublicName := "   "
+
+	_, err := service.Execute(context.Background(), CreatePropertyInput{
+		Name:                             "Property A",
+		PropertyPublicName:               &propertyPublicName,
+		Address:                          "Address A",
+		ElectricityUnitPrice:             4.5,
+		DefaultElectricityBillingCadence: "monthly",
+		OwnerID:                          "owner-1",
+	})
+	if err == nil {
 		t.Fatal("expected validation error, got nil")
 	}
 }

--- a/internal/application/property/errors.go
+++ b/internal/application/property/errors.go
@@ -58,6 +58,10 @@ func mapDomainError(err error) error {
 	switch {
 	case errors.Is(err, domainproperty.ErrNameRequired):
 		return apperr.ErrValidationNameRequired
+	case errors.Is(err, domainproperty.ErrPropertyPublicNameRequired):
+		return apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+			"field": "property_public_name",
+		})
 	case errors.Is(err, domainproperty.ErrAddressRequired):
 		return apperr.ErrValidationAddressRequired
 	case errors.Is(err, domainproperty.ErrOwnerIDRequired):

--- a/internal/application/property/repository.go
+++ b/internal/application/property/repository.go
@@ -14,6 +14,7 @@ var ErrPropertyNotFound = errors.New("property not found")
 type Property struct {
 	ID                               string
 	Name                             string
+	PropertyPublicName               string
 	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
@@ -132,6 +133,7 @@ type DashboardRecentJournal struct {
 // property.
 type CreatePropertyParams struct {
 	Name                             string
+	PropertyPublicName               string
 	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             float64
@@ -154,6 +156,7 @@ type CreatePropertyAccountParams struct {
 type UpdatePropertyParams struct {
 	ID                               string
 	Name                             string
+	PropertyPublicName               string
 	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64

--- a/internal/application/property/update_property.go
+++ b/internal/application/property/update_property.go
@@ -16,6 +16,7 @@ type UpdatePropertyInput struct {
 	ID                               string
 	ActorRole                        string
 	Name                             *string
+	PropertyPublicName               *string
 	Subtitle                         *string
 	ClearSubtitle                    bool
 	Address                          *string
@@ -57,7 +58,7 @@ func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropert
 	if strings.TrimSpace(input.ActorRole) == "" {
 		return nil, apperr.ErrUnauthorized
 	}
-	if input.Name == nil && input.Subtitle == nil && !input.ClearSubtitle && input.Address == nil && input.ElectricityUnitPrice == nil && input.DefaultElectricityBillingCadence == nil && input.ContactPhone == nil && !input.ClearContactPhone && input.ContactEmail == nil && !input.ClearContactEmail && input.Notes == nil && !input.ClearNotes && input.Facilities == nil && !input.ClearFacilities {
+	if input.Name == nil && input.PropertyPublicName == nil && input.Subtitle == nil && !input.ClearSubtitle && input.Address == nil && input.ElectricityUnitPrice == nil && input.DefaultElectricityBillingCadence == nil && input.ContactPhone == nil && !input.ClearContactPhone && input.ContactEmail == nil && !input.ClearContactEmail && input.Notes == nil && !input.ClearNotes && input.Facilities == nil && !input.ClearFacilities {
 		return nil, apperr.ErrBadRequest
 	}
 
@@ -76,6 +77,7 @@ func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropert
 		aggregate, err := domainproperty.Rehydrate(domainproperty.State{
 			ID:                               current.ID,
 			Name:                             current.Name,
+			PropertyPublicName:               current.PropertyPublicName,
 			Subtitle:                         current.Subtitle,
 			Address:                          current.Address,
 			ElectricityUnitPrice:             current.ElectricityUnitPrice,
@@ -94,6 +96,7 @@ func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropert
 		if err := aggregate.Update(domainproperty.UpdateInput{
 			ActorRole:                        input.ActorRole,
 			Name:                             input.Name,
+			PropertyPublicName:               input.PropertyPublicName,
 			Subtitle:                         input.Subtitle,
 			ClearSubtitle:                    input.ClearSubtitle,
 			Address:                          input.Address,
@@ -115,6 +118,7 @@ func (s *UpdatePropertyService) Execute(ctx context.Context, input UpdatePropert
 		property, err := s.propertyRepo.Update(ctx, tx, UpdatePropertyParams{
 			ID:                               state.ID,
 			Name:                             state.Name,
+			PropertyPublicName:               state.PropertyPublicName,
 			Subtitle:                         state.Subtitle,
 			Address:                          state.Address,
 			ElectricityUnitPrice:             state.ElectricityUnitPrice,

--- a/internal/devseed/dev_seed.go
+++ b/internal/devseed/dev_seed.go
@@ -282,6 +282,7 @@ func seedPropertyAndRooms(ctx context.Context, tx *sql.Tx, ownerID string) error
 INSERT INTO properties (
 	id,
 	name,
+	property_public_name,
 	subtitle,
 	address,
 	electricity_unit_price,
@@ -295,6 +296,7 @@ INSERT INTO properties (
 	updated_at
 ) VALUES (
 	$1,
+	'前端展示公寓',
 	'前端展示公寓',
 	'Frontend Demo Property',
 	'台北市中正區測試路 157 號',

--- a/internal/domain/property/aggregate.go
+++ b/internal/domain/property/aggregate.go
@@ -17,6 +17,7 @@ const (
 type State struct {
 	ID                               string
 	Name                             string
+	PropertyPublicName               string
 	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
@@ -72,6 +73,7 @@ type RoomAggregate struct {
 type UpdateInput struct {
 	ActorRole                        string
 	Name                             *string
+	PropertyPublicName               *string
 	Subtitle                         *string
 	ClearSubtitle                    bool
 	Address                          *string
@@ -124,6 +126,13 @@ func (a *Aggregate) Update(input UpdateInput) error {
 			return ErrNameRequired
 		}
 		a.state.Name = name
+	}
+	if input.PropertyPublicName != nil {
+		propertyPublicName := strings.TrimSpace(*input.PropertyPublicName)
+		if propertyPublicName == "" {
+			return ErrPropertyPublicNameRequired
+		}
+		a.state.PropertyPublicName = propertyPublicName
 	}
 	if input.Subtitle != nil {
 		a.state.Subtitle = normalizeOptionalString(*input.Subtitle)
@@ -222,6 +231,10 @@ func normalizeState(state State, requireElectricityPrice bool) (State, error) {
 	state.Name = strings.TrimSpace(state.Name)
 	if state.Name == "" {
 		return State{}, ErrNameRequired
+	}
+	state.PropertyPublicName = strings.TrimSpace(state.PropertyPublicName)
+	if state.PropertyPublicName == "" {
+		state.PropertyPublicName = state.Name
 	}
 	state.Subtitle = normalizeOptionalStringPtr(state.Subtitle)
 

--- a/internal/domain/property/errors.go
+++ b/internal/domain/property/errors.go
@@ -4,6 +4,7 @@ import "errors"
 
 var (
 	ErrNameRequired                    = errors.New("property name is required")
+	ErrPropertyPublicNameRequired      = errors.New("property public name is required")
 	ErrAddressRequired                 = errors.New("property address is required")
 	ErrOwnerIDRequired                 = errors.New("property owner id is required")
 	ErrElectricityPriceMustBePositive  = errors.New("property electricity price must be positive")

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -798,7 +798,10 @@ type CreatePropertyRequest struct {
 	Name                 string                  `json:"name"`
 	Notes                *string                 `json:"notes"`
 	OwnerId              openapi_types.UUID      `json:"owner_id"`
-	Subtitle             *string                 `json:"subtitle"`
+
+	// PropertyPublicName Public brand-page display name. Defaults from name when omitted.
+	PropertyPublicName *string `json:"property_public_name,omitempty"`
+	Subtitle           *string `json:"subtitle"`
 }
 
 // CreatePropertyRequestDefaultElectricityBillingCadence 物業預設電費計費 cadence，僅影響新建 Lease
@@ -1281,9 +1284,12 @@ type PropertyResponse struct {
 	Notes                *string                 `json:"notes"`
 	OccupancySummary     *OccupancySummary       `json:"occupancy_summary,omitempty"`
 	OwnerId              *openapi_types.UUID     `json:"owner_id,omitempty"`
-	Subtitle             *string                 `json:"subtitle"`
-	UpdatedAt            *time.Time              `json:"updated_at,omitempty"`
-	Version              *int                    `json:"version,omitempty"`
+
+	// PropertyPublicName Public brand-page display name. Internal management name remains name.
+	PropertyPublicName *string    `json:"property_public_name,omitempty"`
+	Subtitle           *string    `json:"subtitle"`
+	UpdatedAt          *time.Time `json:"updated_at,omitempty"`
+	Version            *int       `json:"version,omitempty"`
 }
 
 // PropertyResponseDefaultElectricityBillingCadence defines model for PropertyResponse.DefaultElectricityBillingCadence.
@@ -1536,7 +1542,10 @@ type UpdatePropertyRequest struct {
 	Facilities           *map[string]interface{} `json:"facilities"`
 	Name                 *string                 `json:"name,omitempty"`
 	Notes                *string                 `json:"notes"`
-	Subtitle             *string                 `json:"subtitle"`
+
+	// PropertyPublicName Public brand-page display name. Can be updated independently from name.
+	PropertyPublicName *string `json:"property_public_name,omitempty"`
+	Subtitle           *string `json:"subtitle"`
 }
 
 // UpdatePropertyRequestDefaultElectricityBillingCadence 僅影響之後新建的 Lease，不回頭修改既有 Lease

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -1596,6 +1596,7 @@ func (s *APIServer) CreateProperty(c *gin.Context) {
 
 	property, err := s.createPropertySvc.Execute(c.Request.Context(), appproperty.CreatePropertyInput{
 		Name:                             request.Name,
+		PropertyPublicName:               request.PropertyPublicName,
 		Subtitle:                         request.Subtitle,
 		Address:                          request.Address,
 		ElectricityUnitPrice:             request.ElectricityUnitPrice,
@@ -1677,6 +1678,7 @@ func (s *APIServer) UpdateProperty(c *gin.Context, id string) {
 		ID:                               id,
 		ActorRole:                        principal.Role,
 		Name:                             request.Name,
+		PropertyPublicName:               request.PropertyPublicName,
 		Subtitle:                         request.Subtitle,
 		ClearSubtitle:                    jsonFieldIsNull(fields, "subtitle"),
 		Address:                          request.Address,
@@ -3730,16 +3732,17 @@ func toPropertyResponse(property *dbpropertyquery.Property) api.PropertyResponse
 	version := property.Version
 
 	response := api.PropertyResponse{
-		Address:          &address,
-		ContactPhone:     property.ContactPhone,
-		CreatedAt:        &createdAt,
-		Name:             &name,
-		Notes:            property.Notes,
-		OccupancySummary: toDBPropertyOccupancySummaryResponse(property.Occupancy),
-		Facilities:       property.Facilities,
-		Subtitle:         property.Subtitle,
-		UpdatedAt:        &updatedAt,
-		Version:          &version,
+		Address:            &address,
+		ContactPhone:       property.ContactPhone,
+		CreatedAt:          &createdAt,
+		Name:               &name,
+		PropertyPublicName: &property.PropertyPublicName,
+		Notes:              property.Notes,
+		OccupancySummary:   toDBPropertyOccupancySummaryResponse(property.Occupancy),
+		Facilities:         property.Facilities,
+		Subtitle:           property.Subtitle,
+		UpdatedAt:          &updatedAt,
+		Version:            &version,
 	}
 	if property.ContactEmail != nil {
 		if parsed, err := mail.ParseAddress(*property.ContactEmail); err == nil {
@@ -3800,6 +3803,7 @@ func toCreatedPropertyResponse(property *appproperty.Property) api.PropertyRespo
 	queryShape := &dbpropertyquery.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		PropertyPublicName:               property.PropertyPublicName,
 		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -63,22 +63,26 @@ func TestToPropertyResponseIncludesWritableV1Fields(t *testing.T) {
 	facilities := map[string]interface{}{"elevator": true}
 
 	response := toPropertyResponse(&dbpropertyquery.Property{
-		ID:           "00000000-0000-0000-0000-000000000001",
-		Name:         "Property",
-		Subtitle:     &subtitle,
-		Address:      "Address",
-		OwnerID:      "00000000-0000-0000-0000-000000000002",
-		ContactPhone: &contactPhone,
-		ContactEmail: &contactEmail,
-		Notes:        &notes,
-		Facilities:   &facilities,
-		CreatedAt:    time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
-		UpdatedAt:    time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
-		Version:      1,
+		ID:                 "00000000-0000-0000-0000-000000000001",
+		Name:               "Property",
+		PropertyPublicName: "Public Property",
+		Subtitle:           &subtitle,
+		Address:            "Address",
+		OwnerID:            "00000000-0000-0000-0000-000000000002",
+		ContactPhone:       &contactPhone,
+		ContactEmail:       &contactEmail,
+		Notes:              &notes,
+		Facilities:         &facilities,
+		CreatedAt:          time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		UpdatedAt:          time.Date(2026, 4, 16, 10, 0, 0, 0, time.UTC),
+		Version:            1,
 	})
 
 	if response.Subtitle == nil || *response.Subtitle != subtitle {
 		t.Fatalf("subtitle = %v, want %s", response.Subtitle, subtitle)
+	}
+	if response.PropertyPublicName == nil || *response.PropertyPublicName != "Public Property" {
+		t.Fatalf("property_public_name = %v, want Public Property", response.PropertyPublicName)
 	}
 	if response.ContactEmail == nil || string(*response.ContactEmail) != contactEmail {
 		t.Fatalf("contact_email = %v, want %s", response.ContactEmail, contactEmail)

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -3014,11 +3014,12 @@ func TestCreatePropertyAcceptsDecimalElectricityPrice(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectQuery("INSERT INTO properties").
-		WithArgs("Property A", nil, "Address A", 4.5, "monthly", "00000000-0000-0000-0000-000000000010", nil, nil, nil, nil).
+		WithArgs("Property A", "Property A", nil, "Address A", 4.5, "monthly", "00000000-0000-0000-0000-000000000010", nil, nil, nil, nil).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "name", "subtitle", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id", "contact_phone", "contact_email", "notes", "facilities", "created_at", "updated_at", "version",
+			"id", "name", "property_public_name", "subtitle", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id", "contact_phone", "contact_email", "notes", "facilities", "created_at", "updated_at", "version",
 		}).AddRow(
 			"property-new",
+			"Property A",
 			"Property A",
 			nil,
 			"Address A",
@@ -3077,6 +3078,9 @@ func TestCreatePropertyAcceptsDecimalElectricityPrice(t *testing.T) {
 
 	if payload["electricity_unit_price"] != 4.5 {
 		t.Fatalf("expected electricity_unit_price 4.5, got %v", payload["electricity_unit_price"])
+	}
+	if payload["property_public_name"] != "Property A" {
+		t.Fatalf("expected property_public_name Property A, got %v", payload["property_public_name"])
 	}
 	if payload["default_electricity_billing_cadence"] != "monthly" {
 		t.Fatalf("expected default_electricity_billing_cadence monthly, got %v", payload["default_electricity_billing_cadence"])
@@ -3169,6 +3173,7 @@ func TestUpdatePropertyClearsNullableFieldsWithExplicitNull(t *testing.T) {
 			testPropertyID1: {
 				ID:                               testPropertyID1,
 				Name:                             "Property A",
+				PropertyPublicName:               "Property A",
 				Subtitle:                         &subtitle,
 				Address:                          "Address A",
 				ElectricityUnitPrice:             ptrFloat64(4.0),
@@ -3198,6 +3203,7 @@ func TestUpdatePropertyClearsNullableFieldsWithExplicitNull(t *testing.T) {
 	)
 
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/properties/"+testPropertyID1, strings.NewReader(`{
+		"property_public_name":"Public Property A",
 		"subtitle":null,
 		"contact_phone":null,
 		"contact_email":null,
@@ -3215,6 +3221,9 @@ func TestUpdatePropertyClearsNullableFieldsWithExplicitNull(t *testing.T) {
 	}
 	if updateParams.Subtitle != nil {
 		t.Fatalf("expected subtitle to be cleared, got %v", *updateParams.Subtitle)
+	}
+	if updateParams.PropertyPublicName != "Public Property A" {
+		t.Fatalf("expected property_public_name Public Property A, got %q", updateParams.PropertyPublicName)
 	}
 	if updateParams.ContactPhone != nil {
 		t.Fatalf("expected contact_phone to be cleared, got %v", *updateParams.ContactPhone)
@@ -5615,6 +5624,7 @@ func (f fakePropertyRepo) Create(_ context.Context, _ *sql.Tx, params apppropert
 	return &appproperty.Property{
 		ID:                               "property-new",
 		Name:                             params.Name,
+		PropertyPublicName:               params.PropertyPublicName,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             &electricityUnitPrice,
 		DefaultElectricityBillingCadence: params.DefaultElectricityBillingCadence,
@@ -5634,6 +5644,7 @@ func (f fakePropertyRepo) FindByID(_ context.Context, _ *sql.Tx, id string) (*ap
 	return &appproperty.Property{
 		ID:                               id,
 		Name:                             "Property",
+		PropertyPublicName:               "Property",
 		Address:                          "Address",
 		ElectricityUnitPrice:             &electricityUnitPrice,
 		DefaultElectricityBillingCadence: "monthly",
@@ -5652,6 +5663,7 @@ func (f fakePropertyRepo) Update(_ context.Context, _ *sql.Tx, params apppropert
 	return &appproperty.Property{
 		ID:                               params.ID,
 		Name:                             params.Name,
+		PropertyPublicName:               params.PropertyPublicName,
 		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
@@ -5754,6 +5766,7 @@ func (f fakePropertyRepo) CreateRepairRequest(_ context.Context, _ *sql.Tx, para
 func (a testSQLPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params appproperty.CreatePropertyParams) (*appproperty.Property, error) {
 	property, err := a.repo.Create(ctx, tx, dbproperties.CreatePropertyParams{
 		Name:                             params.Name,
+		PropertyPublicName:               params.PropertyPublicName,
 		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
@@ -5771,6 +5784,7 @@ func (a testSQLPropertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx
 	return &appproperty.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		PropertyPublicName:               property.PropertyPublicName,
 		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,
@@ -5799,6 +5813,7 @@ func (a testSQLPropertyRepositoryAdapter) FindByID(ctx context.Context, tx *sql.
 	return &appproperty.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		PropertyPublicName:               property.PropertyPublicName,
 		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,
@@ -5818,6 +5833,7 @@ func (a testSQLPropertyRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx
 	property, err := a.repo.Update(ctx, tx, dbproperties.UpdatePropertyParams{
 		ID:                               params.ID,
 		Name:                             params.Name,
+		PropertyPublicName:               params.PropertyPublicName,
 		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
@@ -5836,6 +5852,7 @@ func (a testSQLPropertyRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx
 	return &appproperty.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		PropertyPublicName:               property.PropertyPublicName,
 		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,

--- a/internal/migration/legacy/properties.go
+++ b/internal/migration/legacy/properties.go
@@ -417,6 +417,7 @@ func insertMigratedProperty(ctx context.Context, tx *sql.Tx, property normalized
 	const query = `
 INSERT INTO properties (
 	name,
+	property_public_name,
 	subtitle,
 	address,
 	contact_phone,
@@ -426,7 +427,7 @@ INSERT INTO properties (
 	electricity_unit_price,
 	default_electricity_billing_cadence,
 	owner_id
-) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11)
 RETURNING id
 `
 
@@ -434,6 +435,7 @@ RETURNING id
 	if err := tx.QueryRowContext(
 		ctx,
 		query,
+		property.Name,
 		property.Name,
 		nullIfEmpty(property.Subtitle),
 		property.Address,

--- a/internal/migration/legacy/properties_test.go
+++ b/internal/migration/legacy/properties_test.go
@@ -119,6 +119,7 @@ RETURNING id
 	mock.ExpectQuery(regexp.QuoteMeta(`
 INSERT INTO properties (
 	name,
+	property_public_name,
 	subtitle,
 	address,
 	contact_phone,
@@ -128,10 +129,11 @@ INSERT INTO properties (
 	electricity_unit_price,
 	default_electricity_billing_cadence,
 	owner_id
-) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11)
 RETURNING id
 `)).
 		WithArgs(
+			"第一雅築",
 			"第一雅築",
 			"第一雅築",
 			"台南市永康區中華路619巷22弄29號",
@@ -336,6 +338,7 @@ RETURNING id
 	mock.ExpectQuery(regexp.QuoteMeta(`
 INSERT INTO properties (
 	name,
+	property_public_name,
 	subtitle,
 	address,
 	contact_phone,
@@ -345,10 +348,11 @@ INSERT INTO properties (
 	electricity_unit_price,
 	default_electricity_billing_cadence,
 	owner_id
-) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, $10)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10, $11)
 RETURNING id
 `)).
 		WithArgs(
+			"第一雅築",
 			"第一雅築",
 			nil,
 			"台南市永康區中華路619巷22弄29號",

--- a/internal/platform/database/migrate/migrations/000021_add_property_public_name.down.sql
+++ b/internal/platform/database/migrate/migrations/000021_add_property_public_name.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE properties
+    DROP CONSTRAINT IF EXISTS properties_property_public_name_non_empty_check,
+    DROP COLUMN IF EXISTS property_public_name;

--- a/internal/platform/database/migrate/migrations/000021_add_property_public_name.up.sql
+++ b/internal/platform/database/migrate/migrations/000021_add_property_public_name.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE properties
+    ADD COLUMN IF NOT EXISTS property_public_name VARCHAR(200);
+
+UPDATE properties
+SET property_public_name = name
+WHERE property_public_name IS NULL;
+
+ALTER TABLE properties
+    ALTER COLUMN property_public_name SET NOT NULL,
+    ADD CONSTRAINT properties_property_public_name_non_empty_check CHECK (btrim(property_public_name) <> '');

--- a/internal/platform/database/migrate/runner_test.go
+++ b/internal/platform/database/migrate/runner_test.go
@@ -36,6 +36,7 @@ var expectedMigrationVersions = []string{
 	"000018",
 	"000019",
 	"000020",
+	"000021",
 }
 
 func TestRunnerUpAppliesMigrationsAndRecordsVersions(t *testing.T) {
@@ -222,6 +223,37 @@ func TestCheckoutDatesAndRentRefundMigrationAddsNullableColumnAndCategories(t *t
 	downSQL := migrationsByVersion(t, "down")["000020"].SQL
 	if !strings.Contains(downSQL, "DROP COLUMN IF EXISTS actual_move_out_date") {
 		t.Fatal("000020 down migration missing actual_move_out_date drop")
+	}
+}
+
+func TestPropertyPublicNameMigrationBackfillsAndEnforcesNonEmptyValue(t *testing.T) {
+	migrations := migrationsByVersion(t, "up")
+	sql := migrations["000021"].SQL
+
+	requiredSnippets := []string{
+		"ALTER TABLE properties",
+		"ADD COLUMN IF NOT EXISTS property_public_name VARCHAR(200)",
+		"UPDATE properties",
+		"SET property_public_name = name",
+		"ALTER COLUMN property_public_name SET NOT NULL",
+		"properties_property_public_name_non_empty_check",
+		"btrim(property_public_name) <> ''",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(sql, snippet) {
+			t.Fatalf("000021 migration missing %q", snippet)
+		}
+	}
+
+	downSQL := migrationsByVersion(t, "down")["000021"].SQL
+	requiredDownSnippets := []string{
+		"DROP CONSTRAINT IF EXISTS properties_property_public_name_non_empty_check",
+		"DROP COLUMN IF EXISTS property_public_name",
+	}
+	for _, snippet := range requiredDownSnippets {
+		if !strings.Contains(downSQL, snippet) {
+			t.Fatalf("000021 down migration missing %q", snippet)
+		}
 	}
 }
 

--- a/internal/platform/database/properties/repository.go
+++ b/internal/platform/database/properties/repository.go
@@ -35,6 +35,7 @@ type CommandRepository interface {
 type Property struct {
 	ID                               string
 	Name                             string
+	PropertyPublicName               string
 	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
@@ -86,6 +87,7 @@ type RepairRequest struct {
 // CreatePropertyParams contains the writable fields required to persist a property.
 type CreatePropertyParams struct {
 	Name                             string
+	PropertyPublicName               string
 	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             float64
@@ -101,6 +103,7 @@ type CreatePropertyParams struct {
 type UpdatePropertyParams struct {
 	ID                               string
 	Name                             string
+	PropertyPublicName               string
 	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
@@ -191,6 +194,7 @@ func (r *SQLRepository) Create(ctx context.Context, tx *sql.Tx, params CreatePro
 	const query = `
 INSERT INTO properties (
 	name,
+	property_public_name,
 	subtitle,
 	address,
 	electricity_unit_price,
@@ -200,10 +204,11 @@ INSERT INTO properties (
 	contact_email,
 	notes,
 	facilities
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::jsonb)
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)
 RETURNING
 	id,
 	name,
+	property_public_name,
 	subtitle,
 	address,
 	electricity_unit_price,
@@ -218,7 +223,7 @@ RETURNING
 	version
 `
 
-	property, err := scanProperty(tx.QueryRowContext(ctx, query, params.Name, params.Subtitle, params.Address, params.ElectricityUnitPrice, params.DefaultElectricityBillingCadence, params.OwnerID, params.ContactPhone, params.ContactEmail, params.Notes, facilitiesJSON))
+	property, err := scanProperty(tx.QueryRowContext(ctx, query, params.Name, params.PropertyPublicName, params.Subtitle, params.Address, params.ElectricityUnitPrice, params.DefaultElectricityBillingCadence, params.OwnerID, params.ContactPhone, params.ContactEmail, params.Notes, facilitiesJSON))
 	if err != nil {
 		return nil, fmt.Errorf("create property: %w", err)
 	}
@@ -232,6 +237,7 @@ func (r *SQLRepository) FindByID(ctx context.Context, tx *sql.Tx, id string) (*P
 SELECT
 	id,
 	name,
+	property_public_name,
 	subtitle,
 	address,
 	electricity_unit_price,
@@ -271,23 +277,25 @@ func (r *SQLRepository) Update(ctx context.Context, tx *sql.Tx, params UpdatePro
 	const query = `
 UPDATE properties
 SET name = $2,
-	subtitle = $3,
-	address = $4,
-	electricity_unit_price = $5,
-	default_electricity_billing_cadence = $6,
-	owner_id = $7,
-	contact_phone = $8,
-	contact_email = $9,
-	notes = $10,
-	facilities = $11::jsonb,
+	property_public_name = $3,
+	subtitle = $4,
+	address = $5,
+	electricity_unit_price = $6,
+	default_electricity_billing_cadence = $7,
+	owner_id = $8,
+	contact_phone = $9,
+	contact_email = $10,
+	notes = $11,
+	facilities = $12::jsonb,
 	updated_at = now(),
 	version = version + 1
 WHERE id = $1
-  AND version = $12
+  AND version = $13
   AND deleted_at IS NULL
 RETURNING
 	id,
 	name,
+	property_public_name,
 	subtitle,
 	address,
 	electricity_unit_price,
@@ -302,7 +310,7 @@ RETURNING
 	version
 `
 
-	property, err := scanProperty(tx.QueryRowContext(ctx, query, params.ID, params.Name, params.Subtitle, params.Address, params.ElectricityUnitPrice, params.DefaultElectricityBillingCadence, params.OwnerID, params.ContactPhone, params.ContactEmail, params.Notes, facilitiesJSON, params.Version))
+	property, err := scanProperty(tx.QueryRowContext(ctx, query, params.ID, params.Name, params.PropertyPublicName, params.Subtitle, params.Address, params.ElectricityUnitPrice, params.DefaultElectricityBillingCadence, params.OwnerID, params.ContactPhone, params.ContactEmail, params.Notes, facilitiesJSON, params.Version))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -581,6 +589,7 @@ func scanProperty(row rowScanner) (*Property, error) {
 	if err := row.Scan(
 		&property.ID,
 		&property.Name,
+		&property.PropertyPublicName,
 		&subtitle,
 		&property.Address,
 		&electricityUnitPrice,

--- a/internal/platform/database/properties/repository_test.go
+++ b/internal/platform/database/properties/repository_test.go
@@ -73,10 +73,11 @@ func TestCreatePersistsPropertyInTransaction(t *testing.T) {
 	facilities := map[string]interface{}{"elevator": true}
 
 	mock.ExpectQuery("INSERT INTO properties").
-		WithArgs("Green Villa", &subtitle, "Taipei", 4.5, "monthly", "owner-1", &contactPhone, &contactEmail, &notes, `{"elevator":true}`).
+		WithArgs("Green Villa", "Green Villa Public", &subtitle, "Taipei", 4.5, "monthly", "owner-1", &contactPhone, &contactEmail, &notes, `{"elevator":true}`).
 		WillReturnRows(propertyRows().AddRow(
 			"property-1",
 			"Green Villa",
+			"Green Villa Public",
 			subtitle,
 			"Taipei",
 			4.5,
@@ -93,6 +94,7 @@ func TestCreatePersistsPropertyInTransaction(t *testing.T) {
 
 	property, err := repo.Create(context.Background(), tx, CreatePropertyParams{
 		Name:                             "Green Villa",
+		PropertyPublicName:               "Green Villa Public",
 		Subtitle:                         &subtitle,
 		Address:                          "Taipei",
 		ElectricityUnitPrice:             4.5,
@@ -106,7 +108,7 @@ func TestCreatePersistsPropertyInTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if property.ID != "property-1" || property.Name != "Green Villa" || property.Address != "Taipei" || property.OwnerID != "owner-1" {
+	if property.ID != "property-1" || property.Name != "Green Villa" || property.PropertyPublicName != "Green Villa Public" || property.Address != "Taipei" || property.OwnerID != "owner-1" {
 		t.Fatalf("unexpected property: %+v", property)
 	}
 	if property.ElectricityUnitPrice == nil || *property.ElectricityUnitPrice != 4.5 {
@@ -145,6 +147,7 @@ func TestFindByIDScansNullableElectricityUnitPrice(t *testing.T) {
 		WithArgs("property-1").
 		WillReturnRows(propertyRows().AddRow(
 			"property-1",
+			"Green Villa",
 			"Green Villa",
 			nil,
 			"Taipei",
@@ -214,10 +217,11 @@ func TestUpdatePersistsPropertyWithNullableElectricityUnitPrice(t *testing.T) {
 	updatedAt := createdAt.Add(time.Minute)
 
 	mock.ExpectQuery("UPDATE properties").
-		WithArgs("property-1", "Green Villa Updated", nil, "New Taipei", nil, "bimonthly", "owner-2", nil, nil, nil, nil, 3).
+		WithArgs("property-1", "Green Villa Updated", "Public Green Villa", nil, "New Taipei", nil, "bimonthly", "owner-2", nil, nil, nil, nil, 3).
 		WillReturnRows(propertyRows().AddRow(
 			"property-1",
 			"Green Villa Updated",
+			"Public Green Villa",
 			nil,
 			"New Taipei",
 			nil,
@@ -235,6 +239,7 @@ func TestUpdatePersistsPropertyWithNullableElectricityUnitPrice(t *testing.T) {
 	property, err := repo.Update(context.Background(), tx, UpdatePropertyParams{
 		ID:                               "property-1",
 		Name:                             "Green Villa Updated",
+		PropertyPublicName:               "Public Green Villa",
 		Address:                          "New Taipei",
 		ElectricityUnitPrice:             nil,
 		DefaultElectricityBillingCadence: "bimonthly",
@@ -244,7 +249,7 @@ func TestUpdatePersistsPropertyWithNullableElectricityUnitPrice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Update: %v", err)
 	}
-	if property.Name != "Green Villa Updated" || property.Address != "New Taipei" || property.OwnerID != "owner-2" {
+	if property.Name != "Green Villa Updated" || property.PropertyPublicName != "Public Green Villa" || property.Address != "New Taipei" || property.OwnerID != "owner-2" {
 		t.Fatalf("unexpected property: %+v", property)
 	}
 	if property.ElectricityUnitPrice != nil {
@@ -270,12 +275,13 @@ func TestUpdateMapsNoRowsToNotFound(t *testing.T) {
 	unitPrice := 5.25
 
 	mock.ExpectQuery("UPDATE properties").
-		WithArgs("property-404", "Green Villa", nil, "Taipei", &unitPrice, "monthly", "owner-1", nil, nil, nil, nil, 9).
+		WithArgs("property-404", "Green Villa", "Green Villa", nil, "Taipei", &unitPrice, "monthly", "owner-1", nil, nil, nil, nil, 9).
 		WillReturnError(sql.ErrNoRows)
 
 	_, err := repo.Update(context.Background(), tx, UpdatePropertyParams{
 		ID:                               "property-404",
 		Name:                             "Green Villa",
+		PropertyPublicName:               "Green Villa",
 		Address:                          "Taipei",
 		ElectricityUnitPrice:             &unitPrice,
 		DefaultElectricityBillingCadence: "monthly",
@@ -729,6 +735,7 @@ func propertyRows() *sqlmock.Rows {
 	return sqlmock.NewRows([]string{
 		"id",
 		"name",
+		"property_public_name",
 		"subtitle",
 		"address",
 		"electricity_unit_price",

--- a/internal/platform/database/propertyquery/repository.go
+++ b/internal/platform/database/propertyquery/repository.go
@@ -19,6 +19,7 @@ var ErrNotFound = errors.New("property query not found")
 type Property struct {
 	ID                               string
 	Name                             string
+	PropertyPublicName               string
 	Subtitle                         *string
 	Address                          string
 	ElectricityUnitPrice             *float64
@@ -90,6 +91,7 @@ func (r *SQLRepository) FindByID(ctx context.Context, propertyID string) (*Prope
 SELECT
 	p.id,
 	p.name,
+	p.property_public_name,
 	p.subtitle,
 	p.address,
 	p.electricity_unit_price,
@@ -132,6 +134,7 @@ func (r *SQLRepository) ListAccessible(ctx context.Context, role string, userID 
 SELECT
 	p.id,
 	p.name,
+	p.property_public_name,
 	p.subtitle,
 	p.address,
 	p.electricity_unit_price,
@@ -292,6 +295,7 @@ func scanProperty(row rowScanner) (*Property, error) {
 	if err := row.Scan(
 		&property.ID,
 		&property.Name,
+		&property.PropertyPublicName,
 		&subtitle,
 		&property.Address,
 		&electricityUnitPrice,

--- a/internal/platform/database/propertyquery/repository_test.go
+++ b/internal/platform/database/propertyquery/repository_test.go
@@ -24,13 +24,14 @@ func TestListAccessibleReturnsOccupancySummary(t *testing.T) {
 
 	mock.ExpectQuery(`(?s)LEFT JOIN rooms ON rooms.property_id = p.id AND rooms.deleted_at IS NULL\s+WHERE p.deleted_at IS NULL\s+GROUP BY p.id ORDER BY p.created_at DESC`).
 		WillReturnRows(sqlmock.NewRows([]string{
-			"id", "name", "subtitle", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id",
+			"id", "name", "property_public_name", "subtitle", "address", "electricity_unit_price", "default_electricity_billing_cadence", "owner_id",
 			"contact_phone", "contact_email", "notes", "facilities",
 			"total_rooms", "occupied_rooms", "vacant_rooms", "maintenance_rooms", "occupancy_rate",
 			"created_at", "updated_at", "version",
 		}).AddRow(
 			"10000000-0000-0000-0000-000000000001",
 			"Demo Property",
+			"Demo Public Property",
 			nil,
 			"Demo Address",
 			4.5,
@@ -59,6 +60,9 @@ func TestListAccessibleReturnsOccupancySummary(t *testing.T) {
 	}
 	if properties[0].Occupancy.TotalRooms != 4 || properties[0].Occupancy.OccupancyRate != 0.5 {
 		t.Fatalf("unexpected occupancy summary: %+v", properties[0].Occupancy)
+	}
+	if properties[0].PropertyPublicName != "Demo Public Property" {
+		t.Fatalf("PropertyPublicName = %q, want Demo Public Property", properties[0].PropertyPublicName)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/server/property_adapters.go
+++ b/internal/server/property_adapters.go
@@ -42,6 +42,7 @@ func (a propertyAccountRepositoryAdapter) CreatePropertyAccount(ctx context.Cont
 func (a propertyRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params appproperty.CreatePropertyParams) (*appproperty.Property, error) {
 	property, err := a.repo.Create(ctx, tx, dbproperties.CreatePropertyParams{
 		Name:                             params.Name,
+		PropertyPublicName:               params.PropertyPublicName,
 		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
@@ -75,6 +76,7 @@ func (a propertyRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx, param
 	property, err := a.repo.Update(ctx, tx, dbproperties.UpdatePropertyParams{
 		ID:                               params.ID,
 		Name:                             params.Name,
+		PropertyPublicName:               params.PropertyPublicName,
 		Subtitle:                         params.Subtitle,
 		Address:                          params.Address,
 		ElectricityUnitPrice:             params.ElectricityUnitPrice,
@@ -189,6 +191,7 @@ func toApplicationProperty(property *dbproperties.Property) *appproperty.Propert
 	return &appproperty.Property{
 		ID:                               property.ID,
 		Name:                             property.Name,
+		PropertyPublicName:               property.PropertyPublicName,
 		Subtitle:                         property.Subtitle,
 		Address:                          property.Address,
 		ElectricityUnitPrice:             property.ElectricityUnitPrice,

--- a/internal/server/server_wiring_test.go
+++ b/internal/server/server_wiring_test.go
@@ -175,6 +175,7 @@ func TestPropertyMappingsPreserveContractFields(t *testing.T) {
 	property := toApplicationProperty(&dbproperties.Property{
 		ID:                               "property-1",
 		Name:                             "Property One",
+		PropertyPublicName:               "Public Property One",
 		Address:                          "Address One",
 		ElectricityUnitPrice:             &unitPrice,
 		DefaultElectricityBillingCadence: "bimonthly",
@@ -186,6 +187,7 @@ func TestPropertyMappingsPreserveContractFields(t *testing.T) {
 	expectedProperty := &appproperty.Property{
 		ID:                               "property-1",
 		Name:                             "Property One",
+		PropertyPublicName:               "Public Property One",
 		Address:                          "Address One",
 		ElectricityUnitPrice:             &unitPrice,
 		DefaultElectricityBillingCadence: "bimonthly",


### PR DESCRIPTION
Closes #179

## Summary
- add properties.property_public_name with backfill, NOT NULL, and non-empty DB check
- thread property_public_name through property create/update/read/list contracts, OpenAPI, generated bindings, handlers, application/domain, repositories, and server adapters
- update legacy property migration and demo seed inserts to populate property_public_name from the normalized property name

## Validation
- npm run openapi:generate
- GOCACHE=/tmp/go-cache go test ./...
- E2E_BASE_URL=http://127.0.0.1:8081 GOCACHE=/tmp/go-cache ./scripts/e2e_test.sh
- git diff --check