### PR TITLE
[codex] Define staging contract and DB pool limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ POSTGRES_PORT=5432
 
 
 DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend?sslmode=disable
+DB_MAX_OPEN_CONNS=5
+DB_MAX_IDLE_CONNS=2
+DB_CONN_MAX_LIFETIME=5m
 
 FIREBASE_PROJECT_ID=
 FIREBASE_CREDENTIALS_FILE=.secrets/firebase-admin.json

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The generated Go bindings live in `internal/http/api/openapi.gen.go`.
   E2E flows, environment variables, CI command details, and migration planning.
 - [Cloud architecture](docs/cloud-architecture.md): proposed GCP staging and
   production-candidate architecture baseline.
+- [Staging runbook](docs/staging-runbook.md): staging v1 environment, secrets,
+  IAM, private networking, and verification evidence contract.
 - [Infrastructure guideline](docs/infra-guideline.md): infrastructure operating
   guidance.
 - [Vertical slice handbook](docs/vertical-slice-handbook.md): implementation

--- a/cmd/auth-emulator/main.go
+++ b/cmd/auth-emulator/main.go
@@ -82,7 +82,11 @@ func runBootstrapDevUser(cfg *config.Config, args []string) error {
 		return err
 	}
 
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, database.PoolConfig{
+		MaxOpenConns:    cfg.DB.MaxOpenConns,
+		MaxIdleConns:    cfg.DB.MaxIdleConns,
+		ConnMaxLifetime: cfg.DB.ConnMaxLifetime,
+	})
 	if err != nil {
 		return err
 	}

--- a/cmd/dev_seed/main.go
+++ b/cmd/dev_seed/main.go
@@ -28,7 +28,11 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	db, err := database.Open(ctx, cfg.DB.URL)
+	db, err := database.Open(ctx, cfg.DB.URL, database.PoolConfig{
+		MaxOpenConns:    cfg.DB.MaxOpenConns,
+		MaxIdleConns:    cfg.DB.MaxIdleConns,
+		ConnMaxLifetime: cfg.DB.ConnMaxLifetime,
+	})
 	if err != nil {
 		log.Fatalf("open database: %v", err)
 	}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -20,7 +20,11 @@ func main() {
 		log.Fatalf("load config: %v", err)
 	}
 
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, database.PoolConfig{
+		MaxOpenConns:    cfg.DB.MaxOpenConns,
+		MaxIdleConns:    cfg.DB.MaxIdleConns,
+		ConnMaxLifetime: cfg.DB.ConnMaxLifetime,
+	})
 	if err != nil {
 		log.Fatalf("open database: %v", err)
 	}

--- a/cmd/migrate_legacy/main.go
+++ b/cmd/migrate_legacy/main.go
@@ -124,7 +124,7 @@ func runProperties(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, databasePoolConfig(cfg.DB))
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -162,7 +162,7 @@ func runRooms(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, databasePoolConfig(cfg.DB))
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -201,7 +201,7 @@ func runTenants(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, databasePoolConfig(cfg.DB))
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -241,7 +241,7 @@ func runLeases(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, databasePoolConfig(cfg.DB))
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -280,7 +280,7 @@ func runRoomStatus(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, databasePoolConfig(cfg.DB))
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -318,7 +318,7 @@ func runBills(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, databasePoolConfig(cfg.DB))
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -361,7 +361,7 @@ func runJournal(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, databasePoolConfig(cfg.DB))
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -401,7 +401,7 @@ func runValidate(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, databasePoolConfig(cfg.DB))
 	if err != nil {
 		return fmt.Errorf("open database: %w", err)
 	}
@@ -425,4 +425,12 @@ func runValidate(args []string) error {
 	)
 
 	return nil
+}
+
+func databasePoolConfig(cfg config.DatabaseConfig) database.PoolConfig {
+	return database.PoolConfig{
+		MaxOpenConns:    cfg.MaxOpenConns,
+		MaxIdleConns:    cfg.MaxIdleConns,
+		ConnMaxLifetime: cfg.ConnMaxLifetime,
+	}
 }

--- a/docs/cloud-architecture.md
+++ b/docs/cloud-architecture.md
@@ -15,8 +15,7 @@ the early production candidate. It intentionally avoids an external Application
 Load Balancer in the first version. Firebase Hosting is the browser-facing edge
 for frontend traffic, while Cloud Run hosts backend services.
 
-Cloud SQL private IP and Cloud Run Direct VPC egress are included in the
-target architecture from staging v1 onward if the operational setup is accepted.
+Cloud SQL private IP and Cloud Run Direct VPC egress are included in staging v1.
 This is a security hardening choice because legacy property data will be
 migrated early. It is not treated as an HTTP ingress boundary.
 
@@ -102,8 +101,8 @@ DB_MAX_IDLE_CONNS
 DB_CONN_MAX_LIFETIME
 ```
 
-This is a required repo-side implementation item before relying on the values
-below. The current runtime must be reviewed before marking this decision done.
+The Go runtime reads these values from the environment and applies them to the
+`database/sql` pool when opening the PostgreSQL connection.
 
 Initial target values:
 
@@ -113,9 +112,9 @@ staging:
   DB_MAX_IDLE_CONNS=2
   DB_CONN_MAX_LIFETIME=5m
 
-production candidate:
-  DB_MAX_OPEN_CONNS=10
-  DB_MAX_IDLE_CONNS=5
+production candidate initial:
+  DB_MAX_OPEN_CONNS=5
+  DB_MAX_IDLE_CONNS=2
   DB_CONN_MAX_LIFETIME=5m
 ```
 
@@ -384,14 +383,15 @@ verified with GCP Billing and the Pricing Calculator before production go-live.
 
 - Firebase Hosting frontend.
 - Cloud Run core backend.
-- Cloud SQL private-IP target architecture, if operator setup is accepted.
+- Cloud SQL private IP with VPC / Direct VPC egress.
 - Secret Manager env injection.
 - GCS signed URL upload.
 - Cloud Logging / Monitoring baseline.
 - Cloud Run `max-instances=2`.
 - DB pool limits implemented and configured.
-- Smoke checks for deployment, DB migration, Firebase Auth, scheduler
-  protection, signed URL upload, and log visibility.
+- Smoke checks for deployment, DB migration, Firebase Auth, signed URL upload,
+  and log visibility.
+- Cloud Scheduler jobs are excluded from the first staging demo wave.
 
 ### Production Readiness Review
 
@@ -425,8 +425,6 @@ deployment line.
 ## Open Decisions
 
 - Should staging and production share one Cloud SQL instance initially?
-- Should staging enable Cloud SQL private IP from day one, or should private IP
-  be allowed to slip to staging hardening if setup blocks the deployment line?
 - How will Cloud Build migrations reach private Cloud SQL?
 - How will operators inspect the database without enabling public IP?
 - Should production require Cloud SQL HA before go-live?

--- a/docs/local-operations.md
+++ b/docs/local-operations.md
@@ -219,6 +219,21 @@ storage emulator.
 
 Production or staging environments must provide Google Application Default Credentials, for example through `GOOGLE_APPLICATION_CREDENTIALS` or the runtime service account. The service account needs permission to create signed upload URLs and read object metadata for registration checks.
 
+## Database pool settings
+
+Cloud Run instances each own a `database/sql` pool. Staging and production
+deployments should set explicit limits so Cloud SQL connection usage stays
+bounded as Cloud Run scales:
+
+```bash
+DB_MAX_OPEN_CONNS=5
+DB_MAX_IDLE_CONNS=2
+DB_CONN_MAX_LIFETIME=5m
+```
+
+Invalid integer or duration values fail startup instead of falling back
+silently. Local development may leave these unset.
+
 ## CI checks
 
 The PR CI gate runs these checks for pull requests targeting `dev` and pushes to `dev`:

--- a/docs/staging-runbook.md
+++ b/docs/staging-runbook.md
@@ -1,0 +1,250 @@
+# Staging Deployment Runbook
+
+Status: staging v1 contract for the first demo wave.
+
+This runbook defines the repository-side staging contract. The human operator
+performs GCP Console or `gcloud` changes. Do not paste secret values, tokens,
+private keys, database passwords, or full bearer credentials into issues, pull
+requests, logs, or evidence.
+
+## Scope
+
+Staging v1 includes:
+
+- Firebase Hosting admin frontend with `/api/**` rewrite to the core backend.
+- Cloud Run core backend.
+- Cloud SQL PostgreSQL using private IP.
+- VPC / Direct VPC egress from Cloud Run to Cloud SQL.
+- Secret Manager environment injection.
+- Cloud Storage signed URL attachment upload.
+- Firebase Auth integration.
+- Resend email configuration.
+- Cloud Logging / Monitoring baseline.
+
+Staging v1 excludes:
+
+- Cloud Scheduler jobs and scheduler smoke checks.
+- Brand thin backend deployment.
+- Production deployment gates.
+- Preview or candidate environments.
+
+Scheduler endpoints remain protected by `APP_SCHEDULER_KEY` when enabled in a
+later pass. Do not create Cloud Scheduler jobs for the first staging demo wave.
+
+## Runtime Environment
+
+Set these plain Cloud Run environment variables for the core backend:
+
+```text
+APP_NAME=stds-backend
+APP_ENV=staging
+APP_HOST=0.0.0.0
+APP_PORT=8080
+APP_BASE_URL=https://<staging-admin-domain>
+APP_READ_TIMEOUT=5s
+APP_WRITE_TIMEOUT=10s
+APP_SCHEDULER_JOB_TIMEOUT=2m
+APP_SCHEDULER_MAX_RETRIES=3
+FIREBASE_PROJECT_ID=<staging-firebase-project-id>
+FIREBASE_PASSWORD_RESET_REDIRECT_URL=https://<staging-admin-domain>/reset-password
+RESEND_FROM_EMAIL=<verified-staging-sender>
+RESEND_FROM_NAME=STDS
+RESEND_BASE_URL=https://api.resend.com
+GCS_BUCKET_NAME=<staging-attachments-bucket>
+GCS_SIGNED_URL_TTL=15m
+DB_MAX_OPEN_CONNS=5
+DB_MAX_IDLE_CONNS=2
+DB_CONN_MAX_LIFETIME=5m
+```
+
+Inject these values from Secret Manager:
+
+```text
+DATABASE_URL
+RESEND_API_KEY
+```
+
+Do not set these local/test-only variables in staging:
+
+```text
+FIREBASE_AUTH_EMULATOR_HOST
+FIREBASE_TEST_UID
+STORAGE_EMULATOR_HOST
+ATTACHMENT_STORAGE_MODE=fake-metadata
+GOOGLE_APPLICATION_CREDENTIALS
+```
+
+Cloud Run should use the runtime service account and Application Default
+Credentials instead of a checked-in or mounted service account key file.
+
+## Secret Manager
+
+Recommended staging secret names:
+
+```text
+stds-staging-database-url
+stds-staging-resend-api-key
+```
+
+Later scheduler enablement should add:
+
+```text
+stds-staging-scheduler-key
+```
+
+The runbook and review evidence should list secret names and IAM bindings only.
+Never include secret values.
+
+## Service Accounts And IAM
+
+Create service-specific accounts instead of using broad default service
+accounts.
+
+Core backend runtime service account:
+
+```text
+stds-cloud-run-core-staging
+```
+
+Expected access:
+
+- Secret Manager Secret Accessor for core backend staging secrets only.
+- Cloud SQL Client for the staging Cloud SQL instance.
+- Object access needed for the staging attachment bucket signed URL and
+  metadata flows.
+- No project-wide Owner or Editor role.
+
+Cloud Build service account:
+
+```text
+stds-cloud-build-staging
+```
+
+Expected access:
+
+- Push to the staging Artifact Registry repository.
+- Deploy or update the staging Cloud Run service.
+- Act as the core backend runtime service account only for deployment.
+- Access private Cloud SQL for migrations only after the migration path is
+  explicitly documented and verified.
+
+Cloud Scheduler is intentionally excluded from staging v1. Do not create a
+scheduler service account or scheduler jobs for the first demo wave.
+
+## Cloud Run
+
+Initial staging settings:
+
+```text
+region=asia-east1
+min-instances=0
+max-instances=2
+DB_MAX_OPEN_CONNS=5
+DB_MAX_IDLE_CONNS=2
+DB_CONN_MAX_LIFETIME=5m
+```
+
+Keep Cloud Run container concurrency at the platform default unless staging
+evidence shows a reason to change it.
+
+The browser-facing API contract is Firebase Hosting `/api/**`, not the Cloud Run
+`run.app` URL. Do not assume the default `run.app` URL can be disabled until it
+is verified with the selected Hosting rewrite path. If the default URL remains
+reachable, Firebase Auth, DB-backed authorization, and application-level checks
+remain the security boundary.
+
+## Cloud SQL And VPC
+
+Staging v1 requires:
+
+- Cloud SQL PostgreSQL staging database.
+- Staging-specific database credential.
+- Private IP enabled.
+- VPC and subnet configured for Cloud Run Direct VPC egress.
+- No public DB IP as the default access path.
+
+The operator must document how migrations reach private Cloud SQL. If Cloud
+Build cannot reach the private database in the first pass, migrations must be a
+manual operator step with non-secret evidence. Do not temporarily enable public
+DB IP unless an explicit exception, rollback plan, and expiry are documented.
+
+Operators also need a documented database inspection path that does not require
+enabling public IP.
+
+## Cloud Storage
+
+The staging attachment bucket must not be public. Browser upload uses scoped
+signed URLs from the backend.
+
+Bucket CORS must allow only approved staging frontend origins. At minimum it
+must support:
+
+```text
+method=PUT
+header=Content-Type
+```
+
+The core backend runtime service account needs enough bucket access to generate
+signed upload/download URLs and read object metadata during attachment
+registration checks.
+
+## Verification Evidence
+
+Attach only non-secret evidence to the issue or pull request.
+
+Cloud Run evidence:
+
+- Service name.
+- Region.
+- Latest revision ID.
+- Runtime service account.
+- Ingress setting.
+- Min and max instances.
+- Configured environment variable names with secret values redacted.
+
+Secret Manager evidence:
+
+- Secret names.
+- IAM binding summary.
+- Confirmation that no values were printed.
+
+Cloud SQL / VPC evidence:
+
+- Instance name.
+- Database name.
+- Private IP status.
+- VPC / subnet / Direct VPC egress summary.
+- Database user names only, without passwords.
+- `max_connections` query result.
+- Migration result.
+- Operator database inspection path.
+
+Firebase Hosting evidence:
+
+- Staging domain.
+- `/api/**` rewrite summary.
+- Browser smoke result through the Hosting URL.
+
+Firebase Auth evidence:
+
+- Protected API rejects missing or invalid bearer token.
+- Protected API accepts a valid staging Firebase ID token for a seeded staging
+  user.
+
+GCS evidence:
+
+- Bucket name.
+- Public access prevention status.
+- CORS summary.
+- IAM binding summary.
+- Signed URL upload, registration, and download smoke result.
+
+Logging evidence:
+
+- Cloud Run request log is visible.
+- Application structured log is visible.
+- Logs do not contain bearer tokens, scheduler keys, database passwords, secret
+  values, or full request/response bodies containing sensitive data.
+
+Scheduler evidence is not required for staging v1 because scheduler jobs are
+outside the first demo wave.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,10 @@ type AppConfig struct {
 
 // DatabaseConfig contains database connection settings.
 type DatabaseConfig struct {
-	URL string
+	URL             string
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
 }
 
 // FirebaseConfig contains Firebase authentication client settings.
@@ -73,6 +76,19 @@ func (c FirebaseConfig) UsesAuthEmulator() bool {
 func Load() (*Config, error) {
 	_ = godotenv.Load()
 
+	dbMaxOpenConns, err := getOptionalIntEnv("DB_MAX_OPEN_CONNS")
+	if err != nil {
+		return nil, err
+	}
+	dbMaxIdleConns, err := getOptionalIntEnv("DB_MAX_IDLE_CONNS")
+	if err != nil {
+		return nil, err
+	}
+	dbConnMaxLifetime, err := getOptionalDurationEnv("DB_CONN_MAX_LIFETIME")
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := &Config{
 		App: AppConfig{
 			Name:                getEnv("APP_NAME", "stds-backend"),
@@ -87,7 +103,10 @@ func Load() (*Config, error) {
 			WriteTimeout:        getDurationEnv("APP_WRITE_TIMEOUT", 10*time.Second),
 		},
 		DB: DatabaseConfig{
-			URL: os.Getenv("DATABASE_URL"),
+			URL:             os.Getenv("DATABASE_URL"),
+			MaxOpenConns:    dbMaxOpenConns,
+			MaxIdleConns:    dbMaxIdleConns,
+			ConnMaxLifetime: dbConnMaxLifetime,
 		},
 		Firebase: FirebaseConfig{
 			ProjectID:                os.Getenv("FIREBASE_PROJECT_ID"),
@@ -156,4 +175,38 @@ func getIntEnv(key string, fallback int) int {
 	}
 
 	return parsed
+}
+
+func getOptionalIntEnv(key string) (int, error) {
+	value := os.Getenv(key)
+	if value == "" {
+		return 0, nil
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be an integer: %w", key, err)
+	}
+	if parsed < 0 {
+		return 0, fmt.Errorf("%s must be non-negative", key)
+	}
+
+	return parsed, nil
+}
+
+func getOptionalDurationEnv(key string) (time.Duration, error) {
+	value := os.Getenv(key)
+	if value == "" {
+		return 0, nil
+	}
+
+	duration, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a duration: %w", key, err)
+	}
+	if duration < 0 {
+		return 0, fmt.Errorf("%s must be non-negative", key)
+	}
+
+	return duration, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadReadsDatabasePoolConfig(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://stds:stds@localhost:5432/stds_backend?sslmode=disable")
+	t.Setenv("DB_MAX_OPEN_CONNS", "5")
+	t.Setenv("DB_MAX_IDLE_CONNS", "2")
+	t.Setenv("DB_CONN_MAX_LIFETIME", "5m")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.DB.MaxOpenConns != 5 {
+		t.Fatalf("MaxOpenConns = %d, want 5", cfg.DB.MaxOpenConns)
+	}
+	if cfg.DB.MaxIdleConns != 2 {
+		t.Fatalf("MaxIdleConns = %d, want 2", cfg.DB.MaxIdleConns)
+	}
+	if cfg.DB.ConnMaxLifetime != 5*time.Minute {
+		t.Fatalf("ConnMaxLifetime = %s, want 5m", cfg.DB.ConnMaxLifetime)
+	}
+}
+
+func TestLoadRejectsInvalidDatabasePoolConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		value   string
+		wantErr string
+	}{
+		{
+			name:    "max open must be integer",
+			key:     "DB_MAX_OPEN_CONNS",
+			value:   "many",
+			wantErr: "DB_MAX_OPEN_CONNS must be an integer",
+		},
+		{
+			name:    "max idle must be non-negative",
+			key:     "DB_MAX_IDLE_CONNS",
+			value:   "-1",
+			wantErr: "DB_MAX_IDLE_CONNS must be non-negative",
+		},
+		{
+			name:    "lifetime must be duration",
+			key:     "DB_CONN_MAX_LIFETIME",
+			value:   "soon",
+			wantErr: "DB_CONN_MAX_LIFETIME must be a duration",
+		},
+		{
+			name:    "lifetime must be non-negative",
+			key:     "DB_CONN_MAX_LIFETIME",
+			value:   "-5m",
+			wantErr: "DB_CONN_MAX_LIFETIME must be non-negative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DATABASE_URL", "postgres://stds:stds@localhost:5432/stds_backend?sslmode=disable")
+			t.Setenv(tt.key, tt.value)
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("Load() error = nil, want %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Load() error = %q, want contains %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/platform/database/postgres.go
+++ b/internal/platform/database/postgres.go
@@ -11,12 +11,23 @@ import (
 
 const pingTimeout = 3 * time.Second
 
+// PoolConfig contains optional database/sql pool limits.
+type PoolConfig struct {
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+}
+
 // Open creates a PostgreSQL connection pool and verifies connectivity with a
 // bounded ping.
-func Open(ctx context.Context, databaseURL string) (*sql.DB, error) {
+func Open(ctx context.Context, databaseURL string, poolConfigs ...PoolConfig) (*sql.DB, error) {
 	db, err := sql.Open("pgx", databaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
+	}
+
+	if len(poolConfigs) > 0 {
+		applyPoolConfig(db, poolConfigs[0])
 	}
 
 	pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
@@ -28,4 +39,16 @@ func Open(ctx context.Context, databaseURL string) (*sql.DB, error) {
 	}
 
 	return db, nil
+}
+
+func applyPoolConfig(db *sql.DB, cfg PoolConfig) {
+	if cfg.MaxOpenConns > 0 {
+		db.SetMaxOpenConns(cfg.MaxOpenConns)
+	}
+	if cfg.MaxIdleConns > 0 {
+		db.SetMaxIdleConns(cfg.MaxIdleConns)
+	}
+	if cfg.ConnMaxLifetime > 0 {
+		db.SetConnMaxLifetime(cfg.ConnMaxLifetime)
+	}
 }

--- a/internal/platform/database/postgres_test.go
+++ b/internal/platform/database/postgres_test.go
@@ -1,0 +1,25 @@
+package database
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+)
+
+func TestApplyPoolConfigSetsMaxOpenConns(t *testing.T) {
+	db, err := sql.Open("pgx", "")
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer db.Close()
+
+	applyPoolConfig(db, PoolConfig{
+		MaxOpenConns:    5,
+		MaxIdleConns:    2,
+		ConnMaxLifetime: 5 * time.Minute,
+	})
+
+	if got := db.Stats().MaxOpenConnections; got != 5 {
+		t.Fatalf("MaxOpenConnections = %d, want 5", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -56,7 +56,11 @@ type Server struct {
 // New wires configuration, infrastructure clients, and the HTTP router into a
 // runnable server instance.
 func New(cfg *config.Config) (*Server, error) {
-	db, err := database.Open(context.Background(), cfg.DB.URL)
+	db, err := database.Open(context.Background(), cfg.DB.URL, database.PoolConfig{
+		MaxOpenConns:    cfg.DB.MaxOpenConns,
+		MaxIdleConns:    cfg.DB.MaxIdleConns,
+		ConnMaxLifetime: cfg.DB.ConnMaxLifetime,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Refs #194

## Summary
- Add staging v1 runbook for env vars, Secret Manager, IAM, Cloud Run, Cloud SQL private IP/VPC, GCS, and non-secret evidence.
- Update the cloud architecture baseline and env example for staging/prod initial DB pool limits of 5/2/5m.
- Add runtime support for DB_MAX_OPEN_CONNS, DB_MAX_IDLE_CONNS, and DB_CONN_MAX_LIFETIME across server and command entrypoints.

## Validation
- go test ./...

## Notes
- Staging v1 includes Cloud SQL private IP and VPC/Direct VPC egress.
- Cloud Scheduler is intentionally excluded from the first demo wave.
- Actual GCP setup remains an operator action; evidence should not include secret values.