### PR TITLE
[codex] Add brand profile core controls

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -764,6 +764,91 @@ paths:
                   value:
                     error_code: FORBIDDEN
                     message: Forbidden.
+  /brand/profile:
+    get:
+      operationId: getBrandProfile
+      summary: 取得品牌基本資料
+      description: |
+        x-required-role: admin, organizer
+        Singleton brand profile for the demo brand frontend content controls.
+      tags:
+        - Brand
+      x-required-role:
+        - admin
+        - organizer
+      responses:
+        '200':
+          description: 品牌基本資料
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BrandProfileResponse'
+        '401':
+          description: 未認證
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: 權限不足
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 尚未建立品牌基本資料
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    put:
+      operationId: upsertBrandProfile
+      summary: 建立或更新品牌基本資料
+      description: |
+        x-required-role: admin, organizer
+        Upserts the singleton brand profile. version is required when updating an existing profile.
+      tags:
+        - Brand
+      x-required-role:
+        - admin
+        - organizer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertBrandProfileRequest'
+      responses:
+        '200':
+          description: 品牌基本資料已建立或更新
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BrandProfileResponse'
+        '400':
+          description: 欄位驗證錯誤
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: 未認證
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: 權限不足
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 樂觀鎖版本衝突
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /properties:
     get:
       operationId: listProperties
@@ -7320,6 +7405,52 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/HomeDashboardRecentJournalItem'
+    BrandProfileResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        brand_name:
+          type: string
+        contact_phone:
+          type: string
+          nullable: true
+        contact_email:
+          type: string
+          format: email
+          nullable: true
+        contact_address:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        version:
+          type: integer
+    UpsertBrandProfileRequest:
+      type: object
+      required:
+        - brand_name
+      properties:
+        brand_name:
+          type: string
+        contact_phone:
+          type: string
+          nullable: true
+        contact_email:
+          type: string
+          format: email
+          nullable: true
+        contact_address:
+          type: string
+          nullable: true
+        version:
+          type: integer
+          description: Required when updating an existing brand profile; omit for first creation.
     PropertyResponse:
       type: object
       properties:

--- a/docs/spec/schema.sql
+++ b/docs/spec/schema.sql
@@ -85,6 +85,34 @@ CREATE INDEX idx_properties_owner_id ON properties (owner_id) WHERE deleted_at I
 
 
 -- ============================================================
+-- Table: brand_profiles
+-- Aggregate: BrandProfile（Demo Brand Content BC）
+-- 說明: Demo 品牌頁第一版的全域 singleton 品牌聯絡資料，由 core admin API 管理
+-- ============================================================
+
+CREATE TABLE brand_profiles (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    singleton_key   BOOLEAN     NOT NULL DEFAULT true UNIQUE CHECK (singleton_key),
+    brand_name      VARCHAR(200) NOT NULL CHECK (btrim(brand_name) <> ''),
+    contact_phone   VARCHAR(50),
+    contact_email   VARCHAR(255),
+    contact_address TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    version         INTEGER     NOT NULL DEFAULT 1
+);
+
+CREATE VIEW approved_brand_profile_v1 AS
+SELECT
+    brand_name,
+    contact_phone,
+    contact_email,
+    contact_address,
+    updated_at
+FROM brand_profiles;
+
+
+-- ============================================================
 -- Table: rooms
 -- Aggregate: Property Aggregate（Property BC）—— Room Entity
 -- 說明: 房間資料，隸屬於 Property，狀態由 Property Aggregate 統一管理

--- a/docs/spec/src/components/schemas/brand/BrandProfileResponse.yaml
+++ b/docs/spec/src/components/schemas/brand/BrandProfileResponse.yaml
@@ -1,0 +1,25 @@
+type: object
+properties:
+  id:
+    type: string
+    format: uuid
+  brand_name:
+    type: string
+  contact_phone:
+    type: string
+    nullable: true
+  contact_email:
+    type: string
+    format: email
+    nullable: true
+  contact_address:
+    type: string
+    nullable: true
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time
+  version:
+    type: integer

--- a/docs/spec/src/components/schemas/brand/UpsertBrandProfileRequest.yaml
+++ b/docs/spec/src/components/schemas/brand/UpsertBrandProfileRequest.yaml
@@ -1,0 +1,19 @@
+type: object
+required:
+  - brand_name
+properties:
+  brand_name:
+    type: string
+  contact_phone:
+    type: string
+    nullable: true
+  contact_email:
+    type: string
+    format: email
+    nullable: true
+  contact_address:
+    type: string
+    nullable: true
+  version:
+    type: integer
+    description: Required when updating an existing brand profile; omit for first creation.

--- a/docs/spec/src/openapi.yaml
+++ b/docs/spec/src/openapi.yaml
@@ -91,6 +91,8 @@ paths:
     $ref: paths/iam/users_{id}_password-reset.yaml
   /dashboard:
     $ref: paths/property/dashboard.yaml
+  /brand/profile:
+    $ref: paths/brand/brand_profile.yaml
   /properties:
     $ref: paths/property/properties.yaml
   /properties/{id}:

--- a/docs/spec/src/paths/brand/brand_profile.yaml
+++ b/docs/spec/src/paths/brand/brand_profile.yaml
@@ -1,0 +1,84 @@
+get:
+  operationId: getBrandProfile
+  summary: 取得品牌基本資料
+  description: |
+    x-required-role: admin, organizer
+    Singleton brand profile for the demo brand frontend content controls.
+  tags:
+    - Brand
+  x-required-role:
+    - admin
+    - organizer
+  responses:
+    '200':
+      description: 品牌基本資料
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/brand/BrandProfileResponse.yaml
+    '401':
+      description: 未認證
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+    '403':
+      description: 權限不足
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+    '404':
+      description: 尚未建立品牌基本資料
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+put:
+  operationId: upsertBrandProfile
+  summary: 建立或更新品牌基本資料
+  description: |
+    x-required-role: admin, organizer
+    Upserts the singleton brand profile. version is required when updating an existing profile.
+  tags:
+    - Brand
+  x-required-role:
+    - admin
+    - organizer
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: ../../components/schemas/brand/UpsertBrandProfileRequest.yaml
+  responses:
+    '200':
+      description: 品牌基本資料已建立或更新
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/brand/BrandProfileResponse.yaml
+    '400':
+      description: 欄位驗證錯誤
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+    '401':
+      description: 未認證
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+    '403':
+      description: 權限不足
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml
+    '409':
+      description: 樂觀鎖版本衝突
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/shared/ErrorResponse.yaml

--- a/internal/application/brand/errors.go
+++ b/internal/application/brand/errors.go
@@ -1,0 +1,30 @@
+package brand
+
+import (
+	"errors"
+	"net/http"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+const codeBrandProfileNotFound = "BRAND_PROFILE_NOT_FOUND"
+
+var (
+	// ErrBrandProfileNotFound indicates that the singleton brand profile has not been created.
+	ErrBrandProfileNotFound = errors.New("brand profile not found")
+
+	errBrandProfileNotFound = apperr.New(
+		codeBrandProfileNotFound,
+		http.StatusNotFound,
+		"Brand profile not found.",
+	)
+)
+
+func mapError(err error) error {
+	switch {
+	case errors.Is(err, ErrBrandProfileNotFound):
+		return errBrandProfileNotFound
+	default:
+		return apperr.ErrInternalServerError.WithCause(err)
+	}
+}

--- a/internal/application/brand/profile.go
+++ b/internal/application/brand/profile.go
@@ -1,0 +1,186 @@
+package brand
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/mail"
+	"strings"
+	"time"
+
+	"stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+// Profile is the application-facing singleton brand profile.
+type Profile struct {
+	ID             string
+	BrandName      string
+	ContactPhone   *string
+	ContactEmail   *string
+	ContactAddress *string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	Version        int
+}
+
+// UpsertProfileInput contains writable brand profile fields.
+type UpsertProfileInput struct {
+	BrandName      string
+	ContactPhone   *string
+	ContactEmail   *string
+	ContactAddress *string
+	Version        *int
+}
+
+// CreateProfileParams contains normalized fields for creating the singleton profile.
+type CreateProfileParams struct {
+	BrandName      string
+	ContactPhone   *string
+	ContactEmail   *string
+	ContactAddress *string
+}
+
+// UpdateProfileParams contains normalized fields for updating the singleton profile.
+type UpdateProfileParams struct {
+	BrandName      string
+	ContactPhone   *string
+	ContactEmail   *string
+	ContactAddress *string
+	Version        int
+}
+
+// Repository defines persistence needed by brand profile application services.
+type Repository interface {
+	Find(ctx context.Context) (*Profile, error)
+	FindForUpdate(ctx context.Context, tx *sql.Tx) (*Profile, error)
+	Create(ctx context.Context, tx *sql.Tx, params CreateProfileParams) (*Profile, error)
+	Update(ctx context.Context, tx *sql.Tx, params UpdateProfileParams) (*Profile, error)
+}
+
+// Service owns brand profile read and write use cases.
+type Service struct {
+	repo     Repository
+	txRunner *txrunner.Runner
+}
+
+// NewService returns a brand profile service.
+func NewService(repo Repository, txRunner *txrunner.Runner) *Service {
+	return &Service{repo: repo, txRunner: txRunner}
+}
+
+// GetProfile returns the singleton brand profile.
+func (s *Service) GetProfile(ctx context.Context) (*Profile, error) {
+	profile, err := s.repo.Find(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	return profile, nil
+}
+
+// UpsertProfile creates the singleton profile or updates it with optimistic locking.
+func (s *Service) UpsertProfile(ctx context.Context, input UpsertProfileInput) (*Profile, error) {
+	params, err := normalizeUpsertInput(input)
+	if err != nil {
+		return nil, err
+	}
+
+	var saved *Profile
+	err = s.txRunner.WithinTransaction(ctx, func(ctx context.Context, tx *sql.Tx, _ *txrunner.EventRecorder) error {
+		_, err := s.repo.FindForUpdate(ctx, tx)
+		if err != nil {
+			if errors.Is(err, ErrBrandProfileNotFound) {
+				profile, err := s.repo.Create(ctx, tx, CreateProfileParams{
+					BrandName:      params.BrandName,
+					ContactPhone:   params.ContactPhone,
+					ContactEmail:   params.ContactEmail,
+					ContactAddress: params.ContactAddress,
+				})
+				if err != nil {
+					return mapError(err)
+				}
+				saved = profile
+				return nil
+			}
+			return mapError(err)
+		}
+
+		if params.Version == nil {
+			return apperr.ErrBadRequest.WithDetails(map[string]interface{}{
+				"field": "version",
+			})
+		}
+
+		profile, err := s.repo.Update(ctx, tx, UpdateProfileParams{
+			BrandName:      params.BrandName,
+			ContactPhone:   params.ContactPhone,
+			ContactEmail:   params.ContactEmail,
+			ContactAddress: params.ContactAddress,
+			Version:        *params.Version,
+		})
+		if err != nil {
+			if errors.Is(err, ErrBrandProfileNotFound) {
+				return apperr.ErrConcurrentUpdateConflict
+			}
+			return mapError(err)
+		}
+		saved = profile
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return saved, nil
+}
+
+func normalizeUpsertInput(input UpsertProfileInput) (UpsertProfileInput, error) {
+	brandName := strings.TrimSpace(input.BrandName)
+	if brandName == "" {
+		return UpsertProfileInput{}, apperr.ErrValidationNameRequired.WithDetails(map[string]interface{}{
+			"field": "brand_name",
+		})
+	}
+
+	contactEmail, err := normalizeEmail(input.ContactEmail)
+	if err != nil {
+		return UpsertProfileInput{}, err
+	}
+
+	return UpsertProfileInput{
+		BrandName:      brandName,
+		ContactPhone:   normalizeOptionalString(input.ContactPhone),
+		ContactEmail:   contactEmail,
+		ContactAddress: normalizeOptionalString(input.ContactAddress),
+		Version:        input.Version,
+	}, nil
+}
+
+func normalizeOptionalString(value *string) *string {
+	if value == nil {
+		return nil
+	}
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return nil
+	}
+	return &trimmed
+}
+
+func normalizeEmail(value *string) (*string, error) {
+	normalized := normalizeOptionalString(value)
+	if normalized == nil {
+		return nil, nil
+	}
+
+	address, err := mail.ParseAddress(*normalized)
+	if err != nil || address.Address != *normalized {
+		return nil, apperr.ErrValidationEmailInvalid.WithDetails(map[string]interface{}{
+			"field": "contact_email",
+		})
+	}
+
+	email := address.Address
+	return &email, nil
+}

--- a/internal/application/brand/profile_test.go
+++ b/internal/application/brand/profile_test.go
@@ -1,0 +1,148 @@
+package brand
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+
+	dbtxrunner "stds_backend/internal/platform/database/txrunner"
+	"stds_backend/internal/shared/apperr"
+)
+
+func TestGetProfileMapsNotFound(t *testing.T) {
+	service := NewService(&profileRepoStub{findErr: ErrBrandProfileNotFound}, nil)
+
+	_, err := service.GetProfile(context.Background())
+	if !errors.Is(err, errBrandProfileNotFound) {
+		t.Fatalf("expected brand profile not found error, got %v", err)
+	}
+}
+
+func TestUpsertProfileValidatesBrandName(t *testing.T) {
+	service := NewService(&profileRepoStub{}, nil)
+
+	_, err := service.UpsertProfile(context.Background(), UpsertProfileInput{BrandName: "   "})
+	if !errors.Is(err, apperr.ErrValidationNameRequired) {
+		t.Fatalf("expected validation name error, got %v", err)
+	}
+}
+
+func TestUpsertProfileCreatesWhenMissing(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("open sqlmock: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	repo := &profileRepoStub{
+		findForUpdateErr: ErrBrandProfileNotFound,
+		createProfile: &Profile{
+			ID:        "10000000-0000-0000-0000-000000000001",
+			BrandName: "STDS",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+			Version:   1,
+		},
+	}
+	service := NewService(repo, dbtxrunner.New(db, nil))
+
+	profile, err := service.UpsertProfile(context.Background(), UpsertProfileInput{
+		BrandName:    " STDS ",
+		ContactEmail: stringPtr("hello@example.com"),
+	})
+	if err != nil {
+		t.Fatalf("upsert profile: %v", err)
+	}
+	if profile.BrandName != "STDS" {
+		t.Fatalf("expected trimmed brand name, got %q", profile.BrandName)
+	}
+	if repo.createParams == nil || repo.createParams.ContactEmail == nil || *repo.createParams.ContactEmail != "hello@example.com" {
+		t.Fatalf("expected normalized create params, got %+v", repo.createParams)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestUpsertProfileRequiresVersionWhenExisting(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("open sqlmock: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectRollback()
+
+	repo := &profileRepoStub{findForUpdateProfile: &Profile{ID: "10000000-0000-0000-0000-000000000001", Version: 2}}
+	service := NewService(repo, dbtxrunner.New(db, nil))
+
+	_, err = service.UpsertProfile(context.Background(), UpsertProfileInput{BrandName: "STDS"})
+	if !errors.Is(err, apperr.ErrBadRequest) {
+		t.Fatalf("expected bad request for missing version, got %v", err)
+	}
+	if repo.updateParams != nil {
+		t.Fatalf("expected no update call, got %+v", repo.updateParams)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+type profileRepoStub struct {
+	findProfile          *Profile
+	findErr              error
+	findForUpdateProfile *Profile
+	findForUpdateErr     error
+	createProfile        *Profile
+	createErr            error
+	createParams         *CreateProfileParams
+	updateProfile        *Profile
+	updateErr            error
+	updateParams         *UpdateProfileParams
+}
+
+func (r *profileRepoStub) Find(context.Context) (*Profile, error) {
+	if r.findErr != nil {
+		return nil, r.findErr
+	}
+	if r.findProfile != nil {
+		return r.findProfile, nil
+	}
+	return nil, ErrBrandProfileNotFound
+}
+
+func (r *profileRepoStub) FindForUpdate(context.Context, *sql.Tx) (*Profile, error) {
+	if r.findForUpdateErr != nil {
+		return nil, r.findForUpdateErr
+	}
+	if r.findForUpdateProfile != nil {
+		return r.findForUpdateProfile, nil
+	}
+	return nil, ErrBrandProfileNotFound
+}
+
+func (r *profileRepoStub) Create(_ context.Context, _ *sql.Tx, params CreateProfileParams) (*Profile, error) {
+	r.createParams = &params
+	if r.createErr != nil {
+		return nil, r.createErr
+	}
+	return r.createProfile, nil
+}
+
+func (r *profileRepoStub) Update(_ context.Context, _ *sql.Tx, params UpdateProfileParams) (*Profile, error) {
+	r.updateParams = &params
+	if r.updateErr != nil {
+		return nil, r.updateErr
+	}
+	return r.updateProfile, nil
+}

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -585,6 +585,18 @@ type BillResponseStatus string
 // BillResponseType defines model for BillResponse.Type.
 type BillResponseType string
 
+// BrandProfileResponse defines model for BrandProfileResponse.
+type BrandProfileResponse struct {
+	BrandName      *string              `json:"brand_name,omitempty"`
+	ContactAddress *string              `json:"contact_address"`
+	ContactEmail   *openapi_types.Email `json:"contact_email"`
+	ContactPhone   *string              `json:"contact_phone"`
+	CreatedAt      *time.Time           `json:"created_at,omitempty"`
+	Id             *openapi_types.UUID  `json:"id,omitempty"`
+	UpdatedAt      *time.Time           `json:"updated_at,omitempty"`
+	Version        *int                 `json:"version,omitempty"`
+}
+
 // CancelRepairRequest defines model for CancelRepairRequest.
 type CancelRepairRequest struct {
 	Reason *string `json:"reason,omitempty"`
@@ -1590,6 +1602,17 @@ type UpdateUserRequest struct {
 // UpdateUserRequestRole defines model for UpdateUserRequest.Role.
 type UpdateUserRequestRole string
 
+// UpsertBrandProfileRequest defines model for UpsertBrandProfileRequest.
+type UpsertBrandProfileRequest struct {
+	BrandName      string               `json:"brand_name"`
+	ContactAddress *string              `json:"contact_address"`
+	ContactEmail   *openapi_types.Email `json:"contact_email"`
+	ContactPhone   *string              `json:"contact_phone"`
+
+	// Version Required when updating an existing brand profile; omit for first creation.
+	Version *int `json:"version,omitempty"`
+}
+
 // UserListResponse defines model for UserListResponse.
 type UserListResponse struct {
 	Data       *[]UserResponse     `json:"data,omitempty"`
@@ -1850,6 +1873,9 @@ type SubmitBillMeterJSONRequestBody = RecordMeterRequest
 // RecordBillPaymentJSONRequestBody defines body for RecordBillPayment for application/json ContentType.
 type RecordBillPaymentJSONRequestBody = RecordPaymentRequest
 
+// UpsertBrandProfileJSONRequestBody defines body for UpsertBrandProfile for application/json ContentType.
+type UpsertBrandProfileJSONRequestBody = UpsertBrandProfileRequest
+
 // CreateJournalLogJSONRequestBody defines body for CreateJournalLog for application/json ContentType.
 type CreateJournalLogJSONRequestBody = CreateJournalLogRequest
 
@@ -1978,6 +2004,12 @@ type ServerInterface interface {
 	// Export bill receipt as HTML
 	// (GET /bills/{id}/receipt)
 	ExportBillReceipt(c *gin.Context, id string, params ExportBillReceiptParams)
+	// 取得品牌基本資料
+	// (GET /brand/profile)
+	GetBrandProfile(c *gin.Context)
+	// 建立或更新品牌基本資料
+	// (PUT /brand/profile)
+	UpsertBrandProfile(c *gin.Context)
 	// Home dashboard summary read model
 	// (GET /dashboard)
 	GetDashboard(c *gin.Context)
@@ -2569,6 +2601,36 @@ func (siw *ServerInterfaceWrapper) ExportBillReceipt(c *gin.Context) {
 	}
 
 	siw.Handler.ExportBillReceipt(c, id, params)
+}
+
+// GetBrandProfile operation middleware
+func (siw *ServerInterfaceWrapper) GetBrandProfile(c *gin.Context) {
+
+	c.Set(BearerAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetBrandProfile(c)
+}
+
+// UpsertBrandProfile operation middleware
+func (siw *ServerInterfaceWrapper) UpsertBrandProfile(c *gin.Context) {
+
+	c.Set(BearerAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.UpsertBrandProfile(c)
 }
 
 // GetDashboard operation middleware
@@ -5163,6 +5225,8 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/bills/:id/meter", wrapper.SubmitBillMeter)
 	router.POST(options.BaseURL+"/bills/:id/payment", wrapper.RecordBillPayment)
 	router.GET(options.BaseURL+"/bills/:id/receipt", wrapper.ExportBillReceipt)
+	router.GET(options.BaseURL+"/brand/profile", wrapper.GetBrandProfile)
+	router.PUT(options.BaseURL+"/brand/profile", wrapper.UpsertBrandProfile)
 	router.GET(options.BaseURL+"/dashboard", wrapper.GetDashboard)
 	router.GET(options.BaseURL+"/force-terminations/:id", wrapper.GetForceTermination)
 	router.POST(options.BaseURL+"/internal/jobs/force-terminations/compensate", wrapper.RunForceTerminationCompensationJob)

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -14,6 +14,7 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	appattachment "stds_backend/internal/application/attachment"
+	appbrand "stds_backend/internal/application/brand"
 	appiam "stds_backend/internal/application/iam"
 	appjobs "stds_backend/internal/application/jobs"
 	appjournal "stds_backend/internal/application/journal"
@@ -45,6 +46,7 @@ type APIServer struct {
 	updateCurrentUser *appiam.UpdateCurrentUserService
 	updateUser        *appiam.UpdateUserService
 	assignProperties  *appiam.AssignUserPropertiesService
+	brandProfile      *appbrand.Service
 	jobTriggerService *appjobs.TriggerService
 	propertyQueryRepo dbpropertyquery.Repository
 	propertyDashboard *appproperty.DashboardService
@@ -86,6 +88,7 @@ type APIServerDeps struct {
 	UpdateCurrentUser *appiam.UpdateCurrentUserService
 	UpdateUser        *appiam.UpdateUserService
 	AssignProperties  *appiam.AssignUserPropertiesService
+	BrandProfile      *appbrand.Service
 	JobTrigger        *appjobs.TriggerService
 	PropertyQuery     dbpropertyquery.Repository
 	PropertyDashboard *appproperty.DashboardService
@@ -468,6 +471,7 @@ func NewAPIServer(deps APIServerDeps) *APIServer {
 		updateCurrentUser: deps.UpdateCurrentUser,
 		updateUser:        deps.UpdateUser,
 		assignProperties:  deps.AssignProperties,
+		brandProfile:      deps.BrandProfile,
 		jobTriggerService: deps.JobTrigger,
 		propertyQueryRepo: deps.PropertyQuery,
 		propertyDashboard: deps.PropertyDashboard,
@@ -512,6 +516,7 @@ func validateAPIServerDeps(deps APIServerDeps) {
 		{"update_current_user", deps.UpdateCurrentUser},
 		{"update_user", deps.UpdateUser},
 		{"assign_properties", deps.AssignProperties},
+		{"brand_profile", deps.BrandProfile},
 		{"job_trigger", deps.JobTrigger},
 		{"property_query", deps.PropertyQuery},
 		{"property_dashboard", deps.PropertyDashboard},
@@ -1537,6 +1542,40 @@ func (s *APIServer) ExportLeaseCheckoutSettlement(c *gin.Context, id string, par
 		return
 	}
 	writeHTMLDocument(c, document)
+}
+
+// GetBrandProfile handles singleton brand profile retrieval.
+func (s *APIServer) GetBrandProfile(c *gin.Context) {
+	profile, err := s.brandProfile.GetProfile(c.Request.Context())
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toBrandProfileResponse(profile))
+}
+
+// UpsertBrandProfile handles singleton brand profile creation and update.
+func (s *APIServer) UpsertBrandProfile(c *gin.Context) {
+	var request api.UpsertBrandProfileRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.Error(apperr.ErrBadRequest.WithCause(err))
+		return
+	}
+
+	profile, err := s.brandProfile.UpsertProfile(c.Request.Context(), appbrand.UpsertProfileInput{
+		BrandName:      request.BrandName,
+		ContactPhone:   request.ContactPhone,
+		ContactEmail:   emailPtrToStringPtr(request.ContactEmail),
+		ContactAddress: request.ContactAddress,
+		Version:        request.Version,
+	})
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toBrandProfileResponse(profile))
 }
 
 // ListProperties handles the property listing endpoint.
@@ -3720,6 +3759,32 @@ func (s *APIServer) runJob(c *gin.Context, jobKey appjobs.JobKey, windowKey stri
 	})
 
 	c.JSON(http.StatusAccepted, response)
+}
+
+func toBrandProfileResponse(profile *appbrand.Profile) api.BrandProfileResponse {
+	id, idOK := parseUUID(profile.ID)
+	brandName := profile.BrandName
+	createdAt := profile.CreatedAt
+	updatedAt := profile.UpdatedAt
+	version := profile.Version
+
+	response := api.BrandProfileResponse{
+		BrandName:      &brandName,
+		ContactAddress: profile.ContactAddress,
+		ContactPhone:   profile.ContactPhone,
+		CreatedAt:      &createdAt,
+		UpdatedAt:      &updatedAt,
+		Version:        &version,
+	}
+	if profile.ContactEmail != nil {
+		email := openapi_types.Email(*profile.ContactEmail)
+		response.ContactEmail = &email
+	}
+	if idOK {
+		response.Id = &id
+	}
+
+	return response
 }
 
 func toPropertyResponse(property *dbpropertyquery.Property) api.PropertyResponse {

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -11,11 +11,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
 	googleuuid "github.com/google/uuid"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 
 	appattachment "stds_backend/internal/application/attachment"
+	appbrand "stds_backend/internal/application/brand"
 	applease "stds_backend/internal/application/lease"
 	appproperty "stds_backend/internal/application/property"
 	apprepair "stds_backend/internal/application/repair"
@@ -118,6 +120,83 @@ func TestToPropertyResponseDropsInvalidContactEmail(t *testing.T) {
 
 	if value, ok := payload["contact_email"]; !ok || value != nil {
 		t.Fatalf("expected contact_email null, got %v", payload["contact_email"])
+	}
+}
+
+func TestUpsertBrandProfileReturnsUpdatedProfile(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("open sqlmock: %v", err)
+	}
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectCommit()
+
+	now := time.Date(2026, 5, 13, 10, 0, 0, 0, time.UTC)
+	repo := &handlerBrandProfileRepoStub{
+		findForUpdateProfile: &appbrand.Profile{ID: "10000000-0000-0000-0000-000000000001", Version: 1},
+		updateProfile: &appbrand.Profile{
+			ID:             "10000000-0000-0000-0000-000000000001",
+			BrandName:      "STDS Demo",
+			ContactEmail:   handlerStringPtr("hello@example.com"),
+			ContactAddress: handlerStringPtr("Taipei"),
+			CreatedAt:      now,
+			UpdatedAt:      now,
+			Version:        2,
+		},
+	}
+	server := &APIServer{brandProfile: appbrand.NewService(repo, txrunner.New(db, nil))}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPut, "/api/v1/brand/profile", bytes.NewBufferString(`{"brand_name":" STDS Demo ","contact_email":"hello@example.com","contact_address":"Taipei","version":1}`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	server.UpsertBrandProfile(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	if repo.updateParams == nil || repo.updateParams.BrandName != "STDS Demo" || repo.updateParams.Version != 1 {
+		t.Fatalf("unexpected update params: %+v", repo.updateParams)
+	}
+	var response api.BrandProfileResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.BrandName == nil || *response.BrandName != "STDS Demo" {
+		t.Fatalf("unexpected brand name: %+v", response.BrandName)
+	}
+	if response.Version == nil || *response.Version != 2 {
+		t.Fatalf("unexpected version: %+v", response.Version)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestUpsertBrandProfileRejectsMalformedBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := &APIServer{brandProfile: appbrand.NewService(&handlerBrandProfileRepoStub{}, nil)}
+	engine := gin.New()
+	engine.Use(middleware.ErrorHandler(nil))
+	engine.PUT("/brand/profile", server.UpsertBrandProfile)
+
+	req := httptest.NewRequest(http.MethodPut, "/brand/profile", bytes.NewBufferString(`{"brand_name":`))
+	resp := httptest.NewRecorder()
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", resp.Code, resp.Body.String())
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if payload["error_code"] != apperr.CodeBadRequest {
+		t.Fatalf("expected bad request, got %v", payload["error_code"])
 	}
 }
 
@@ -2000,8 +2079,61 @@ func intPtr(value int) *int {
 	return &value
 }
 
+func handlerStringPtr(value string) *string {
+	return &value
+}
+
 func uuidPtr(value string) *openapi_types.UUID {
 	parsed := googleuuid.MustParse(value)
 	result := openapi_types.UUID(parsed)
 	return &result
+}
+
+type handlerBrandProfileRepoStub struct {
+	findProfile          *appbrand.Profile
+	findErr              error
+	findForUpdateProfile *appbrand.Profile
+	findForUpdateErr     error
+	createProfile        *appbrand.Profile
+	createParams         *appbrand.CreateProfileParams
+	createErr            error
+	updateProfile        *appbrand.Profile
+	updateParams         *appbrand.UpdateProfileParams
+	updateErr            error
+}
+
+func (r *handlerBrandProfileRepoStub) Find(context.Context) (*appbrand.Profile, error) {
+	if r.findErr != nil {
+		return nil, r.findErr
+	}
+	if r.findProfile != nil {
+		return r.findProfile, nil
+	}
+	return nil, appbrand.ErrBrandProfileNotFound
+}
+
+func (r *handlerBrandProfileRepoStub) FindForUpdate(context.Context, *sql.Tx) (*appbrand.Profile, error) {
+	if r.findForUpdateErr != nil {
+		return nil, r.findForUpdateErr
+	}
+	if r.findForUpdateProfile != nil {
+		return r.findForUpdateProfile, nil
+	}
+	return nil, appbrand.ErrBrandProfileNotFound
+}
+
+func (r *handlerBrandProfileRepoStub) Create(_ context.Context, _ *sql.Tx, params appbrand.CreateProfileParams) (*appbrand.Profile, error) {
+	r.createParams = &params
+	if r.createErr != nil {
+		return nil, r.createErr
+	}
+	return r.createProfile, nil
+}
+
+func (r *handlerBrandProfileRepoStub) Update(_ context.Context, _ *sql.Tx, params appbrand.UpdateProfileParams) (*appbrand.Profile, error) {
+	r.updateParams = &params
+	if r.updateErr != nil {
+		return nil, r.updateErr
+	}
+	return r.updateProfile, nil
 }

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -202,6 +202,8 @@ func routePolicies(authzRepos AuthorizationRepositories) []routePolicy {
 		{method: "GET", path: "/api/v1/leases/:id/checkout-settlement/export", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}, propertyResolver: middleware.ResourcePropertyIDWithNotFound("id", ownership.FindPropertyIDByLeaseID, apperr.ErrLeaseNotFound)},
 
 		{method: "GET", path: "/api/v1/dashboard", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}},
+		{method: "GET", path: "/api/v1/brand/profile", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer"}},
+		{method: "PUT", path: "/api/v1/brand/profile", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer"}},
 		{method: "GET", path: "/api/v1/properties", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}},
 		{method: "POST", path: "/api/v1/properties", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "GET", path: "/api/v1/properties/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}, propertyResolver: middleware.ParamPropertyID("id")},

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	appattachment "stds_backend/internal/application/attachment"
+	appbrand "stds_backend/internal/application/brand"
 	appiam "stds_backend/internal/application/iam"
 	appjobs "stds_backend/internal/application/jobs"
 	appjournal "stds_backend/internal/application/journal"
@@ -143,6 +144,29 @@ func TestGeneratedWrapperBindingErrorsUseStandardErrorResponse(t *testing.T) {
 			engine.ServeHTTP(resp, req)
 
 			assertStandardErrorResponse(t, resp, http.StatusBadRequest, apperr.CodeBadRequest)
+		})
+	}
+}
+
+func TestBrandProfileRoutePolicyRejectsStaffAndOwner(t *testing.T) {
+	for _, role := range []string{"staff", "owner"} {
+		t.Run(role, func(t *testing.T) {
+			engine := newTestEngine(
+				fakeUserRepo{role: role},
+				fakeAuthenticator{role: role},
+				fakePropertyRepo{},
+				fakeResourceOwnershipRepo{},
+				"",
+				fakeJobRunsRepo{},
+			)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/brand/profile", nil)
+			req.Header.Set("Authorization", "Bearer valid-token")
+			resp := httptest.NewRecorder()
+
+			engine.ServeHTTP(resp, req)
+
+			assertStandardErrorResponse(t, resp, http.StatusForbidden, apperr.CodeForbidden)
 		})
 	}
 }
@@ -6847,6 +6871,7 @@ func defaultAPIServerDeps(userRepo *fakeUserRepo, authenticator fakeAuthenticato
 		UpdateCurrentUser: appiam.NewUpdateCurrentUserService(userRepo),
 		UpdateUser:        appiam.NewUpdateUserService(userAccountRepo, appiam.NewCustomClaimsService(authenticator)),
 		AssignProperties:  appiam.NewAssignUserPropertiesService(testManagedUserRepositoryAdapter{repo: userRepo}, testPropertyExistenceChecker{repo: fakePropertyQueryRepo{}}, appiam.NewCustomClaimsService(authenticator)),
+		BrandProfile:      appbrand.NewService(nil, nil),
 		JobTrigger:        appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		PropertyQuery:     propertyQueryRepo,
 		PropertyDashboard: appproperty.NewDashboardService(nil),

--- a/internal/platform/database/brandprofile/repository.go
+++ b/internal/platform/database/brandprofile/repository.go
@@ -1,0 +1,152 @@
+package brandprofile
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrNotFound indicates that the singleton brand profile has not been created.
+var ErrNotFound = errors.New("brand profile not found")
+
+// Profile is the persisted singleton brand profile.
+type Profile struct {
+	ID             string
+	BrandName      string
+	ContactPhone   *string
+	ContactEmail   *string
+	ContactAddress *string
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
+	Version        int
+}
+
+// CreateProfileParams contains fields for inserting a brand profile.
+type CreateProfileParams struct {
+	BrandName      string
+	ContactPhone   *string
+	ContactEmail   *string
+	ContactAddress *string
+}
+
+// UpdateProfileParams contains fields for updating a brand profile.
+type UpdateProfileParams struct {
+	BrandName      string
+	ContactPhone   *string
+	ContactEmail   *string
+	ContactAddress *string
+	Version        int
+}
+
+// SQLRepository loads and persists the singleton brand profile.
+type SQLRepository struct {
+	db *sql.DB
+}
+
+// NewRepository returns a brand profile repository backed by db.
+func NewRepository(db *sql.DB) *SQLRepository {
+	return &SQLRepository{db: db}
+}
+
+// Find loads the singleton brand profile.
+func (r *SQLRepository) Find(ctx context.Context) (*Profile, error) {
+	const query = `
+SELECT id, brand_name, contact_phone, contact_email, contact_address, created_at, updated_at, version
+FROM brand_profiles
+WHERE singleton_key = true
+LIMIT 1
+`
+
+	profile, err := scanProfile(r.db.QueryRowContext(ctx, query))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find brand profile: %w", err)
+	}
+
+	return profile, nil
+}
+
+// FindForUpdate locks and returns the singleton brand profile inside tx.
+func (r *SQLRepository) FindForUpdate(ctx context.Context, tx *sql.Tx) (*Profile, error) {
+	const query = `
+SELECT id, brand_name, contact_phone, contact_email, contact_address, created_at, updated_at, version
+FROM brand_profiles
+WHERE singleton_key = true
+LIMIT 1
+FOR UPDATE
+`
+
+	profile, err := scanProfile(tx.QueryRowContext(ctx, query))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find brand profile for update: %w", err)
+	}
+
+	return profile, nil
+}
+
+// Create inserts the singleton brand profile inside tx.
+func (r *SQLRepository) Create(ctx context.Context, tx *sql.Tx, params CreateProfileParams) (*Profile, error) {
+	const query = `
+INSERT INTO brand_profiles (brand_name, contact_phone, contact_email, contact_address)
+VALUES ($1, $2, $3, $4)
+RETURNING id, brand_name, contact_phone, contact_email, contact_address, created_at, updated_at, version
+`
+
+	profile, err := scanProfile(tx.QueryRowContext(ctx, query, params.BrandName, params.ContactPhone, params.ContactEmail, params.ContactAddress))
+	if err != nil {
+		return nil, fmt.Errorf("create brand profile: %w", err)
+	}
+
+	return profile, nil
+}
+
+// Update updates the singleton brand profile inside tx.
+func (r *SQLRepository) Update(ctx context.Context, tx *sql.Tx, params UpdateProfileParams) (*Profile, error) {
+	const query = `
+UPDATE brand_profiles
+SET brand_name = $1,
+	contact_phone = $2,
+	contact_email = $3,
+	contact_address = $4,
+	updated_at = now(),
+	version = version + 1
+WHERE singleton_key = true
+  AND version = $5
+RETURNING id, brand_name, contact_phone, contact_email, contact_address, created_at, updated_at, version
+`
+
+	profile, err := scanProfile(tx.QueryRowContext(ctx, query, params.BrandName, params.ContactPhone, params.ContactEmail, params.ContactAddress, params.Version))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update brand profile: %w", err)
+	}
+
+	return profile, nil
+}
+
+func scanProfile(row *sql.Row) (*Profile, error) {
+	var profile Profile
+	if err := row.Scan(
+		&profile.ID,
+		&profile.BrandName,
+		&profile.ContactPhone,
+		&profile.ContactEmail,
+		&profile.ContactAddress,
+		&profile.CreatedAt,
+		&profile.UpdatedAt,
+		&profile.Version,
+	); err != nil {
+		return nil, err
+	}
+
+	return &profile, nil
+}

--- a/internal/platform/database/brandprofile/repository_test.go
+++ b/internal/platform/database/brandprofile/repository_test.go
@@ -1,0 +1,122 @@
+package brandprofile
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestFindReturnsNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("open sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT id, brand_name, contact_phone, contact_email, contact_address, created_at, updated_at, version
+FROM brand_profiles
+WHERE singleton_key = true
+LIMIT 1
+`)).WillReturnError(sql.ErrNoRows)
+
+	_, err = NewRepository(db).Find(context.Background())
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestCreateScansNullableContactFields(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("open sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	tx := expectBegin(t, db, mock)
+	now := time.Now().UTC()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+INSERT INTO brand_profiles (brand_name, contact_phone, contact_email, contact_address)
+VALUES ($1, $2, $3, $4)
+RETURNING id, brand_name, contact_phone, contact_email, contact_address, created_at, updated_at, version
+`)).
+		WithArgs("STDS", nil, "hello@example.com", nil).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "brand_name", "contact_phone", "contact_email", "contact_address", "created_at", "updated_at", "version"}).
+			AddRow("10000000-0000-0000-0000-000000000001", "STDS", nil, "hello@example.com", nil, now, now, 1))
+
+	email := "hello@example.com"
+	profile, err := NewRepository(db).Create(context.Background(), tx, CreateProfileParams{
+		BrandName:    "STDS",
+		ContactEmail: &email,
+	})
+	if err != nil {
+		t.Fatalf("create profile: %v", err)
+	}
+	if profile.ContactPhone != nil || profile.ContactAddress != nil {
+		t.Fatalf("expected nil nullable fields, got phone=%v address=%v", profile.ContactPhone, profile.ContactAddress)
+	}
+	if profile.ContactEmail == nil || *profile.ContactEmail != "hello@example.com" {
+		t.Fatalf("expected contact email, got %v", profile.ContactEmail)
+	}
+	mock.ExpectCommit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestUpdateMapsVersionMissToNotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("open sqlmock: %v", err)
+	}
+	defer db.Close()
+
+	tx := expectBegin(t, db, mock)
+	mock.ExpectQuery(regexp.QuoteMeta(`
+UPDATE brand_profiles
+SET brand_name = $1,
+	contact_phone = $2,
+	contact_email = $3,
+	contact_address = $4,
+	updated_at = now(),
+	version = version + 1
+WHERE singleton_key = true
+  AND version = $5
+RETURNING id, brand_name, contact_phone, contact_email, contact_address, created_at, updated_at, version
+`)).
+		WithArgs("STDS", nil, nil, nil, 2).
+		WillReturnError(sql.ErrNoRows)
+
+	_, err = NewRepository(db).Update(context.Background(), tx, UpdateProfileParams{BrandName: "STDS", Version: 2})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	mock.ExpectRollback()
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func expectBegin(t *testing.T, db *sql.DB, mock sqlmock.Sqlmock) *sql.Tx {
+	t.Helper()
+	mock.ExpectBegin()
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+	return tx
+}

--- a/internal/platform/database/migrate/migrations/000022_add_brand_profile.down.sql
+++ b/internal/platform/database/migrate/migrations/000022_add_brand_profile.down.sql
@@ -1,0 +1,3 @@
+DROP VIEW IF EXISTS approved_brand_profile_v1;
+
+DROP TABLE IF EXISTS brand_profiles;

--- a/internal/platform/database/migrate/migrations/000022_add_brand_profile.up.sql
+++ b/internal/platform/database/migrate/migrations/000022_add_brand_profile.up.sql
@@ -1,0 +1,20 @@
+CREATE TABLE brand_profiles (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    singleton_key   BOOLEAN     NOT NULL DEFAULT true UNIQUE CHECK (singleton_key),
+    brand_name      VARCHAR(200) NOT NULL CHECK (btrim(brand_name) <> ''),
+    contact_phone   VARCHAR(50),
+    contact_email   VARCHAR(255),
+    contact_address TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    version         INTEGER     NOT NULL DEFAULT 1
+);
+
+CREATE VIEW approved_brand_profile_v1 AS
+SELECT
+    brand_name,
+    contact_phone,
+    contact_email,
+    contact_address,
+    updated_at
+FROM brand_profiles;

--- a/internal/platform/database/migrate/runner_test.go
+++ b/internal/platform/database/migrate/runner_test.go
@@ -37,6 +37,7 @@ var expectedMigrationVersions = []string{
 	"000019",
 	"000020",
 	"000021",
+	"000022",
 }
 
 func TestRunnerUpAppliesMigrationsAndRecordsVersions(t *testing.T) {
@@ -253,6 +254,48 @@ func TestPropertyPublicNameMigrationBackfillsAndEnforcesNonEmptyValue(t *testing
 	for _, snippet := range requiredDownSnippets {
 		if !strings.Contains(downSQL, snippet) {
 			t.Fatalf("000021 down migration missing %q", snippet)
+		}
+	}
+}
+
+func TestBrandProfileMigrationCreatesApprovedViewShape(t *testing.T) {
+	migrations := migrationsByVersion(t, "up")
+	sql := migrations["000022"].SQL
+
+	requiredSnippets := []string{
+		"CREATE TABLE brand_profiles",
+		"singleton_key   BOOLEAN",
+		"brand_name      VARCHAR(200) NOT NULL CHECK (btrim(brand_name) <> '')",
+		"version         INTEGER",
+		"CREATE VIEW approved_brand_profile_v1 AS",
+		"brand_name",
+		"contact_phone",
+		"contact_email",
+		"contact_address",
+		"updated_at",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(sql, snippet) {
+			t.Fatalf("000022 migration missing %q", snippet)
+		}
+	}
+	viewStart := strings.Index(sql, "CREATE VIEW approved_brand_profile_v1 AS")
+	if viewStart < 0 {
+		t.Fatal("000022 migration missing approved view")
+	}
+	viewSQL := sql[viewStart:]
+	if strings.Contains(viewSQL, "SELECT *") || strings.Contains(viewSQL, "created_at") || strings.Contains(viewSQL, "version") {
+		t.Fatalf("000022 approved view exposes disallowed metadata: %s", viewSQL)
+	}
+
+	downSQL := migrationsByVersion(t, "down")["000022"].SQL
+	requiredDownSnippets := []string{
+		"DROP VIEW IF EXISTS approved_brand_profile_v1",
+		"DROP TABLE IF EXISTS brand_profiles",
+	}
+	for _, snippet := range requiredDownSnippets {
+		if !strings.Contains(downSQL, snippet) {
+			t.Fatalf("000022 down migration missing %q", snippet)
 		}
 	}
 }

--- a/internal/server/brand_adapters.go
+++ b/internal/server/brand_adapters.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+
+	appbrand "stds_backend/internal/application/brand"
+	dbbrandprofile "stds_backend/internal/platform/database/brandprofile"
+)
+
+type brandProfileRepositoryAdapter struct {
+	repo *dbbrandprofile.SQLRepository
+}
+
+func (a brandProfileRepositoryAdapter) Find(ctx context.Context) (*appbrand.Profile, error) {
+	profile, err := a.repo.Find(ctx)
+	if err != nil {
+		if err == dbbrandprofile.ErrNotFound {
+			return nil, appbrand.ErrBrandProfileNotFound
+		}
+		return nil, err
+	}
+
+	return toApplicationBrandProfile(profile), nil
+}
+
+func (a brandProfileRepositoryAdapter) FindForUpdate(ctx context.Context, tx *sql.Tx) (*appbrand.Profile, error) {
+	profile, err := a.repo.FindForUpdate(ctx, tx)
+	if err != nil {
+		if err == dbbrandprofile.ErrNotFound {
+			return nil, appbrand.ErrBrandProfileNotFound
+		}
+		return nil, err
+	}
+
+	return toApplicationBrandProfile(profile), nil
+}
+
+func (a brandProfileRepositoryAdapter) Create(ctx context.Context, tx *sql.Tx, params appbrand.CreateProfileParams) (*appbrand.Profile, error) {
+	profile, err := a.repo.Create(ctx, tx, dbbrandprofile.CreateProfileParams{
+		BrandName:      params.BrandName,
+		ContactPhone:   params.ContactPhone,
+		ContactEmail:   params.ContactEmail,
+		ContactAddress: params.ContactAddress,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toApplicationBrandProfile(profile), nil
+}
+
+func (a brandProfileRepositoryAdapter) Update(ctx context.Context, tx *sql.Tx, params appbrand.UpdateProfileParams) (*appbrand.Profile, error) {
+	profile, err := a.repo.Update(ctx, tx, dbbrandprofile.UpdateProfileParams{
+		BrandName:      params.BrandName,
+		ContactPhone:   params.ContactPhone,
+		ContactEmail:   params.ContactEmail,
+		ContactAddress: params.ContactAddress,
+		Version:        params.Version,
+	})
+	if err != nil {
+		if err == dbbrandprofile.ErrNotFound {
+			return nil, appbrand.ErrBrandProfileNotFound
+		}
+		return nil, err
+	}
+
+	return toApplicationBrandProfile(profile), nil
+}
+
+func toApplicationBrandProfile(profile *dbbrandprofile.Profile) *appbrand.Profile {
+	return &appbrand.Profile{
+		ID:             profile.ID,
+		BrandName:      profile.BrandName,
+		ContactPhone:   profile.ContactPhone,
+		ContactEmail:   profile.ContactEmail,
+		ContactAddress: profile.ContactAddress,
+		CreatedAt:      profile.CreatedAt,
+		UpdatedAt:      profile.UpdatedAt,
+		Version:        profile.Version,
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 
 	appattachment "stds_backend/internal/application/attachment"
+	appbrand "stds_backend/internal/application/brand"
 	appiam "stds_backend/internal/application/iam"
 	appjobs "stds_backend/internal/application/jobs"
 	appjournal "stds_backend/internal/application/journal"
@@ -22,6 +23,7 @@ import (
 	"stds_backend/internal/platform/database"
 	dbattachments "stds_backend/internal/platform/database/attachments"
 	dbbilling "stds_backend/internal/platform/database/billing"
+	dbbrandprofile "stds_backend/internal/platform/database/brandprofile"
 	dbjobruns "stds_backend/internal/platform/database/jobruns"
 	dbjournal "stds_backend/internal/platform/database/journal"
 	dbleasequery "stds_backend/internal/platform/database/leasequery"
@@ -80,6 +82,7 @@ func New(cfg *config.Config) (*Server, error) {
 	resourceOwnershipRepo := dbresourceownership.NewRepository(db)
 	jobRunsRepo := dbjobruns.NewRepository(db)
 	attachmentRepo := dbattachments.NewRepository(db)
+	brandProfileRepo := dbbrandprofile.NewRepository(db)
 
 	storageClient, err := platformstorage.NewAttachmentStorage(context.Background(), cfg.App.Env, cfg.Storage)
 	if err != nil {
@@ -111,6 +114,7 @@ func New(cfg *config.Config) (*Server, error) {
 		customClaimsService,
 	)
 	txRunner := dbtxrunner.New(db, bus)
+	brandProfileService := appbrand.NewService(brandProfileRepositoryAdapter{repo: brandProfileRepo}, txRunner)
 	createPropertyService := appproperty.NewCreatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, propertyAccountRepositoryAdapter{repo: billingRepo}, txRunner)
 	updatePropertyService := appproperty.NewUpdatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	deletePropertyService := appproperty.NewDeletePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
@@ -168,6 +172,7 @@ func New(cfg *config.Config) (*Server, error) {
 		UpdateCurrentUser: updateCurrentUserService,
 		UpdateUser:        updateUserService,
 		AssignProperties:  assignUserPropertiesService,
+		BrandProfile:      brandProfileService,
 		JobTrigger:        jobTriggerService,
 		PropertyQuery:     propertyQueryRepo,
 		PropertyDashboard: propertyDashboardService,


### PR DESCRIPTION
Closes #180

## Summary
- add the singleton brand profile table and approved_brand_profile_v1 readonly view
- add internal admin GET/PUT /api/v1/brand/profile with versioned upsert semantics
- wire brand profile application service, database repository, server adapter, handler, route policy, OpenAPI, and generated bindings
- cover validation, repository SQL/nullables, route policy, handler binding, and migration/view shape

## Scope Notes
- GET returns 404 before the singleton profile exists
- PUT creates the first profile and requires version for updates
- route policy is admin/organizer only; staff and owner are not allowed
- FAQ, property availability, thin backend, and public brand API remain out of scope

## Validation
- GOCACHE=/tmp/go-cache go test ./internal/application/brand ./internal/platform/database/brandprofile ./internal/platform/database/migrate ./internal/http/handler ./internal/http/router ./internal/server
- GOCACHE=/tmp/go-cache go test ./...
- git diff --check