### PR TITLE
[codex] Add brand property availability approved view

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Run migration PostgreSQL contract tests
         env:
           TEST_DATABASE_URL: postgres://stds:stds@localhost:5432/stds_backend?sslmode=disable
-        run: go test ./internal/platform/database/migrate -run TestAccountingTitleMigrationPostgresContract -count=1
+        run: go test ./internal/platform/database/migrate -run 'Test.*MigrationPostgresContract|TestBrandPropertyAvailabilityViewPostgresContract' -count=1
 
   e2e:
     name: E2E harness smoke

--- a/README.md
+++ b/README.md
@@ -277,6 +277,26 @@ go test -tags=e2e ./test/e2e
 - Run all pending migrations: `go run ./cmd/migrate up`
 - Roll back applied migrations in reverse order: `go run ./cmd/migrate down`
 
+## Brand readonly database access
+
+Demo brand frontend data is exposed to a future thin backend through approved
+PostgreSQL views only. The core backend migrations create the views; deployment
+or DBA provisioning must create the Cloud SQL readonly principal and grant only
+the approved view access.
+
+The current approved views are:
+
+- `approved_brand_profile_v1`
+- `approved_brand_faq_items_v1`
+- `approved_brand_property_availability_v1`
+
+The brand readonly principal should receive `USAGE` on the schema and `SELECT`
+on those views only. Do not grant it direct access to base tables such as
+`properties`, `rooms`, `brand_profiles`, `brand_faq_items`, `tenants`, `leases`,
+`bills`, `attachments`, or deposit/accounting tables. Local PostgreSQL contract
+tests use an ephemeral equivalent role to verify that the approved views are
+selectable while base tables are not.
+
 ## Legacy migration planning
 
 - Validate the checked-in legacy JSON exports and generate the Task 5 architecture report: `go run ./cmd/migrate_legacy plan`

--- a/docs/spec/schema.sql
+++ b/docs/spec/schema.sql
@@ -102,6 +102,7 @@ CREATE TABLE brand_profiles (
     version         INTEGER     NOT NULL DEFAULT 1
 );
 
+-- Approved readonly view: future brand thin backend may read this view, not brand_profiles.
 CREATE VIEW approved_brand_profile_v1 AS
 SELECT
     brand_name,
@@ -134,6 +135,7 @@ CREATE INDEX idx_brand_faq_items_sort_order
     ON brand_faq_items (sort_order)
     WHERE deleted_at IS NULL;
 
+-- Approved readonly view: future brand thin backend may read active FAQ rows through this view only.
 CREATE VIEW approved_brand_faq_items_v1 AS
 SELECT
     question,
@@ -177,6 +179,27 @@ CREATE TABLE rooms (
 CREATE INDEX idx_rooms_property_id ON rooms (property_id) WHERE deleted_at IS NULL;
 -- idx_rooms_property_status: 篩選物業內特定狀態房間（dashboard、出租率計算）
 CREATE INDEX idx_rooms_property_status ON rooms (property_id, status) WHERE deleted_at IS NULL;
+
+
+-- ============================================================
+-- Approved readonly brand property availability view
+-- 說明: Future brand thin backend 只讀 approved views，不直接讀 core base tables
+-- ============================================================
+
+CREATE VIEW approved_brand_property_availability_v1 AS
+SELECT
+    p.id AS property_id,
+    p.property_public_name,
+    p.address,
+    EXISTS (
+        SELECT 1
+        FROM rooms r
+        WHERE r.property_id = p.id
+          AND r.status = 'vacant'
+          AND r.deleted_at IS NULL
+    ) AS has_vacant_room
+FROM properties p
+WHERE p.deleted_at IS NULL;
 
 
 -- ============================================================

--- a/docs/spec/tech-stack.md
+++ b/docs/spec/tech-stack.md
@@ -39,6 +39,14 @@
   - db-g1-small（$25/month，超預算且超出需求）
   - Neon/Supabase（非 GCP 全套）
 
+### Brand Readonly DB Boundary
+
+- **用途**：未來 brand thin backend 只讀 demo 品牌頁需要的 approved DB views，不直接讀 core backend base tables。
+- **Core migration 責任**：建立 approved views，例如 `approved_brand_profile_v1`、`approved_brand_faq_items_v1`、`approved_brand_property_availability_v1`。
+- **Cloud SQL provisioning 責任**：由部署/DBA 流程建立 brand readonly principal，授予 schema `USAGE` 與 approved views 的 `SELECT`，不得授予 `properties`、`rooms`、`brand_profiles`、`brand_faq_items`、tenant、lease、bill、deposit、attachment、accounting 等 base table 權限。
+- **Credential 邊界**：brand thin backend 使用自己的 Cloud SQL credential / secret，不共用 core backend runtime 或 migration DB user。
+- **測試策略**：repo 的 PostgreSQL migration contract test 使用 ephemeral equivalent role 驗證 approved views 可讀、base tables 不可讀；本地 Docker bootstrap 若補 readonly user，只作為 fresh local DB 便利設定，不是 production 權限來源。
+
 ### Persistence / Data Access
 
 - **整體策略**：SQL-first；migration、schema、index、constraint 以 SQL 為準，business rule 不下沉至 DB trigger / stored procedure

--- a/internal/platform/database/migrate/migrations/000024_add_brand_property_availability_view.down.sql
+++ b/internal/platform/database/migrate/migrations/000024_add_brand_property_availability_view.down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS approved_brand_property_availability_v1;

--- a/internal/platform/database/migrate/migrations/000024_add_brand_property_availability_view.up.sql
+++ b/internal/platform/database/migrate/migrations/000024_add_brand_property_availability_view.up.sql
@@ -1,0 +1,14 @@
+CREATE VIEW approved_brand_property_availability_v1 AS
+SELECT
+    p.id AS property_id,
+    p.property_public_name,
+    p.address,
+    EXISTS (
+        SELECT 1
+        FROM rooms r
+        WHERE r.property_id = p.id
+          AND r.status = 'vacant'
+          AND r.deleted_at IS NULL
+    ) AS has_vacant_room
+FROM properties p
+WHERE p.deleted_at IS NULL;

--- a/internal/platform/database/migrate/runner_test.go
+++ b/internal/platform/database/migrate/runner_test.go
@@ -39,6 +39,7 @@ var expectedMigrationVersions = []string{
 	"000021",
 	"000022",
 	"000023",
+	"000024",
 }
 
 func TestRunnerUpAppliesMigrationsAndRecordsVersions(t *testing.T) {
@@ -79,6 +80,53 @@ func TestBrandFAQApprovedViewContract(t *testing.T) {
 		if !strings.Contains(migration, snippet) {
 			t.Fatalf("expected migration to contain %q", snippet)
 		}
+	}
+}
+
+func TestBrandPropertyAvailabilityApprovedViewContract(t *testing.T) {
+	migrations := migrationsByVersion(t, "up")
+	sql := migrations["000024"].SQL
+
+	requiredSnippets := []string{
+		"CREATE VIEW approved_brand_property_availability_v1 AS",
+		"p.id AS property_id",
+		"p.property_public_name",
+		"p.address",
+		"AS has_vacant_room",
+		"FROM properties p",
+		"FROM rooms r",
+		"r.status = 'vacant'",
+		"r.deleted_at IS NULL",
+		"p.deleted_at IS NULL",
+	}
+	for _, snippet := range requiredSnippets {
+		if !strings.Contains(sql, snippet) {
+			t.Fatalf("000024 migration missing %q", snippet)
+		}
+	}
+
+	forbiddenSnippets := []string{
+		"SELECT *",
+		"r.id",
+		"r.name",
+		"tenant",
+		"lease",
+		"bill",
+		"deposit",
+		"attachment",
+		"created_at",
+		"updated_at",
+		"version",
+	}
+	for _, snippet := range forbiddenSnippets {
+		if strings.Contains(sql, snippet) {
+			t.Fatalf("000024 approved view exposes disallowed snippet %q", snippet)
+		}
+	}
+
+	downMigration := migrationsByVersion(t, "down")["000024"].SQL
+	if !strings.Contains(downMigration, "DROP VIEW IF EXISTS approved_brand_property_availability_v1") {
+		t.Fatal("000024 down migration missing approved view drop")
 	}
 }
 
@@ -447,6 +495,102 @@ WHERE at.id IS NULL
 	assertColumnAbsent(t, ctx, db, "monthly_snapshot_entries", "accounting_title_name")
 }
 
+func TestBrandPropertyAvailabilityViewPostgresContract(t *testing.T) {
+	databaseURL := os.Getenv("TEST_DATABASE_URL")
+	if databaseURL == "" {
+		databaseURL = os.Getenv("DATABASE_URL")
+	}
+	if databaseURL == "" {
+		t.Skip("set TEST_DATABASE_URL or DATABASE_URL to run PostgreSQL migration contract test")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	db, err := sql.Open("pgx", databaseURL)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatalf("PingContext: %v", err)
+	}
+
+	schemaName := fmt.Sprintf("brand_availability_test_%d", time.Now().UnixNano())
+	roleName := fmt.Sprintf("brand_readonly_test_%d", time.Now().UnixNano())
+	if _, err := db.ExecContext(ctx, `CREATE SCHEMA `+schemaName); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+	defer func() {
+		if _, err := db.ExecContext(context.Background(), `RESET ROLE`); err != nil {
+			t.Errorf("reset role: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `DROP OWNED BY `+roleName); err != nil {
+			t.Errorf("drop owned by readonly role: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `REVOKE `+roleName+` FROM CURRENT_USER`); err != nil {
+			t.Errorf("revoke readonly role membership: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `DROP SCHEMA IF EXISTS `+schemaName+` CASCADE`); err != nil {
+			t.Errorf("drop schema: %v", err)
+		}
+		if _, err := db.ExecContext(context.Background(), `DROP ROLE IF EXISTS `+roleName); err != nil {
+			t.Errorf("drop role: %v", err)
+		}
+	}()
+	if _, err := db.ExecContext(ctx, `SET search_path TO `+schemaName+`, public`); err != nil {
+		t.Fatalf("set search_path: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `CREATE ROLE `+roleName); err != nil {
+		t.Fatalf("create readonly role: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `GRANT `+roleName+` TO CURRENT_USER`); err != nil {
+		t.Fatalf("grant readonly role to current user: %v", err)
+	}
+
+	upMigrations, err := loadMigrations("up")
+	if err != nil {
+		t.Fatalf("load up migrations: %v", err)
+	}
+	if err := NewRunner(db).apply(ctx, upMigrations, true); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	seedBrandPropertyAvailabilityRows(t, ctx, db)
+	assertBrandPropertyAvailabilityRows(t, ctx, db)
+
+	if _, err := db.ExecContext(ctx, `GRANT USAGE ON SCHEMA `+schemaName+` TO `+roleName); err != nil {
+		t.Fatalf("grant schema usage: %v", err)
+	}
+	approvedViews := []string{
+		"approved_brand_profile_v1",
+		"approved_brand_faq_items_v1",
+		"approved_brand_property_availability_v1",
+	}
+	for _, viewName := range approvedViews {
+		if _, err := db.ExecContext(ctx, `GRANT SELECT ON `+schemaName+`.`+viewName+` TO `+roleName); err != nil {
+			t.Fatalf("grant %s select: %v", viewName, err)
+		}
+	}
+
+	if _, err := db.ExecContext(ctx, `SET ROLE `+roleName); err != nil {
+		t.Fatalf("set readonly role: %v", err)
+	}
+	for _, viewName := range approvedViews {
+		if _, err := db.ExecContext(ctx, `SELECT * FROM `+schemaName+`.`+viewName+` LIMIT 1`); err != nil {
+			t.Fatalf("readonly role should select %s: %v", viewName, err)
+		}
+	}
+	for _, tableName := range []string{"properties", "rooms", "brand_profiles", "brand_faq_items"} {
+		if _, err := db.ExecContext(ctx, `SELECT * FROM `+schemaName+`.`+tableName+` LIMIT 1`); err == nil {
+			t.Fatalf("readonly role should not select base table %s", tableName)
+		}
+	}
+}
+
 func newRunnerTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *Runner) {
 	t.Helper()
 
@@ -558,6 +702,169 @@ VALUES ($1, $2, 'legacy snapshot row', 100, '{}'::jsonb)
 `, snapshotID, category); err != nil {
 			t.Fatalf("insert monthly snapshot entry %s: %v", category, err)
 		}
+	}
+}
+
+func seedBrandPropertyAvailabilityRows(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+
+	var userID string
+	if err := db.QueryRowContext(ctx, `
+INSERT INTO users (firebase_uid, email, name, role)
+VALUES ('brand-availability-owner', 'brand-availability-owner@example.com', 'Brand Availability Owner', 'owner')
+RETURNING id
+`).Scan(&userID); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+
+	properties := []struct {
+		name       string
+		publicName string
+		address    string
+		deleted    bool
+		rooms      []struct {
+			status  string
+			deleted bool
+		}
+	}{
+		{
+			name:       "Vacant Property",
+			publicName: "Public Vacant Property",
+			address:    "Vacant Address",
+			rooms: []struct {
+				status  string
+				deleted bool
+			}{
+				{status: "vacant"},
+				{status: "occupied"},
+				{status: "maintenance"},
+			},
+		},
+		{
+			name:       "Occupied Property",
+			publicName: "Public Occupied Property",
+			address:    "Occupied Address",
+			rooms: []struct {
+				status  string
+				deleted bool
+			}{
+				{status: "occupied"},
+				{status: "maintenance"},
+				{status: "vacant", deleted: true},
+			},
+		},
+		{
+			name:       "Deleted Property",
+			publicName: "Public Deleted Property",
+			address:    "Deleted Address",
+			deleted:    true,
+			rooms: []struct {
+				status  string
+				deleted bool
+			}{
+				{status: "vacant"},
+			},
+		},
+	}
+
+	for _, property := range properties {
+		var propertyID string
+		deletedAt := "NULL"
+		if property.deleted {
+			deletedAt = "now()"
+		}
+		if err := db.QueryRowContext(ctx, `
+INSERT INTO properties (name, property_public_name, address, electricity_unit_price, owner_id, deleted_at)
+VALUES ($1, $2, $3, 5, $4, `+deletedAt+`)
+RETURNING id
+`, property.name, property.publicName, property.address, userID).Scan(&propertyID); err != nil {
+			t.Fatalf("insert property %s: %v", property.name, err)
+		}
+
+		for i, room := range property.rooms {
+			roomDeletedAt := "NULL"
+			if room.deleted {
+				roomDeletedAt = "now()"
+			}
+			if _, err := db.ExecContext(ctx, `
+INSERT INTO rooms (property_id, name, status, deleted_at)
+VALUES ($1, $2, $3, `+roomDeletedAt+`)
+`, propertyID, fmt.Sprintf("%s Room %d", property.name, i+1), room.status); err != nil {
+				t.Fatalf("insert room for %s: %v", property.name, err)
+			}
+		}
+	}
+}
+
+func assertBrandPropertyAvailabilityRows(t *testing.T, ctx context.Context, db *sql.DB) {
+	t.Helper()
+
+	rows, err := db.QueryContext(ctx, `
+SELECT property_public_name, address, has_vacant_room
+FROM approved_brand_property_availability_v1
+ORDER BY property_public_name
+`)
+	if err != nil {
+		t.Fatalf("query approved brand property availability: %v", err)
+	}
+	defer rows.Close()
+
+	type availabilityRow struct {
+		publicName    string
+		address       string
+		hasVacantRoom bool
+	}
+	var got []availabilityRow
+	for rows.Next() {
+		var row availabilityRow
+		if err := rows.Scan(&row.publicName, &row.address, &row.hasVacantRoom); err != nil {
+			t.Fatalf("scan approved brand property availability: %v", err)
+		}
+		got = append(got, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate approved brand property availability: %v", err)
+	}
+
+	want := []availabilityRow{
+		{publicName: "Public Occupied Property", address: "Occupied Address", hasVacantRoom: false},
+		{publicName: "Public Vacant Property", address: "Vacant Address", hasVacantRoom: true},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d availability rows, got %+v", len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("availability row %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+
+	columns, err := db.QueryContext(ctx, `
+SELECT column_name
+FROM information_schema.columns
+WHERE table_schema = current_schema()
+  AND table_name = 'approved_brand_property_availability_v1'
+ORDER BY ordinal_position
+`)
+	if err != nil {
+		t.Fatalf("query approved view columns: %v", err)
+	}
+	defer columns.Close()
+
+	var columnNames []string
+	for columns.Next() {
+		var columnName string
+		if err := columns.Scan(&columnName); err != nil {
+			t.Fatalf("scan approved view column: %v", err)
+		}
+		columnNames = append(columnNames, columnName)
+	}
+	if err := columns.Err(); err != nil {
+		t.Fatalf("iterate approved view columns: %v", err)
+	}
+	expectedColumns := []string{"property_id", "property_public_name", "address", "has_vacant_room"}
+	if strings.Join(columnNames, ",") != strings.Join(expectedColumns, ",") {
+		t.Fatalf("approved view columns = %v, want %v", columnNames, expectedColumns)
 	}
 }
 


### PR DESCRIPTION
Closes #182

## Summary
- add approved_brand_property_availability_v1 for demo brand property availability
- document the Cloud SQL readonly boundary in README and tech-stack notes
- verify approved view shape, real PostgreSQL semantics, and ephemeral readonly role access

## Validation
- go test ./internal/platform/database/migrate
- TEST_DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend?sslmode=disable go test ./internal/platform/database/migrate -run 'Test.*MigrationPostgresContract|TestBrandPropertyAvailabilityViewPostgresContract' -count=1
- go test ./...