### PR TITLE
Promote dev to staging for controlled deploy

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - staging
   push:
     branches:
       - dev

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,6 +1,9 @@
 name: Staging Deploy
 
 on:
+  push:
+    branches:
+      - staging
   workflow_dispatch:
     inputs:
       ref:
@@ -17,6 +20,10 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  group: backend-staging-deploy
+  cancel-in-progress: false
+
 permissions:
   contents: read
   id-token: write
@@ -27,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       commit_sha: ${{ steps.validate.outputs.commit_sha }}
+      image_tag: ${{ steps.validate.outputs.image_tag }}
+      run_smoke: ${{ steps.validate.outputs.run_smoke }}
 
     services:
       postgres:
@@ -53,33 +62,49 @@ jobs:
       - name: Validate deployment inputs
         id: validate
         env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_SHA_VALUE: ${{ github.sha }}
           DEPLOY_REF: ${{ inputs.ref }}
           IMAGE_TAG: ${{ inputs.image_tag }}
+          RUN_SMOKE: ${{ inputs.run_smoke }}
         run: |
-          if ! [[ "$IMAGE_TAG" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
-            echo "image_tag must be a Docker-compatible tag without spaces, commas, quotes, or shell metacharacters" >&2
-            exit 1
-          fi
-
           git fetch --no-tags origin dev
           git fetch --no-tags origin staging || true
 
-          case "$DEPLOY_REF" in
-            dev|refs/heads/dev)
-              target_ref="origin/dev"
-              ;;
-            staging|refs/heads/staging)
-              target_ref="origin/staging"
-              ;;
-            *)
-              if [[ "$DEPLOY_REF" =~ ^[0-9a-f]{40}$ ]]; then
-                target_ref="$DEPLOY_REF"
-              else
-                echo "ref must be dev, staging, refs/heads/dev, refs/heads/staging, or a full 40-character commit SHA" >&2
-                exit 1
-              fi
-              ;;
-          esac
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            if [[ "$GITHUB_REF_NAME" != "staging" ]]; then
+              echo "automatic staging deploys must come from the staging branch" >&2
+              exit 1
+            fi
+            target_ref="$GITHUB_SHA_VALUE"
+            resolved_image_tag="$GITHUB_SHA_VALUE"
+            resolved_run_smoke="true"
+          else
+            if ! [[ "$IMAGE_TAG" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "image_tag must be a Docker-compatible tag without spaces, commas, quotes, or shell metacharacters" >&2
+              exit 1
+            fi
+
+            case "$DEPLOY_REF" in
+              dev|refs/heads/dev)
+                target_ref="origin/dev"
+                ;;
+              staging|refs/heads/staging)
+                target_ref="origin/staging"
+                ;;
+              *)
+                if [[ "$DEPLOY_REF" =~ ^[0-9a-f]{40}$ ]]; then
+                  target_ref="$DEPLOY_REF"
+                else
+                  echo "ref must be dev, staging, refs/heads/dev, refs/heads/staging, or a full 40-character commit SHA" >&2
+                  exit 1
+                fi
+                ;;
+            esac
+            resolved_image_tag="$IMAGE_TAG"
+            resolved_run_smoke="$RUN_SMOKE"
+          fi
 
           git cat-file -e "$target_ref^{commit}"
           commit_sha="$(git rev-parse "$target_ref^{commit}")"
@@ -94,6 +119,8 @@ jobs:
 
           git checkout --detach "$commit_sha"
           echo "commit_sha=$commit_sha" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$resolved_image_tag" >> "$GITHUB_OUTPUT"
+          echo "run_smoke=$resolved_run_smoke" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -143,7 +170,9 @@ jobs:
           test -f cloudbuild.staging.yaml
           test -f .github/workflows/staging-deploy.yml
           grep -q "workflow_dispatch:" .github/workflows/staging-deploy.yml
-          ! grep -q "branches: \\[staging\\]" .github/workflows/staging-deploy.yml
+          grep -q "backend-staging-deploy" .github/workflows/staging-deploy.yml
+          grep -q "environment: staging" .github/workflows/staging-deploy.yml
+          grep -q "rollback" .github/workflows/staging-deploy.yml
           grep -q "_DATABASE_URL_SECRET" cloudbuild.staging.yaml
           grep -q "_RESEND_API_KEY_SECRET" cloudbuild.staging.yaml
           grep -q "_VPC_NETWORK" cloudbuild.staging.yaml
@@ -154,6 +183,11 @@ jobs:
     name: Submit Cloud Build staging deploy
     runs-on: ubuntu-latest
     needs: predeploy
+    environment: staging
+    outputs:
+      build_id: ${{ steps.cloud_build.outputs.build_id }}
+      pre_traffic: ${{ steps.pre_traffic.outputs.pre_traffic }}
+      deployed_revision: ${{ steps.deployed_revision.outputs.deployed_revision }}
 
     steps:
       - name: Check out repository
@@ -178,23 +212,139 @@ jobs:
           echo "::add-mask::$STAGING_APP_BASE_URL"
           echo "::add-mask::$STAGING_SMOKE_BASE_URL"
 
+      - name: Capture pre-deploy Cloud Run traffic
+        id: pre_traffic
+        env:
+          STAGING_GCP_PROJECT_ID: ${{ vars.STAGING_GCP_PROJECT_ID }}
+          STAGING_REGION: ${{ vars.STAGING_REGION }}
+          STAGING_CLOUD_RUN_SERVICE: ${{ vars.STAGING_CLOUD_RUN_SERVICE }}
+        run: |
+          gcloud run services describe "$STAGING_CLOUD_RUN_SERVICE" \
+            --project="$STAGING_GCP_PROJECT_ID" \
+            --region="$STAGING_REGION" \
+            --format=json > /tmp/pre-deploy-service.json
+
+          pre_traffic="$(jq -r '[.status.traffic[]? | select((.percent // 0) > 0 and .revisionName != null) | "\(.revisionName)=\(.percent)"] | join(",")' /tmp/pre-deploy-service.json)"
+          if [[ -z "$pre_traffic" ]]; then
+            echo "No pre-deploy serving Cloud Run revision was found; automatic rollback cannot be prepared." >&2
+            exit 1
+          fi
+
+          echo "pre_traffic=$pre_traffic" >> "$GITHUB_OUTPUT"
+          echo "Pre-deploy traffic: $pre_traffic"
+
       - name: Submit Cloud Build
+        id: cloud_build
         env:
           STAGING_APP_BASE_URL: ${{ vars.STAGING_APP_BASE_URL }}
+          STAGING_GCP_PROJECT_ID: ${{ vars.STAGING_GCP_PROJECT_ID }}
+          STAGING_REGION: ${{ vars.STAGING_REGION }}
+          STAGING_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL: ${{ vars.STAGING_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL }}
+          IMAGE_TAG: ${{ needs.predeploy.outputs.image_tag }}
         run: |
-          gcloud builds submit \
+          build_id="$(gcloud builds submit . \
             --project="${{ vars.STAGING_GCP_PROJECT_ID }}" \
             --region="${{ vars.STAGING_REGION }}" \
             --config=cloudbuild.staging.yaml \
             --gcs-source-staging-dir="gs://${{ vars.STAGING_GCP_PROJECT_ID }}_cloudbuild/source" \
             --service-account="projects/${{ vars.STAGING_GCP_PROJECT_ID }}/serviceAccounts/${{ vars.STAGING_CLOUD_BUILD_SERVICE_ACCOUNT_EMAIL }}" \
-            --substitutions="_REGION=${{ vars.STAGING_REGION }},_SERVICE_NAME=${{ vars.STAGING_CLOUD_RUN_SERVICE }},_ARTIFACT_REGISTRY_REPO=${{ vars.STAGING_ARTIFACT_REGISTRY_REPO }},_IMAGE_NAME=stds-backend,_IMAGE_TAG=${{ inputs.image_tag }},_RUNTIME_SERVICE_ACCOUNT=${{ vars.STAGING_RUNTIME_SERVICE_ACCOUNT_EMAIL }},_VPC_NETWORK=${{ vars.STAGING_VPC_NETWORK }},_VPC_SUBNET=${{ vars.STAGING_VPC_SUBNET }},_VPC_EGRESS=${{ vars.STAGING_VPC_EGRESS }},_APP_BASE_URL=$STAGING_APP_BASE_URL,_FIREBASE_PROJECT_ID=${{ vars.STAGING_FIREBASE_PROJECT_ID }},_RESEND_FROM_EMAIL=${{ vars.STAGING_RESEND_FROM_EMAIL }},_GCS_BUCKET_NAME=${{ vars.STAGING_GCS_BUCKET_NAME }},_DATABASE_URL_SECRET=${{ vars.STAGING_DATABASE_URL_SECRET }},_RESEND_API_KEY_SECRET=${{ vars.STAGING_RESEND_API_KEY_SECRET }}" \
-            .
+            --substitutions="_REGION=${{ vars.STAGING_REGION }},_SERVICE_NAME=${{ vars.STAGING_CLOUD_RUN_SERVICE }},_ARTIFACT_REGISTRY_REPO=${{ vars.STAGING_ARTIFACT_REGISTRY_REPO }},_IMAGE_NAME=stds-backend,_IMAGE_TAG=$IMAGE_TAG,_RUNTIME_SERVICE_ACCOUNT=${{ vars.STAGING_RUNTIME_SERVICE_ACCOUNT_EMAIL }},_VPC_NETWORK=${{ vars.STAGING_VPC_NETWORK }},_VPC_SUBNET=${{ vars.STAGING_VPC_SUBNET }},_VPC_EGRESS=${{ vars.STAGING_VPC_EGRESS }},_APP_BASE_URL=$STAGING_APP_BASE_URL,_FIREBASE_PROJECT_ID=${{ vars.STAGING_FIREBASE_PROJECT_ID }},_RESEND_FROM_EMAIL=${{ vars.STAGING_RESEND_FROM_EMAIL }},_GCS_BUCKET_NAME=${{ vars.STAGING_GCS_BUCKET_NAME }},_DATABASE_URL_SECRET=${{ vars.STAGING_DATABASE_URL_SECRET }},_RESEND_API_KEY_SECRET=${{ vars.STAGING_RESEND_API_KEY_SECRET }}" \
+            --async \
+            --format="value(id)")"
+          echo "build_id=$build_id" >> "$GITHUB_OUTPUT"
+          echo "Cloud Build ID: $build_id"
+
+          gcloud builds log "$build_id" \
+            --project="$STAGING_GCP_PROJECT_ID" \
+            --region="$STAGING_REGION" \
+            --stream
+
+          build_status="$(gcloud builds describe "$build_id" \
+            --project="$STAGING_GCP_PROJECT_ID" \
+            --region="$STAGING_REGION" \
+            --format="value(status)")"
+          if [[ "$build_status" != "SUCCESS" ]]; then
+            echo "Cloud Build finished with status: $build_status" >&2
+            exit 1
+          fi
+
+      - name: Capture deployed Cloud Run revision
+        id: deployed_revision
+        env:
+          STAGING_GCP_PROJECT_ID: ${{ vars.STAGING_GCP_PROJECT_ID }}
+          STAGING_REGION: ${{ vars.STAGING_REGION }}
+          STAGING_CLOUD_RUN_SERVICE: ${{ vars.STAGING_CLOUD_RUN_SERVICE }}
+        run: |
+          deployed_revision="$(gcloud run services describe "$STAGING_CLOUD_RUN_SERVICE" \
+            --project="$STAGING_GCP_PROJECT_ID" \
+            --region="$STAGING_REGION" \
+            --format="value(status.latestReadyRevisionName)")"
+          if [[ -z "$deployed_revision" ]]; then
+            echo "Cloud Run deployed revision could not be determined." >&2
+            exit 1
+          fi
+          echo "deployed_revision=$deployed_revision" >> "$GITHUB_OUTPUT"
+          echo "Deployed revision: $deployed_revision"
 
       - name: Minimal deployed smoke
-        if: ${{ inputs.run_smoke }}
+        id: smoke
+        if: ${{ needs.predeploy.outputs.run_smoke == 'true' }}
+        continue-on-error: true
         env:
           STAGING_SMOKE_BASE_URL: ${{ vars.STAGING_SMOKE_BASE_URL }}
         run: |
           curl -fsS "$STAGING_SMOKE_BASE_URL/health"
           curl -fsS "$STAGING_SMOKE_BASE_URL/openapi.yaml" > /tmp/staging-openapi.yaml
+
+      - name: Roll back Cloud Run traffic after smoke failure
+        id: rollback
+        if: ${{ needs.predeploy.outputs.run_smoke == 'true' && steps.smoke.outcome == 'failure' }}
+        env:
+          STAGING_GCP_PROJECT_ID: ${{ vars.STAGING_GCP_PROJECT_ID }}
+          STAGING_REGION: ${{ vars.STAGING_REGION }}
+          STAGING_CLOUD_RUN_SERVICE: ${{ vars.STAGING_CLOUD_RUN_SERVICE }}
+          PRE_TRAFFIC: ${{ steps.pre_traffic.outputs.pre_traffic }}
+        run: |
+          if [[ -z "$PRE_TRAFFIC" ]]; then
+            echo "Pre-deploy traffic was not captured; manual recovery is required." >&2
+            exit 1
+          fi
+
+          gcloud run services update-traffic "$STAGING_CLOUD_RUN_SERVICE" \
+            --project="$STAGING_GCP_PROJECT_ID" \
+            --region="$STAGING_REGION" \
+            --to-revisions="$PRE_TRAFFIC"
+
+      - name: Emit deployment evidence
+        if: ${{ always() }}
+        env:
+          SOURCE_COMMIT_SHA: ${{ needs.predeploy.outputs.commit_sha }}
+          IMAGE_TAG: ${{ needs.predeploy.outputs.image_tag }}
+          RUN_SMOKE: ${{ needs.predeploy.outputs.run_smoke }}
+          CLOUD_BUILD_ID: ${{ steps.cloud_build.outputs.build_id }}
+          PRE_TRAFFIC: ${{ steps.pre_traffic.outputs.pre_traffic }}
+          DEPLOYED_REVISION: ${{ steps.deployed_revision.outputs.deployed_revision }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
+          ROLLBACK_OUTCOME: ${{ steps.rollback.outcome }}
+        run: |
+          {
+            echo "## Staging deployment evidence"
+            echo ""
+            echo "- Source commit SHA: $SOURCE_COMMIT_SHA"
+            echo "- Image tag: $IMAGE_TAG"
+            echo "- GitHub Actions run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+            echo "- Cloud Build build ID: ${CLOUD_BUILD_ID:-not-submitted}"
+            echo "- Cloud Run service: ${{ vars.STAGING_CLOUD_RUN_SERVICE }}"
+            echo "- Cloud Run region: ${{ vars.STAGING_REGION }}"
+            echo "- Pre-deploy traffic: ${PRE_TRAFFIC:-not-captured}"
+            echo "- Deployed revision: ${DEPLOYED_REVISION:-not-captured}"
+            echo "- Smoke enabled: $RUN_SMOKE"
+            echo "- Smoke result: ${SMOKE_OUTCOME:-skipped}"
+            echo "- Rollback result: ${ROLLBACK_OUTCOME:-not-run}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail after smoke rollback
+        if: ${{ needs.predeploy.outputs.run_smoke == 'true' && steps.smoke.outcome == 'failure' }}
+        run: |
+          echo "Post-deploy smoke failed. Cloud Run traffic rollback was attempted; inspect the deployment evidence summary for the result." >&2
+          exit 1

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ STDS is split across focused repositories:
   truth for operational workflows and backend contracts.
 - [STDS Admin Frontend](https://github.com/ifan0927/stds_fronted): internal
   management console for property operations.
-- [STDS Brand Backend](https://github.com/ifan0927/stds_brand_backend):
-  restricted read-only backend boundary for brand/public data.
 - [STDS Brand Frontend](https://github.com/ifan0927/stds_brand_frontend):
-  public-facing brand site.
+  public-facing brand site deployed as a static Cloudflare Pages site.
 
-The core backend remains the authority for operational state. The brand backend
-is intentionally separated and limited to approved read-only database views.
+The core backend remains the authority for operational state. Public brand
+content is exposed through dedicated public read-only endpoints that read the
+approved brand views and stay separate from the authenticated admin brand
+management endpoints.
 
 ## Design Approach
 
@@ -45,7 +45,8 @@ is intentionally separated and limited to approved read-only database views.
 
 The staging architecture uses GCP-managed services:
 
-- Firebase Hosting for browser-facing admin and brand frontends.
+- Firebase Hosting for the browser-facing admin frontend.
+- Cloudflare Pages for the browser-facing brand frontend.
 - Cloud Run for backend services.
 - Cloud SQL for PostgreSQL with private connectivity.
 - Secret Manager for runtime secrets.
@@ -55,8 +56,8 @@ The staging architecture uses GCP-managed services:
 - Cloud Logging and Cloud Monitoring for baseline observability.
 
 The first staging line has been deployed and verified for the core backend and
-admin frontend. Production deployment, stricter ingress hardening, brand backend
-deployment, and brand frontend deployment are separate follow-up work.
+admin frontend. Production deployment, stricter ingress hardening, core public
+brand endpoints, and brand frontend deployment are separate follow-up work.
 
 ## Runtime Responsibilities
 
@@ -144,8 +145,8 @@ See [docs/local-operations.md](docs/local-operations.md) for setup details.
 
 Core backend and admin frontend staging v1 are complete for the first demo / UAT
 wave. The staging line has proven container build, Cloud Build deployment, Cloud
-Run startup, Cloud SQL private connectivity, Firebase Hosting frontend deploy,
-and deployed Playwright smoke coverage.
+Run startup, Cloud SQL private connectivity, Firebase Hosting admin frontend
+deploy, and deployed Playwright smoke coverage.
 
 This is not a production readiness claim. Production deployment and hardening
 remain separate work.

--- a/docs/cloud-architecture.md
+++ b/docs/cloud-architecture.md
@@ -8,12 +8,14 @@ production readiness review.
 ## Overview
 
 STDS runs on GCP using Firebase Hosting, Cloud Run, Cloud SQL, Secret Manager,
-Cloud Storage, Cloud Scheduler, and Cloud Logging / Monitoring.
+Cloud Storage, Cloud Scheduler, and Cloud Logging / Monitoring. The public
+brand frontend is deployed separately on Cloudflare Pages.
 
 This document is the deployment architecture baseline for the staging line and
 the early production candidate. It intentionally avoids an external Application
 Load Balancer in the first version. Firebase Hosting is the browser-facing edge
-for frontend traffic, while Cloud Run hosts backend services.
+for the admin frontend, Cloudflare Pages is the browser-facing edge for the
+brand frontend, and Cloud Run hosts the core backend service.
 
 Cloud SQL private IP and Cloud Run Direct VPC egress are included in staging v1.
 This is a security hardening choice because legacy property data will be
@@ -23,22 +25,26 @@ migrated early. It is not treated as an HTTP ingress boundary.
 
 ### No External Application Load Balancer In The First Version
 
-Firebase Hosting handles browser-facing TLS, custom domains, CDN behavior, and
-frontend rewrites. API security remains enforced by Firebase Auth, DB-backed
-authorization, service account IAM, and scheduler keys.
+Firebase Hosting handles admin browser-facing TLS, custom domains, CDN
+behavior, and admin API rewrites. Cloudflare Pages handles the public brand
+site. API security remains enforced by Firebase Auth, DB-backed authorization,
+service account IAM, and scheduler keys.
 
 An external Application Load Balancer is a future option for a stronger
 production edge, Cloud Armor, host/path routing across many services, WAF,
 rate limiting, or strict Cloud Run ingress through the load balancer. It is out
 of scope for the staging deployment line.
 
-### Firebase Hosting Rewrites For Browser-To-Backend Calls
+### Browser-To-Backend Calls
 
-Admin and brand frontends should call backend APIs through Firebase Hosting
-rewrites where practical:
+Admin frontend browser calls should use Firebase Hosting rewrites where
+practical:
 
 - admin frontend: `/api/**` to the core backend Cloud Run service.
-- brand frontend: `/brand-api/**` to the brand thin backend Cloud Run service.
+
+The brand frontend is a Cloudflare Pages static site. It fetches public brand
+data at build time from core backend public read-only endpoints and does not
+require a Firebase Hosting brand rewrite or separate brand backend runtime.
 
 The Cloud Run `run.app` URL is not part of the browser-facing contract. Whether
 the default `run.app` URL can be disabled safely is a separate hardening
@@ -74,18 +80,23 @@ availability behavior. A staging migration, bad query, or connection spike can
 affect the shared instance. If this risk becomes unacceptable, split staging and
 production into separate Cloud SQL instances.
 
-### Brand Thin Backend Isolation
+### Brand Public Read Boundary
 
-The brand-facing backend is a separate Cloud Run service with its own service
-account and DB credential. It may only query approved read-only views:
+The brand site reads data through dedicated public read-only core backend
+endpoints. These routes must live under an independent public namespace, remain
+separate from authenticated admin brand management endpoints, and query only
+approved read-only views:
 
 - `approved_brand_profile_v1`
 - `approved_brand_faq_items_v1`
 - `approved_brand_property_availability_v1`
 
-It must not have direct access to core base tables such as tenants, leases,
-bills, deposits, accounting, attachments, or operational property/room tables
-except through explicitly approved views.
+The first version intentionally uses the core backend runtime DB credential for
+these low-traffic build-time reads. This avoids the operational cost of a
+separate brand Cloud Run service and readonly credential while keeping approved
+views as the public data exposure boundary. Public handlers must not query core
+base tables such as tenants, leases, bills, deposits, accounting, attachments,
+or operational property/room tables directly.
 
 ### Explicit DB Connection Pool Limits
 
@@ -129,16 +140,15 @@ document.
 ```mermaid
 flowchart TD
     AdminUser[Admin / staff browser] --> AdminHosting[Firebase Hosting<br/>admin domain]
-    PublicUser[Public visitor] --> BrandHosting[Firebase Hosting<br/>brand domain]
+    PublicUser[Public visitor] --> BrandPages[Cloudflare Pages<br/>brand domain]
 
     AdminHosting -->|/api/** rewrite| CoreRun[Cloud Run<br/>Core Backend]
-    BrandHosting -->|/brand-api/** rewrite| BrandThinRun[Cloud Run<br/>Brand Thin Backend]
+    BrandPages -.->|build-time fetch public brand JSON| CoreRun
 
     Scheduler[Cloud Scheduler] -->|X-Scheduler-Key| CoreRun
 
     subgraph GCPProject[GCP Project]
         CoreRun
-        BrandThinRun
 
         subgraph PrivateDataPath[Private DB Connectivity]
             DirectVPC[Direct VPC egress]
@@ -148,7 +158,6 @@ flowchart TD
     end
 
     CoreRun --> DirectVPC
-    BrandThinRun --> DirectVPC
     DirectVPC --> VPC
     VPC --> CloudSQL
 
@@ -159,12 +168,10 @@ flowchart TD
     AdminHosting --> FirebaseAuth
 
     CoreRun --> SecretManager[Secret Manager<br/>env injection]
-    BrandThinRun --> SecretManager
 
     CoreRun --> Resend[Resend Email API]
 
     CoreRun --> Observability[Cloud Logging / Monitoring]
-    BrandThinRun --> Observability
 ```
 
 ### Browser API Flow
@@ -240,20 +247,30 @@ browser traffic and may call scheduler endpoints directly.
   Manager.
 - Starts with `max-instances=2` to bound DB connection pressure.
 
-### Brand Thin Backend
+### Public Brand Endpoints
 
-- Serves public brand and property availability APIs.
-- Uses its own Cloud Run service account.
-- Uses its own readonly DB credential.
-- Reads approved views only.
-- Does not use the core backend runtime DB credential.
+- Serve public brand and property availability JSON for Cloudflare Pages
+  build-time fetches.
+- Live under an independent public namespace.
+- Do not require Firebase JWT.
+- Read approved views only.
+- Use the core backend runtime DB credential in the first version.
 
 ### Firebase Hosting
 
-- Hosts admin frontend and brand frontend.
+- Hosts admin frontend.
 - Provides custom domains and TLS for browser traffic.
-- Rewrites API paths to Cloud Run services.
+- Rewrites admin API paths to the core backend Cloud Run service.
 - Does not replace backend authentication or authorization.
+
+### Cloudflare Pages
+
+- Hosts the public brand frontend.
+- Provides branch and pull-request preview deployments.
+- Builds static Astro output into `dist`.
+- Fetches public brand data from core backend public read-only endpoints at
+  build time.
+- Can be rebuilt on a schedule through a protected Pages deploy hook.
 
 ### Cloud SQL
 
@@ -344,10 +361,10 @@ No single layer is the only security boundary.
 | Layer | Control |
 | --- | --- |
 | Network | Cloud SQL private IP; no public DB endpoint in the target architecture. |
-| Browser ingress | Firebase Hosting custom domains and rewrites. |
+| Browser ingress | Firebase Hosting for admin; Cloudflare Pages for public brand. |
 | Authentication | Firebase Auth bearer token on admin APIs. |
 | Authorization | DB-backed principal, RBAC, and property-scoped middleware. |
-| Brand data boundary | Readonly DB principal and approved views only. |
+| Brand data boundary | Core public read-only endpoints over approved views only. |
 | Secrets | Secret Manager values injected into Cloud Run env vars. |
 | Storage | Browser receives scoped signed URLs, not broad GCS credentials. |
 | Scheduler | `X-Scheduler-Key` for internal job endpoints. |
@@ -360,6 +377,7 @@ Accepted tradeoffs:
 | No external Application Load Balancer | Current scale does not justify cost or operational complexity. |
 | No Cloud Armor / WAF | Revisit when public abuse or stronger production edge controls are needed. |
 | One Cloud SQL instance for staging and production | Cost-conscious choice; instance-level resource contention is accepted initially. |
+| No separate brand thin backend | Brand site is static, has no booking/write flow, and accepts build-time freshness; the extra Cloud Run service and readonly credential are retired. |
 | No HA in first version | Acceptable until a production uptime SLA is required. |
 | Cloud Run default URL disabling is not assumed | Hosting rewrites hide the URL from browser contracts, but default URL hardening must be verified separately. |
 
@@ -373,6 +391,7 @@ Approximate low-traffic monthly cost:
 | Cloud SQL storage / backups | 2-5 USD |
 | Cloud Run | 0-2 USD |
 | Firebase Hosting | 0 USD in free-tier scale |
+| Cloudflare Pages | 0 USD in free-tier scale |
 | Secret Manager | 0-1 USD at current scale |
 | Cloud Storage attachments | 0-1 USD initially |
 | Direct VPC egress | traffic-proportional; expected low at current scale |
@@ -386,7 +405,8 @@ verified with GCP Billing and the Pricing Calculator before production go-live.
 
 ### Staging v1
 
-- Firebase Hosting frontend.
+- Firebase Hosting admin frontend.
+- Cloudflare Pages brand frontend.
 - Cloud Run core backend.
 - Cloud SQL private IP with VPC / Direct VPC egress.
 - Secret Manager env injection.
@@ -396,15 +416,16 @@ verified with GCP Billing and the Pricing Calculator before production go-live.
 - DB pool limits implemented and configured.
 - Staging database preparation uses a local operator plain SQL dump from
   `scripts/prepare_legacy_db_dump.sh`, manual GCS upload, Cloud SQL
-  Console/manual import, post-import readonly principal/grant provisioning, and
-  first admin Firebase/backend user alignment.
+  Console/manual import, and first admin Firebase/backend user alignment.
 - Smoke checks for deployment, database preparation, Firebase Auth, signed URL
   upload, and log visibility.
 - Cloud Scheduler jobs are excluded from the first staging demo wave.
-- Deployment starts as a manual GitHub Actions trigger that runs predeploy
-  checks, then submits Cloud Build for image build, Artifact Registry push, and
-  Cloud Run deploy. Automatic deployment on `staging` branch push is a later
-  hardening step after the first setup evidence is reviewed.
+- Deployment starts from the backend `staging` branch as the deployment-intent
+  branch. Promotion is normally `dev` to `staging` by pull request. A `staging`
+  branch push runs GitHub Actions predeploy checks, waits for GitHub `staging`
+  Environment approval, then submits Cloud Build for image build, Artifact
+  Registry push, and Cloud Run deploy. Manual workflow dispatch remains as a
+  controlled operator rerun path.
 
 ### Production Readiness Review
 
@@ -418,8 +439,10 @@ Before production go-live:
 - Confirm operator DB access path without public DB IP.
 - Confirm whether the local dump/manual import flow remains sufficient after the
   first staging demo wave.
-- Confirm Firebase Hosting rewrite behavior and whether Cloud Run default URL
-  disabling is safe.
+- Confirm Firebase Hosting admin rewrite behavior and whether Cloud Run default
+  URL disabling is safe.
+- Confirm Cloudflare Pages branch/preview/prod environment variables and deploy
+  hook protection.
 - Confirm GCS CORS for production frontend origins.
 - Confirm Cloud Monitoring alert policies and billing budgets.
 
@@ -431,10 +454,10 @@ Expected repo changes for this architecture:
 - Cloud Build staging deployment config.
 - GitHub Actions trigger/status workflow if needed.
 - Staging database preparation runbook covering local dump generation, manual
-  GCS upload, Cloud SQL import, validation evidence, manual readonly principal
-  provisioning, and first admin bootstrap.
+  GCS upload, Cloud SQL import, validation evidence, and first admin bootstrap.
 - DB pool config support.
 - Staging smoke script.
+- Core public brand endpoint implementation and brand Pages deployment notes.
 - Deployment runbooks and verification evidence templates.
 
 Application domain logic should not need broad runtime changes for the staging
@@ -450,6 +473,4 @@ deployment line.
   first demo wave?
 - Should production require Cloud SQL HA before go-live?
 - Should Cloud Run default `run.app` URLs be disabled, and does that work with
-  the selected Firebase Hosting rewrite path?
-- When should the brand thin backend be deployed relative to core backend
-  staging?
+  the selected Firebase Hosting admin rewrite path?

--- a/docs/local-operations.md
+++ b/docs/local-operations.md
@@ -68,16 +68,17 @@ demo property with rooms, tenants, leases, bills, meter history, reports,
 journal, repair, and checkout data. It is local frontend support data and is
 separate from schema migrations and legacy migration validation.
 
-5. Create or repair the local brand readonly database user when developing the
-   future brand thin backend boundary:
+5. Optionally create or repair the local brand readonly database user when
+   diagnosing the retired brand thin backend boundary:
 
 ```bash
 scripts/dev_brand_readonly.sh
 ```
 
-This local helper uses `DATABASE_URL` as the admin connection by default,
-creates or repairs `brand_readonly`, grants only the approved brand views, and
-verifies representative core base tables are not selectable. Override
+This helper is not required for the active brand site architecture. It uses
+`DATABASE_URL` as the admin connection by default, creates or repairs
+`brand_readonly`, grants only the approved brand views, and verifies
+representative core base tables are not selectable. Override
 `BRAND_READONLY_PASSWORD`, `BRAND_READONLY_ADMIN_DATABASE_URL`, or
 `BRAND_READONLY_DATABASE_URL` when your local database connection differs from
 the Docker defaults.
@@ -186,8 +187,8 @@ legacy mapping-table counts before writing a plain SQL dump under
 The dump includes migrated schema objects such as approved views and table data
 from the temporary database, including application `users` rows that exist at
 dump time. Because it uses `--no-owner --no-privileges`, it does not include
-PostgreSQL users, roles, owners, or grants. Cloud SQL readonly principals and
-grants must be provisioned manually after import, not by this dump.
+PostgreSQL users, roles, owners, or grants. The active brand site architecture
+does not require post-import brand readonly principal provisioning.
 
 By default, the temporary database and role are dropped after the dump. Set
 `KEEP_TEMP_DB=1` to keep them for debugging:
@@ -315,10 +316,11 @@ go test -tags=e2e ./test/e2e
 
 ## Brand readonly database access
 
-Demo brand frontend data is exposed to a future thin backend through approved
-PostgreSQL views only. The core backend migrations create the views; deployment
-or DBA provisioning must create the Cloud SQL readonly principal and grant only
-the approved view access.
+Demo brand frontend data is exposed through core backend public read-only
+endpoints that read approved PostgreSQL views only. The separate brand thin
+backend path has been retired for the active architecture; a dedicated
+`brand_readonly` principal is no longer a deployment dependency for the brand
+site.
 
 The current approved views are:
 
@@ -326,14 +328,14 @@ The current approved views are:
 - `approved_brand_faq_items_v1`
 - `approved_brand_property_availability_v1`
 
-The brand readonly principal should receive `USAGE` on the schema and `SELECT`
-on those views only. Do not grant it direct access to base tables such as
-`properties`, `rooms`, `brand_profiles`, `brand_faq_items`, `tenants`, `leases`,
-`bills`, `attachments`, or deposit/accounting tables. Local PostgreSQL contract
-tests use an ephemeral equivalent role to verify that the approved views are
-selectable while base tables are not.
+Public handlers should read those views only and should not query base tables
+such as `properties`, `rooms`, `brand_profiles`, `brand_faq_items`, `tenants`,
+`leases`, `bills`, `attachments`, or deposit/accounting tables. Local
+PostgreSQL contract tests still use an ephemeral equivalent role to verify that
+the approved views are selectable while base tables are not.
 
-For local thin-backend development, the expected order is:
+For local diagnosis of the retired readonly-principal path, the optional order
+is:
 
 ```bash
 docker compose up -d postgres
@@ -348,12 +350,10 @@ The local readonly connection string defaults to:
 BRAND_READONLY_DATABASE_URL=postgres://brand_readonly:brand_readonly@localhost:5432/stds_backend?sslmode=disable
 ```
 
-Staging and production must provision the equivalent Cloud SQL principal outside
-application migrations. The deployment or DBA workflow should create the
-dedicated readonly principal, grant schema `USAGE`, grant `SELECT` only on the
-approved views, store the thin-backend credential through the environment or
-Secret Manager, and run a deployed smoke check that mirrors the local approved
-view and base-table denial checks.
+Staging and production do not need a brand readonly Cloud SQL principal for the
+active Cloudflare Pages plus core public endpoint architecture. Reintroduce a
+dedicated readonly principal only if a future issue revives a separate runtime
+brand service or requires stronger database credential isolation.
 
 ## Legacy migration planning
 

--- a/docs/spec/schema.sql
+++ b/docs/spec/schema.sql
@@ -102,7 +102,7 @@ CREATE TABLE brand_profiles (
     version         INTEGER     NOT NULL DEFAULT 1
 );
 
--- Approved readonly view: future brand thin backend may read this view, not brand_profiles.
+-- Approved readonly view: core public brand endpoints read this view, not brand_profiles.
 CREATE VIEW approved_brand_profile_v1 AS
 SELECT
     brand_name,
@@ -135,7 +135,7 @@ CREATE INDEX idx_brand_faq_items_sort_order
     ON brand_faq_items (sort_order)
     WHERE deleted_at IS NULL;
 
--- Approved readonly view: future brand thin backend may read active FAQ rows through this view only.
+-- Approved readonly view: core public brand endpoints read active FAQ rows through this view only.
 CREATE VIEW approved_brand_faq_items_v1 AS
 SELECT
     question,
@@ -183,7 +183,7 @@ CREATE INDEX idx_rooms_property_status ON rooms (property_id, status) WHERE dele
 
 -- ============================================================
 -- Approved readonly brand property availability view
--- 說明: Future brand thin backend 只讀 approved views，不直接讀 core base tables
+-- 說明: Core public brand endpoints 只讀 approved views，不直接讀 core base tables
 -- ============================================================
 
 CREATE VIEW approved_brand_property_availability_v1 AS

--- a/docs/spec/tech-stack.md
+++ b/docs/spec/tech-stack.md
@@ -39,13 +39,13 @@
   - db-g1-small（$25/month，超預算且超出需求）
   - Neon/Supabase（非 GCP 全套）
 
-### Brand Readonly DB Boundary
+### Brand Public Read Boundary
 
-- **用途**：未來 brand thin backend 只讀 demo 品牌頁需要的 approved DB views，不直接讀 core backend base tables。
+- **用途**：core backend 透過獨立 public namespace 提供品牌頁 build-time 需要的 read-only endpoints，不直接暴露 admin brand management endpoints。
 - **Core migration 責任**：建立 approved views，例如 `approved_brand_profile_v1`、`approved_brand_faq_items_v1`、`approved_brand_property_availability_v1`。
-- **Cloud SQL provisioning 責任**：由部署/DBA 流程建立 brand readonly principal，授予 schema `USAGE` 與 approved views 的 `SELECT`，不得授予 `properties`、`rooms`、`brand_profiles`、`brand_faq_items`、tenant、lease、bill、deposit、attachment、accounting 等 base table 權限。
-- **Credential 邊界**：brand thin backend 使用自己的 Cloud SQL credential / secret，不共用 core backend runtime 或 migration DB user。
-- **測試策略**：repo 的 PostgreSQL migration contract test 使用 ephemeral equivalent role 驗證 approved views 可讀、base tables 不可讀；本地 Docker bootstrap 若補 readonly user，只作為 fresh local DB 便利設定，不是 production 權限來源。
+- **Public endpoint 責任**：只讀 approved views，不直接讀 `properties`、`rooms`、`brand_profiles`、`brand_faq_items`、tenant、lease、bill、deposit、attachment、accounting 等 base tables。
+- **Credential 邊界**：第一版使用 core backend runtime DB credential，避免為低流量 build-time brand site 增加額外 readonly credential / service 部署複雜度。approved views 仍是 public data exposure boundary。
+- **測試策略**：repo 的 PostgreSQL migration contract test 繼續使用 ephemeral equivalent role 驗證 approved views 可讀、base tables 不可讀；本地 `brand_readonly` helper 保留作為歷史/診斷用途，不是現行 brand site deployment dependency。
 
 ### Persistence / Data Access
 
@@ -103,7 +103,7 @@
   - 最小實例：0（省錢，冷啟動對內部工具可接受）
   - 最大實例：2（避免意外擴展產生費用）
   - 記憶體：512 MB，CPU：1
-- **前端部署**：Firebase Hosting（免費 tier，含 CDN、HTTPS）
+- **前端部署**：admin frontend 使用 Firebase Hosting；brand frontend 使用 Cloudflare Pages 靜態部署與 preview。
 - **Container Registry**：Artifact Registry（$0.10/GB/月，image 小費用極低）
 - **CI/CD**：Cloud Build
   - 免費 tier：120 build-minutes/day，完全足夠

--- a/docs/staging-runbook.md
+++ b/docs/staging-runbook.md
@@ -28,7 +28,8 @@ Staging v1 includes:
 Staging v1 excludes:
 
 - Cloud Scheduler jobs and scheduler smoke checks.
-- Brand thin backend deployment.
+- Brand frontend Cloudflare Pages deployment and core public brand endpoint
+  smoke checks.
 - Production deployment gates.
 - Preview or candidate environments.
 
@@ -126,20 +127,28 @@ files, credentials, private keys, or other local secrets into the image.
 
 ## Dev To Staging Deployment
 
-The first staging deployment wave uses a manual GitHub Actions trigger. Do not
-enable automatic `push` deployment from the `staging` branch until the first GCP
-setup, deploy, and smoke evidence have been reviewed.
+The backend `staging` branch is the deployment-intent branch for staging. Feature
+work still lands on `dev` first. Normal staging promotion is a `dev` to
+`staging` pull request; direct pushes to `staging` are not part of normal
+operation.
 
 The intended flow is:
 
 1. Merge application changes to `dev` through the existing PR CI gate.
-2. Choose the exact `dev` commit SHA or staging branch ref to deploy.
-3. Manually run the `Staging Deploy` GitHub Actions workflow with that ref and
-   an image tag.
-4. Let GitHub Actions run staging predeploy checks.
-5. Let Cloud Build build the image, push Artifact Registry, and deploy Cloud Run.
-6. Run minimal smoke from the workflow only when requested, then complete the
-   fuller deployed smoke checklist under the staging smoke issue.
+2. Open a `dev` to `staging` promotion pull request.
+3. Let backend PR CI run against the `staging` target.
+4. Merge the promotion pull request after review.
+5. Let the `staging` branch push start the `Staging Deploy` workflow.
+6. Let GitHub Actions run staging predeploy checks before approval.
+7. Approve the GitHub `staging` Environment deployment.
+8. Let Cloud Build build the image, push Artifact Registry, and deploy Cloud Run.
+9. Let the workflow run minimal deployed smoke and rollback Cloud Run traffic if
+   smoke fails after a successful deploy.
+
+`workflow_dispatch` remains available as a controlled operator rerun path. Manual
+dispatch may choose a reachable `dev` or `staging` ref, or a full commit SHA, and
+may provide a manual image tag. Automatic `staging` branch deploys always use the
+pushed `staging` commit SHA and a commit-SHA image tag.
 
 The predeploy checks should catch low-cost failures before touching GCP:
 
@@ -147,17 +156,27 @@ The predeploy checks should catch low-cost failures before touching GCP:
 - OpenAPI lint and generated artifact sync.
 - Empty PostgreSQL migration smoke.
 - Docker image build.
-- Staging deployment contract checks for manual trigger, Cloud Build config, and
-  Secret Manager references.
+- Staging deployment contract checks for branch trigger, manual rerun support,
+  approval gate, rollback support, Cloud Build config, and Secret Manager
+  references.
 
 GitHub Actions is the trigger and status-reporting entry point. Deployment-layer
 execution stays in Cloud Build. Do not put secret values, database passwords,
 private keys, or full bearer credentials into GitHub workflow files, Cloud Build
 substitutions, logs, pull requests, or issue evidence.
 
+Concurrent backend staging deploys are serialized by the workflow concurrency
+group. New deploys wait for the active staging deploy instead of canceling it.
+
 ### GitHub Configuration
 
-Configure these GitHub repository variables before running the manual workflow:
+Configure the GitHub `staging` Environment with the required human reviewer
+before enabling automatic promotion deploys. The GCP-touching deploy job must use
+that environment so approval happens after predeploy checks and before Cloud
+Build submission.
+
+Configure these GitHub repository or environment variables before running the
+workflow:
 
 ```text
 STAGING_GCP_PROJECT_ID
@@ -234,17 +253,37 @@ Cloud Build performs:
 Manager by secret name. The staging workflow and Cloud Build config must not
 contain the secret values.
 
+### Smoke Failure Rollback
+
+Before each deploy, the workflow records the Cloud Run traffic split that is
+serving traffic. After Cloud Build deploys the new revision, the workflow records
+the deployed revision and runs minimal smoke when enabled.
+
+For automatic `staging` branch deploys, minimal smoke is enabled. If deploy
+succeeds but smoke fails, GitHub Actions rolls Cloud Run traffic back to the
+pre-deploy traffic split with `gcloud run services update-traffic`. Rollback is
+application traffic rollback only. It does not roll back database schema, data,
+migrations, secrets, repository history, or pull requests.
+
+If rollback cannot be performed automatically, the workflow fails loudly and
+records non-secret evidence for manual recovery. The GitHub deploy service
+account therefore needs permission to read the Cloud Run service and update
+Cloud Run traffic for the staging service.
+
 ### Deployment Evidence
 
 Attach only non-secret evidence after a staging deploy:
 
-- GitHub Actions run URL and selected source ref.
+- GitHub Actions run URL and selected source commit SHA.
 - Cloud Build build ID and final status.
 - Artifact Registry image path and tag.
-- Cloud Run service name, region, revision, runtime service account, ingress,
-  min/max instances, and redacted env summary.
+- Cloud Run service name, region, pre-deploy serving revision or traffic split,
+  deployed revision, runtime service account, ingress, min/max instances, and
+  redacted env summary.
 - Secret Manager secret names referenced by Cloud Run, without values.
-- Minimal smoke status when `run_smoke` was enabled.
+- Minimal smoke status when enabled.
+- Rollback command/result when rollback runs.
+- Failure summary when rollback cannot be performed automatically.
 
 If deployment fails, keep Cloud Build and Cloud Run logs available for diagnosis
 and rerun from a known `dev` ref after fixing the repo-side or GCP-side cause.
@@ -361,12 +400,9 @@ Run the steps in this order:
 2. Upload the generated SQL dump to an operator-controlled GCS location.
 3. Import the dump into the staging database with Cloud SQL Console/manual
    import.
-4. Provision Cloud SQL-only database principals and grants, such as the brand
-   readonly principal, through DataGrip, Cloud SQL Studio, or another approved
-   manual SQL path.
-5. Create the initial Firebase Auth users in Firebase Console when needed.
-6. Align backend app `users` rows through dump opt-in or manual SQL upsert.
-7. Run deployed smoke checks through the staging API.
+4. Create the initial Firebase Auth users in Firebase Console when needed.
+5. Align backend app `users` rows through dump opt-in or manual SQL upsert.
+6. Run deployed smoke checks through the staging API.
 
 The staging database must not be destructively reset as part of this runbook.
 If a preparation step fails, stop the deployment or demo handoff, keep the
@@ -429,24 +465,18 @@ After import, record:
 - confirmation that no PostgreSQL roles, grants, or owner metadata were expected
   from the dump.
 
-### Cloud SQL Principals And Grants
+### Public Brand Views
 
 Approved brand views are created by repository migrations and therefore are
-present in the dump/import. The brand readonly database principal and its grants
-are not created by the dump and are not application migration responsibility.
-Provision them after import through DataGrip, Cloud SQL Studio, or another
-approved manual SQL path.
-
-Grant the brand readonly principal schema `USAGE` and `SELECT` only on approved
-views. Do not grant access to base tables such as `properties`, `rooms`,
-`brand_profiles`, `brand_faq_items`, `tenants`, `leases`, `bills`,
-`attachments`, or deposit/accounting tables.
+present in the dump/import. The active brand site architecture uses core
+backend public read-only endpoints over these views and does not require a
+separate brand readonly database principal.
 
 Expected evidence:
 
-- readonly database principal name only, without password.
-- approved view `SELECT` check.
-- representative base-table denial check.
+- approved views are present after migration/import.
+- core public brand endpoints are not part of staging v1 unless issue #209 is
+  explicitly included in the deployment wave.
 
 ### First Staging Admin Bootstrap
 
@@ -782,8 +812,7 @@ Cloud SQL / VPC evidence:
 - `max_connections` query result.
 - Cloud SQL manual import status and latest imported `schema_migrations.version`.
 - Legacy validation summary from the local dump preparation run.
-- Confirmation that approved views came from migration/dump and readonly
-  principals/grants were provisioned manually after import.
+- Confirmation that approved views came from migration/dump.
 - First admin Firebase UID/email and backend user row summary.
 - Operator database inspection path.
 

--- a/docs/wiki-drafts/staging-v1-operator-handbook-2026-05-15-v1.md
+++ b/docs/wiki-drafts/staging-v1-operator-handbook-2026-05-15-v1.md
@@ -24,8 +24,8 @@ wave:
 - Admin frontend deploy path: GitHub Actions -> Cloud Build -> Firebase
   Hosting is proven.
 - Admin frontend deployed Playwright smoke passed against Firebase Hosting.
-- Brand thin backend and brand frontend are later work, not part of this v1
-  completion.
+- Brand frontend Cloudflare Pages deployment and core public brand endpoints are
+  later work, not part of this v1 completion.
 
 Cloud Run deploy success is not the same as full staging readiness. Database
 import, auth seed state, GCS, Resend, logging, and frontend E2E evidence must be


### PR DESCRIPTION
## Summary

Refs #210

- promote the controlled staging deployment workflow changes from dev to staging
- verify backend PR CI runs for a pull request targeting staging before the staging branch deploy is triggered

## Expected follow-up after merge

- merging this PR to staging should trigger the Staging Deploy workflow from the pushed staging SHA
- automatic deploy should use the pushed staging SHA as the image tag and run minimal smoke by default
- the deploy job should wait for GitHub staging Environment approval before touching GCP

## Validation before promotion

- source PR #211 passed PR CI and CodeQL before merge to dev