### PR TITLE
Mask staging base URLs in deploy logs

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -170,7 +170,17 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3
 
+      - name: Mask staging base URLs
+        env:
+          STAGING_APP_BASE_URL: ${{ vars.STAGING_APP_BASE_URL }}
+          STAGING_SMOKE_BASE_URL: ${{ vars.STAGING_SMOKE_BASE_URL }}
+        run: |
+          echo "::add-mask::$STAGING_APP_BASE_URL"
+          echo "::add-mask::$STAGING_SMOKE_BASE_URL"
+
       - name: Submit Cloud Build
+        env:
+          STAGING_APP_BASE_URL: ${{ vars.STAGING_APP_BASE_URL }}
         run: |
           gcloud builds submit \
             --project="${{ vars.STAGING_GCP_PROJECT_ID }}" \
@@ -178,7 +188,7 @@ jobs:
             --config=cloudbuild.staging.yaml \
             --gcs-source-staging-dir="gs://${{ vars.STAGING_GCP_PROJECT_ID }}_cloudbuild/source" \
             --service-account="projects/${{ vars.STAGING_GCP_PROJECT_ID }}/serviceAccounts/${{ vars.STAGING_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL }}" \
-            --substitutions="_REGION=${{ vars.STAGING_REGION }},_SERVICE_NAME=${{ vars.STAGING_CLOUD_RUN_SERVICE }},_ARTIFACT_REGISTRY_REPO=${{ vars.STAGING_ARTIFACT_REGISTRY_REPO }},_IMAGE_NAME=stds-backend,_IMAGE_TAG=${{ inputs.image_tag }},_RUNTIME_SERVICE_ACCOUNT=${{ vars.STAGING_RUNTIME_SERVICE_ACCOUNT_EMAIL }},_VPC_NETWORK=${{ vars.STAGING_VPC_NETWORK }},_VPC_SUBNET=${{ vars.STAGING_VPC_SUBNET }},_VPC_EGRESS=${{ vars.STAGING_VPC_EGRESS }},_APP_BASE_URL=${{ vars.STAGING_APP_BASE_URL }},_FIREBASE_PROJECT_ID=${{ vars.STAGING_FIREBASE_PROJECT_ID }},_RESEND_FROM_EMAIL=${{ vars.STAGING_RESEND_FROM_EMAIL }},_GCS_BUCKET_NAME=${{ vars.STAGING_GCS_BUCKET_NAME }},_DATABASE_URL_SECRET=${{ vars.STAGING_DATABASE_URL_SECRET }},_RESEND_API_KEY_SECRET=${{ vars.STAGING_RESEND_API_KEY_SECRET }}" \
+            --substitutions="_REGION=${{ vars.STAGING_REGION }},_SERVICE_NAME=${{ vars.STAGING_CLOUD_RUN_SERVICE }},_ARTIFACT_REGISTRY_REPO=${{ vars.STAGING_ARTIFACT_REGISTRY_REPO }},_IMAGE_NAME=stds-backend,_IMAGE_TAG=${{ inputs.image_tag }},_RUNTIME_SERVICE_ACCOUNT=${{ vars.STAGING_RUNTIME_SERVICE_ACCOUNT_EMAIL }},_VPC_NETWORK=${{ vars.STAGING_VPC_NETWORK }},_VPC_SUBNET=${{ vars.STAGING_VPC_SUBNET }},_VPC_EGRESS=${{ vars.STAGING_VPC_EGRESS }},_APP_BASE_URL=$STAGING_APP_BASE_URL,_FIREBASE_PROJECT_ID=${{ vars.STAGING_FIREBASE_PROJECT_ID }},_RESEND_FROM_EMAIL=${{ vars.STAGING_RESEND_FROM_EMAIL }},_GCS_BUCKET_NAME=${{ vars.STAGING_GCS_BUCKET_NAME }},_DATABASE_URL_SECRET=${{ vars.STAGING_DATABASE_URL_SECRET }},_RESEND_API_KEY_SECRET=${{ vars.STAGING_RESEND_API_KEY_SECRET }}" \
             .
 
       - name: Minimal deployed smoke


### PR DESCRIPTION
## Summary
- register staging app/smoke base URLs with GitHub Actions add-mask before deploy commands
- pass STAGING_APP_BASE_URL through an env var in the Cloud Build substitution so logs do not directly expand the repo variable value

## Verification
- git diff --check

## Notes
- This keeps the values as repository variables; it only redacts them from subsequent workflow logs as a hygiene improvement.