### PR TITLE
[codex] Add local brand readonly bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,21 @@ demo property with rooms, tenants, leases, bills, meter history, reports,
 journal, repair, and checkout data. It is local frontend support data and is
 separate from schema migrations and legacy migration validation.
 
-5. Get an ID token from the emulator:
+5. Create or repair the local brand readonly database user when developing the
+   future brand thin backend boundary:
+
+```bash
+scripts/dev_brand_readonly.sh
+```
+
+This local helper uses `DATABASE_URL` as the admin connection by default,
+creates or repairs `brand_readonly`, grants only the approved brand views, and
+verifies representative core base tables are not selectable. Override
+`BRAND_READONLY_PASSWORD`, `BRAND_READONLY_ADMIN_DATABASE_URL`, or
+`BRAND_READONLY_DATABASE_URL` when your local database connection differs from
+the Docker defaults.
+
+6. Get an ID token from the emulator:
 
 ```bash
 go run ./cmd/auth-emulator issue-token \
@@ -102,7 +116,7 @@ go run ./cmd/auth-emulator issue-token \
   --password 'Test123!'
 ```
 
-6. Use the returned token to call a protected route:
+7. Use the returned token to call a protected route:
 
 ```bash
 curl -i \
@@ -296,6 +310,28 @@ on those views only. Do not grant it direct access to base tables such as
 `bills`, `attachments`, or deposit/accounting tables. Local PostgreSQL contract
 tests use an ephemeral equivalent role to verify that the approved views are
 selectable while base tables are not.
+
+For local thin-backend development, the expected order is:
+
+```bash
+docker compose up -d postgres
+go run ./cmd/migrate up
+scripts/dev_demo_seed.sh
+scripts/dev_brand_readonly.sh
+```
+
+The local readonly connection string defaults to:
+
+```bash
+BRAND_READONLY_DATABASE_URL=postgres://brand_readonly:brand_readonly@localhost:5432/stds_backend?sslmode=disable
+```
+
+Staging and production must provision the equivalent Cloud SQL principal outside
+application migrations. The deployment or DBA workflow should create the
+dedicated readonly principal, grant schema `USAGE`, grant `SELECT` only on the
+approved views, store the thin-backend credential through the environment or
+Secret Manager, and run a deployed smoke check that mirrors the local approved
+view and base-table denial checks.
 
 ## Legacy migration planning
 

--- a/scripts/dev_brand_readonly.sh
+++ b/scripts/dev_brand_readonly.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+
+set -eu
+
+ADMIN_DATABASE_URL="${BRAND_READONLY_ADMIN_DATABASE_URL:-${DATABASE_URL:-postgres://stds:stds@localhost:5432/stds_backend?sslmode=disable}}"
+READONLY_PASSWORD="${BRAND_READONLY_PASSWORD:-brand_readonly}"
+READONLY_DATABASE_URL="${BRAND_READONLY_DATABASE_URL:-postgres://brand_readonly:${READONLY_PASSWORD}@localhost:5432/stds_backend?sslmode=disable}"
+
+psql_cmd() {
+  if command -v psql >/dev/null 2>&1; then
+    psql "$@"
+    return
+  fi
+
+  if command -v docker >/dev/null 2>&1 && docker ps --filter name=stds-postgres --format '{{.Names}}' 2>/dev/null | grep -qx stds-postgres; then
+    docker exec -i stds-postgres psql "$@"
+    return
+  fi
+
+  echo "psql is required, or the stds-postgres Docker container must be running" >&2
+  exit 1
+}
+
+psql_cmd "$ADMIN_DATABASE_URL" -v ON_ERROR_STOP=1 -v readonly_password="$READONLY_PASSWORD" <<'SQL'
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'brand_readonly') THEN
+    CREATE ROLE brand_readonly LOGIN;
+  END IF;
+END
+$$;
+
+ALTER ROLE brand_readonly WITH LOGIN PASSWORD :'readonly_password';
+REVOKE ALL PRIVILEGES ON SCHEMA public FROM brand_readonly;
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM brand_readonly;
+REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM brand_readonly;
+GRANT USAGE ON SCHEMA public TO brand_readonly;
+GRANT SELECT ON public.approved_brand_profile_v1 TO brand_readonly;
+GRANT SELECT ON public.approved_brand_faq_items_v1 TO brand_readonly;
+GRANT SELECT ON public.approved_brand_property_availability_v1 TO brand_readonly;
+SQL
+
+check_can_select() {
+  view_name="$1"
+  psql_cmd "$READONLY_DATABASE_URL" -v ON_ERROR_STOP=1 -c "SELECT * FROM public.${view_name} LIMIT 1" >/dev/null
+}
+
+check_cannot_select() {
+  table_name="$1"
+  if psql_cmd "$READONLY_DATABASE_URL" -v ON_ERROR_STOP=1 -c "SELECT * FROM public.${table_name} LIMIT 1" >/dev/null 2>&1; then
+    echo "brand_readonly unexpectedly selected base table: ${table_name}" >&2
+    exit 1
+  fi
+}
+
+check_can_select approved_brand_profile_v1
+check_can_select approved_brand_faq_items_v1
+check_can_select approved_brand_property_availability_v1
+
+check_cannot_select properties
+check_cannot_select rooms
+check_cannot_select brand_profiles
+check_cannot_select brand_faq_items
+
+echo "brand_readonly can select approved views and cannot select representative base tables"


### PR DESCRIPTION
Closes #188

## Summary
- Add a rerunnable local brand readonly DB bootstrap script for thin backend development.
- Grant only approved brand views and verify representative core base tables are denied.
- Document the local setup order, readonly connection string, env overrides, and staging/prod provisioning boundary.

## Validation
- sh -n scripts/dev_brand_readonly.sh
- scripts/dev_brand_readonly.sh
- go test ./internal/platform/database/migrate -run 'TestBrand.*Approved|TestBrandPropertyAvailabilityViewPostgresContract' -count=1