### PR TITLE
[codex] Document staging database preparation

### DIFF
--- a/docs/cloud-architecture.md
+++ b/docs/cloud-architecture.md
@@ -389,8 +389,10 @@ verified with GCP Billing and the Pricing Calculator before production go-live.
 - Cloud Logging / Monitoring baseline.
 - Cloud Run `max-instances=2`.
 - DB pool limits implemented and configured.
-- Smoke checks for deployment, DB migration, Firebase Auth, signed URL upload,
-  and log visibility.
+- Staging database preparation covers schema migrations, legacy data import,
+  legacy validation, and first admin Firebase/DB user bootstrap.
+- Smoke checks for deployment, database preparation, Firebase Auth, signed URL
+  upload, and log visibility.
 - Cloud Scheduler jobs are excluded from the first staging demo wave.
 
 ### Production Readiness Review
@@ -403,6 +405,8 @@ Before production go-live:
 - Confirm DB pool limits under realistic load.
 - Confirm Cloud Build migration connectivity to private Cloud SQL.
 - Confirm operator DB access path without public DB IP.
+- Confirm whether legacy data import remains a manual operator step or moves
+  into a controlled deployment workflow.
 - Confirm Firebase Hosting rewrite behavior and whether Cloud Run default URL
   disabling is safe.
 - Confirm GCS CORS for production frontend origins.
@@ -415,6 +419,8 @@ Expected repo changes for this architecture:
 - Dockerfile and `.dockerignore`.
 - Cloud Build staging deployment config.
 - GitHub Actions trigger/status workflow if needed.
+- Staging database preparation runbook covering schema migration, legacy data
+  import, validation, and first admin bootstrap.
 - DB pool config support.
 - Staging smoke script.
 - Deployment runbooks and verification evidence templates.
@@ -427,6 +433,8 @@ deployment line.
 - Should staging and production share one Cloud SQL instance initially?
 - How will Cloud Build migrations reach private Cloud SQL?
 - How will operators inspect the database without enabling public IP?
+- Should legacy data import stay manual for staging v1, or become a controlled
+  Cloud Build/operator workflow after the first demo wave?
 - Should production require Cloud SQL HA before go-live?
 - Should Cloud Run default `run.app` URLs be disabled, and does that work with
   the selected Firebase Hosting rewrite path?

--- a/docs/staging-runbook.md
+++ b/docs/staging-runbook.md
@@ -214,6 +214,245 @@ DB IP unless an explicit exception, rollback plan, and expiry are documented.
 Operators also need a documented database inspection path that does not require
 enabling public IP.
 
+## Staging Database Preparation
+
+Prepare the staging demo database as one coordinated operator step after the
+repo-side contracts for the staging issue set have landed. The preparation path
+uses the documented private Cloud SQL access path and must not temporarily
+enable a public database IP unless an explicit exception, rollback plan, and
+expiry are documented.
+
+The operator runner can be a Cloud Build private pool, a controlled VM, or
+another approved environment. It must have:
+
+- a checkout of this repository.
+- the project Go toolchain.
+- `psql`.
+- private network access to the staging Cloud SQL database.
+- `DATABASE_URL` provided without printing the value.
+
+Run the steps in this order against the staging database:
+
+1. Apply schema migrations.
+2. Import legacy data from the checked-in legacy JSON exports.
+3. Validate the imported legacy data.
+4. Bootstrap the first staging admin user by aligning a Firebase Auth user with
+   a backend `users` row.
+5. Run deployed smoke checks through the staging API.
+
+The staging database must not be destructively reset as part of this runbook.
+If a preparation step fails, stop the deployment or demo handoff, keep the
+failed state for diagnosis where practical, and attach non-secret evidence.
+Do not assume automatic `down` rollback for staging.
+
+### Schema Migrations
+
+Run pending schema migrations with the same embedded migration runner used by
+local operations and PR CI:
+
+```bash
+go run ./cmd/migrate up
+```
+
+`DATABASE_URL` must target the staging Cloud SQL database through the documented
+private access path. Do not print the connection string. If this command runs in
+Cloud Build later, the build service account needs only the secret and private
+Cloud SQL access required for this step. If Cloud Build private connectivity is
+not ready in the first pass, run this as a manual operator step and attach
+non-secret evidence.
+
+Expected evidence:
+
+- command status or Cloud Build step ID.
+- latest `schema_migrations.version`.
+- redacted database target summary showing staging database name only.
+
+Operator script from the repository root:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+set +x
+
+: "${DATABASE_URL:?DATABASE_URL must point to the staging database}"
+
+go run ./cmd/migrate up
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c \
+  "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1;"
+```
+
+### Legacy Data Import
+
+Legacy data import is separate from schema migration. Confirm the source
+inventory, then use the existing stage-owned legacy migration commands against
+the same staging database:
+
+```bash
+go run ./cmd/migrate_legacy plan
+go run ./cmd/migrate_legacy properties
+go run ./cmd/migrate_legacy rooms
+go run ./cmd/migrate_legacy tenants
+go run ./cmd/migrate_legacy leases
+go run ./cmd/migrate_legacy room-status
+go run ./cmd/migrate_legacy bills
+go run ./cmd/migrate_legacy journal
+go run ./cmd/migrate_legacy validate
+```
+
+The source for this staging demo wave is the checked-in legacy JSON export set
+under `docs/mirgations`. Do not read directly from the legacy production
+database during staging setup. The command writes reports under
+`artifacts/legacy_migration`; review the validation report before treating the
+database as demo-ready.
+
+Expected evidence:
+
+- stage command status for each legacy import step.
+- `task13_validation_report.json` summary counts.
+- confirmation that validation completed without required-check failures.
+- mapping-table counts for `legacy_property_mappings`,
+  `legacy_room_mappings`, `legacy_tenant_mappings`, `legacy_lease_mappings`,
+  `legacy_bill_mappings`, and `legacy_schedule_mappings`.
+
+Operator script from the repository root:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+set +x
+
+: "${DATABASE_URL:?DATABASE_URL must point to the staging database}"
+
+go run ./cmd/migrate_legacy plan
+go run ./cmd/migrate_legacy properties
+go run ./cmd/migrate_legacy rooms
+go run ./cmd/migrate_legacy tenants
+go run ./cmd/migrate_legacy leases
+go run ./cmd/migrate_legacy room-status
+go run ./cmd/migrate_legacy bills
+go run ./cmd/migrate_legacy journal
+go run ./cmd/migrate_legacy validate
+
+psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+SELECT 'legacy_property_mappings' AS table_name, COUNT(*) FROM legacy_property_mappings
+UNION ALL
+SELECT 'legacy_room_mappings', COUNT(*) FROM legacy_room_mappings
+UNION ALL
+SELECT 'legacy_tenant_mappings', COUNT(*) FROM legacy_tenant_mappings
+UNION ALL
+SELECT 'legacy_lease_mappings', COUNT(*) FROM legacy_lease_mappings
+UNION ALL
+SELECT 'legacy_bill_mappings', COUNT(*) FROM legacy_bill_mappings
+UNION ALL
+SELECT 'legacy_schedule_mappings', COUNT(*) FROM legacy_schedule_mappings
+ORDER BY table_name;
+SQL
+```
+
+### First Staging Admin Bootstrap
+
+The first staging admin has a chicken-and-egg boundary: normal `POST /users`
+requires an existing authenticated admin, but the first admin does not exist
+yet. For staging v1, bootstrap exactly one initial admin through an operator
+step, then create later users through the normal admin API.
+
+1. Create or identify the first admin user in the staging Firebase Auth project.
+2. Record the Firebase UID and email as non-secret setup inputs.
+3. Upsert the matching backend user row through the documented private database
+   access path:
+
+Operator script from the repository root or another controlled runner with
+private staging database access:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+set +x
+
+: "${DATABASE_URL:?DATABASE_URL must point to the staging database}"
+: "${STAGING_ADMIN_FIREBASE_UID:?first admin Firebase UID is required}"
+: "${STAGING_ADMIN_EMAIL:?first admin email is required}"
+: "${STAGING_ADMIN_NAME:?first admin display name is required}"
+
+psql "$DATABASE_URL" \
+  -v ON_ERROR_STOP=1 \
+  -v firebase_uid="$STAGING_ADMIN_FIREBASE_UID" \
+  -v admin_email="$STAGING_ADMIN_EMAIL" \
+  -v admin_name="$STAGING_ADMIN_NAME" <<'SQL'
+INSERT INTO users (
+    firebase_uid,
+    email,
+    name,
+    role,
+    permission_overrides,
+    assigned_property_ids
+) VALUES (
+    :'firebase_uid',
+    :'admin_email',
+    :'admin_name',
+    'admin',
+    '[]'::jsonb,
+    '[]'::jsonb
+)
+ON CONFLICT (firebase_uid) WHERE deleted_at IS NULL
+DO UPDATE SET
+    email = EXCLUDED.email,
+    name = EXCLUDED.name,
+    role = EXCLUDED.role,
+    permission_overrides = EXCLUDED.permission_overrides,
+    assigned_property_ids = EXCLUDED.assigned_property_ids,
+    updated_at = now(),
+    version = users.version + 1
+RETURNING id, firebase_uid, email, role, deleted_at IS NULL AS active;
+SQL
+```
+
+The SQL executed by the script is:
+
+```sql
+INSERT INTO users (
+    firebase_uid,
+    email,
+    name,
+    role,
+    permission_overrides,
+    assigned_property_ids
+) VALUES (
+    '<firebase_uid>',
+    '<admin_email>',
+    '<admin_name>',
+    'admin',
+    '[]'::jsonb,
+    '[]'::jsonb
+)
+ON CONFLICT (firebase_uid) WHERE deleted_at IS NULL
+DO UPDATE SET
+    email = EXCLUDED.email,
+    name = EXCLUDED.name,
+    role = EXCLUDED.role,
+    permission_overrides = EXCLUDED.permission_overrides,
+    assigned_property_ids = EXCLUDED.assigned_property_ids,
+    updated_at = now(),
+    version = users.version + 1
+RETURNING id, firebase_uid, email, role, deleted_at IS NULL AS active;
+```
+
+After the first admin can sign in, run `POST /auth/sync` through the staging
+frontend/API path and use the normal user-management APIs for additional demo
+users. Do not use the local Firebase Auth Emulator bootstrap commands in
+staging. Do not give Cloud Build or the database preparation runner Firebase
+Auth admin permissions for this first staging wave; Firebase Auth user creation
+remains an operator action in the Firebase project.
+
+Expected evidence:
+
+- Firebase Auth project ID.
+- first admin Firebase UID and email.
+- backend `users` row ID, role, and `deleted_at IS NULL` status.
+- successful `/auth/sync` result for the first admin, with bearer token
+  redacted.
+
 ## Cloud Storage
 
 The staging attachment bucket must not be public. Browser upload uses scoped
@@ -259,7 +498,9 @@ Cloud SQL / VPC evidence:
 - VPC / subnet / Direct VPC egress summary.
 - Database user names only, without passwords.
 - `max_connections` query result.
-- Migration result.
+- Schema migration result and latest `schema_migrations.version`.
+- Legacy migration validation summary.
+- First admin Firebase UID/email and backend user row summary.
 - Operator database inspection path.
 
 Firebase Hosting evidence:


### PR DESCRIPTION
## Summary

Refs #192

Documents the repo-side staging database preparation contract for the first demo wave. The runbook now covers schema migration, legacy data import and validation, and first staging admin DB bootstrap after the operator creates the Firebase Auth user.

Also updates the cloud architecture baseline so staging database preparation is explicitly broader than schema migration only.

## Notes

- This PR intentionally references #192 without closing it.
- Operator-side GCP setup and non-secret evidence should happen later with the coordinated #190-#195 staging setup pass.
- Firebase Auth user creation remains an operator action for staging v1; the DB preparation runner should not receive Firebase Auth admin permissions.

## Validation

- `git diff --check -- docs/staging-runbook.md docs/cloud-architecture.md`