### PR TITLE
Fix staging smoke health path and dump runbook

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -175,7 +175,7 @@ jobs:
         run: |
           /tmp/stds-api > /tmp/stds-api.log 2>&1 &
           for i in {1..30}; do
-            if curl -fsS http://127.0.0.1:8080/healthz > /dev/null; then
+            if curl -fsS http://127.0.0.1:8080/health > /dev/null; then
               exit 0
             fi
             sleep 1

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -186,5 +186,5 @@ jobs:
         env:
           STAGING_SMOKE_BASE_URL: ${{ vars.STAGING_SMOKE_BASE_URL }}
         run: |
-          curl -fsS "$STAGING_SMOKE_BASE_URL/healthz"
+          curl -fsS "$STAGING_SMOKE_BASE_URL/health"
           curl -fsS "$STAGING_SMOKE_BASE_URL/openapi.yaml" > /tmp/staging-openapi.yaml

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ go run ./cmd/api
 
 - Scalar UI: `http://localhost:8080/scalar`
 - OpenAPI file: `http://localhost:8080/openapi.yaml`
-- Health check: `http://localhost:8080/healthz`
+- Health check: `http://localhost:8080/health`
 
 For Firebase Auth Emulator setup, local demo data, E2E flows, attachment
 storage, and other operational details, see

--- a/docs/cloud-architecture.md
+++ b/docs/cloud-architecture.md
@@ -394,8 +394,10 @@ verified with GCP Billing and the Pricing Calculator before production go-live.
 - Cloud Logging / Monitoring baseline.
 - Cloud Run `max-instances=2`.
 - DB pool limits implemented and configured.
-- Staging database preparation covers schema migrations, legacy data import,
-  legacy validation, and first admin Firebase/DB user bootstrap.
+- Staging database preparation uses a local operator plain SQL dump from
+  `scripts/prepare_legacy_db_dump.sh`, manual GCS upload, Cloud SQL
+  Console/manual import, post-import readonly principal/grant provisioning, and
+  first admin Firebase/backend user alignment.
 - Smoke checks for deployment, database preparation, Firebase Auth, signed URL
   upload, and log visibility.
 - Cloud Scheduler jobs are excluded from the first staging demo wave.
@@ -412,10 +414,10 @@ Before production go-live:
 - Confirm backup window and PITR.
 - Confirm whether HA is required.
 - Confirm DB pool limits under realistic load.
-- Confirm Cloud Build migration connectivity to private Cloud SQL.
+- Confirm the operator Cloud SQL manual import and post-import inspection path.
 - Confirm operator DB access path without public DB IP.
-- Confirm whether legacy data import remains a manual operator step or moves
-  into a controlled deployment workflow.
+- Confirm whether the local dump/manual import flow remains sufficient after the
+  first staging demo wave.
 - Confirm Firebase Hosting rewrite behavior and whether Cloud Run default URL
   disabling is safe.
 - Confirm GCS CORS for production frontend origins.
@@ -428,8 +430,9 @@ Expected repo changes for this architecture:
 - Dockerfile and `.dockerignore`.
 - Cloud Build staging deployment config.
 - GitHub Actions trigger/status workflow if needed.
-- Staging database preparation runbook covering schema migration, legacy data
-  import, validation, and first admin bootstrap.
+- Staging database preparation runbook covering local dump generation, manual
+  GCS upload, Cloud SQL import, validation evidence, manual readonly principal
+  provisioning, and first admin bootstrap.
 - DB pool config support.
 - Staging smoke script.
 - Deployment runbooks and verification evidence templates.
@@ -440,10 +443,11 @@ deployment line.
 ## Open Decisions
 
 - Should staging and production share one Cloud SQL instance initially?
-- How will Cloud Build migrations reach private Cloud SQL?
+- How long should staging rely on local dump generation plus Cloud SQL manual
+  import before introducing a controlled migration/import runner?
 - How will operators inspect the database without enabling public IP?
-- Should legacy data import stay manual for staging v1, or become a controlled
-  Cloud Build/operator workflow after the first demo wave?
+- Should the legacy dump/import artifact retention policy be stricter after the
+  first demo wave?
 - Should production require Cloud SQL HA before go-live?
 - Should Cloud Run default `run.app` URLs be disabled, and does that work with
   the selected Firebase Hosting rewrite path?

--- a/docs/local-operations.md
+++ b/docs/local-operations.md
@@ -157,6 +157,61 @@ DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode
 DATABASE_URL=postgres://stds:stds@localhost:5432/stds_backend_legacy_e2e?sslmode=disable go run ./cmd/migrate_legacy validate
 ```
 
+To prepare a one-time local plain SQL dump from the local legacy JSON exports,
+use the operator script:
+
+```bash
+docker compose up -d postgres
+scripts/prepare_legacy_db_dump.sh
+```
+
+With no arguments, the script uses the already-running `stds-postgres`
+container from `docker-compose.yml`. It fails with an instruction to run
+`docker compose up -d postgres` when that container is not running; it does not
+start PostgreSQL automatically. Each run creates a temporary PostgreSQL
+role/user, password, and database with timestamp/pid-based defaults. Override
+`TEMP_DB_ROLE`, `TEMP_DB_PASSWORD`, `TEMP_DB_NAME`, `TEMP_DB_HOST`, or
+`TEMP_DB_PORT` only when an operator needs explicit names or connection
+metadata.
+
+The script runs `go run ./cmd/migrate up`, then the complete
+`cmd/migrate_legacy` sequence: `plan`, `properties`, `rooms`, `tenants`,
+`leases`, `room-status`, `bills`, `journal`, and `validate`. It prints the
+temporary role/user, password, database name, host, and port, but treats the
+full `DATABASE_URL` as an internal migration setting rather than the primary
+operator output. It also prints the latest `schema_migrations.version` and the
+legacy mapping-table counts before writing a plain SQL dump under
+`artifacts/db_dumps` with `pg_dump --no-owner --no-privileges`.
+
+The dump includes migrated schema objects such as approved views and table data
+from the temporary database, including application `users` rows that exist at
+dump time. Because it uses `--no-owner --no-privileges`, it does not include
+PostgreSQL users, roles, owners, or grants. Cloud SQL readonly principals and
+grants must be provisioned manually after import, not by this dump.
+
+By default, the temporary database and role are dropped after the dump. Set
+`KEEP_TEMP_DB=1` to keep them for debugging:
+
+```bash
+KEEP_TEMP_DB=1 scripts/prepare_legacy_db_dump.sh
+```
+
+The script does not add admin or e2e application users by default. To include
+one admin backend `users` row in the dump, opt in explicitly and provide all
+admin fields:
+
+```bash
+INCLUDE_ADMIN_USER=1 \
+ADMIN_FIREBASE_UID=local-admin-uid \
+ADMIN_EMAIL=admin@example.com \
+ADMIN_NAME='Local Admin' \
+scripts/prepare_legacy_db_dump.sh
+```
+
+Database dumps may contain sensitive operational and tenant data. Do not commit
+files under `artifacts/db_dumps`, attach them to issues or pull requests, paste
+dump contents into chat, or post full GCS object URLs after manual upload.
+
 Before sign-off, review the generated validation report and source/target
 reconciliation. By default, `scripts/legacy_e2e_test.sh` requires
 `artifacts/legacy_migration/task13_validation_report.json` to exist.

--- a/docs/staging-runbook.md
+++ b/docs/staging-runbook.md
@@ -109,7 +109,7 @@ docker run --rm --name stds-backend-smoke \
 From another terminal, verify health:
 
 ```bash
-curl http://localhost:8080/healthz
+curl http://localhost:8080/health
 ```
 
 The expected smoke result is HTTP 200 with `"ok":true`. `"db":true` requires
@@ -183,7 +183,7 @@ not be copied into GitHub repository variables.
 `STAGING_APP_BASE_URL` is the browser-facing application URL used by the
 backend for generated links. `STAGING_SMOKE_BASE_URL` is the deployed backend
 base URL used by the optional minimal smoke step and must route directly to the
-backend paths `/healthz` and `/openapi.yaml`.
+backend paths `/health` and `/openapi.yaml`.
 
 `STAGING_GITHUB_DEPLOY_SERVICE_ACCOUNT` is the account GitHub OIDC impersonates
 to submit the build. `STAGING_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL` is the Cloud
@@ -294,8 +294,9 @@ Expected access:
 - Push to the staging Artifact Registry repository.
 - Deploy or update the staging Cloud Run service.
 - Act as the core backend runtime service account only for deployment.
-- Access private Cloud SQL for migrations only after the migration path is
-  explicitly documented and verified.
+- No Cloud SQL access for staging database preparation in the v1 dump/import
+  path unless a separate future migration workflow is explicitly documented and
+  verified.
 
 Cloud Scheduler is intentionally excluded from staging v1. Do not create a
 scheduler service account or scheduler jobs for the first demo wave.
@@ -332,10 +333,10 @@ Staging v1 requires:
 - VPC and subnet configured for Cloud Run Direct VPC egress.
 - No public DB IP as the default access path.
 
-The operator must document how migrations reach private Cloud SQL. If Cloud
-Build cannot reach the private database in the first pass, migrations must be a
-manual operator step with non-secret evidence. Do not temporarily enable public
-DB IP unless an explicit exception, rollback plan, and expiry are documented.
+The operator must document how manual import, inspection, and post-import SQL
+provisioning reach Cloud SQL without enabling a public database IP. Do not
+temporarily enable public DB IP unless an explicit exception, rollback plan, and
+expiry are documented.
 
 Operators also need a documented database inspection path that does not require
 enabling public IP.
@@ -343,138 +344,105 @@ enabling public IP.
 ## Staging Database Preparation
 
 Prepare the staging demo database as one coordinated operator step after the
-repo-side contracts for the staging issue set have landed. The preparation path
-uses the documented private Cloud SQL access path and must not temporarily
-enable a public database IP unless an explicit exception, rollback plan, and
-expiry are documented.
+repo-side contracts for the staging issue set have landed. Staging v1 does not
+run repository legacy migration commands directly against Cloud SQL or require a
+private migration runner for this step. The operator prepares a local plain SQL
+dump from the existing local `stds-postgres` container, manually uploads that
+dump to GCS, imports it through Cloud SQL Console/manual import, and then
+records non-secret database evidence.
 
-The operator runner can be a Cloud Build private pool, a controlled VM, or
-another approved environment. It must have:
+Run the steps in this order:
 
-- a checkout of this repository.
-- the project Go toolchain.
-- `psql`.
-- private network access to the staging Cloud SQL database.
-- `DATABASE_URL` provided without printing the value.
-
-Run the steps in this order against the staging database:
-
-1. Apply schema migrations.
-2. Import legacy data from the checked-in legacy JSON exports.
-3. Validate the imported legacy data.
-4. Bootstrap the first staging admin user by aligning a Firebase Auth user with
-   a backend `users` row.
-5. Run deployed smoke checks through the staging API.
+1. Prepare a local dump with `scripts/prepare_legacy_db_dump.sh`.
+2. Upload the generated SQL dump to an operator-controlled GCS location.
+3. Import the dump into the staging database with Cloud SQL Console/manual
+   import.
+4. Provision Cloud SQL-only database principals and grants, such as the brand
+   readonly principal, through DataGrip, Cloud SQL Studio, or another approved
+   manual SQL path.
+5. Create the initial Firebase Auth users in Firebase Console when needed.
+6. Align backend app `users` rows through dump opt-in or manual SQL upsert.
+7. Run deployed smoke checks through the staging API.
 
 The staging database must not be destructively reset as part of this runbook.
 If a preparation step fails, stop the deployment or demo handoff, keep the
 failed state for diagnosis where practical, and attach non-secret evidence.
 Do not assume automatic `down` rollback for staging.
 
-### Schema Migrations
+### Local Dump Preparation
 
-Run pending schema migrations with the same embedded migration runner used by
-local operations and PR CI:
+Prepare the import artifact from the repository root on the operator machine.
+The script expects the local Docker Compose PostgreSQL container to already be
+running:
 
 ```bash
-go run ./cmd/migrate up
+docker compose up -d postgres
+scripts/prepare_legacy_db_dump.sh
 ```
 
-`DATABASE_URL` must target the staging Cloud SQL database through the documented
-private access path. Do not print the connection string. If this command runs in
-Cloud Build later, the build service account needs only the secret and private
-Cloud SQL access required for this step. If Cloud Build private connectivity is
-not ready in the first pass, run this as a manual operator step and attach
-non-secret evidence.
+The script creates a temporary database and role beside the existing
+`stds-postgres` container, runs `go run ./cmd/migrate up`, runs the full
+`cmd/migrate_legacy` sequence through `validate`, prints non-secret summary
+checks, and writes a plain SQL dump under `artifacts/db_dumps` using
+`pg_dump --no-owner --no-privileges`.
+
+The dump includes schema objects from migrations, including approved views, and
+table data such as the application `users` table rows that exist in the
+temporary database. It does not include PostgreSQL roles, database users,
+ownership, or grants. By default the script does not add staging admin or e2e
+application users; include exactly one initial admin backend `users` row only
+when the operator explicitly sets `INCLUDE_ADMIN_USER=1` with the required admin
+fields.
+
+Do not commit the dump, attach it to issues or pull requests, paste dump
+contents, paste the full GCS object URL, or paste database connection strings.
+The dump and uploaded object are sensitive operational artifacts.
 
 Expected evidence:
 
-- command status or Cloud Build step ID.
-- latest `schema_migrations.version`.
-- redacted database target summary showing staging database name only.
-
-Operator script from the repository root:
-
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-set +x
-
-: "${DATABASE_URL:?DATABASE_URL must point to the staging database}"
-
-go run ./cmd/migrate up
-
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c \
-  "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1;"
-```
-
-### Legacy Data Import
-
-Legacy data import is separate from schema migration. Confirm the source
-inventory, then use the existing stage-owned legacy migration commands against
-the same staging database:
-
-```bash
-go run ./cmd/migrate_legacy plan
-go run ./cmd/migrate_legacy properties
-go run ./cmd/migrate_legacy rooms
-go run ./cmd/migrate_legacy tenants
-go run ./cmd/migrate_legacy leases
-go run ./cmd/migrate_legacy room-status
-go run ./cmd/migrate_legacy bills
-go run ./cmd/migrate_legacy journal
-go run ./cmd/migrate_legacy validate
-```
-
-The source for this staging demo wave is the checked-in legacy JSON export set
-under `docs/mirgations`. Do not read directly from the legacy production
-database during staging setup. The command writes reports under
-`artifacts/legacy_migration`; review the validation report before treating the
-database as demo-ready.
-
-Expected evidence:
-
-- stage command status for each legacy import step.
+- dump script command status.
+- generated dump filename only, not the object URL.
+- latest `schema_migrations.version` from the temporary database.
 - `task13_validation_report.json` summary counts.
 - confirmation that validation completed without required-check failures.
 - mapping-table counts for `legacy_property_mappings`,
   `legacy_room_mappings`, `legacy_tenant_mappings`, `legacy_lease_mappings`,
   `legacy_bill_mappings`, and `legacy_schedule_mappings`.
 
-Operator script from the repository root:
+### Cloud SQL Manual Import
 
-```bash
-#!/usr/bin/env bash
-set -euo pipefail
-set +x
+Upload the generated plain SQL dump to a controlled GCS location, then import it
+with Cloud SQL Console/manual import into the staging database. Keep the object
+private, remove it according to the operator retention decision, and do not post
+the object URL or dump content as evidence.
 
-: "${DATABASE_URL:?DATABASE_URL must point to the staging database}"
+After import, record:
 
-go run ./cmd/migrate_legacy plan
-go run ./cmd/migrate_legacy properties
-go run ./cmd/migrate_legacy rooms
-go run ./cmd/migrate_legacy tenants
-go run ./cmd/migrate_legacy leases
-go run ./cmd/migrate_legacy room-status
-go run ./cmd/migrate_legacy bills
-go run ./cmd/migrate_legacy journal
-go run ./cmd/migrate_legacy validate
+- Cloud SQL import status.
+- staging database name.
+- latest imported `schema_migrations.version`.
+- legacy validation and mapping-count summary copied from the local dump run.
+- confirmation that no PostgreSQL roles, grants, or owner metadata were expected
+  from the dump.
 
-psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
-SELECT 'legacy_property_mappings' AS table_name, COUNT(*) FROM legacy_property_mappings
-UNION ALL
-SELECT 'legacy_room_mappings', COUNT(*) FROM legacy_room_mappings
-UNION ALL
-SELECT 'legacy_tenant_mappings', COUNT(*) FROM legacy_tenant_mappings
-UNION ALL
-SELECT 'legacy_lease_mappings', COUNT(*) FROM legacy_lease_mappings
-UNION ALL
-SELECT 'legacy_bill_mappings', COUNT(*) FROM legacy_bill_mappings
-UNION ALL
-SELECT 'legacy_schedule_mappings', COUNT(*) FROM legacy_schedule_mappings
-ORDER BY table_name;
-SQL
-```
+### Cloud SQL Principals And Grants
+
+Approved brand views are created by repository migrations and therefore are
+present in the dump/import. The brand readonly database principal and its grants
+are not created by the dump and are not application migration responsibility.
+Provision them after import through DataGrip, Cloud SQL Studio, or another
+approved manual SQL path.
+
+Grant the brand readonly principal schema `USAGE` and `SELECT` only on approved
+views. Do not grant access to base tables such as `properties`, `rooms`,
+`brand_profiles`, `brand_faq_items`, `tenants`, `leases`, `bills`,
+`attachments`, or deposit/accounting tables.
+
+Expected evidence:
+
+- readonly database principal name only, without password.
+- approved view `SELECT` check.
+- representative base-table denial check.
 
 ### First Staging Admin Bootstrap
 
@@ -483,20 +451,21 @@ requires an existing authenticated admin, but the first admin does not exist
 yet. For staging v1, bootstrap exactly one initial admin through an operator
 step, then create later users through the normal admin API.
 
-1. Create or identify the first admin user in the staging Firebase Auth project.
-2. Record the Firebase UID and email as non-secret setup inputs.
-3. Upsert the matching backend user row through the documented private database
-   access path:
+Create or identify the first admin user in the staging Firebase Auth project
+through Firebase Console. Do not describe Firebase Auth user creation as a
+repository script flow for this first staging wave. Record the Firebase UID and
+email as non-secret setup inputs.
 
-Operator script from the repository root or another controlled runner with
-private staging database access:
+The matching backend app `users` row can be handled in either of these ways:
+
+- Include it in the dump by running `scripts/prepare_legacy_db_dump.sh` with
+  `INCLUDE_ADMIN_USER=1` and the required admin fields.
+- Upsert it after Cloud SQL import through DataGrip, Cloud SQL Studio, or
+  another approved manual SQL path.
+
+Manual SQL template:
 
 ```bash
-#!/usr/bin/env bash
-set -euo pipefail
-set +x
-
-: "${DATABASE_URL:?DATABASE_URL must point to the staging database}"
 : "${STAGING_ADMIN_FIREBASE_UID:?first admin Firebase UID is required}"
 : "${STAGING_ADMIN_EMAIL:?first admin email is required}"
 : "${STAGING_ADMIN_NAME:?first admin display name is required}"
@@ -534,41 +503,11 @@ RETURNING id, firebase_uid, email, role, deleted_at IS NULL AS active;
 SQL
 ```
 
-The SQL executed by the script is:
-
-```sql
-INSERT INTO users (
-    firebase_uid,
-    email,
-    name,
-    role,
-    permission_overrides,
-    assigned_property_ids
-) VALUES (
-    '<firebase_uid>',
-    '<admin_email>',
-    '<admin_name>',
-    'admin',
-    '[]'::jsonb,
-    '[]'::jsonb
-)
-ON CONFLICT (firebase_uid) WHERE deleted_at IS NULL
-DO UPDATE SET
-    email = EXCLUDED.email,
-    name = EXCLUDED.name,
-    role = EXCLUDED.role,
-    permission_overrides = EXCLUDED.permission_overrides,
-    assigned_property_ids = EXCLUDED.assigned_property_ids,
-    updated_at = now(),
-    version = users.version + 1
-RETURNING id, firebase_uid, email, role, deleted_at IS NULL AS active;
-```
-
 After the first admin can sign in, run `POST /auth/sync` through the staging
 frontend/API path and use the normal user-management APIs for additional demo
 users. Do not use the local Firebase Auth Emulator bootstrap commands in
-staging. Do not give Cloud Build or the database preparation runner Firebase
-Auth admin permissions for this first staging wave; Firebase Auth user creation
+staging. Do not give Cloud Build or the database preparation flow Firebase Auth
+admin permissions for this first staging wave; Firebase Auth user creation
 remains an operator action in the Firebase project.
 
 Expected evidence:
@@ -700,7 +639,7 @@ Check one deployed path:
 resource.type="cloud_run_revision"
 resource.labels.service_name="<staging-cloud-run-service>"
 resource.labels.location="<staging-region>"
-jsonPayload.path="/healthz"
+jsonPayload.path="/health"
 ```
 
 Authenticated smoke requests should prove that `user_id`, `firebase_uid`, and
@@ -730,7 +669,7 @@ These are accepted staging v1 constraints, not blockers for the first demo
 wave:
 
 - Successful API startup does not emit a dedicated application startup log; use
-  Cloud Run revision/system logs and `/healthz` smoke evidence to confirm the
+  Cloud Run revision/system logs and `/health` smoke evidence to confirm the
   revision is serving.
 - 5xx `cause`, panic values, stack traces, and migration driver errors are not
   redacted by a centralized scrubber. Evidence must be reviewed before posting.
@@ -837,8 +776,10 @@ Cloud SQL / VPC evidence:
 - VPC / subnet / Direct VPC egress summary.
 - Database user names only, without passwords.
 - `max_connections` query result.
-- Schema migration result and latest `schema_migrations.version`.
-- Legacy migration validation summary.
+- Cloud SQL manual import status and latest imported `schema_migrations.version`.
+- Legacy validation summary from the local dump preparation run.
+- Confirmation that approved views came from migration/dump and readonly
+  principals/grants were provisioned manually after import.
 - First admin Firebase UID/email and backend user row summary.
 - Operator database inspection path.
 

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -54,7 +54,7 @@ func New(
 	healthHandler := handler.NewHealthHandler(appCfg, db)
 	docsHandler := handler.NewDocsHandler()
 
-	engine.GET("/healthz", healthHandler.Live)
+	engine.GET("/health", healthHandler.Live)
 	engine.GET("/openapi.yaml", docsHandler.OpenAPI)
 	engine.GET("/scalar", docsHandler.Scalar)
 

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -73,6 +73,41 @@ func TestGetPropertyUsesFormalAPIWiring(t *testing.T) {
 	}
 }
 
+func TestHealthUsesCloudRunSafeRoute(t *testing.T) {
+	engine := newTestEngine(fakeUserRepo{}, fakeAuthenticator{}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	resp := httptest.NewRecorder()
+
+	engine.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	var payload struct {
+		Name string `json:"name"`
+		Env  string `json:"env"`
+		OK   bool   `json:"ok"`
+		DB   bool   `json:"db"`
+	}
+	if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+	if payload.Name != "test" || payload.Env != "test" || !payload.OK {
+		t.Fatalf("unexpected health payload: %+v", payload)
+	}
+
+	oldReq := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	oldResp := httptest.NewRecorder()
+
+	engine.ServeHTTP(oldResp, oldReq)
+
+	if oldResp.Code != http.StatusNotFound {
+		t.Fatalf("expected /healthz to be unregistered, got %d: %s", oldResp.Code, oldResp.Body.String())
+	}
+}
+
 func TestGeneratedAPIRoutesHaveRoutePolicies(t *testing.T) {
 	engine := newTestEngine(fakeUserRepo{}, fakeAuthenticator{}, fakePropertyRepo{}, fakeResourceOwnershipRepo{}, "", fakeJobRunsRepo{})
 

--- a/scripts/prepare_legacy_db_dump.sh
+++ b/scripts/prepare_legacy_db_dump.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+
+LEGACY_SOURCE_DIR="${LEGACY_SOURCE_DIR:-docs/mirgations}"
+LEGACY_REPORT_DIR="${LEGACY_REPORT_DIR:-artifacts/legacy_migration}"
+DB_DUMP_DIR="${DB_DUMP_DIR:-artifacts/db_dumps}"
+DB_DUMP_NAME="${DB_DUMP_NAME:-legacy_db_dump_$(date +%Y%m%d_%H%M%S).sql}"
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-stds-postgres}"
+POSTGRES_ADMIN_USER="${POSTGRES_ADMIN_USER:-stds}"
+TEMP_DB_HOST="${TEMP_DB_HOST:-127.0.0.1}"
+RUN_ID="$(date +%Y%m%d_%H%M%S)_$$"
+TEMP_DB_ROLE="${TEMP_DB_ROLE:-${TEMP_DB_USER:-stds_legacy_dump_$RUN_ID}}"
+TEMP_DB_NAME="${TEMP_DB_NAME:-stds_legacy_dump_$RUN_ID}"
+KEEP_TEMP_DB="${KEEP_TEMP_DB:-0}"
+INCLUDE_ADMIN_USER="${INCLUDE_ADMIN_USER:-0}"
+
+find_tool() {
+  tool_name="$1"
+  fallback_path="$2"
+
+  if command -v "$tool_name" >/dev/null 2>&1; then
+    command -v "$tool_name"
+    return 0
+  fi
+
+  if [ -x "$fallback_path" ]; then
+    printf '%s\n' "$fallback_path"
+    return 0
+  fi
+
+  printf 'missing required tool: %s\n' "$tool_name" >&2
+  printf 'install PostgreSQL client tools or add %s to PATH\n' "$(dirname "$fallback_path")" >&2
+  return 1
+}
+
+run_legacy_stage() {
+  stage="$1"
+
+  if [ "$stage" = "room-status" ]; then
+    "$GO_BIN" run ./cmd/migrate_legacy "$stage" \
+      --report-dir "$LEGACY_REPORT_DIR"
+    return 0
+  fi
+
+  "$GO_BIN" run ./cmd/migrate_legacy "$stage" \
+    --source-dir "$LEGACY_SOURCE_DIR" \
+    --report-dir "$LEGACY_REPORT_DIR"
+}
+
+validate_identifier() {
+  value="$1"
+  label="$2"
+
+  case "$value" in
+    ""|[!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_]*|*[!abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_0123456789]*)
+      printf '%s must be a PostgreSQL identifier using letters, numbers, and underscores, starting with a letter or underscore: %s\n' "$label" "$value" >&2
+      return 1
+      ;;
+  esac
+}
+
+generate_password() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 16
+    return 0
+  fi
+
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+    return 0
+  fi
+
+  printf 'missing required tool: openssl or uuidgen\n' >&2
+  return 1
+}
+
+admin_psql() {
+  "$DOCKER_BIN" exec -i "$POSTGRES_CONTAINER" psql -U "$POSTGRES_ADMIN_USER" -d postgres "$@"
+}
+
+cleanup_temp_db() {
+  if [ "$KEEP_TEMP_DB" = "1" ]; then
+    printf '\nKeeping temporary database for debugging: %s\n' "$TEMP_DB_NAME"
+    printf 'Temporary DB role/user: %s\n' "$TEMP_DB_ROLE"
+    return 0
+  fi
+
+  if [ "${TEMP_DB_CREATED:-0}" = "1" ]; then
+    printf '\nRemoving temporary database and role: %s / %s\n' "$TEMP_DB_NAME" "$TEMP_DB_ROLE"
+    admin_psql -v ON_ERROR_STOP=1 \
+      -v temp_db="$TEMP_DB_NAME" \
+      -v temp_role="$TEMP_DB_ROLE" <<'SQL' >/dev/null 2>&1 || true
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE datname = :'temp_db'
+  AND pid <> pg_backend_pid();
+DROP DATABASE IF EXISTS :"temp_db" WITH (FORCE);
+DROP ROLE IF EXISTS :"temp_role";
+SQL
+  fi
+}
+
+bootstrap_admin_user() {
+  if [ "$INCLUDE_ADMIN_USER" != "1" ]; then
+    return 0
+  fi
+
+  : "${ADMIN_FIREBASE_UID:?ADMIN_FIREBASE_UID is required when INCLUDE_ADMIN_USER=1}"
+  : "${ADMIN_EMAIL:?ADMIN_EMAIL is required when INCLUDE_ADMIN_USER=1}"
+  : "${ADMIN_NAME:?ADMIN_NAME is required when INCLUDE_ADMIN_USER=1}"
+
+  printf '\nUpserting opt-in admin user row before dump...\n'
+  "$PSQL_BIN" "$DATABASE_URL" \
+    -v ON_ERROR_STOP=1 \
+    -v firebase_uid="$ADMIN_FIREBASE_UID" \
+    -v admin_email="$ADMIN_EMAIL" \
+    -v admin_name="$ADMIN_NAME" <<'SQL'
+INSERT INTO users (
+    firebase_uid,
+    email,
+    name,
+    role,
+    permission_overrides,
+    assigned_property_ids
+) VALUES (
+    :'firebase_uid',
+    :'admin_email',
+    :'admin_name',
+    'admin',
+    '[]'::jsonb,
+    '[]'::jsonb
+)
+ON CONFLICT (firebase_uid) WHERE deleted_at IS NULL
+DO UPDATE SET
+    email = EXCLUDED.email,
+    name = EXCLUDED.name,
+    role = EXCLUDED.role,
+    permission_overrides = EXCLUDED.permission_overrides,
+    assigned_property_ids = EXCLUDED.assigned_property_ids,
+    updated_at = now(),
+    version = users.version + 1
+RETURNING id, firebase_uid, email, role, deleted_at IS NULL AS active;
+SQL
+}
+
+PSQL_BIN=$(find_tool psql /opt/homebrew/opt/libpq/bin/psql)
+PG_DUMP_BIN=$(find_tool pg_dump /opt/homebrew/opt/libpq/bin/pg_dump)
+GO_BIN=$(find_tool go /opt/homebrew/bin/go)
+DOCKER_BIN=$(find_tool docker /opt/homebrew/bin/docker)
+
+cd "$REPO_ROOT"
+
+validate_identifier "$TEMP_DB_ROLE" TEMP_DB_ROLE
+validate_identifier "$TEMP_DB_NAME" TEMP_DB_NAME
+
+if [ ! -d "$LEGACY_SOURCE_DIR" ]; then
+  printf 'legacy source directory does not exist: %s\n' "$LEGACY_SOURCE_DIR" >&2
+  exit 1
+fi
+
+if ! find "$LEGACY_SOURCE_DIR" -maxdepth 1 -type f -name '*.json' | grep -q .; then
+  printf 'legacy source directory has no JSON exports: %s\n' "$LEGACY_SOURCE_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$LEGACY_REPORT_DIR" "$DB_DUMP_DIR"
+
+TEMP_DB_PASSWORD="${TEMP_DB_PASSWORD:-$(generate_password)}"
+
+if [ "$("$DOCKER_BIN" inspect -f '{{.State.Running}}' "$POSTGRES_CONTAINER" 2>/dev/null || true)" != "true" ]; then
+  printf 'PostgreSQL container is not running: %s\n' "$POSTGRES_CONTAINER" >&2
+  printf 'Start it first with: docker compose up -d postgres\n' >&2
+  exit 1
+fi
+
+TEMP_DB_PORT="${TEMP_DB_PORT:-$("$DOCKER_BIN" port "$POSTGRES_CONTAINER" 5432/tcp | sed -n '1s/.*://p')}"
+if [ -z "$TEMP_DB_PORT" ]; then
+  printf 'could not determine host port for %s 5432/tcp; set TEMP_DB_PORT explicitly\n' "$POSTGRES_CONTAINER" >&2
+  exit 1
+fi
+
+printf 'Creating temporary PostgreSQL role and database in container: %s\n' "$POSTGRES_CONTAINER"
+admin_psql -v ON_ERROR_STOP=1 \
+  -v temp_role="$TEMP_DB_ROLE" \
+  -v temp_password="$TEMP_DB_PASSWORD" \
+  -v temp_db="$TEMP_DB_NAME" <<'SQL'
+CREATE ROLE :"temp_role" LOGIN PASSWORD :'temp_password';
+CREATE DATABASE :"temp_db" OWNER :"temp_role";
+SQL
+
+TEMP_DB_CREATED=1
+trap cleanup_temp_db EXIT INT TERM
+
+DATABASE_URL="postgres://$TEMP_DB_ROLE:$TEMP_DB_PASSWORD@$TEMP_DB_HOST:$TEMP_DB_PORT/$TEMP_DB_NAME?sslmode=disable"
+export DATABASE_URL
+
+printf 'Waiting for temporary database to accept connections...\n'
+ready_attempt=0
+while ! "$PSQL_BIN" "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "SELECT 1;" >/dev/null 2>&1; do
+  ready_attempt=$((ready_attempt + 1))
+  if [ "$ready_attempt" -ge 60 ]; then
+    printf 'temporary PostgreSQL did not become ready in time\n' >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+printf 'Preparing legacy database dump.\n'
+printf 'PostgreSQL container: %s\n' "$POSTGRES_CONTAINER"
+printf 'Temporary DB role/user: %s\n' "$TEMP_DB_ROLE"
+printf 'Temporary DB password: %s\n' "$TEMP_DB_PASSWORD"
+printf 'Temporary DB name: %s\n' "$TEMP_DB_NAME"
+printf 'Temporary DB host: %s\n' "$TEMP_DB_HOST"
+printf 'Temporary DB port: %s\n' "$TEMP_DB_PORT"
+printf 'Legacy source dir: %s\n' "$LEGACY_SOURCE_DIR"
+printf 'Legacy report dir: %s\n' "$LEGACY_REPORT_DIR"
+printf 'Dump output dir: %s\n' "$DB_DUMP_DIR"
+printf 'Temporary DATABASE_URL is set internally for migration commands.\n'
+
+printf '\nRunning schema migrations...\n'
+"$GO_BIN" run ./cmd/migrate up
+
+printf '\nRunning legacy migration stages...\n'
+run_legacy_stage plan
+run_legacy_stage properties
+run_legacy_stage rooms
+run_legacy_stage tenants
+run_legacy_stage leases
+run_legacy_stage room-status
+run_legacy_stage bills
+run_legacy_stage journal
+run_legacy_stage validate
+
+bootstrap_admin_user
+
+printf '\nLatest schema migration version:\n'
+"$PSQL_BIN" "$DATABASE_URL" -v ON_ERROR_STOP=1 -c \
+  "SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 1;"
+
+printf '\nLegacy mapping table counts:\n'
+"$PSQL_BIN" "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+SELECT 'legacy_property_mappings' AS table_name, COUNT(*) FROM legacy_property_mappings
+UNION ALL
+SELECT 'legacy_room_mappings', COUNT(*) FROM legacy_room_mappings
+UNION ALL
+SELECT 'legacy_tenant_mappings', COUNT(*) FROM legacy_tenant_mappings
+UNION ALL
+SELECT 'legacy_lease_mappings', COUNT(*) FROM legacy_lease_mappings
+UNION ALL
+SELECT 'legacy_bill_mappings', COUNT(*) FROM legacy_bill_mappings
+UNION ALL
+SELECT 'legacy_schedule_mappings', COUNT(*) FROM legacy_schedule_mappings
+ORDER BY table_name;
+SQL
+
+DUMP_PATH="$DB_DUMP_DIR/$DB_DUMP_NAME"
+
+printf '\nWriting plain SQL dump: %s\n' "$DUMP_PATH"
+"$PG_DUMP_BIN" \
+  --format=plain \
+  --no-owner \
+  --no-privileges \
+  --file "$DUMP_PATH" \
+  "$DATABASE_URL"
+
+printf '\nLegacy database dump prepared: %s\n' "$DUMP_PATH"
+printf 'Treat this dump as sensitive operational data. Do not commit or attach it to issues.\n'

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -36,7 +36,7 @@ func TestE2EHarnessAuthenticatedSmoke(t *testing.T) {
 	client := newAPIClient(cfg.BaseURL, token.IDToken)
 
 	t.Run("health endpoint reaches API and database", func(t *testing.T) {
-		resp, body, err := client.getJSON(ctx, "/healthz")
+		resp, body, err := client.getJSON(ctx, "/health")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/legacye2e/legacy_read_test.go
+++ b/test/legacye2e/legacy_read_test.go
@@ -48,7 +48,7 @@ func TestLegacyE2EMigratedDataReadChecks(t *testing.T) {
 	targets := discoverLegacyReadTargets(t, ctx, db)
 
 	t.Run("health endpoint reaches migrated database", func(t *testing.T) {
-		resp, body, err := client.getJSON(ctx, "/healthz")
+		resp, body, err := client.getJSON(ctx, "/health")
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Refs #202

## Summary
- move public health check and smoke references from /healthz to /health for Cloud Run staging smoke
- add router coverage that /health is registered and /healthz is no longer registered
- add scripts/prepare_legacy_db_dump.sh for local clean legacy dump generation and update staging/local/cloud docs for manual GCS upload, Cloud SQL import, readonly DB principal grants, and manual Firebase/app user bootstrap
- set STAGING_SMOKE_BASE_URL repository variable to the current Cloud Run backend URL for run_smoke=true

## Verification
- bash -n scripts/prepare_legacy_db_dump.sh
- GOCACHE=/tmp/go-cache go test ./internal/http/router -run TestHealthUsesCloudRunSafeRoute -count=1
- GOCACHE=/tmp/go-cache go build -o /tmp/stds-api ./cmd/api
- GOCACHE=/tmp/go-cache go test -count=1 ./...
- prior local full dump run completed with schema_migrations.version 000024, legacy validation, mapping counts, and temp DB/role cleanup

## Notes
- The staging deploy workflow still only deploys dev/staging or a SHA reachable from those branches, so run_smoke=true can be exercised after this lands on dev unless we intentionally widen that policy in a separate change.