### PR TITLE
Document cloud architecture and local operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # STDS Backend
 
-Minimal backend scaffold for local development with Go, Gin, PostgreSQL, and Scalar API docs.
+Backend service for the STDS property management system, built with Go, Gin,
+PostgreSQL, Firebase Auth, and OpenAPI-generated HTTP contracts.
 
-## Local development
+## Local development quickstart
 
 1. Copy `.env.example` to `.env` if needed.
 2. Start PostgreSQL:
@@ -29,229 +30,48 @@ go run ./cmd/api
 - OpenAPI file: `http://localhost:8080/openapi.yaml`
 - Health check: `http://localhost:8080/healthz`
 
-## Firebase Auth Emulator
+For Firebase Auth Emulator setup, local demo data, E2E flows, attachment
+storage, and other operational details, see
+[docs/local-operations.md](docs/local-operations.md).
 
-Use the Auth Emulator for local backend development. In emulator mode, the backend still verifies Firebase ID tokens, but it does not require a service account JSON file.
-
-1. Set `.env`:
-
-```bash
-FIREBASE_PROJECT_ID=demo-stds-backend
-FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
-```
-
-2. Start the Auth Emulator with any Firebase project alias you use locally.
-```bash
-firebase emulators:start --only auth
-```
-
-3. Create or update the local emulator user and matching backend DB user:
+## Common local scripts / commands
 
 ```bash
 scripts/dev_auth_user.sh
-```
-
-By default this creates an `admin` backend user for `testuser@example.com` with
-password `Test123!` in the database pointed at by `DATABASE_URL`. The database
-must already exist and have migrations applied. You can override the local
-account fields:
-
-```bash
-scripts/dev_auth_user.sh \
-  --uid 72sjYQv3GoNts3glUeiXmvbuBUx1 \
-  --email testuser@example.com \
-  --password 'Test123!' \
-  --name 'Local Admin' \
-  --role admin
-```
-
-To create one local account per backend role for frontend testing:
-
-```bash
 scripts/dev_auth_users.sh
-```
-
-This creates or updates:
-
-| Email | Password | Role |
-| --- | --- | --- |
-| `local-admin@example.com` | `Test123!` | `admin` |
-| `local-organizer@example.com` | `Test123!` | `organizer` |
-| `local-staff@example.com` | `Test123!` | `staff` |
-| `local-owner@example.com` | `Test123!` | `owner` |
-
-Set `DEV_AUTH_PASSWORD` to override the shared local password.
-
-4. Seed deterministic frontend demo data when the UI needs non-empty local
-   screens:
-
-```bash
 scripts/dev_demo_seed.sh
-```
-
-This opt-in seed refuses production-like environments and creates a rerunnable
-demo property with rooms, tenants, leases, bills, meter history, reports,
-journal, repair, and checkout data. It is local frontend support data and is
-separate from schema migrations and legacy migration validation.
-
-5. Create or repair the local brand readonly database user when developing the
-   future brand thin backend boundary:
-
-```bash
 scripts/dev_brand_readonly.sh
-```
-
-This local helper uses `DATABASE_URL` as the admin connection by default,
-creates or repairs `brand_readonly`, grants only the approved brand views, and
-verifies representative core base tables are not selectable. Override
-`BRAND_READONLY_PASSWORD`, `BRAND_READONLY_ADMIN_DATABASE_URL`, or
-`BRAND_READONLY_DATABASE_URL` when your local database connection differs from
-the Docker defaults.
-
-6. Get an ID token from the emulator:
-
-```bash
-go run ./cmd/auth-emulator issue-token \
-  --email testuser@example.com \
-  --password 'Test123!'
-```
-
-7. Use the returned token to call a protected route:
-
-```bash
-curl -i \
-  -H "Authorization: Bearer <ID_TOKEN>" \
-  http://127.0.0.1:8080/api/v1/authz-test/properties/property-1
-```
-
-If the `users` table contains the same `firebase_uid`, the request will pass auth and resolve the DB user.
-
-## E2E tests
-
-The E2E suite is opt-in and uses Go `testing` with the `e2e` build tag. It calls an already-running API through HTTP, resets a dedicated PostgreSQL test database schema, runs migrations, seeds the backend user row, and obtains a real bearer token from the Firebase Auth Emulator.
-
-Use a separate database name for E2E, for example `stds_backend_e2e`. This can live in the same local PostgreSQL container as the normal development database; `docker-compose.yml` does not need a second PostgreSQL service.
-
-Start dependencies:
-
-```bash
-docker compose up -d postgres
-docker exec stds-postgres psql -U stds -d postgres -c "CREATE DATABASE stds_backend_e2e"
-firebase emulators:start --only auth
-```
-
-Start the API against the E2E database:
-
-```bash
 ./scripts/e2e_api.sh
-```
-
-Run the E2E suite:
-
-```bash
 ./scripts/e2e_test.sh
-```
-
-The harness refuses to reset a database unless the database name contains `e2e` or `test`.
-The local scripts provide defaults for E2E environment variables and still allow overrides, for example `APP_PORT=8081 E2E_BASE_URL=http://127.0.0.1:8081 ./scripts/e2e_test.sh`.
-
-## Legacy migrated E2E sign-off
-
-Legacy migrated data checks are separate from the normal seed-based E2E suite.
-They are intended for one-time legacy migration sign-off and are not wired into
-required PR CI.
-
-Use a separate database name for this mode, for example
-`stds_backend_legacy_e2e`. The legacy E2E tests do not reset the database or
-seed business data. They only seed the backend admin user row needed for the
-Firebase Auth Emulator token, then discover representative migrated records
-through legacy mapping tables.
-
-Prepare the legacy E2E database:
-
-```bash
-docker compose up -d postgres
-docker exec stds-postgres psql -U stds -d postgres -c "CREATE DATABASE stds_backend_legacy_e2e"
-DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate up
-DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy properties
-DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy rooms
-DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy tenants
-DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy leases
-DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy room-status
-DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy bills
-DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy journal
-DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy validate
-```
-
-Before sign-off, review the generated validation report and source/target
-reconciliation. By default, `scripts/legacy_e2e_test.sh` requires
-`artifacts/legacy_migration/task13_validation_report.json` to exist.
-
-Start dependencies and the API:
-
-```bash
-firebase emulators:start --only auth
 ./scripts/legacy_e2e_api.sh
-```
-
-Run the legacy read checks:
-
-```bash
 ./scripts/legacy_e2e_test.sh
 ```
 
-## Email notifications
-
-`POST /api/v1/users` now creates the Firebase Auth user, generates a Firebase password reset URL, and sends the onboarding email through Resend.
-
-Required environment variables:
+Common migration commands:
 
 ```bash
-RESEND_API_KEY=
-RESEND_FROM_EMAIL=onboarding@example.com
-RESEND_FROM_NAME=STDS
-FIREBASE_PASSWORD_RESET_REDIRECT_URL=
+go run ./cmd/migrate up
+go run ./cmd/migrate down
+go run ./cmd/migrate_legacy plan
 ```
 
-`FIREBASE_PASSWORD_RESET_REDIRECT_URL` is optional. When set, Firebase will embed it in the generated password reset link as the continue URL.
-
-## Attachment storage
-
-Attachment upload URLs use Google Cloud Storage. Local unit tests should inject a fake storage port and must not require real GCS credentials.
-
-Required environment variables for real GCS-backed attachment uploads:
+## Test commands summary
 
 ```bash
-GCS_BUCKET_NAME=
-GCS_SIGNED_URL_TTL=15m
+go test ./...
+go test -tags=e2e ./test/e2e
+./scripts/e2e_test.sh
+./scripts/legacy_e2e_test.sh
 ```
 
-Optional local emulator setting:
-
-```bash
-STORAGE_EMULATOR_HOST=http://127.0.0.1:4443
-```
-
-E2E attachment acceptance uses metadata-only storage by default:
-
-```bash
-ATTACHMENT_STORAGE_MODE=fake-metadata
-```
-
-This mode is only allowed when `APP_ENV` is `e2e` or `test`. It returns a fake
-upload URL and valid object metadata so E2E tests can cover upload-token,
-registration, read, and authorization behavior without production GCS or a
-storage emulator.
-
-Production or staging environments must provide Google Application Default Credentials, for example through `GOOGLE_APPLICATION_CREDENTIALS` or the runtime service account. The service account needs permission to create signed upload URLs and read object metadata for registration checks.
+The E2E scripts expect local PostgreSQL and Firebase Auth Emulator dependencies.
+See [docs/local-operations.md](docs/local-operations.md) for setup details.
 
 ## OpenAPI workflow
 
 - Edit source files under `docs/spec/src`
 - Bundle source files into `docs/spec/openapi.yaml` with `npm run openapi:bundle`
 - Regenerate bundled spec and Go bindings with `npm run openapi:generate`
-
-### Tooling
 
 Install the Node dependency once:
 
@@ -267,76 +87,16 @@ go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
 
 The generated Go bindings live in `internal/http/api/openapi.gen.go`.
 
-## CI checks
+## Documentation index
 
-The PR CI gate runs these checks for pull requests targeting `dev` and pushes to `dev`:
-
-```bash
-go test ./...
-go build -o /tmp/stds-api ./cmd/api
-npm ci
-go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
-npm run openapi:lint
-npm run openapi:generate
-git diff --exit-code -- docs/spec/openapi.yaml internal/http/api/openapi.gen.go
-docker exec stds-postgres psql -U stds -d postgres -c "DROP DATABASE IF EXISTS ci_migration_smoke"
-docker exec stds-postgres psql -U stds -d postgres -c "CREATE DATABASE ci_migration_smoke"
-DATABASE_URL=postgres://stds:stds@localhost:5432/ci_migration_smoke?sslmode=disable go run ./cmd/migrate up
-docker exec stds-postgres psql -U stds -d postgres -c "DROP DATABASE IF EXISTS ci_migration_smoke"
-go test -tags=e2e ./test/e2e
-```
-
-## Database migrations
-
-- Run all pending migrations: `go run ./cmd/migrate up`
-- Roll back applied migrations in reverse order: `go run ./cmd/migrate down`
-
-## Brand readonly database access
-
-Demo brand frontend data is exposed to a future thin backend through approved
-PostgreSQL views only. The core backend migrations create the views; deployment
-or DBA provisioning must create the Cloud SQL readonly principal and grant only
-the approved view access.
-
-The current approved views are:
-
-- `approved_brand_profile_v1`
-- `approved_brand_faq_items_v1`
-- `approved_brand_property_availability_v1`
-
-The brand readonly principal should receive `USAGE` on the schema and `SELECT`
-on those views only. Do not grant it direct access to base tables such as
-`properties`, `rooms`, `brand_profiles`, `brand_faq_items`, `tenants`, `leases`,
-`bills`, `attachments`, or deposit/accounting tables. Local PostgreSQL contract
-tests use an ephemeral equivalent role to verify that the approved views are
-selectable while base tables are not.
-
-For local thin-backend development, the expected order is:
-
-```bash
-docker compose up -d postgres
-go run ./cmd/migrate up
-scripts/dev_demo_seed.sh
-scripts/dev_brand_readonly.sh
-```
-
-The local readonly connection string defaults to:
-
-```bash
-BRAND_READONLY_DATABASE_URL=postgres://brand_readonly:brand_readonly@localhost:5432/stds_backend?sslmode=disable
-```
-
-Staging and production must provision the equivalent Cloud SQL principal outside
-application migrations. The deployment or DBA workflow should create the
-dedicated readonly principal, grant schema `USAGE`, grant `SELECT` only on the
-approved views, store the thin-backend credential through the environment or
-Secret Manager, and run a deployed smoke check that mirrors the local approved
-view and base-table denial checks.
-
-## Legacy migration planning
-
-- Validate the checked-in legacy JSON exports and generate the Task 5 architecture report: `go run ./cmd/migrate_legacy plan`
-- Override source/report directories when needed: `go run ./cmd/migrate_legacy plan --source-dir docs/mirgations --report-dir artifacts/legacy_migration`
+- [Local operations](docs/local-operations.md): emulator setup, local scripts,
+  E2E flows, environment variables, CI command details, and migration planning.
+- [Cloud architecture](docs/cloud-architecture.md): proposed GCP staging and
+  production-candidate architecture baseline.
+- [Infrastructure guideline](docs/infra-guideline.md): infrastructure operating
+  guidance.
+- [Vertical slice handbook](docs/vertical-slice-handbook.md): implementation
+  workflow and slice guidance.
 
 ## Project structure
 

--- a/docs/cloud-architecture.md
+++ b/docs/cloud-architecture.md
@@ -1,0 +1,436 @@
+# STDS Cloud Architecture
+
+Project: STDS - Property Management System
+Version: 1.0
+Status: Proposed baseline for staging; production use requires a separate
+production readiness review.
+
+## Overview
+
+STDS runs on GCP using Firebase Hosting, Cloud Run, Cloud SQL, Secret Manager,
+Cloud Storage, Cloud Scheduler, and Cloud Logging / Monitoring.
+
+This document is the deployment architecture baseline for the staging line and
+the early production candidate. It intentionally avoids an external Application
+Load Balancer in the first version. Firebase Hosting is the browser-facing edge
+for frontend traffic, while Cloud Run hosts backend services.
+
+Cloud SQL private IP and Cloud Run Direct VPC egress are included in the
+target architecture from staging v1 onward if the operational setup is accepted.
+This is a security hardening choice because legacy property data will be
+migrated early. It is not treated as an HTTP ingress boundary.
+
+## Core Decisions
+
+### No External Application Load Balancer In The First Version
+
+Firebase Hosting handles browser-facing TLS, custom domains, CDN behavior, and
+frontend rewrites. API security remains enforced by Firebase Auth, DB-backed
+authorization, service account IAM, and scheduler keys.
+
+An external Application Load Balancer is a future option for a stronger
+production edge, Cloud Armor, host/path routing across many services, WAF,
+rate limiting, or strict Cloud Run ingress through the load balancer. It is out
+of scope for the staging deployment line.
+
+### Firebase Hosting Rewrites For Browser-To-Backend Calls
+
+Admin and brand frontends should call backend APIs through Firebase Hosting
+rewrites where practical:
+
+- admin frontend: `/api/**` to the core backend Cloud Run service.
+- brand frontend: `/brand-api/**` to the brand thin backend Cloud Run service.
+
+The Cloud Run `run.app` URL is not part of the browser-facing contract. Whether
+the default `run.app` URL can be disabled safely is a separate hardening
+decision and must be verified before relying on it. Firebase Hosting rewrites
+must be tested against the chosen Cloud Run ingress/default-URL settings.
+
+### VPC With Direct VPC Egress For Cloud SQL
+
+Cloud Run services should connect to Cloud SQL through private IP using Direct
+VPC egress if the staging operator accepts the added setup complexity.
+
+Direct VPC egress is preferred over Serverless VPC Access connector for this
+project because it avoids fixed connector VM cost and scales with Cloud Run
+traffic. The tradeoff is extra networking setup and a more complex migration /
+operator access path.
+
+VPC/private IP is used for backend-to-database connectivity. It is not the
+browser ingress boundary.
+
+### One Cloud SQL Instance, Separate Databases
+
+The cost-conscious baseline is one Cloud SQL PostgreSQL instance with separate
+databases:
+
+- `stds_staging`
+- `stds_production`
+
+Each environment uses a separate DB credential scoped to its own database.
+
+This is an accepted cost tradeoff, not a hard security boundary. Staging and
+production share instance-level CPU, memory, connection, maintenance, and
+availability behavior. A staging migration, bad query, or connection spike can
+affect the shared instance. If this risk becomes unacceptable, split staging and
+production into separate Cloud SQL instances.
+
+### Brand Thin Backend Isolation
+
+The brand-facing backend is a separate Cloud Run service with its own service
+account and DB credential. It may only query approved read-only views:
+
+- `approved_brand_profile_v1`
+- `approved_brand_faq_items_v1`
+- `approved_brand_property_availability_v1`
+
+It must not have direct access to core base tables such as tenants, leases,
+bills, deposits, accounting, attachments, or operational property/room tables
+except through explicitly approved views.
+
+### Explicit DB Connection Pool Limits
+
+Cloud Run can scale horizontally. Each instance owns its own DB connection
+pool, so small Cloud SQL instances can hit connection pressure before CPU
+becomes the bottleneck.
+
+The runtime should support environment-controlled pool settings:
+
+```text
+DB_MAX_OPEN_CONNS
+DB_MAX_IDLE_CONNS
+DB_CONN_MAX_LIFETIME
+```
+
+This is a required repo-side implementation item before relying on the values
+below. The current runtime must be reviewed before marking this decision done.
+
+Initial target values:
+
+```text
+staging:
+  DB_MAX_OPEN_CONNS=5
+  DB_MAX_IDLE_CONNS=2
+  DB_CONN_MAX_LIFETIME=5m
+
+production candidate:
+  DB_MAX_OPEN_CONNS=10
+  DB_MAX_IDLE_CONNS=5
+  DB_CONN_MAX_LIFETIME=5m
+```
+
+The actual Cloud SQL `max_connections` value must be verified on the created
+instance, for example through `pg_settings`, instead of being hardcoded in this
+document.
+
+## Architecture
+
+### High-Level Runtime
+
+```mermaid
+flowchart TD
+    AdminUser[Admin / staff browser] --> AdminHosting[Firebase Hosting<br/>admin domain]
+    PublicUser[Public visitor] --> BrandHosting[Firebase Hosting<br/>brand domain]
+
+    AdminHosting -->|/api/** rewrite| CoreRun[Cloud Run<br/>Core Backend]
+    BrandHosting -->|/brand-api/** rewrite| BrandThinRun[Cloud Run<br/>Brand Thin Backend]
+
+    Scheduler[Cloud Scheduler] -->|X-Scheduler-Key| CoreRun
+
+    subgraph GCPProject[GCP Project]
+        CoreRun
+        BrandThinRun
+
+        subgraph PrivateDataPath[Private DB Connectivity]
+            DirectVPC[Direct VPC egress]
+            VPC[VPC network]
+            CloudSQL[(Cloud SQL PostgreSQL<br/>private IP)]
+        end
+    end
+
+    CoreRun --> DirectVPC
+    BrandThinRun --> DirectVPC
+    DirectVPC --> VPC
+    VPC --> CloudSQL
+
+    CoreRun -->|generate signed URL / metadata check| GCS[(Cloud Storage<br/>attachments bucket)]
+    AdminUser -->|PUT signed URL| GCS
+
+    CoreRun --> FirebaseAuth[Firebase Auth]
+    AdminHosting --> FirebaseAuth
+
+    CoreRun --> SecretManager[Secret Manager<br/>env injection]
+    BrandThinRun --> SecretManager
+
+    CoreRun --> Resend[Resend Email API]
+
+    CoreRun --> Observability[Cloud Logging / Monitoring]
+    BrandThinRun --> Observability
+```
+
+### Browser API Flow
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant Hosting as Firebase Hosting
+    participant API as Cloud Run Core Backend
+    participant Auth as Firebase Auth
+    participant DB as Cloud SQL
+
+    Browser->>Auth: Sign in / obtain ID token
+    Browser->>Hosting: Load admin app
+    Hosting-->>Browser: Static assets
+    Browser->>Hosting: /api/v1/... with bearer token
+    Hosting->>API: Rewrite request to Cloud Run
+    API->>Auth: Verify Firebase ID token
+    API->>DB: Load DB principal / execute request
+    API-->>Browser: API response
+```
+
+### Attachment Upload Flow
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant API as Cloud Run Core Backend
+    participant GCS as Cloud Storage
+
+    Browser->>API: POST /attachments/upload-url
+    API-->>Browser: Signed upload URL
+    Browser->>GCS: PUT file to signed URL
+    Browser->>API: Register attachment
+    API->>GCS: Read object metadata
+    API-->>Browser: Attachment response
+```
+
+GCS is not routed through VPC or Firebase Hosting. Browser upload uses scoped
+signed URLs. The bucket CORS policy must allow only approved frontend origins.
+
+### Scheduler Flow
+
+```mermaid
+sequenceDiagram
+    participant Scheduler as Cloud Scheduler
+    participant API as Cloud Run Core Backend
+    participant DB as Cloud SQL
+
+    Scheduler->>API: POST /api/v1/internal/jobs/... ?window_key=YYYY-MM-DD<br/>X-Scheduler-Key
+    API->>API: Validate scheduler key
+    API->>DB: Acquire scheduler_job_runs row
+    API->>DB: Execute job logic
+    API-->>Scheduler: 202 accepted / skipped / failed
+```
+
+All browser traffic enters through Firebase Hosting. Cloud Scheduler is not
+browser traffic and may call scheduler endpoints directly.
+
+## Service Responsibilities
+
+### Core Backend
+
+- Serves admin APIs.
+- Validates Firebase Auth bearer tokens.
+- Resolves DB-backed user principal.
+- Enforces RBAC and property-scoped middleware.
+- Executes scheduler jobs.
+- Generates GCS signed URLs and checks attachment metadata.
+- Dispatches transactional email through Resend.
+- Connects to Cloud SQL through the chosen private connectivity path.
+- Receives secrets through Cloud Run environment variables backed by Secret
+  Manager.
+- Starts with `max-instances=2` to bound DB connection pressure.
+
+### Brand Thin Backend
+
+- Serves public brand and property availability APIs.
+- Uses its own Cloud Run service account.
+- Uses its own readonly DB credential.
+- Reads approved views only.
+- Does not use the core backend runtime DB credential.
+
+### Firebase Hosting
+
+- Hosts admin frontend and brand frontend.
+- Provides custom domains and TLS for browser traffic.
+- Rewrites API paths to Cloud Run services.
+- Does not replace backend authentication or authorization.
+
+### Cloud SQL
+
+- PostgreSQL.
+- Target machine type for the cost-conscious production candidate:
+  `db-g1-small`.
+- `db-f1-micro` remains acceptable for staging or low-risk demo environments,
+  but `db-g1-small` is preferred for early production candidate stability.
+- Daily automated backups.
+- Seven-day backup retention.
+- PITR enabled for production before go-live; optional for staging.
+- No HA in the first version unless a production uptime requirement is
+  accepted.
+
+### Secret Manager
+
+Secret Manager is the source of runtime secret values. Cloud Run injects those
+secrets into environment variables where the current Go runtime reads them.
+Application code should not require direct Secret Manager API calls for the
+first version.
+
+Secret values must never be committed or printed in logs.
+
+## Observability
+
+### Logging
+
+Cloud Run automatically sends stdout/stderr, request logs, and system logs to
+Cloud Logging. The current Go runtime uses structured JSON logging with
+`log/slog`.
+
+Important fields:
+
+- `request_id`
+- `user_id` when available
+- `property_id` when available
+- `method`
+- `path`
+- `status`
+- `latency`
+- scheduler `job_key`
+- scheduler `window_key`
+- scheduler result
+
+Do not log bearer tokens, scheduler keys, DB passwords, private keys, or full
+request/response bodies containing sensitive data.
+
+### Monitoring
+
+Use GCP-native monitoring in the first version. Do not introduce Prometheus or
+Grafana for staging.
+
+Baseline metrics:
+
+- Cloud Run request count.
+- Cloud Run latency.
+- Cloud Run 5xx/error count.
+- Cloud Run instance count.
+- Cloud SQL CPU.
+- Cloud SQL connection count.
+- Cloud SQL storage usage.
+
+Baseline alerts:
+
+- Cloud Run service unavailable.
+- Elevated Cloud Run 5xx/error count.
+- Cloud Run instance count reaches `max-instances`.
+- Cloud SQL CPU over threshold.
+- Cloud SQL connection count approaching actual `max_connections`.
+- Cloud SQL disk usage over threshold.
+- Billing budget alert.
+
+Log-based metrics are optional for staging. If added, keep them narrow:
+
+- scheduler failed results.
+- auth validation failures.
+- signed URL generation count.
+
+## Security Posture
+
+No single layer is the only security boundary.
+
+| Layer | Control |
+| --- | --- |
+| Network | Cloud SQL private IP; no public DB endpoint in the target architecture. |
+| Browser ingress | Firebase Hosting custom domains and rewrites. |
+| Authentication | Firebase Auth bearer token on admin APIs. |
+| Authorization | DB-backed principal, RBAC, and property-scoped middleware. |
+| Brand data boundary | Readonly DB principal and approved views only. |
+| Secrets | Secret Manager values injected into Cloud Run env vars. |
+| Storage | Browser receives scoped signed URLs, not broad GCS credentials. |
+| Scheduler | `X-Scheduler-Key` for internal job endpoints. |
+| IAM | Separate Cloud Run service accounts with least privilege. |
+
+Accepted tradeoffs:
+
+| Tradeoff | Rationale |
+| --- | --- |
+| No external Application Load Balancer | Current scale does not justify cost or operational complexity. |
+| No Cloud Armor / WAF | Revisit when public abuse or stronger production edge controls are needed. |
+| One Cloud SQL instance for staging and production | Cost-conscious choice; instance-level resource contention is accepted initially. |
+| No HA in first version | Acceptable until a production uptime SLA is required. |
+| Cloud Run default URL disabling is not assumed | Hosting rewrites hide the URL from browser contracts, but default URL hardening must be verified separately. |
+
+## Cost Baseline
+
+Approximate low-traffic monthly cost:
+
+| Component | Monthly estimate |
+| --- | --- |
+| Cloud SQL `db-g1-small` | 25-30 USD |
+| Cloud SQL storage / backups | 2-5 USD |
+| Cloud Run | 0-2 USD |
+| Firebase Hosting | 0 USD in free-tier scale |
+| Secret Manager | 0-1 USD at current scale |
+| Cloud Storage attachments | 0-1 USD initially |
+| Direct VPC egress | traffic-proportional; expected low at current scale |
+| Cloud Logging / Monitoring | 0-2 USD if logs stay modest |
+| Cloud Scheduler | about 0.30 USD for six jobs after free jobs |
+
+Cloud SQL is expected to dominate the cost profile. Cost assumptions must be
+verified with GCP Billing and the Pricing Calculator before production go-live.
+
+## Deployment Phases
+
+### Staging v1
+
+- Firebase Hosting frontend.
+- Cloud Run core backend.
+- Cloud SQL private-IP target architecture, if operator setup is accepted.
+- Secret Manager env injection.
+- GCS signed URL upload.
+- Cloud Logging / Monitoring baseline.
+- Cloud Run `max-instances=2`.
+- DB pool limits implemented and configured.
+- Smoke checks for deployment, DB migration, Firebase Auth, scheduler
+  protection, signed URL upload, and log visibility.
+
+### Production Readiness Review
+
+Before production go-live:
+
+- Confirm Cloud SQL machine type.
+- Confirm backup window and PITR.
+- Confirm whether HA is required.
+- Confirm DB pool limits under realistic load.
+- Confirm Cloud Build migration connectivity to private Cloud SQL.
+- Confirm operator DB access path without public DB IP.
+- Confirm Firebase Hosting rewrite behavior and whether Cloud Run default URL
+  disabling is safe.
+- Confirm GCS CORS for production frontend origins.
+- Confirm Cloud Monitoring alert policies and billing budgets.
+
+## Repo Impact
+
+Expected repo changes for this architecture:
+
+- Dockerfile and `.dockerignore`.
+- Cloud Build staging deployment config.
+- GitHub Actions trigger/status workflow if needed.
+- DB pool config support.
+- Staging smoke script.
+- Deployment runbooks and verification evidence templates.
+
+Application domain logic should not need broad runtime changes for the staging
+deployment line.
+
+## Open Decisions
+
+- Should staging and production share one Cloud SQL instance initially?
+- Should staging enable Cloud SQL private IP from day one, or should private IP
+  be allowed to slip to staging hardening if setup blocks the deployment line?
+- How will Cloud Build migrations reach private Cloud SQL?
+- How will operators inspect the database without enabling public IP?
+- Should production require Cloud SQL HA before go-live?
+- Should Cloud Run default `run.app` URLs be disabled, and does that work with
+  the selected Firebase Hosting rewrite path?
+- When should the brand thin backend be deployed relative to core backend
+  staging?

--- a/docs/local-operations.md
+++ b/docs/local-operations.md
@@ -1,0 +1,291 @@
+# Local Operations
+
+Operational details for local development, E2E verification, environment
+configuration, CI command parity, and legacy migration planning.
+
+## Firebase Auth Emulator
+
+Use the Auth Emulator for local backend development. In emulator mode, the backend still verifies Firebase ID tokens, but it does not require a service account JSON file.
+
+1. Set `.env`:
+
+```bash
+FIREBASE_PROJECT_ID=demo-stds-backend
+FIREBASE_AUTH_EMULATOR_HOST=127.0.0.1:9099
+```
+
+2. Start the Auth Emulator with any Firebase project alias you use locally.
+```bash
+firebase emulators:start --only auth
+```
+
+3. Create or update the local emulator user and matching backend DB user:
+
+```bash
+scripts/dev_auth_user.sh
+```
+
+By default this creates an `admin` backend user for `testuser@example.com` with
+password `Test123!` in the database pointed at by `DATABASE_URL`. The database
+must already exist and have migrations applied. You can override the local
+account fields:
+
+```bash
+scripts/dev_auth_user.sh \
+  --uid 72sjYQv3GoNts3glUeiXmvbuBUx1 \
+  --email testuser@example.com \
+  --password 'Test123!' \
+  --name 'Local Admin' \
+  --role admin
+```
+
+To create one local account per backend role for frontend testing:
+
+```bash
+scripts/dev_auth_users.sh
+```
+
+This creates or updates:
+
+| Email | Password | Role |
+| --- | --- | --- |
+| `local-admin@example.com` | `Test123!` | `admin` |
+| `local-organizer@example.com` | `Test123!` | `organizer` |
+| `local-staff@example.com` | `Test123!` | `staff` |
+| `local-owner@example.com` | `Test123!` | `owner` |
+
+Set `DEV_AUTH_PASSWORD` to override the shared local password.
+
+4. Seed deterministic frontend demo data when the UI needs non-empty local
+   screens:
+
+```bash
+scripts/dev_demo_seed.sh
+```
+
+This opt-in seed refuses production-like environments and creates a rerunnable
+demo property with rooms, tenants, leases, bills, meter history, reports,
+journal, repair, and checkout data. It is local frontend support data and is
+separate from schema migrations and legacy migration validation.
+
+5. Create or repair the local brand readonly database user when developing the
+   future brand thin backend boundary:
+
+```bash
+scripts/dev_brand_readonly.sh
+```
+
+This local helper uses `DATABASE_URL` as the admin connection by default,
+creates or repairs `brand_readonly`, grants only the approved brand views, and
+verifies representative core base tables are not selectable. Override
+`BRAND_READONLY_PASSWORD`, `BRAND_READONLY_ADMIN_DATABASE_URL`, or
+`BRAND_READONLY_DATABASE_URL` when your local database connection differs from
+the Docker defaults.
+
+6. Get an ID token from the emulator:
+
+```bash
+go run ./cmd/auth-emulator issue-token \
+  --email testuser@example.com \
+  --password 'Test123!'
+```
+
+7. Use the returned token to call a protected route:
+
+```bash
+curl -i \
+  -H "Authorization: Bearer <ID_TOKEN>" \
+  http://127.0.0.1:8080/api/v1/authz-test/properties/property-1
+```
+
+If the `users` table contains the same `firebase_uid`, the request will pass auth and resolve the DB user.
+
+## E2E tests
+
+The E2E suite is opt-in and uses Go `testing` with the `e2e` build tag. It calls an already-running API through HTTP, resets a dedicated PostgreSQL test database schema, runs migrations, seeds the backend user row, and obtains a real bearer token from the Firebase Auth Emulator.
+
+Use a separate database name for E2E, for example `stds_backend_e2e`. This can live in the same local PostgreSQL container as the normal development database; `docker-compose.yml` does not need a second PostgreSQL service.
+
+Start dependencies:
+
+```bash
+docker compose up -d postgres
+docker exec stds-postgres psql -U stds -d postgres -c "CREATE DATABASE stds_backend_e2e"
+firebase emulators:start --only auth
+```
+
+Start the API against the E2E database:
+
+```bash
+./scripts/e2e_api.sh
+```
+
+Run the E2E suite:
+
+```bash
+./scripts/e2e_test.sh
+```
+
+The harness refuses to reset a database unless the database name contains `e2e` or `test`.
+The local scripts provide defaults for E2E environment variables and still allow overrides, for example `APP_PORT=8081 E2E_BASE_URL=http://127.0.0.1:8081 ./scripts/e2e_test.sh`.
+
+## Legacy migrated E2E sign-off
+
+Legacy migrated data checks are separate from the normal seed-based E2E suite.
+They are intended for one-time legacy migration sign-off and are not wired into
+required PR CI.
+
+Use a separate database name for this mode, for example
+`stds_backend_legacy_e2e`. The legacy E2E tests do not reset the database or
+seed business data. They only seed the backend admin user row needed for the
+Firebase Auth Emulator token, then discover representative migrated records
+through legacy mapping tables.
+
+Prepare the legacy E2E database:
+
+```bash
+docker compose up -d postgres
+docker exec stds-postgres psql -U stds -d postgres -c "CREATE DATABASE stds_backend_legacy_e2e"
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate up
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy properties
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy rooms
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy tenants
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy leases
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy room-status
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy bills
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy journal
+DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy validate
+```
+
+Before sign-off, review the generated validation report and source/target
+reconciliation. By default, `scripts/legacy_e2e_test.sh` requires
+`artifacts/legacy_migration/task13_validation_report.json` to exist.
+
+Start dependencies and the API:
+
+```bash
+firebase emulators:start --only auth
+./scripts/legacy_e2e_api.sh
+```
+
+Run the legacy read checks:
+
+```bash
+./scripts/legacy_e2e_test.sh
+```
+
+## Email notifications
+
+`POST /api/v1/users` now creates the Firebase Auth user, generates a Firebase password reset URL, and sends the onboarding email through Resend.
+
+Required environment variables:
+
+```bash
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=onboarding@example.com
+RESEND_FROM_NAME=STDS
+FIREBASE_PASSWORD_RESET_REDIRECT_URL=
+```
+
+`FIREBASE_PASSWORD_RESET_REDIRECT_URL` is optional. When set, Firebase will embed it in the generated password reset link as the continue URL.
+
+## Attachment storage
+
+Attachment upload URLs use Google Cloud Storage. Local unit tests should inject a fake storage port and must not require real GCS credentials.
+
+Required environment variables for real GCS-backed attachment uploads:
+
+```bash
+GCS_BUCKET_NAME=
+GCS_SIGNED_URL_TTL=15m
+```
+
+Optional local emulator setting:
+
+```bash
+STORAGE_EMULATOR_HOST=http://127.0.0.1:4443
+```
+
+E2E attachment acceptance uses metadata-only storage by default:
+
+```bash
+ATTACHMENT_STORAGE_MODE=fake-metadata
+```
+
+This mode is only allowed when `APP_ENV` is `e2e` or `test`. It returns a fake
+upload URL and valid object metadata so E2E tests can cover upload-token,
+registration, read, and authorization behavior without production GCS or a
+storage emulator.
+
+Production or staging environments must provide Google Application Default Credentials, for example through `GOOGLE_APPLICATION_CREDENTIALS` or the runtime service account. The service account needs permission to create signed upload URLs and read object metadata for registration checks.
+
+## CI checks
+
+The PR CI gate runs these checks for pull requests targeting `dev` and pushes to `dev`:
+
+```bash
+go test ./...
+go build -o /tmp/stds-api ./cmd/api
+npm ci
+go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
+npm run openapi:lint
+npm run openapi:generate
+git diff --exit-code -- docs/spec/openapi.yaml internal/http/api/openapi.gen.go
+docker exec stds-postgres psql -U stds -d postgres -c "DROP DATABASE IF EXISTS ci_migration_smoke"
+docker exec stds-postgres psql -U stds -d postgres -c "CREATE DATABASE ci_migration_smoke"
+DATABASE_URL=postgres://stds:stds@localhost:5432/ci_migration_smoke?sslmode=disable go run ./cmd/migrate up
+docker exec stds-postgres psql -U stds -d postgres -c "DROP DATABASE IF EXISTS ci_migration_smoke"
+go test -tags=e2e ./test/e2e
+```
+
+## Database migrations
+
+- Run all pending migrations: `go run ./cmd/migrate up`
+- Roll back applied migrations in reverse order: `go run ./cmd/migrate down`
+
+## Brand readonly database access
+
+Demo brand frontend data is exposed to a future thin backend through approved
+PostgreSQL views only. The core backend migrations create the views; deployment
+or DBA provisioning must create the Cloud SQL readonly principal and grant only
+the approved view access.
+
+The current approved views are:
+
+- `approved_brand_profile_v1`
+- `approved_brand_faq_items_v1`
+- `approved_brand_property_availability_v1`
+
+The brand readonly principal should receive `USAGE` on the schema and `SELECT`
+on those views only. Do not grant it direct access to base tables such as
+`properties`, `rooms`, `brand_profiles`, `brand_faq_items`, `tenants`, `leases`,
+`bills`, `attachments`, or deposit/accounting tables. Local PostgreSQL contract
+tests use an ephemeral equivalent role to verify that the approved views are
+selectable while base tables are not.
+
+For local thin-backend development, the expected order is:
+
+```bash
+docker compose up -d postgres
+go run ./cmd/migrate up
+scripts/dev_demo_seed.sh
+scripts/dev_brand_readonly.sh
+```
+
+The local readonly connection string defaults to:
+
+```bash
+BRAND_READONLY_DATABASE_URL=postgres://brand_readonly:brand_readonly@localhost:5432/stds_backend?sslmode=disable
+```
+
+Staging and production must provision the equivalent Cloud SQL principal outside
+application migrations. The deployment or DBA workflow should create the
+dedicated readonly principal, grant schema `USAGE`, grant `SELECT` only on the
+approved views, store the thin-backend credential through the environment or
+Secret Manager, and run a deployed smoke check that mirrors the local approved
+view and base-table denial checks.
+
+## Legacy migration planning
+
+- Validate the checked-in legacy JSON exports and generate the Task 5 architecture report: `go run ./cmd/migrate_legacy plan`
+- Override source/report directories when needed: `go run ./cmd/migrate_legacy plan --source-dir docs/mirgations --report-dir artifacts/legacy_migration`


### PR DESCRIPTION
Refs #72

## Summary
- Rework README into a concise project entry point with quickstart commands and a documentation index.
- Add local operations docs for Firebase Auth Emulator, dev users, E2E flows, attachments, email config, CI, migrations, and brand readonly DB setup.
- Add the cloud architecture baseline for staging/UAT and future production review, including Firebase Hosting rewrites, Cloud Run, Cloud SQL private IP/VPC considerations, observability, security posture, cost, and open decisions.

## Validation
- git diff --cached --check