### PR TITLE
[codex] Add startup database ping retry

### DIFF
--- a/internal/platform/database/postgres.go
+++ b/internal/platform/database/postgres.go
@@ -3,13 +3,21 @@ package database
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
-const pingTimeout = 3 * time.Second
+const (
+	startupPingTimeout  = 10 * time.Second
+	startupPingAttempts = 3
+	startupPingDelay    = 2 * time.Second
+)
+
+type pingFunc func(context.Context) error
+type sleepFunc func(context.Context, time.Duration) error
 
 // PoolConfig contains optional database/sql pool limits.
 type PoolConfig struct {
@@ -30,15 +38,48 @@ func Open(ctx context.Context, databaseURL string, poolConfigs ...PoolConfig) (*
 		applyPoolConfig(db, poolConfigs[0])
 	}
 
-	pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
-	defer cancel()
-
-	if err := db.PingContext(pingCtx); err != nil {
+	if err := pingWithRetry(ctx, db.PingContext, sleepContext); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("ping database: %w", err)
 	}
 
 	return db, nil
+}
+
+func pingWithRetry(ctx context.Context, ping pingFunc, sleep sleepFunc) error {
+	var attemptErrs []error
+
+	for attempt := 1; attempt <= startupPingAttempts; attempt++ {
+		pingCtx, cancel := context.WithTimeout(ctx, startupPingTimeout)
+		err := ping(pingCtx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+
+		attemptErrs = append(attemptErrs, fmt.Errorf("attempt %d/%d: %w", attempt, startupPingAttempts, err))
+		if attempt == startupPingAttempts {
+			break
+		}
+		if err := sleep(ctx, startupPingDelay); err != nil {
+			attemptErrs = append(attemptErrs, fmt.Errorf("wait before retry: %w", err))
+			break
+		}
+	}
+
+	return errors.Join(attemptErrs...)
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func applyPoolConfig(db *sql.DB, cfg PoolConfig) {

--- a/internal/platform/database/postgres_test.go
+++ b/internal/platform/database/postgres_test.go
@@ -1,7 +1,10 @@
 package database
 
 import (
+	"context"
 	"database/sql"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -21,5 +24,97 @@ func TestApplyPoolConfigSetsMaxOpenConns(t *testing.T) {
 
 	if got := db.Stats().MaxOpenConnections; got != 5 {
 		t.Fatalf("MaxOpenConnections = %d, want 5", got)
+	}
+}
+
+func TestPingWithRetryReturnsAfterFirstSuccess(t *testing.T) {
+	var pingCalls int
+	var sleepCalls int
+
+	err := pingWithRetry(context.Background(), func(ctx context.Context) error {
+		pingCalls++
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatal("ping context has no deadline")
+		}
+		if got := time.Until(deadline); got <= 0 || got > startupPingTimeout {
+			t.Fatalf("ping timeout = %v, want up to %v", got, startupPingTimeout)
+		}
+		return nil
+	}, func(ctx context.Context, d time.Duration) error {
+		sleepCalls++
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("pingWithRetry() error = %v", err)
+	}
+	if pingCalls != 1 {
+		t.Fatalf("ping calls = %d, want 1", pingCalls)
+	}
+	if sleepCalls != 0 {
+		t.Fatalf("sleep calls = %d, want 0", sleepCalls)
+	}
+}
+
+func TestPingWithRetryRetriesTemporaryFailure(t *testing.T) {
+	var pingCalls int
+	var sleepDelays []time.Duration
+	temporaryErr := errors.New("temporary unavailable")
+
+	err := pingWithRetry(context.Background(), func(ctx context.Context) error {
+		pingCalls++
+		if pingCalls < 3 {
+			return temporaryErr
+		}
+		return nil
+	}, func(ctx context.Context, d time.Duration) error {
+		sleepDelays = append(sleepDelays, d)
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("pingWithRetry() error = %v", err)
+	}
+	if pingCalls != 3 {
+		t.Fatalf("ping calls = %d, want 3", pingCalls)
+	}
+	if len(sleepDelays) != 2 {
+		t.Fatalf("sleep calls = %d, want 2", len(sleepDelays))
+	}
+	for i, got := range sleepDelays {
+		if got != startupPingDelay {
+			t.Fatalf("sleep delay %d = %v, want %v", i, got, startupPingDelay)
+		}
+	}
+}
+
+func TestPingWithRetryReturnsErrorAfterAttempts(t *testing.T) {
+	var pingCalls int
+	var sleepCalls int
+	pingErr := errors.New("connection timeout")
+
+	err := pingWithRetry(context.Background(), func(ctx context.Context) error {
+		pingCalls++
+		return pingErr
+	}, func(ctx context.Context, d time.Duration) error {
+		sleepCalls++
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("pingWithRetry() error = nil, want error")
+	}
+	if pingCalls != startupPingAttempts {
+		t.Fatalf("ping calls = %d, want %d", pingCalls, startupPingAttempts)
+	}
+	if sleepCalls != startupPingAttempts-1 {
+		t.Fatalf("sleep calls = %d, want %d", sleepCalls, startupPingAttempts-1)
+	}
+	if !strings.Contains(err.Error(), "attempt 3/3") {
+		t.Fatalf("error = %q, want final attempt context", err.Error())
+	}
+	if !errors.Is(err, pingErr) {
+		t.Fatalf("errors.Is(error, pingErr) = false, want true")
 	}
 }


### PR DESCRIPTION
Refs #202

## Summary
- Replace the single 3s startup database ping with bounded retry: 10s per attempt, 3 attempts, 2s delay.
- Preserve the final `ping database: ...` error wrapping while retaining per-attempt context.
- Add focused unit coverage for first-attempt success, retry success, and final failure.

## Validation
- `go test ./internal/platform/database`
- `go test ./...`

## Notes
- This targets the Cloud Run staging blocker recorded in #202 where app startup exits before port 8080 after a Go/pgx database ping timeout.