### PR TITLE
Add core public brand readonly endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ The staging architecture uses GCP-managed services:
 - Cloud Logging and Cloud Monitoring for baseline observability.
 
 The first staging line has been deployed and verified for the core backend and
-admin frontend. Production deployment, stricter ingress hardening, core public
-brand endpoints, and brand frontend deployment are separate follow-up work.
+admin frontend. Core public brand endpoints are part of the core backend
+contract for the Cloudflare Pages brand frontend. Production deployment,
+stricter ingress hardening, and brand frontend deployment remain separate
+follow-up work.
 
 ## Runtime Responsibilities
 

--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -1053,6 +1053,54 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /public/brand/profile:
+    get:
+      operationId: getPublicBrandProfile
+      summary: 取得公開品牌基本資料
+      description: |
+        Public readonly brand profile for the brand site build-time data fetch. No Firebase JWT is required.
+      tags:
+        - Public
+      security: []
+      responses:
+        '200':
+          description: 公開品牌基本資料
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicBrandProfileResponse'
+  /public/brand/faqs:
+    get:
+      operationId: listPublicBrandFAQs
+      summary: 列出公開品牌 FAQ
+      description: |
+        Public readonly active brand FAQ items for the brand site build-time data fetch. No Firebase JWT is required.
+      tags:
+        - Public
+      security: []
+      responses:
+        '200':
+          description: 公開品牌 FAQ 清單
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicBrandFAQListResponse'
+  /public/properties/availability:
+    get:
+      operationId: listPublicPropertyAvailability
+      summary: 列出公開物業空房狀態
+      description: |
+        Public readonly property availability for the brand site build-time data fetch. No Firebase JWT is required.
+      tags:
+        - Public
+      security: []
+      responses:
+        '200':
+          description: 公開物業空房狀態清單
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicPropertyAvailabilityListResponse'
   /properties:
     get:
       operationId: listProperties
@@ -7726,6 +7774,88 @@ components:
       properties:
         version:
           type: integer
+    PublicBrandProfile:
+      type: object
+      required:
+        - brand_name
+        - contact_phone
+        - contact_email
+        - contact_address
+        - updated_at
+      properties:
+        brand_name:
+          type: string
+        contact_phone:
+          type: string
+          nullable: true
+        contact_email:
+          type: string
+          format: email
+          nullable: true
+        contact_address:
+          type: string
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+    PublicBrandProfileResponse:
+      type: object
+      required:
+        - profile
+      properties:
+        profile:
+          type: object
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/PublicBrandProfile'
+    PublicBrandFAQItem:
+      type: object
+      required:
+        - question
+        - answer
+        - sort_order
+      properties:
+        question:
+          type: string
+        answer:
+          type: string
+        sort_order:
+          type: integer
+    PublicBrandFAQListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicBrandFAQItem'
+    PublicPropertyAvailabilityItem:
+      type: object
+      required:
+        - property_id
+        - property_public_name
+        - address
+        - has_vacant_room
+      properties:
+        property_id:
+          type: string
+          format: uuid
+        property_public_name:
+          type: string
+        address:
+          type: string
+        has_vacant_room:
+          type: boolean
+    PublicPropertyAvailabilityListResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicPropertyAvailabilityItem'
     PropertyResponse:
       type: object
       properties:

--- a/docs/spec/src/components/schemas/public/PublicBrandFAQItem.yaml
+++ b/docs/spec/src/components/schemas/public/PublicBrandFAQItem.yaml
@@ -1,0 +1,12 @@
+type: object
+required:
+  - question
+  - answer
+  - sort_order
+properties:
+  question:
+    type: string
+  answer:
+    type: string
+  sort_order:
+    type: integer

--- a/docs/spec/src/components/schemas/public/PublicBrandFAQListResponse.yaml
+++ b/docs/spec/src/components/schemas/public/PublicBrandFAQListResponse.yaml
@@ -1,0 +1,8 @@
+type: object
+required:
+  - items
+properties:
+  items:
+    type: array
+    items:
+      $ref: ./PublicBrandFAQItem.yaml

--- a/docs/spec/src/components/schemas/public/PublicBrandProfile.yaml
+++ b/docs/spec/src/components/schemas/public/PublicBrandProfile.yaml
@@ -1,0 +1,23 @@
+type: object
+required:
+  - brand_name
+  - contact_phone
+  - contact_email
+  - contact_address
+  - updated_at
+properties:
+  brand_name:
+    type: string
+  contact_phone:
+    type: string
+    nullable: true
+  contact_email:
+    type: string
+    format: email
+    nullable: true
+  contact_address:
+    type: string
+    nullable: true
+  updated_at:
+    type: string
+    format: date-time

--- a/docs/spec/src/components/schemas/public/PublicBrandProfileResponse.yaml
+++ b/docs/spec/src/components/schemas/public/PublicBrandProfileResponse.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - profile
+properties:
+  profile:
+    type: object
+    nullable: true
+    allOf:
+      - $ref: ./PublicBrandProfile.yaml

--- a/docs/spec/src/components/schemas/public/PublicPropertyAvailabilityItem.yaml
+++ b/docs/spec/src/components/schemas/public/PublicPropertyAvailabilityItem.yaml
@@ -1,0 +1,16 @@
+type: object
+required:
+  - property_id
+  - property_public_name
+  - address
+  - has_vacant_room
+properties:
+  property_id:
+    type: string
+    format: uuid
+  property_public_name:
+    type: string
+  address:
+    type: string
+  has_vacant_room:
+    type: boolean

--- a/docs/spec/src/components/schemas/public/PublicPropertyAvailabilityListResponse.yaml
+++ b/docs/spec/src/components/schemas/public/PublicPropertyAvailabilityListResponse.yaml
@@ -1,0 +1,8 @@
+type: object
+required:
+  - items
+properties:
+  items:
+    type: array
+    items:
+      $ref: ./PublicPropertyAvailabilityItem.yaml

--- a/docs/spec/src/openapi.yaml
+++ b/docs/spec/src/openapi.yaml
@@ -99,6 +99,12 @@ paths:
     $ref: paths/brand/brand_faq_items_{id}.yaml
   /brand/faq-items/{id}/deactivate:
     $ref: paths/brand/brand_faq_items_{id}_deactivate.yaml
+  /public/brand/profile:
+    $ref: paths/public/brand_profile.yaml
+  /public/brand/faqs:
+    $ref: paths/public/brand_faqs.yaml
+  /public/properties/availability:
+    $ref: paths/public/properties_availability.yaml
   /properties:
     $ref: paths/property/properties.yaml
   /properties/{id}:

--- a/docs/spec/src/paths/public/brand_faqs.yaml
+++ b/docs/spec/src/paths/public/brand_faqs.yaml
@@ -1,0 +1,15 @@
+get:
+  operationId: listPublicBrandFAQs
+  summary: 列出公開品牌 FAQ
+  description: |
+    Public readonly active brand FAQ items for the brand site build-time data fetch. No Firebase JWT is required.
+  tags:
+    - Public
+  security: []
+  responses:
+    '200':
+      description: 公開品牌 FAQ 清單
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/public/PublicBrandFAQListResponse.yaml

--- a/docs/spec/src/paths/public/brand_profile.yaml
+++ b/docs/spec/src/paths/public/brand_profile.yaml
@@ -1,0 +1,15 @@
+get:
+  operationId: getPublicBrandProfile
+  summary: 取得公開品牌基本資料
+  description: |
+    Public readonly brand profile for the brand site build-time data fetch. No Firebase JWT is required.
+  tags:
+    - Public
+  security: []
+  responses:
+    '200':
+      description: 公開品牌基本資料
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/public/PublicBrandProfileResponse.yaml

--- a/docs/spec/src/paths/public/properties_availability.yaml
+++ b/docs/spec/src/paths/public/properties_availability.yaml
@@ -1,0 +1,15 @@
+get:
+  operationId: listPublicPropertyAvailability
+  summary: 列出公開物業空房狀態
+  description: |
+    Public readonly property availability for the brand site build-time data fetch. No Firebase JWT is required.
+  tags:
+    - Public
+  security: []
+  responses:
+    '200':
+      description: 公開物業空房狀態清單
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/public/PublicPropertyAvailabilityListResponse.yaml

--- a/docs/staging-runbook.md
+++ b/docs/staging-runbook.md
@@ -513,8 +513,8 @@ separate brand readonly database principal.
 Expected evidence:
 
 - approved views are present after migration/import.
-- core public brand endpoints are not part of staging v1 unless issue #209 is
-  explicitly included in the deployment wave.
+- core public brand endpoints are included when issue #209 is promoted into the
+  staging deployment wave.
 
 ### First Staging Admin Bootstrap
 

--- a/internal/application/publicbrand/service.go
+++ b/internal/application/publicbrand/service.go
@@ -1,0 +1,135 @@
+package publicbrand
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+// Profile is the public readonly brand profile.
+type Profile struct {
+	BrandName      string
+	ContactPhone   *string
+	ContactEmail   *string
+	ContactAddress *string
+	UpdatedAt      time.Time
+}
+
+// FAQItem is one public readonly brand FAQ item.
+type FAQItem struct {
+	Question  string
+	Answer    string
+	SortOrder int
+}
+
+// PropertyAvailability is one public readonly property availability row.
+type PropertyAvailability struct {
+	PropertyID         string
+	PropertyPublicName string
+	Address            string
+	HasVacantRoom      bool
+}
+
+// ProfileRepository loads the approved public brand profile.
+type ProfileRepository interface {
+	GetProfile(ctx context.Context) (*Profile, error)
+}
+
+// FAQRepository loads approved public brand FAQ items.
+type FAQRepository interface {
+	ListFAQItems(ctx context.Context) ([]FAQItem, error)
+}
+
+// AvailabilityRepository loads approved public property availability rows.
+type AvailabilityRepository interface {
+	ListPropertyAvailability(ctx context.Context) ([]PropertyAvailability, error)
+}
+
+// ProfileService owns the public brand profile read use case.
+type ProfileService struct {
+	repo ProfileRepository
+}
+
+// NewProfileService returns a ProfileService.
+func NewProfileService(repo ProfileRepository) *ProfileService {
+	return &ProfileService{repo: repo}
+}
+
+// GetProfile returns the approved public brand profile, or nil when absent.
+func (s *ProfileService) GetProfile(ctx context.Context) (*Profile, error) {
+	profile, err := s.repo.GetProfile(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	return profile, nil
+}
+
+// FAQService owns the public brand FAQ read use case.
+type FAQService struct {
+	repo FAQRepository
+}
+
+// NewFAQService returns a FAQService.
+func NewFAQService(repo FAQRepository) *FAQService {
+	return &FAQService{repo: repo}
+}
+
+// ListFAQItems returns approved public FAQ items in display order.
+func (s *FAQService) ListFAQItems(ctx context.Context) ([]FAQItem, error) {
+	items, err := s.repo.ListFAQItems(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	return ensureFAQItems(items), nil
+}
+
+// AvailabilityService owns the public property availability read use case.
+type AvailabilityService struct {
+	repo AvailabilityRepository
+}
+
+// NewAvailabilityService returns an AvailabilityService.
+func NewAvailabilityService(repo AvailabilityRepository) *AvailabilityService {
+	return &AvailabilityService{repo: repo}
+}
+
+// ListPropertyAvailability returns approved public property availability rows.
+func (s *AvailabilityService) ListPropertyAvailability(ctx context.Context) ([]PropertyAvailability, error) {
+	items, err := s.repo.ListPropertyAvailability(ctx)
+	if err != nil {
+		return nil, mapError(err)
+	}
+
+	return ensurePropertyAvailability(items), nil
+}
+
+func ensureFAQItems(items []FAQItem) []FAQItem {
+	if items == nil {
+		return []FAQItem{}
+	}
+
+	return items
+}
+
+func ensurePropertyAvailability(items []PropertyAvailability) []PropertyAvailability {
+	if items == nil {
+		return []PropertyAvailability{}
+	}
+
+	return items
+}
+
+func mapError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, apperr.ErrInternalServerError) {
+		return err
+	}
+
+	return apperr.ErrInternalServerError.WithCause(err)
+}

--- a/internal/application/publicbrand/service_test.go
+++ b/internal/application/publicbrand/service_test.go
@@ -1,0 +1,167 @@
+package publicbrand
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"stds_backend/internal/shared/apperr"
+)
+
+func TestProfileServiceReturnsApprovedProfile(t *testing.T) {
+	updatedAt := time.Now().UTC()
+	phone := "02-1234-5678"
+	repo := &fakeProfileRepository{
+		profile: &Profile{
+			BrandName:    "STDS",
+			ContactPhone: &phone,
+			UpdatedAt:    updatedAt,
+		},
+	}
+
+	profile, err := NewProfileService(repo).GetProfile(context.Background())
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if profile == nil || profile.BrandName != "STDS" || profile.ContactPhone == nil || *profile.ContactPhone != phone {
+		t.Fatalf("unexpected profile: %+v", profile)
+	}
+}
+
+func TestProfileServiceReturnsNilWhenProfileIsAbsent(t *testing.T) {
+	profile, err := NewProfileService(&fakeProfileRepository{}).GetProfile(context.Background())
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if profile != nil {
+		t.Fatalf("expected nil profile, got %+v", profile)
+	}
+}
+
+func TestProfileServiceMapsRepositoryError(t *testing.T) {
+	repoErr := errors.New("database unavailable")
+
+	profile, err := NewProfileService(&fakeProfileRepository{err: repoErr}).GetProfile(context.Background())
+	if profile != nil {
+		t.Fatalf("expected nil profile, got %+v", profile)
+	}
+	if !errors.Is(err, apperr.ErrInternalServerError) {
+		t.Fatalf("expected internal server error, got %v", err)
+	}
+	if !errors.Is(err, repoErr) {
+		t.Fatalf("expected repository cause, got %v", err)
+	}
+}
+
+func TestFAQServiceReturnsItemsAndNonNilEmptySlice(t *testing.T) {
+	service := NewFAQService(&fakeFAQRepository{
+		items: []FAQItem{{Question: "Q1", Answer: "A1", SortOrder: 10}},
+	})
+
+	items, err := service.ListFAQItems(context.Background())
+	if err != nil {
+		t.Fatalf("list FAQ items: %v", err)
+	}
+	if len(items) != 1 || items[0].Question != "Q1" || items[0].SortOrder != 10 {
+		t.Fatalf("unexpected FAQ items: %+v", items)
+	}
+
+	empty, err := NewFAQService(&fakeFAQRepository{}).ListFAQItems(context.Background())
+	if err != nil {
+		t.Fatalf("list empty FAQ items: %v", err)
+	}
+	if empty == nil {
+		t.Fatal("expected non-nil empty FAQ slice")
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected empty FAQ slice, got %+v", empty)
+	}
+}
+
+func TestFAQServiceMapsRepositoryError(t *testing.T) {
+	repoErr := errors.New("query failed")
+
+	items, err := NewFAQService(&fakeFAQRepository{err: repoErr}).ListFAQItems(context.Background())
+	if items != nil {
+		t.Fatalf("expected nil FAQ items, got %+v", items)
+	}
+	if !errors.Is(err, apperr.ErrInternalServerError) {
+		t.Fatalf("expected internal server error, got %v", err)
+	}
+	if !errors.Is(err, repoErr) {
+		t.Fatalf("expected repository cause, got %v", err)
+	}
+}
+
+func TestAvailabilityServiceReturnsItemsAndNonNilEmptySlice(t *testing.T) {
+	service := NewAvailabilityService(&fakeAvailabilityRepository{
+		items: []PropertyAvailability{{
+			PropertyID:         "10000000-0000-0000-0000-000000000001",
+			PropertyPublicName: "信義館",
+			Address:            "台北市信義區",
+			HasVacantRoom:      true,
+		}},
+	})
+
+	items, err := service.ListPropertyAvailability(context.Background())
+	if err != nil {
+		t.Fatalf("list availability: %v", err)
+	}
+	if len(items) != 1 || !items[0].HasVacantRoom {
+		t.Fatalf("unexpected availability items: %+v", items)
+	}
+
+	empty, err := NewAvailabilityService(&fakeAvailabilityRepository{}).ListPropertyAvailability(context.Background())
+	if err != nil {
+		t.Fatalf("list empty availability: %v", err)
+	}
+	if empty == nil {
+		t.Fatal("expected non-nil empty availability slice")
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected empty availability slice, got %+v", empty)
+	}
+}
+
+func TestAvailabilityServiceMapsRepositoryError(t *testing.T) {
+	repoErr := errors.New("query failed")
+
+	items, err := NewAvailabilityService(&fakeAvailabilityRepository{err: repoErr}).ListPropertyAvailability(context.Background())
+	if items != nil {
+		t.Fatalf("expected nil availability items, got %+v", items)
+	}
+	if !errors.Is(err, apperr.ErrInternalServerError) {
+		t.Fatalf("expected internal server error, got %v", err)
+	}
+	if !errors.Is(err, repoErr) {
+		t.Fatalf("expected repository cause, got %v", err)
+	}
+}
+
+type fakeProfileRepository struct {
+	profile *Profile
+	err     error
+}
+
+func (r *fakeProfileRepository) GetProfile(context.Context) (*Profile, error) {
+	return r.profile, r.err
+}
+
+type fakeFAQRepository struct {
+	items []FAQItem
+	err   error
+}
+
+func (r *fakeFAQRepository) ListFAQItems(context.Context) ([]FAQItem, error) {
+	return r.items, r.err
+}
+
+type fakeAvailabilityRepository struct {
+	items []PropertyAvailability
+	err   error
+}
+
+func (r *fakeAvailabilityRepository) ListPropertyAvailability(context.Context) ([]PropertyAvailability, error) {
+	return r.items, r.err
+}

--- a/internal/http/api/openapi.gen.go
+++ b/internal/http/api/openapi.gen.go
@@ -1365,6 +1365,45 @@ type PropertyTenantLeaseRosterRow struct {
 	TenantPhone        *string             `json:"tenant_phone"`
 }
 
+// PublicBrandFAQItem defines model for PublicBrandFAQItem.
+type PublicBrandFAQItem struct {
+	Answer    string `json:"answer"`
+	Question  string `json:"question"`
+	SortOrder int    `json:"sort_order"`
+}
+
+// PublicBrandFAQListResponse defines model for PublicBrandFAQListResponse.
+type PublicBrandFAQListResponse struct {
+	Items []PublicBrandFAQItem `json:"items"`
+}
+
+// PublicBrandProfile defines model for PublicBrandProfile.
+type PublicBrandProfile struct {
+	BrandName      string               `json:"brand_name"`
+	ContactAddress *string              `json:"contact_address"`
+	ContactEmail   *openapi_types.Email `json:"contact_email"`
+	ContactPhone   *string              `json:"contact_phone"`
+	UpdatedAt      time.Time            `json:"updated_at"`
+}
+
+// PublicBrandProfileResponse defines model for PublicBrandProfileResponse.
+type PublicBrandProfileResponse struct {
+	Profile *PublicBrandProfile `json:"profile"`
+}
+
+// PublicPropertyAvailabilityItem defines model for PublicPropertyAvailabilityItem.
+type PublicPropertyAvailabilityItem struct {
+	Address            string             `json:"address"`
+	HasVacantRoom      bool               `json:"has_vacant_room"`
+	PropertyId         openapi_types.UUID `json:"property_id"`
+	PropertyPublicName string             `json:"property_public_name"`
+}
+
+// PublicPropertyAvailabilityListResponse defines model for PublicPropertyAvailabilityListResponse.
+type PublicPropertyAvailabilityListResponse struct {
+	Items []PublicPropertyAvailabilityItem `json:"items"`
+}
+
 // RecordMeterRequest defines model for RecordMeterRequest.
 type RecordMeterRequest struct {
 	// CurrentReading 本月電表度數（員工輸入）
@@ -2225,6 +2264,15 @@ type ServerInterface interface {
 	// 租客名冊 HTML 匯出
 	// (GET /properties/{id}/tenant-roster)
 	ExportPropertyTenantRoster(c *gin.Context, id string, params ExportPropertyTenantRosterParams)
+	// 列出公開品牌 FAQ
+	// (GET /public/brand/faqs)
+	ListPublicBrandFAQs(c *gin.Context)
+	// 取得公開品牌基本資料
+	// (GET /public/brand/profile)
+	GetPublicBrandProfile(c *gin.Context)
+	// 列出公開物業空房狀態
+	// (GET /public/properties/availability)
+	ListPublicPropertyAvailability(c *gin.Context)
 	// 維修列表
 	// (GET /repair-requests)
 	ListRepairRequests(c *gin.Context, params ListRepairRequestsParams)
@@ -4428,6 +4476,45 @@ func (siw *ServerInterfaceWrapper) ExportPropertyTenantRoster(c *gin.Context) {
 	siw.Handler.ExportPropertyTenantRoster(c, id, params)
 }
 
+// ListPublicBrandFAQs operation middleware
+func (siw *ServerInterfaceWrapper) ListPublicBrandFAQs(c *gin.Context) {
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.ListPublicBrandFAQs(c)
+}
+
+// GetPublicBrandProfile operation middleware
+func (siw *ServerInterfaceWrapper) GetPublicBrandProfile(c *gin.Context) {
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetPublicBrandProfile(c)
+}
+
+// ListPublicPropertyAvailability operation middleware
+func (siw *ServerInterfaceWrapper) ListPublicPropertyAvailability(c *gin.Context) {
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.ListPublicPropertyAvailability(c)
+}
+
 // ListRepairRequests operation middleware
 func (siw *ServerInterfaceWrapper) ListRepairRequests(c *gin.Context) {
 
@@ -5441,6 +5528,9 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.POST(options.BaseURL+"/properties/:id/rooms", wrapper.CreatePropertyRoom)
 	router.GET(options.BaseURL+"/properties/:id/tenant-lease-roster", wrapper.ListPropertyTenantLeaseRoster)
 	router.GET(options.BaseURL+"/properties/:id/tenant-roster", wrapper.ExportPropertyTenantRoster)
+	router.GET(options.BaseURL+"/public/brand/faqs", wrapper.ListPublicBrandFAQs)
+	router.GET(options.BaseURL+"/public/brand/profile", wrapper.GetPublicBrandProfile)
+	router.GET(options.BaseURL+"/public/properties/availability", wrapper.ListPublicPropertyAvailability)
 	router.GET(options.BaseURL+"/repair-requests", wrapper.ListRepairRequests)
 	router.POST(options.BaseURL+"/repair-requests", wrapper.CreateRepairRequest)
 	router.DELETE(options.BaseURL+"/repair-requests/:id", wrapper.DeleteRepairRequest)

--- a/internal/http/handler/api_server.go
+++ b/internal/http/handler/api_server.go
@@ -20,6 +20,7 @@ import (
 	appjournal "stds_backend/internal/application/journal"
 	applease "stds_backend/internal/application/lease"
 	appproperty "stds_backend/internal/application/property"
+	apppublicbrand "stds_backend/internal/application/publicbrand"
 	apprepair "stds_backend/internal/application/repair"
 	apptenant "stds_backend/internal/application/tenant"
 	domainusers "stds_backend/internal/domain/users"
@@ -48,6 +49,7 @@ type APIServer struct {
 	assignProperties  *appiam.AssignUserPropertiesService
 	brandProfile      *appbrand.Service
 	brandFAQ          *appbrand.FAQService
+	publicBrand       PublicBrandServices
 	jobTriggerService *appjobs.TriggerService
 	propertyQueryRepo dbpropertyquery.Repository
 	propertyDashboard *appproperty.DashboardService
@@ -91,6 +93,7 @@ type APIServerDeps struct {
 	AssignProperties  *appiam.AssignUserPropertiesService
 	BrandProfile      *appbrand.Service
 	BrandFAQ          *appbrand.FAQService
+	PublicBrand       PublicBrandServices
 	JobTrigger        *appjobs.TriggerService
 	PropertyQuery     dbpropertyquery.Repository
 	PropertyDashboard *appproperty.DashboardService
@@ -161,6 +164,12 @@ type RepairServices struct {
 type RepairQueryRepository interface {
 	List(ctx context.Context, query apprepair.ListQuery) (apprepair.ListResult, error)
 	FindByID(ctx context.Context, id string) (*apprepair.RepairRequest, error)
+}
+
+type PublicBrandServices struct {
+	Profile      *apppublicbrand.ProfileService
+	FAQ          *apppublicbrand.FAQService
+	Availability *apppublicbrand.AvailabilityService
 }
 
 type BillingQueryService interface {
@@ -475,6 +484,7 @@ func NewAPIServer(deps APIServerDeps) *APIServer {
 		assignProperties:  deps.AssignProperties,
 		brandProfile:      deps.BrandProfile,
 		brandFAQ:          deps.BrandFAQ,
+		publicBrand:       deps.PublicBrand,
 		jobTriggerService: deps.JobTrigger,
 		propertyQueryRepo: deps.PropertyQuery,
 		propertyDashboard: deps.PropertyDashboard,
@@ -521,6 +531,9 @@ func validateAPIServerDeps(deps APIServerDeps) {
 		{"assign_properties", deps.AssignProperties},
 		{"brand_profile", deps.BrandProfile},
 		{"brand_faq", deps.BrandFAQ},
+		{"public_brand_profile", deps.PublicBrand.Profile},
+		{"public_brand_faq", deps.PublicBrand.FAQ},
+		{"public_brand_availability", deps.PublicBrand.Availability},
 		{"job_trigger", deps.JobTrigger},
 		{"property_query", deps.PropertyQuery},
 		{"property_dashboard", deps.PropertyDashboard},
@@ -1594,6 +1607,39 @@ func (s *APIServer) ListBrandFAQItems(c *gin.Context, params api.ListBrandFAQIte
 	}
 
 	c.JSON(http.StatusOK, toBrandFAQItemListResponse(items))
+}
+
+// GetPublicBrandProfile handles public approved brand profile retrieval.
+func (s *APIServer) GetPublicBrandProfile(c *gin.Context) {
+	profile, err := s.publicBrand.Profile.GetProfile(c.Request.Context())
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toPublicBrandProfileResponse(profile))
+}
+
+// ListPublicBrandFAQs handles public approved FAQ listing.
+func (s *APIServer) ListPublicBrandFAQs(c *gin.Context) {
+	items, err := s.publicBrand.FAQ.ListFAQItems(c.Request.Context())
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toPublicBrandFAQListResponse(items))
+}
+
+// ListPublicPropertyAvailability handles public approved property availability listing.
+func (s *APIServer) ListPublicPropertyAvailability(c *gin.Context) {
+	items, err := s.publicBrand.Availability.ListPropertyAvailability(c.Request.Context())
+	if err != nil {
+		c.Error(err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toPublicPropertyAvailabilityResponse(items))
 }
 
 // CreateBrandFAQItem handles brand FAQ item creation.
@@ -3913,6 +3959,53 @@ func toBrandFAQItemResponse(item *appbrand.FAQItem) api.BrandFAQItemResponse {
 	}
 
 	return response
+}
+
+func toPublicBrandProfileResponse(profile *apppublicbrand.Profile) api.PublicBrandProfileResponse {
+	if profile == nil {
+		return api.PublicBrandProfileResponse{Profile: nil}
+	}
+
+	payload := api.PublicBrandProfile{
+		BrandName:      profile.BrandName,
+		ContactPhone:   profile.ContactPhone,
+		ContactAddress: profile.ContactAddress,
+		UpdatedAt:      profile.UpdatedAt,
+	}
+	if profile.ContactEmail != nil {
+		email := openapi_types.Email(*profile.ContactEmail)
+		payload.ContactEmail = &email
+	}
+
+	return api.PublicBrandProfileResponse{Profile: &payload}
+}
+
+func toPublicBrandFAQListResponse(items []apppublicbrand.FAQItem) api.PublicBrandFAQListResponse {
+	payloads := make([]api.PublicBrandFAQItem, 0, len(items))
+	for _, item := range items {
+		payloads = append(payloads, api.PublicBrandFAQItem{
+			Question:  item.Question,
+			Answer:    item.Answer,
+			SortOrder: item.SortOrder,
+		})
+	}
+
+	return api.PublicBrandFAQListResponse{Items: payloads}
+}
+
+func toPublicPropertyAvailabilityResponse(items []apppublicbrand.PropertyAvailability) api.PublicPropertyAvailabilityListResponse {
+	payloads := make([]api.PublicPropertyAvailabilityItem, 0, len(items))
+	for _, item := range items {
+		propertyID, _ := parseUUID(item.PropertyID)
+		payloads = append(payloads, api.PublicPropertyAvailabilityItem{
+			PropertyId:         propertyID,
+			PropertyPublicName: item.PropertyPublicName,
+			Address:            item.Address,
+			HasVacantRoom:      item.HasVacantRoom,
+		})
+	}
+
+	return api.PublicPropertyAvailabilityListResponse{Items: payloads}
 }
 
 func toPropertyResponse(property *dbpropertyquery.Property) api.PropertyResponse {

--- a/internal/http/handler/api_server_test.go
+++ b/internal/http/handler/api_server_test.go
@@ -20,6 +20,7 @@ import (
 	appbrand "stds_backend/internal/application/brand"
 	applease "stds_backend/internal/application/lease"
 	appproperty "stds_backend/internal/application/property"
+	apppublicbrand "stds_backend/internal/application/publicbrand"
 	apprepair "stds_backend/internal/application/repair"
 	"stds_backend/internal/http/api"
 	"stds_backend/internal/http/middleware"
@@ -238,6 +239,158 @@ func TestListBrandFAQItemsForwardsIncludeInactive(t *testing.T) {
 	}
 	if response.Data == nil || len(*response.Data) != 1 || (*response.Data)[0].Question == nil || *(*response.Data)[0].Question != "Q1" {
 		t.Fatalf("unexpected response: %+v", response)
+	}
+}
+
+func TestGetPublicBrandProfileReturnsNullableWrapper(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := &APIServer{publicBrand: newHandlerPublicBrandServices(handlerPublicBrandRepoStub{})}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/public/brand/profile", nil)
+
+	server.GetPublicBrandProfile(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	payload := map[string]any{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if _, ok := payload["profile"]; !ok || payload["profile"] != nil {
+		t.Fatalf("expected profile null wrapper, got %#v", payload)
+	}
+}
+
+func TestGetPublicBrandProfileReturnsApprovedProfile(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	phone := "02-1234-5678"
+	updatedAt := time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC)
+	server := &APIServer{publicBrand: newHandlerPublicBrandServices(handlerPublicBrandRepoStub{
+		profile: &apppublicbrand.Profile{
+			BrandName:    "STDS",
+			ContactPhone: &phone,
+			UpdatedAt:    updatedAt,
+		},
+	})}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/public/brand/profile", nil)
+
+	server.GetPublicBrandProfile(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response api.PublicBrandProfileResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if response.Profile == nil || response.Profile.BrandName != "STDS" {
+		t.Fatalf("unexpected profile response: %+v", response)
+	}
+	if response.Profile.ContactPhone == nil || *response.Profile.ContactPhone != phone {
+		t.Fatalf("unexpected contact phone: %+v", response.Profile.ContactPhone)
+	}
+}
+
+func TestListPublicBrandFAQsReturnsItemsArray(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := &APIServer{publicBrand: newHandlerPublicBrandServices(handlerPublicBrandRepoStub{})}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/public/brand/faqs", nil)
+
+	server.ListPublicBrandFAQs(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	payload := map[string][]any{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if payload["items"] == nil || len(payload["items"]) != 0 {
+		t.Fatalf("expected empty items array, got %#v", payload)
+	}
+}
+
+func TestListPublicBrandFAQsReturnsApprovedItems(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := &APIServer{publicBrand: newHandlerPublicBrandServices(handlerPublicBrandRepoStub{
+		faqs: []apppublicbrand.FAQItem{{Question: "Q1", Answer: "A1", SortOrder: 10}},
+	})}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/public/brand/faqs", nil)
+
+	server.ListPublicBrandFAQs(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response api.PublicBrandFAQListResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if len(response.Items) != 1 || response.Items[0].Question != "Q1" || response.Items[0].SortOrder != 10 {
+		t.Fatalf("unexpected FAQ response: %+v", response)
+	}
+}
+
+func TestListPublicPropertyAvailabilityReturnsItemsArray(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := &APIServer{publicBrand: newHandlerPublicBrandServices(handlerPublicBrandRepoStub{})}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/public/properties/availability", nil)
+
+	server.ListPublicPropertyAvailability(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	payload := map[string][]any{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if payload["items"] == nil || len(payload["items"]) != 0 {
+		t.Fatalf("expected empty items array, got %#v", payload)
+	}
+}
+
+func TestListPublicPropertyAvailabilityReturnsApprovedItems(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	server := &APIServer{publicBrand: newHandlerPublicBrandServices(handlerPublicBrandRepoStub{
+		availability: []apppublicbrand.PropertyAvailability{{
+			PropertyID:         "10000000-0000-0000-0000-000000000001",
+			PropertyPublicName: "信義館",
+			Address:            "台北市信義區",
+			HasVacantRoom:      true,
+		}},
+	})}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/public/properties/availability", nil)
+
+	server.ListPublicPropertyAvailability(c)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response api.PublicPropertyAvailabilityListResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if len(response.Items) != 1 || response.Items[0].PropertyPublicName != "信義館" || !response.Items[0].HasVacantRoom {
+		t.Fatalf("unexpected availability response: %+v", response)
 	}
 }
 
@@ -2310,4 +2463,33 @@ func (r *handlerBrandFAQRepoStub) Deactivate(_ context.Context, _ *sql.Tx, _ str
 		return nil, r.deactivateErr
 	}
 	return r.deactivateItem, nil
+}
+
+func newHandlerPublicBrandServices(repo handlerPublicBrandRepoStub) PublicBrandServices {
+	return PublicBrandServices{
+		Profile:      apppublicbrand.NewProfileService(repo),
+		FAQ:          apppublicbrand.NewFAQService(repo),
+		Availability: apppublicbrand.NewAvailabilityService(repo),
+	}
+}
+
+type handlerPublicBrandRepoStub struct {
+	profile         *apppublicbrand.Profile
+	profileErr      error
+	faqs            []apppublicbrand.FAQItem
+	faqsErr         error
+	availability    []apppublicbrand.PropertyAvailability
+	availabilityErr error
+}
+
+func (r handlerPublicBrandRepoStub) GetProfile(context.Context) (*apppublicbrand.Profile, error) {
+	return r.profile, r.profileErr
+}
+
+func (r handlerPublicBrandRepoStub) ListFAQItems(context.Context) ([]apppublicbrand.FAQItem, error) {
+	return r.faqs, r.faqsErr
+}
+
+func (r handlerPublicBrandRepoStub) ListPropertyAvailability(context.Context) ([]apppublicbrand.PropertyAvailability, error) {
+	return r.availability, r.availabilityErr
 }

--- a/internal/http/router/router.go
+++ b/internal/http/router/router.go
@@ -20,6 +20,7 @@ import (
 type authStrategy string
 
 const (
+	authStrategyNone              authStrategy = "none"
 	authStrategyFirebase          authStrategy = "firebase"
 	authStrategyFirebaseTokenOnly authStrategy = "firebase_token_only"
 	authStrategyScheduler         authStrategy = "scheduler"
@@ -123,6 +124,8 @@ func compileRoutePolicies(appCfg config.AppConfig, authenticator platformfirebas
 	for _, policy := range rawPolicies {
 		compiled := compiledRoutePolicy{}
 		switch policy.authStrategy {
+		case authStrategyNone:
+			compiled.authenticate = func(*gin.Context) {}
 		case authStrategyFirebaseTokenOnly:
 			compiled.authenticate = middleware.FirebaseTokenOnly(authenticator)
 		case authStrategyScheduler:
@@ -208,6 +211,9 @@ func routePolicies(authzRepos AuthorizationRepositories) []routePolicy {
 		{method: "POST", path: "/api/v1/brand/faq-items", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer"}},
 		{method: "PATCH", path: "/api/v1/brand/faq-items/:id", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer"}},
 		{method: "POST", path: "/api/v1/brand/faq-items/:id/deactivate", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer"}},
+		{method: "GET", path: "/api/v1/public/brand/profile", authStrategy: authStrategyNone},
+		{method: "GET", path: "/api/v1/public/brand/faqs", authStrategy: authStrategyNone},
+		{method: "GET", path: "/api/v1/public/properties/availability", authStrategy: authStrategyNone},
 		{method: "GET", path: "/api/v1/properties", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}},
 		{method: "POST", path: "/api/v1/properties", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff"}},
 		{method: "GET", path: "/api/v1/properties/:id/attachments", authStrategy: authStrategyFirebase, allowedRoles: []string{"admin", "organizer", "staff", "owner"}, propertyResolver: middleware.ParamPropertyID("id")},

--- a/internal/http/router/router_test.go
+++ b/internal/http/router/router_test.go
@@ -26,6 +26,7 @@ import (
 	applease "stds_backend/internal/application/lease"
 	appnotification "stds_backend/internal/application/notification"
 	appproperty "stds_backend/internal/application/property"
+	apppublicbrand "stds_backend/internal/application/publicbrand"
 	apprepair "stds_backend/internal/application/repair"
 	apptenant "stds_backend/internal/application/tenant"
 	"stds_backend/internal/config"
@@ -202,6 +203,69 @@ func TestBrandProfileRoutePolicyRejectsStaffAndOwner(t *testing.T) {
 			engine.ServeHTTP(resp, req)
 
 			assertStandardErrorResponse(t, resp, http.StatusForbidden, apperr.CodeForbidden)
+		})
+	}
+}
+
+func TestPublicBrandRoutesAllowNoAuth(t *testing.T) {
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: "/api/v1/public/brand/profile"},
+		{method: http.MethodGet, path: "/api/v1/public/brand/faqs"},
+		{method: http.MethodGet, path: "/api/v1/public/properties/availability"},
+	}
+
+	for _, route := range routes {
+		t.Run(route.path, func(t *testing.T) {
+			engine := newTestEngine(
+				fakeUserRepo{},
+				fakeAuthenticator{},
+				fakePropertyRepo{},
+				fakeResourceOwnershipRepo{},
+				"",
+				fakeJobRunsRepo{},
+			)
+
+			req := httptest.NewRequest(route.method, route.path, nil)
+			resp := httptest.NewRecorder()
+
+			engine.ServeHTTP(resp, req)
+
+			if resp.Code != http.StatusOK {
+				t.Fatalf("expected 200 without auth, got %d: %s", resp.Code, resp.Body.String())
+			}
+		})
+	}
+}
+
+func TestAdminBrandRoutesStillRequireAuth(t *testing.T) {
+	routes := []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodGet, path: "/api/v1/brand/profile"},
+		{method: http.MethodGet, path: "/api/v1/brand/faq-items"},
+	}
+
+	for _, route := range routes {
+		t.Run(route.path, func(t *testing.T) {
+			engine := newTestEngine(
+				fakeUserRepo{},
+				fakeAuthenticator{},
+				fakePropertyRepo{},
+				fakeResourceOwnershipRepo{},
+				"",
+				fakeJobRunsRepo{},
+			)
+
+			req := httptest.NewRequest(route.method, route.path, nil)
+			resp := httptest.NewRecorder()
+
+			engine.ServeHTTP(resp, req)
+
+			assertStandardErrorResponse(t, resp, http.StatusUnauthorized, apperr.CodeUnauthorized)
 		})
 	}
 }
@@ -6943,6 +7007,7 @@ func defaultAPIServerDeps(userRepo *fakeUserRepo, authenticator fakeAuthenticato
 		AssignProperties:  appiam.NewAssignUserPropertiesService(testManagedUserRepositoryAdapter{repo: userRepo}, testPropertyExistenceChecker{repo: fakePropertyQueryRepo{}}, appiam.NewCustomClaimsService(authenticator)),
 		BrandProfile:      appbrand.NewService(nil, nil),
 		BrandFAQ:          appbrand.NewFAQService(nil, nil),
+		PublicBrand:       newFakePublicBrandServices(),
 		JobTrigger:        appjobs.NewTriggerService(jobRunsRepo, nil, time.Minute, 3),
 		PropertyQuery:     propertyQueryRepo,
 		PropertyDashboard: appproperty.NewDashboardService(nil),
@@ -7102,6 +7167,29 @@ type testNotificationSender struct {
 
 func (s *testNotificationSender) Send(_ context.Context, _ platformnotification.SendCommand) error {
 	return s.sendErr
+}
+
+func newFakePublicBrandServices() handler.PublicBrandServices {
+	repo := fakePublicBrandRepo{}
+	return handler.PublicBrandServices{
+		Profile:      apppublicbrand.NewProfileService(repo),
+		FAQ:          apppublicbrand.NewFAQService(repo),
+		Availability: apppublicbrand.NewAvailabilityService(repo),
+	}
+}
+
+type fakePublicBrandRepo struct{}
+
+func (fakePublicBrandRepo) GetProfile(context.Context) (*apppublicbrand.Profile, error) {
+	return nil, nil
+}
+
+func (fakePublicBrandRepo) ListFAQItems(context.Context) ([]apppublicbrand.FAQItem, error) {
+	return []apppublicbrand.FAQItem{}, nil
+}
+
+func (fakePublicBrandRepo) ListPropertyAvailability(context.Context) ([]apppublicbrand.PropertyAvailability, error) {
+	return []apppublicbrand.PropertyAvailability{}, nil
 }
 
 func firstAssignedPropertyIDs(assigned []string) []string {

--- a/internal/platform/database/publicbrand/repository.go
+++ b/internal/platform/database/publicbrand/repository.go
@@ -1,0 +1,102 @@
+package publicbrand
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	apppublicbrand "stds_backend/internal/application/publicbrand"
+)
+
+// SQLRepository reads public brand data from approved database views.
+type SQLRepository struct {
+	db *sql.DB
+}
+
+// NewRepository returns a public brand repository backed by db.
+func NewRepository(db *sql.DB) *SQLRepository {
+	return &SQLRepository{db: db}
+}
+
+// GetProfile returns the approved public brand profile, or nil when absent.
+func (r *SQLRepository) GetProfile(ctx context.Context) (*apppublicbrand.Profile, error) {
+	const query = `
+SELECT brand_name, contact_phone, contact_email, contact_address, updated_at
+FROM approved_brand_profile_v1
+LIMIT 1
+`
+
+	var profile apppublicbrand.Profile
+	if err := r.db.QueryRowContext(ctx, query).Scan(
+		&profile.BrandName,
+		&profile.ContactPhone,
+		&profile.ContactEmail,
+		&profile.ContactAddress,
+		&profile.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get approved brand profile: %w", err)
+	}
+
+	return &profile, nil
+}
+
+// ListFAQItems returns approved public FAQ items in display order.
+func (r *SQLRepository) ListFAQItems(ctx context.Context) ([]apppublicbrand.FAQItem, error) {
+	const query = `
+SELECT question, answer, sort_order
+FROM approved_brand_faq_items_v1
+ORDER BY sort_order
+`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list approved brand FAQ items: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]apppublicbrand.FAQItem, 0)
+	for rows.Next() {
+		var item apppublicbrand.FAQItem
+		if err := rows.Scan(&item.Question, &item.Answer, &item.SortOrder); err != nil {
+			return nil, fmt.Errorf("scan approved brand FAQ item: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate approved brand FAQ items: %w", err)
+	}
+
+	return items, nil
+}
+
+// ListPropertyAvailability returns approved public property availability rows.
+func (r *SQLRepository) ListPropertyAvailability(ctx context.Context) ([]apppublicbrand.PropertyAvailability, error) {
+	const query = `
+SELECT property_id, property_public_name, address, has_vacant_room
+FROM approved_brand_property_availability_v1
+`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("list approved brand property availability: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]apppublicbrand.PropertyAvailability, 0)
+	for rows.Next() {
+		var item apppublicbrand.PropertyAvailability
+		if err := rows.Scan(&item.PropertyID, &item.PropertyPublicName, &item.Address, &item.HasVacantRoom); err != nil {
+			return nil, fmt.Errorf("scan approved brand property availability: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate approved brand property availability: %w", err)
+	}
+
+	return items, nil
+}

--- a/internal/platform/database/publicbrand/repository_test.go
+++ b/internal/platform/database/publicbrand/repository_test.go
@@ -1,0 +1,394 @@
+package publicbrand
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestGetProfileReadsApprovedView(t *testing.T) {
+	db, mock, repo := newRepoTest(t)
+	defer db.Close()
+
+	phone := "02-1234-5678"
+	email := "service@example.com"
+	address := "台北市信義區"
+	updatedAt := time.Now().UTC()
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT brand_name, contact_phone, contact_email, contact_address, updated_at
+FROM approved_brand_profile_v1
+LIMIT 1
+`)).
+		WillReturnRows(sqlmock.NewRows(profileColumns()).
+			AddRow("STDS", phone, email, address, updatedAt))
+
+	profile, err := repo.GetProfile(context.Background())
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if profile == nil || profile.BrandName != "STDS" || profile.ContactPhone == nil || *profile.ContactPhone != phone {
+		t.Fatalf("unexpected profile: %+v", profile)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestGetProfileReturnsNilWhenApprovedViewIsEmpty(t *testing.T) {
+	db, mock, repo := newRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT brand_name, contact_phone, contact_email, contact_address, updated_at
+FROM approved_brand_profile_v1
+LIMIT 1
+`)).
+		WillReturnError(sql.ErrNoRows)
+
+	profile, err := repo.GetProfile(context.Background())
+	if err != nil {
+		t.Fatalf("get profile: %v", err)
+	}
+	if profile != nil {
+		t.Fatalf("expected nil profile, got %+v", profile)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestGetProfileWrapsScanError(t *testing.T) {
+	db, mock, repo := newRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT brand_name, contact_phone, contact_email, contact_address, updated_at
+FROM approved_brand_profile_v1
+LIMIT 1
+`)).
+		WillReturnRows(sqlmock.NewRows(profileColumns()).
+			AddRow("STDS", nil, nil, nil, "not-a-time"))
+
+	profile, err := repo.GetProfile(context.Background())
+	if profile != nil {
+		t.Fatalf("expected nil profile, got %+v", profile)
+	}
+	if err == nil {
+		t.Fatal("expected scan error")
+	}
+	if !regexp.MustCompile(`get approved brand profile`).MatchString(err.Error()) {
+		t.Fatalf("expected operation context, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestGetProfileWrapsDatabaseError(t *testing.T) {
+	db, mock, repo := newRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT brand_name, contact_phone, contact_email, contact_address, updated_at
+FROM approved_brand_profile_v1
+LIMIT 1
+`)).
+		WillReturnError(sqlmock.ErrCancelled)
+
+	profile, err := repo.GetProfile(context.Background())
+	if profile != nil {
+		t.Fatalf("expected nil profile, got %+v", profile)
+	}
+	if !errors.Is(err, sqlmock.ErrCancelled) {
+		t.Fatalf("expected wrapped database error, got %v", err)
+	}
+	if !regexp.MustCompile(`get approved brand profile`).MatchString(err.Error()) {
+		t.Fatalf("expected operation context, got %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListFAQItemsReadsApprovedViewInSortOrder(t *testing.T) {
+	db, mock, repo := newRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT question, answer, sort_order
+FROM approved_brand_faq_items_v1
+ORDER BY sort_order
+`)).
+		WillReturnRows(sqlmock.NewRows(faqColumns()).
+			AddRow("Q1", "A1", 10).
+			AddRow("Q2", "A2", 20))
+
+	items, err := repo.ListFAQItems(context.Background())
+	if err != nil {
+		t.Fatalf("list FAQ items: %v", err)
+	}
+	if len(items) != 2 || items[0].SortOrder != 10 || items[1].Question != "Q2" {
+		t.Fatalf("unexpected FAQ items: %+v", items)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListFAQItemsReturnsNonNilEmptySlice(t *testing.T) {
+	db, mock, repo := newRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT question, answer, sort_order
+FROM approved_brand_faq_items_v1
+ORDER BY sort_order
+`)).
+		WillReturnRows(sqlmock.NewRows(faqColumns()))
+
+	items, err := repo.ListFAQItems(context.Background())
+	if err != nil {
+		t.Fatalf("list FAQ items: %v", err)
+	}
+	if items == nil {
+		t.Fatal("expected non-nil empty FAQ slice")
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected empty FAQ slice, got %+v", items)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListFAQItemsWrapsScanRowsAndDatabaseErrors(t *testing.T) {
+	t.Run("scan error", func(t *testing.T) {
+		db, mock, repo := newRepoTest(t)
+		defer db.Close()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT question, answer, sort_order
+FROM approved_brand_faq_items_v1
+ORDER BY sort_order
+`)).
+			WillReturnRows(sqlmock.NewRows(faqColumns()).
+				AddRow("Q1", "A1", "invalid-sort-order"))
+
+		items, err := repo.ListFAQItems(context.Background())
+		if items != nil {
+			t.Fatalf("expected nil FAQ items, got %+v", items)
+		}
+		if err == nil || !regexp.MustCompile(`scan approved brand FAQ item`).MatchString(err.Error()) {
+			t.Fatalf("expected scan operation context, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sql expectations: %v", err)
+		}
+	})
+
+	t.Run("rows error", func(t *testing.T) {
+		db, mock, repo := newRepoTest(t)
+		defer db.Close()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT question, answer, sort_order
+FROM approved_brand_faq_items_v1
+ORDER BY sort_order
+`)).
+			WillReturnRows(sqlmock.NewRows(faqColumns()).RowError(0, sqlmock.ErrCancelled).
+				AddRow("Q1", "A1", 10))
+
+		items, err := repo.ListFAQItems(context.Background())
+		if items != nil {
+			t.Fatalf("expected nil FAQ items, got %+v", items)
+		}
+		if !errors.Is(err, sqlmock.ErrCancelled) {
+			t.Fatalf("expected wrapped rows error, got %v", err)
+		}
+		if err == nil || !regexp.MustCompile(`iterate approved brand FAQ items`).MatchString(err.Error()) {
+			t.Fatalf("expected iterate operation context, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sql expectations: %v", err)
+		}
+	})
+
+	t.Run("database error", func(t *testing.T) {
+		db, mock, repo := newRepoTest(t)
+		defer db.Close()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT question, answer, sort_order
+FROM approved_brand_faq_items_v1
+ORDER BY sort_order
+`)).
+			WillReturnError(sqlmock.ErrCancelled)
+
+		items, err := repo.ListFAQItems(context.Background())
+		if items != nil {
+			t.Fatalf("expected nil FAQ items, got %+v", items)
+		}
+		if !errors.Is(err, sqlmock.ErrCancelled) {
+			t.Fatalf("expected wrapped database error, got %v", err)
+		}
+		if err == nil || !regexp.MustCompile(`list approved brand FAQ items`).MatchString(err.Error()) {
+			t.Fatalf("expected list operation context, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sql expectations: %v", err)
+		}
+	})
+}
+
+func TestListPropertyAvailabilityReadsApprovedView(t *testing.T) {
+	db, mock, repo := newRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT property_id, property_public_name, address, has_vacant_room
+FROM approved_brand_property_availability_v1
+`)).
+		WillReturnRows(sqlmock.NewRows(availabilityColumns()).
+			AddRow("10000000-0000-0000-0000-000000000001", "信義館", "台北市信義區", true).
+			AddRow("10000000-0000-0000-0000-000000000002", "松山館", "台北市松山區", false))
+
+	items, err := repo.ListPropertyAvailability(context.Background())
+	if err != nil {
+		t.Fatalf("list property availability: %v", err)
+	}
+	if len(items) != 2 || !items[0].HasVacantRoom || items[1].PropertyPublicName != "松山館" {
+		t.Fatalf("unexpected availability items: %+v", items)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListPropertyAvailabilityReturnsNonNilEmptySlice(t *testing.T) {
+	db, mock, repo := newRepoTest(t)
+	defer db.Close()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT property_id, property_public_name, address, has_vacant_room
+FROM approved_brand_property_availability_v1
+`)).
+		WillReturnRows(sqlmock.NewRows(availabilityColumns()))
+
+	items, err := repo.ListPropertyAvailability(context.Background())
+	if err != nil {
+		t.Fatalf("list property availability: %v", err)
+	}
+	if items == nil {
+		t.Fatal("expected non-nil empty availability slice")
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected empty availability slice, got %+v", items)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestListPropertyAvailabilityWrapsScanRowsAndDatabaseErrors(t *testing.T) {
+	t.Run("scan error", func(t *testing.T) {
+		db, mock, repo := newRepoTest(t)
+		defer db.Close()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT property_id, property_public_name, address, has_vacant_room
+FROM approved_brand_property_availability_v1
+`)).
+			WillReturnRows(sqlmock.NewRows(availabilityColumns()).
+				AddRow("10000000-0000-0000-0000-000000000001", "信義館", "台北市信義區", "invalid-bool"))
+
+		items, err := repo.ListPropertyAvailability(context.Background())
+		if items != nil {
+			t.Fatalf("expected nil availability items, got %+v", items)
+		}
+		if err == nil || !regexp.MustCompile(`scan approved brand property availability`).MatchString(err.Error()) {
+			t.Fatalf("expected scan operation context, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sql expectations: %v", err)
+		}
+	})
+
+	t.Run("rows error", func(t *testing.T) {
+		db, mock, repo := newRepoTest(t)
+		defer db.Close()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT property_id, property_public_name, address, has_vacant_room
+FROM approved_brand_property_availability_v1
+`)).
+			WillReturnRows(sqlmock.NewRows(availabilityColumns()).RowError(0, sqlmock.ErrCancelled).
+				AddRow("10000000-0000-0000-0000-000000000001", "信義館", "台北市信義區", true))
+
+		items, err := repo.ListPropertyAvailability(context.Background())
+		if items != nil {
+			t.Fatalf("expected nil availability items, got %+v", items)
+		}
+		if !errors.Is(err, sqlmock.ErrCancelled) {
+			t.Fatalf("expected wrapped rows error, got %v", err)
+		}
+		if err == nil || !regexp.MustCompile(`iterate approved brand property availability`).MatchString(err.Error()) {
+			t.Fatalf("expected iterate operation context, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sql expectations: %v", err)
+		}
+	})
+
+	t.Run("database error", func(t *testing.T) {
+		db, mock, repo := newRepoTest(t)
+		defer db.Close()
+
+		mock.ExpectQuery(regexp.QuoteMeta(`
+SELECT property_id, property_public_name, address, has_vacant_room
+FROM approved_brand_property_availability_v1
+`)).
+			WillReturnError(sqlmock.ErrCancelled)
+
+		items, err := repo.ListPropertyAvailability(context.Background())
+		if items != nil {
+			t.Fatalf("expected nil availability items, got %+v", items)
+		}
+		if !errors.Is(err, sqlmock.ErrCancelled) {
+			t.Fatalf("expected wrapped database error, got %v", err)
+		}
+		if err == nil || !regexp.MustCompile(`list approved brand property availability`).MatchString(err.Error()) {
+			t.Fatalf("expected list operation context, got %v", err)
+		}
+		if err := mock.ExpectationsWereMet(); err != nil {
+			t.Fatalf("unmet sql expectations: %v", err)
+		}
+	})
+}
+
+func newRepoTest(t *testing.T) (*sql.DB, sqlmock.Sqlmock, *SQLRepository) {
+	t.Helper()
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("open sqlmock: %v", err)
+	}
+
+	return db, mock, NewRepository(db)
+}
+
+func profileColumns() []string {
+	return []string{"brand_name", "contact_phone", "contact_email", "contact_address", "updated_at"}
+}
+
+func faqColumns() []string {
+	return []string{"question", "answer", "sort_order"}
+}
+
+func availabilityColumns() []string {
+	return []string{"property_id", "property_public_name", "address", "has_vacant_room"}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,7 @@ import (
 	applease "stds_backend/internal/application/lease"
 	appnotification "stds_backend/internal/application/notification"
 	appproperty "stds_backend/internal/application/property"
+	apppublicbrand "stds_backend/internal/application/publicbrand"
 	apprepair "stds_backend/internal/application/repair"
 	apptenant "stds_backend/internal/application/tenant"
 	"stds_backend/internal/config"
@@ -32,6 +33,7 @@ import (
 	dbproperties "stds_backend/internal/platform/database/properties"
 	dbpropertydashboard "stds_backend/internal/platform/database/propertydashboard"
 	dbpropertyquery "stds_backend/internal/platform/database/propertyquery"
+	dbpublicbrand "stds_backend/internal/platform/database/publicbrand"
 	dbrepair "stds_backend/internal/platform/database/repair"
 	dbresourceownership "stds_backend/internal/platform/database/resourceownership"
 	dbtenantquery "stds_backend/internal/platform/database/tenantquery"
@@ -89,6 +91,7 @@ func New(cfg *config.Config) (*Server, error) {
 	attachmentRepo := dbattachments.NewRepository(db)
 	brandProfileRepo := dbbrandprofile.NewRepository(db)
 	brandFAQRepo := dbbrandfaq.NewRepository(db)
+	publicBrandRepo := dbpublicbrand.NewRepository(db)
 
 	storageClient, err := platformstorage.NewAttachmentStorage(context.Background(), cfg.App.Env, cfg.Storage)
 	if err != nil {
@@ -122,6 +125,11 @@ func New(cfg *config.Config) (*Server, error) {
 	txRunner := dbtxrunner.New(db, bus)
 	brandProfileService := appbrand.NewService(brandProfileRepositoryAdapter{repo: brandProfileRepo}, txRunner)
 	brandFAQService := appbrand.NewFAQService(brandFAQRepositoryAdapter{repo: brandFAQRepo}, txRunner)
+	publicBrandServices := handler.PublicBrandServices{
+		Profile:      apppublicbrand.NewProfileService(publicBrandRepo),
+		FAQ:          apppublicbrand.NewFAQService(publicBrandRepo),
+		Availability: apppublicbrand.NewAvailabilityService(publicBrandRepo),
+	}
 	createPropertyService := appproperty.NewCreatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, propertyAccountRepositoryAdapter{repo: billingRepo}, txRunner)
 	updatePropertyService := appproperty.NewUpdatePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
 	deletePropertyService := appproperty.NewDeletePropertyService(propertyRepositoryAdapter{repo: propertyRepo}, txRunner)
@@ -181,6 +189,7 @@ func New(cfg *config.Config) (*Server, error) {
 		AssignProperties:  assignUserPropertiesService,
 		BrandProfile:      brandProfileService,
 		BrandFAQ:          brandFAQService,
+		PublicBrand:       publicBrandServices,
 		JobTrigger:        jobTriggerService,
 		PropertyQuery:     propertyQueryRepo,
 		PropertyDashboard: propertyDashboardService,


### PR DESCRIPTION
## Summary

Closes #209.

Adds the core backend public readonly brand API surface for the Cloudflare Pages brand frontend:

- `GET /api/v1/public/brand/profile`
- `GET /api/v1/public/brand/faqs`
- `GET /api/v1/public/properties/availability`

The new public routes live under an independent `/api/v1/public` namespace, require no Firebase JWT, and keep existing admin brand management routes protected for `admin` / `organizer`.

## Implementation

- Adds OpenAPI source schemas/paths plus regenerated bundled spec and Go bindings.
- Adds `internal/application/publicbrand` read services and ports.
- Adds `internal/platform/database/publicbrand` repository queries that read only approved views:
  - `approved_brand_profile_v1`
  - `approved_brand_faq_items_v1`
  - `approved_brand_property_availability_v1`
- Wires handlers, router policy, and server dependencies using the existing core runtime DB connection.
- Updates README/runbook wording now that #209 is part of the staging promotion wave.

## Non-goals preserved

- Existing `/api/v1/brand/profile` and `/api/v1/brand/faq-items` remain authenticated admin routes.
- No booking, reservation, form, write API, CMS, or realtime availability behavior.
- No separate brand readonly DB credential, pool, Cloud Run service, or Firebase Hosting rewrite.

## Validation

- `go test ./...`
- `npm run openapi:lint` exits 0; Redocly reports 3 warnings because the no-auth/no-input public GET endpoints have no natural 4xx response.
- `npm run openapi:bundle`
- `./scripts/openapi_codegen.sh`
- `go test -tags=e2e ./test/e2e -run '^$'`
