### PR TITLE
Add staging deployment workflow

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,188 @@
+name: Staging Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref or commit SHA to deploy.
+        required: true
+        default: dev
+      image_tag:
+        description: Artifact Registry image tag for this deployment.
+        required: true
+        default: manual
+      run_smoke:
+        description: Run minimal health/openapi smoke after deploy.
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  predeploy:
+    name: Staging predeploy checks
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.validate.outputs.commit_sha }}
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: stds_backend
+          POSTGRES_USER: stds
+          POSTGRES_PASSWORD: stds
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U stds -d stds_backend"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Validate deployment inputs
+        id: validate
+        env:
+          DEPLOY_REF: ${{ inputs.ref }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          if ! [[ "$IMAGE_TAG" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "image_tag must be a Docker-compatible tag without spaces, commas, quotes, or shell metacharacters" >&2
+            exit 1
+          fi
+
+          git fetch --no-tags origin dev
+          git fetch --no-tags origin staging || true
+
+          case "$DEPLOY_REF" in
+            dev|refs/heads/dev)
+              target_ref="origin/dev"
+              ;;
+            staging|refs/heads/staging)
+              target_ref="origin/staging"
+              ;;
+            *)
+              if [[ "$DEPLOY_REF" =~ ^[0-9a-f]{40}$ ]]; then
+                target_ref="$DEPLOY_REF"
+              else
+                echo "ref must be dev, staging, refs/heads/dev, refs/heads/staging, or a full 40-character commit SHA" >&2
+                exit 1
+              fi
+              ;;
+          esac
+
+          git cat-file -e "$target_ref^{commit}"
+          commit_sha="$(git rev-parse "$target_ref^{commit}")"
+          if ! git merge-base --is-ancestor "$commit_sha" origin/dev; then
+            if git show-ref --verify --quiet refs/remotes/origin/staging; then
+              git merge-base --is-ancestor "$commit_sha" origin/staging
+            else
+              echo "commit must be reachable from origin/dev or origin/staging" >&2
+              exit 1
+            fi
+          fi
+
+          git checkout --detach "$commit_sha"
+          echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install oapi-codegen
+        run: go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.4.1
+
+      - name: Run Go tests
+        run: go test ./...
+
+      - name: Build API
+        run: go build -o /tmp/stds-api ./cmd/api
+
+      - name: Lint OpenAPI source
+        run: npm run openapi:lint
+
+      - name: Regenerate OpenAPI artifacts
+        run: npm run openapi:generate
+
+      - name: Check generated OpenAPI artifacts are committed
+        run: |
+          git diff --check --exit-code -- docs/spec/openapi.yaml internal/http/api/openapi.gen.go
+          git diff --exit-code -- docs/spec/openapi.yaml internal/http/api/openapi.gen.go
+
+      - name: Run migrations against empty PostgreSQL
+        env:
+          DATABASE_URL: postgres://stds:stds@localhost:5432/stds_backend?sslmode=disable
+        run: go run ./cmd/migrate up
+
+      - name: Build staging container image
+        run: docker build -t stds-backend:staging-predeploy .
+
+      - name: Check staging deployment contract
+        run: |
+          test -f cloudbuild.staging.yaml
+          test -f .github/workflows/staging-deploy.yml
+          grep -q "workflow_dispatch:" .github/workflows/staging-deploy.yml
+          ! grep -q "branches: \\[staging\\]" .github/workflows/staging-deploy.yml
+          grep -q "_DATABASE_URL_SECRET" cloudbuild.staging.yaml
+          grep -q "_RESEND_API_KEY_SECRET" cloudbuild.staging.yaml
+          grep -q "_VPC_NETWORK" cloudbuild.staging.yaml
+          grep -q "_VPC_SUBNET" cloudbuild.staging.yaml
+          ! grep -E "postgres://|mysql://|RESEND_API_KEY=[A-Za-z0-9_-]|DATABASE_URL=postgres://" cloudbuild.staging.yaml
+
+  deploy:
+    name: Submit Cloud Build staging deploy
+    runs-on: ubuntu-latest
+    needs: predeploy
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.predeploy.outputs.commit_sha }}
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.STAGING_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.STAGING_GITHUB_DEPLOY_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Submit Cloud Build
+        run: |
+          gcloud builds submit \
+            --project="${{ vars.STAGING_GCP_PROJECT_ID }}" \
+            --config=cloudbuild.staging.yaml \
+            --service-account="projects/${{ vars.STAGING_GCP_PROJECT_ID }}/serviceAccounts/${{ vars.STAGING_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL }}" \
+            --substitutions="_REGION=${{ vars.STAGING_REGION }},_SERVICE_NAME=${{ vars.STAGING_CLOUD_RUN_SERVICE }},_ARTIFACT_REGISTRY_REPO=${{ vars.STAGING_ARTIFACT_REGISTRY_REPO }},_IMAGE_NAME=stds-backend,_IMAGE_TAG=${{ inputs.image_tag }},_RUNTIME_SERVICE_ACCOUNT=${{ vars.STAGING_RUNTIME_SERVICE_ACCOUNT_EMAIL }},_VPC_NETWORK=${{ vars.STAGING_VPC_NETWORK }},_VPC_SUBNET=${{ vars.STAGING_VPC_SUBNET }},_VPC_EGRESS=${{ vars.STAGING_VPC_EGRESS }},_APP_BASE_URL=${{ vars.STAGING_APP_BASE_URL }},_FIREBASE_PROJECT_ID=${{ vars.STAGING_FIREBASE_PROJECT_ID }},_RESEND_FROM_EMAIL=${{ vars.STAGING_RESEND_FROM_EMAIL }},_GCS_BUCKET_NAME=${{ vars.STAGING_GCS_BUCKET_NAME }},_DATABASE_URL_SECRET=${{ vars.STAGING_DATABASE_URL_SECRET }},_RESEND_API_KEY_SECRET=${{ vars.STAGING_RESEND_API_KEY_SECRET }}" \
+            .
+
+      - name: Minimal deployed smoke
+        if: ${{ inputs.run_smoke }}
+        env:
+          STAGING_SMOKE_BASE_URL: ${{ vars.STAGING_SMOKE_BASE_URL }}
+        run: |
+          curl -fsS "$STAGING_SMOKE_BASE_URL/healthz"
+          curl -fsS "$STAGING_SMOKE_BASE_URL/openapi.yaml" > /tmp/staging-openapi.yaml

--- a/cloudbuild.staging.yaml
+++ b/cloudbuild.staging.yaml
@@ -1,0 +1,57 @@
+substitutions:
+  _REGION: asia-east1
+  _SERVICE_NAME: stds-backend-staging
+  _ARTIFACT_REGISTRY_REPO: stds-staging
+  _IMAGE_NAME: stds-backend
+  _IMAGE_TAG: manual
+  _RUNTIME_SERVICE_ACCOUNT: stds-cloud-run-core-staging@staging-project.iam.gserviceaccount.com
+  _VPC_NETWORK: stds-staging-vpc
+  _VPC_SUBNET: stds-staging-subnet
+  _VPC_EGRESS: private-ranges-only
+  _APP_BASE_URL: https://staging.example.com
+  _FIREBASE_PROJECT_ID: staging-firebase-project
+  _RESEND_FROM_EMAIL: staging@example.com
+  _GCS_BUCKET_NAME: stds-staging-attachments
+  _DATABASE_URL_SECRET: stds-staging-database-url
+  _RESEND_API_KEY_SECRET: stds-staging-resend-api-key
+
+steps:
+  - id: build-image
+    name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -t
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REGISTRY_REPO}/${_IMAGE_NAME}:${_IMAGE_TAG}
+      - .
+
+  - id: push-image
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REGISTRY_REPO}/${_IMAGE_NAME}:${_IMAGE_TAG}
+
+  - id: deploy-cloud-run
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - ${_SERVICE_NAME}
+      - --image=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REGISTRY_REPO}/${_IMAGE_NAME}:${_IMAGE_TAG}
+      - --region=${_REGION}
+      - --platform=managed
+      - --service-account=${_RUNTIME_SERVICE_ACCOUNT}
+      - --allow-unauthenticated
+      - --network=${_VPC_NETWORK}
+      - --subnet=${_VPC_SUBNET}
+      - --vpc-egress=${_VPC_EGRESS}
+      - --min-instances=0
+      - --max-instances=2
+      - --set-env-vars=APP_NAME=stds-backend,APP_ENV=staging,APP_HOST=0.0.0.0,APP_PORT=8080,GIN_MODE=release,APP_BASE_URL=${_APP_BASE_URL},APP_READ_TIMEOUT=5s,APP_WRITE_TIMEOUT=10s,APP_SCHEDULER_JOB_TIMEOUT=2m,APP_SCHEDULER_MAX_RETRIES=3,FIREBASE_PROJECT_ID=${_FIREBASE_PROJECT_ID},FIREBASE_PASSWORD_RESET_REDIRECT_URL=${_APP_BASE_URL}/reset-password,RESEND_FROM_EMAIL=${_RESEND_FROM_EMAIL},RESEND_FROM_NAME=STDS,RESEND_BASE_URL=https://api.resend.com,GCS_BUCKET_NAME=${_GCS_BUCKET_NAME},GCS_SIGNED_URL_TTL=15m,DB_MAX_OPEN_CONNS=5,DB_MAX_IDLE_CONNS=2,DB_CONN_MAX_LIFETIME=5m
+      - --set-secrets=DATABASE_URL=${_DATABASE_URL_SECRET}:latest,RESEND_API_KEY=${_RESEND_API_KEY_SECRET}:latest
+
+images:
+  - ${_REGION}-docker.pkg.dev/$PROJECT_ID/${_ARTIFACT_REGISTRY_REPO}/${_IMAGE_NAME}:${_IMAGE_TAG}
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/docs/cloud-architecture.md
+++ b/docs/cloud-architecture.md
@@ -394,6 +394,10 @@ verified with GCP Billing and the Pricing Calculator before production go-live.
 - Smoke checks for deployment, database preparation, Firebase Auth, signed URL
   upload, and log visibility.
 - Cloud Scheduler jobs are excluded from the first staging demo wave.
+- Deployment starts as a manual GitHub Actions trigger that runs predeploy
+  checks, then submits Cloud Build for image build, Artifact Registry push, and
+  Cloud Run deploy. Automatic deployment on `staging` branch push is a later
+  hardening step after the first setup evidence is reviewed.
 
 ### Production Readiness Review
 

--- a/docs/staging-runbook.md
+++ b/docs/staging-runbook.md
@@ -120,6 +120,132 @@ The runtime image contains only the compiled `cmd/api` binary plus Alpine
 runtime packages for CA certificates and timezone data. Do not copy `.env`
 files, credentials, private keys, or other local secrets into the image.
 
+## Dev To Staging Deployment
+
+The first staging deployment wave uses a manual GitHub Actions trigger. Do not
+enable automatic `push` deployment from the `staging` branch until the first GCP
+setup, deploy, and smoke evidence have been reviewed.
+
+The intended flow is:
+
+1. Merge application changes to `dev` through the existing PR CI gate.
+2. Choose the exact `dev` commit SHA or staging branch ref to deploy.
+3. Manually run the `Staging Deploy` GitHub Actions workflow with that ref and
+   an image tag.
+4. Let GitHub Actions run staging predeploy checks.
+5. Let Cloud Build build the image, push Artifact Registry, and deploy Cloud Run.
+6. Run minimal smoke from the workflow only when requested, then complete the
+   fuller deployed smoke checklist under the staging smoke issue.
+
+The predeploy checks should catch low-cost failures before touching GCP:
+
+- Go tests and API build.
+- OpenAPI lint and generated artifact sync.
+- Empty PostgreSQL migration smoke.
+- Docker image build.
+- Staging deployment contract checks for manual trigger, Cloud Build config, and
+  Secret Manager references.
+
+GitHub Actions is the trigger and status-reporting entry point. Deployment-layer
+execution stays in Cloud Build. Do not put secret values, database passwords,
+private keys, or full bearer credentials into GitHub workflow files, Cloud Build
+substitutions, logs, pull requests, or issue evidence.
+
+### GitHub Configuration
+
+Configure these GitHub repository variables before running the manual workflow:
+
+```text
+STAGING_GCP_PROJECT_ID
+STAGING_REGION
+STAGING_WORKLOAD_IDENTITY_PROVIDER
+STAGING_GITHUB_DEPLOY_SERVICE_ACCOUNT
+STAGING_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL
+STAGING_CLOUD_RUN_SERVICE
+STAGING_RUNTIME_SERVICE_ACCOUNT_EMAIL
+STAGING_VPC_NETWORK
+STAGING_VPC_SUBNET
+STAGING_VPC_EGRESS
+STAGING_ARTIFACT_REGISTRY_REPO
+STAGING_APP_BASE_URL
+STAGING_SMOKE_BASE_URL
+STAGING_FIREBASE_PROJECT_ID
+STAGING_RESEND_FROM_EMAIL
+STAGING_GCS_BUCKET_NAME
+STAGING_DATABASE_URL_SECRET
+STAGING_RESEND_API_KEY_SECRET
+```
+
+These values are configuration identifiers, service account emails, resource
+names, or public staging URLs. Secret values remain in Secret Manager and must
+not be copied into GitHub repository variables.
+
+`STAGING_APP_BASE_URL` is the browser-facing application URL used by the
+backend for generated links. `STAGING_SMOKE_BASE_URL` is the deployed backend
+base URL used by the optional minimal smoke step and must route directly to the
+backend paths `/healthz` and `/openapi.yaml`.
+
+`STAGING_GITHUB_DEPLOY_SERVICE_ACCOUNT` is the account GitHub OIDC impersonates
+to submit the build. `STAGING_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL` is the Cloud
+Build execution account email; the workflow expands it into the Cloud Build
+resource path expected by `gcloud builds submit`. That account needs Artifact
+Registry push, Cloud Run deploy, runtime service-account act-as, and any
+explicitly approved migration connectivity for later phases.
+
+`STAGING_RUNTIME_SERVICE_ACCOUNT_EMAIL` is the Cloud Run runtime identity. It
+must be a full service account email, not a bare account id. `STAGING_VPC_NETWORK`
+and `STAGING_VPC_SUBNET` configure Cloud Run Direct VPC egress for private Cloud
+SQL connectivity. `STAGING_VPC_EGRESS` should normally be `private-ranges-only`
+for staging v1 unless operator evidence justifies a different value.
+
+### Cloud Build Configuration
+
+`cloudbuild.staging.yaml` accepts these substitutions:
+
+```text
+_REGION
+_SERVICE_NAME
+_ARTIFACT_REGISTRY_REPO
+_IMAGE_NAME
+_IMAGE_TAG
+_RUNTIME_SERVICE_ACCOUNT
+_VPC_NETWORK
+_VPC_SUBNET
+_VPC_EGRESS
+_APP_BASE_URL
+_FIREBASE_PROJECT_ID
+_RESEND_FROM_EMAIL
+_GCS_BUCKET_NAME
+_DATABASE_URL_SECRET
+_RESEND_API_KEY_SECRET
+```
+
+Cloud Build performs:
+
+1. Docker image build from the repository `Dockerfile`.
+2. Artifact Registry push.
+3. Cloud Run deploy for the core backend service with Direct VPC egress.
+
+`DATABASE_URL` and `RESEND_API_KEY` are injected into Cloud Run from Secret
+Manager by secret name. The staging workflow and Cloud Build config must not
+contain the secret values.
+
+### Deployment Evidence
+
+Attach only non-secret evidence after a staging deploy:
+
+- GitHub Actions run URL and selected source ref.
+- Cloud Build build ID and final status.
+- Artifact Registry image path and tag.
+- Cloud Run service name, region, revision, runtime service account, ingress,
+  min/max instances, and redacted env summary.
+- Secret Manager secret names referenced by Cloud Run, without values.
+- Minimal smoke status when `run_smoke` was enabled.
+
+If deployment fails, keep Cloud Build and Cloud Run logs available for diagnosis
+and rerun from a known `dev` ref after fixing the repo-side or GCP-side cause.
+Do not assume automatic database rollback.
+
 ## Secret Manager
 
 Recommended staging secret names:


### PR DESCRIPTION
Ref #193

## Summary

- add a manual `Staging Deploy` GitHub Actions entry point with predeploy checks before Cloud Build submission
- add `cloudbuild.staging.yaml` for staging image build, Artifact Registry push, and Cloud Run deploy
- document the staging deployment contract, required GitHub/GCP configuration, non-secret evidence, and manual operator boundaries
- update the cloud architecture baseline to reference the manual deploy-first staging path

## Verification

- `git diff --check origin/dev...HEAD`
- `GOCACHE=/tmp/go-cache go test -count=1 ./...`
- `npm run openapi:lint`
- `docker build -t stds-backend:staging-predeploy-local .`

## Operator Notes

- This PR does not mutate GCP resources. Per #193, the human operator still configures Workload Identity, Cloud Build/Run IAM, Artifact Registry, Secret Manager, VPC/private Cloud SQL connectivity, and staging repository variables.
- Review evidence must list only non-secret identifiers and statuses: GitHub Actions run URL, Cloud Build ID/status, Artifact Registry image path/tag, Cloud Run metadata, Secret Manager secret names, and smoke status.