### PR TITLE
docs: publish canonical documentation authority

### DIFF
--- a/.antigravitycli/274e07f4-1fff-409e-bcb6-1d0122632d42.json
+++ b/.antigravitycli/274e07f4-1fff-409e-bcb6-1d0122632d42.json
@@ -1,0 +1,14 @@
+{
+  "id": "274e07f4-1fff-409e-bcb6-1d0122632d42",
+  "name": "/Users/cheni-fan/stds_backend",
+  "projectResources": {
+    "resources": [
+      {
+        "gitFolder": {
+          "folderUri": "file:///Users/cheni-fan/stds_backend",
+          "allowWrite": true
+        }
+      }
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ management endpoints.
 - PostgreSQL schema, migrations, and constraints as the persistence source of
   truth.
 - Firebase Auth for identity verification; DB user records remain the runtime
-  authorization source for roles, permission overrides, and property scope.
+  authorization source for roles and property scope. `permission_overrides` is
+  stored but its authorization semantics are not yet defined.
 - Layered Go structure: HTTP transport, application services, domain logic,
   database adapters, and server composition are kept separate.
 - Structured JSON logging with request IDs, error codes, user/property context,
@@ -43,7 +44,8 @@ management endpoints.
 
 ## Cloud Architecture
 
-The staging architecture uses GCP-managed services:
+The overall architecture uses the following managed services. The first backend
+staging/UAT slice excludes the separately deployed Cloudflare brand frontend:
 
 - Firebase Hosting for the browser-facing admin frontend.
 - Cloudflare Pages for the browser-facing brand frontend.
@@ -127,8 +129,15 @@ See [docs/local-operations.md](docs/local-operations.md) for setup details.
 
 ## Documentation Map
 
+- [Documentation authority](docs/README.md): authority order, inventory, and
+  canonical/generated/historical boundaries.
+- [Current-state inventory](docs/current-state.md): implemented, partial,
+  reserved, and not-implemented capabilities.
+- [Domain rules](docs/design/domain-rule.md): confirmed business rules only.
+- [Domain decision backlog](docs/design/decision-backlog.md): unresolved and
+  risky rules that must not be inferred from implementation.
 - [Cloud architecture](docs/cloud-architecture.md): GCP staging and
-  production-candidate architecture decisions.
+  proposed production-candidate architecture baseline.
 - [Staging runbook](docs/staging-runbook.md): staging v1 deployment, secrets,
   IAM, private networking, and evidence checklist.
 - [Local operations](docs/local-operations.md): local environment, scripts,
@@ -137,8 +146,12 @@ See [docs/local-operations.md](docs/local-operations.md) for setup details.
   rules for config, logging, auth, DB, errors, and middleware.
 - [Vertical slice handbook](docs/vertical-slice-handbook.md): guidance for
   adding API slices in the existing architecture.
-- [Domain model](docs/design/domain-model.md): domain model and business-rule
-  baseline.
+- [Domain model](docs/design/domain-model.md): current as-is bounded contexts,
+  lifecycles, and cross-context boundaries.
+- [Legacy migration contract](docs/migration/README.md): tracked scope,
+  validation, evidence, and cutover contracts without production data.
+- [Production readiness](docs/production-readiness.md): unresolved production
+  gates, recovery, and sign-off areas.
 - [GitHub Wiki operator handbook](https://github.com/ifan0927/STDS_backend_go/wiki/Staging-v1-Operator-Handbook-2026-05-15-v1):
   long-term staging operator notes, IAM matrix, OIDC/WIF notes, troubleshooting
   ledger, and observability playbook.

--- a/cicd.md
+++ b/cicd.md
@@ -1,5 +1,9 @@
 # CI/CD Strategy
 
+> Status: historical/provisional delivery notes. Current executable pipeline
+> contracts are `.github/workflows/**`, `cloudbuild.staging.yaml`, and
+> `docs/staging-runbook.md`; this file is not production readiness evidence.
+
 ## Goal
 
 The goal of this CI/CD plan is to provide the minimum necessary delivery guardrails for the backend without introducing unnecessary platform complexity.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,56 @@
+# Documentation Authority
+
+本目錄記錄 STDS Backend 的現行契約、已確認規則、設計決策與操作方式。文件發生衝突時，不以檔名、更新日期或 roadmap checkbox 判定真偽，而依下列權威層級處理。
+
+## Authority Order
+
+1. 已由使用者確認的 business rules：[`design/domain-rule.md`](design/domain-rule.md)。
+2. API transport contract：[`spec/src/openapi.yaml`](spec/src/openapi.yaml) 與其 `$ref` 檔案。
+3. Database as-is schema：`internal/platform/database/migrate/migrations/*.up.sql`；[`spec/schema.sql`](spec/schema.sql) 只作為可讀 reference。
+4. 現行 application/domain/router behavior 與能直接證明該行為的 tests。
+5. 有效 ADR：[`design/decisions/`](design/decisions/)。ADR 不得覆蓋已確認 business rule。
+6. Current-state inventory：[`current-state.md`](current-state.md)，用來區分 implemented、partial、reserved 與 not implemented。
+7. Operations runbooks 與 engineering guidelines；只約束其明示的環境或工作流程。
+8. Historical/provisional 文件與 Git history；只能解釋背景，不能建立現行契約。
+
+若 implementation 與 canonical rule 衝突，implementation 只證明 as-is，不會自動改寫 domain truth。衝突必須記入 [`design/decision-backlog.md`](design/decision-backlog.md)，再由後續工作決定修 code 或修 contract。
+
+## Document Inventory
+
+| 文件／路徑 | 類型 | 狀態 | 責任 |
+| --- | --- | --- | --- |
+| `docs/README.md` | policy | canonical | 文件責任、權威順序與 inventory |
+| `docs/design/domain-rule.md` | domain | canonical | 只收已確認且可約束 schema/API 的 business rules |
+| `docs/design/domain-model.md` | design | current as-is | bounded contexts、aggregates、states、lifecycles 與跨 BC 邊界 |
+| `docs/design/decisions/*.md` | ADR | status per file | 仍有效或已被取代的技術／架構決策 |
+| `docs/design/decision-backlog.md` | decision queue | canonical index | 未確認或具風險、不得默認成規則的議題 |
+| `docs/current-state.md` | inventory | current as-is | implementation、OpenAPI、migration 與 tests 的功能狀態 |
+| `docs/spec/src/**` | API source | canonical | modular OpenAPI source of truth |
+| `docs/spec/openapi.yaml` | generated | derived | bundle output；不得手動維護 |
+| `internal/http/api/openapi.gen.go` | generated | derived | OpenAPI code generation output |
+| `internal/platform/database/migrate/migrations/**` | schema source | canonical as-is | migration order與實際 DB schema |
+| `docs/spec/schema.sql` | schema reference | derived/reference | 人工可讀 schema snapshot；衝突時以 migrations 為準 |
+| `docs/migration/**` | migration | canonical contract | 可版本控制的 scope、mapping、validation、evidence 與 cutover contract |
+| `docs/mirgations/**` | migration input | ignored/private fixture | legacy JSON 與舊 task plan；不是 tracked contract（路徑拼字為歷史遺留） |
+| `artifacts/**` | generated/private | ignored | dump、report、run evidence；不得加入 Git |
+| `docs/.rules/**` | engineering rules | canonical | coding 與 testing 規範 |
+| `docs/local-operations.md` | runbook | current/local | local、E2E、CI 與開發用 migration 操作 |
+| `docs/staging-runbook.md` | runbook | current UAT only | staging demo/UAT；不是 production contract |
+| `docs/production-readiness.md` | readiness | unresolved | production sign-off、rollback 與 RTO/RPO gaps |
+| `docs/cloud-architecture.md` | architecture | proposed baseline | 已驗證 staging 基線與 production 待決項目；非 production final design |
+| `docs/spec/tech-stack.md` | technical decisions | current/provisional | 已採用技術與仍待 production 確認的選項 |
+| `docs/spec/tasks.md` | roadmap | historical | 舊實作切片；checkbox 不代表現況或完成度 |
+| `docs/vertical-slice-handbook.md` | handbook | historical example | 早期 slice 教學；工程規範以 `docs/.rules/**` 為準 |
+| `docs/wiki-drafts/**` | draft | historical/provisional | operator 草稿，不是部署或 production contract |
+| `docs/reportfile/**` | binary reference | local/untracked | legacy 報表樣本；不得視為 API/domain contract |
+| `README.md` | repository overview | current descriptive | 導覽與高階現況；具體contract仍依本頁權威順序 |
+| `CLAUDE.md` | agent context | tooling guidance | 不得覆蓋`AGENTS.md`、canonical rules或machine contracts |
+| `cicd.md` | delivery notes | historical/provisional | 早期CI/CD規劃；現行pipeline以`.github/workflows/**`為準 |
+
+## Maintenance Rules
+
+- 新 business rule 只有在使用者明確確認後才能寫入 `domain-rule.md`。
+- OpenAPI 先改 `docs/spec/src/**`，再 bundle/generate；不直接改 generated output。
+- Schema 變更先新增 DB migration，再更新 `docs/spec/schema.sql` reference。
+- Roadmap、runbook、ADR、as-is model 不可用「規則」語氣替代未確認 business decision。
+- Production data、PII、token、credential、dump、migration JSON 與 runtime report 不得加入 tracked docs。

--- a/docs/cloud-architecture.md
+++ b/docs/cloud-architecture.md
@@ -406,7 +406,6 @@ verified with GCP Billing and the Pricing Calculator before production go-live.
 ### Staging v1
 
 - Firebase Hosting admin frontend.
-- Cloudflare Pages brand frontend.
 - Cloud Run core backend.
 - Cloud SQL private IP with VPC / Direct VPC egress.
 - Secret Manager env injection.
@@ -420,6 +419,8 @@ verified with GCP Billing and the Pricing Calculator before production go-live.
 - Smoke checks for deployment, database preparation, Firebase Auth, signed URL
   upload, and log visibility.
 - Cloud Scheduler jobs are excluded from the first staging demo wave.
+- Cloudflare Pages brand frontend deployment is a separate repository follow-up;
+  only the core public brand endpoints belong to this backend contract.
 - Deployment starts from the backend `staging` branch as the deployment-intent
   branch. Promotion is normally `dev` to `staging` by pull request. A `staging`
   branch push runs GitHub Actions predeploy checks, waits for GitHub `staging`

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -1,0 +1,51 @@
+# Current-State Inventory
+
+狀態日期：2026-07-10。本文只描述 repo 現況，不判定 implementation 是否為最終 domain truth。完成度由 OpenAPI source、DB migrations、application/domain/router 與 tests 交叉驗證，不使用 [`spec/tasks.md`](spec/tasks.md) checkbox。
+
+## Status Definitions
+
+- `implemented`：route/use case/persistence 已存在，且有相符的 contract 或 focused tests。
+- `partial`：主要路徑存在，但必要 side effect、production guarantee 或完整 use case 尚缺。
+- `reserved`：schema、event 或 contract 有預留，但 runtime 沒有承諾對應行為。
+- `not implemented`：文件曾描述或 production 需要，但 repo 沒有可執行路徑。
+
+## Functional Inventory
+
+| Bounded context／能力 | 狀態 | As-is 證據與限制 |
+| --- | --- | --- |
+| Identity authentication | implemented | Firebase 驗 ID token；middleware 再以 `firebase_uid` 載入 DB user principal。 |
+| RBAC + property scope authorization | implemented | Router policy、property resolver 與 DB principal 的 `role` / `assigned_property_ids` 執行授權；owner scope 另以 property ownership 判斷。 |
+| Custom Claims synchronization | partial | Firebase adapter可寫 claims，但 runtime authorization 仍以 DB principal 為準；`permission_overrides` 的正式 domain 語意未確認。 |
+| User lifecycle / property assignments / password reset | implemented | OpenAPI、application services、Firebase/email adapters 與 focused tests 已存在。 |
+| Properties / rooms / dashboards / public availability | implemented | CRUD/read models、room maintenance入口與 approved public availability view 已存在。 |
+| Room recovery after repair completion/cancellation | implemented | Repair complete/cancel在同一transaction執行room recovery；只有該room沒有其他active repair時才恢復vacant。Events只保留trace。 |
+| Tenants / leases / cadence / bill pre-generation | implemented | Tenant、lease、replacement、rent/electric cadence 與預產 bill use cases 已存在。 |
+| Lease termination room/tenant status follow-up | partial | `LeaseCreated` / `LeaseTerminated` 以 synchronous post-commit subscriber 更新 room/tenant；失敗無 durable retry，可能與 lease state 不一致。 |
+| Lease replacement meter baseline | not implemented decision | Replacement流程存在，但新 lease meter baseline 的正式規則未確認。 |
+| Checkout preview/finalize/export | implemented | Backend preview token、transaction內重算/finalize、persisted settlement snapshot與 HTML export 已存在。Amendment/reopen 未實作。 |
+| Bills / meter / payment / receipts | implemented | Meter計價、收款與 receipt 路徑已存在；payment/accounting entry在同一 transaction。 |
+| Force termination | partial/risky | Runtime會 write off 未結帳 bills 並處理押金，但「哪些 bills 可 write off」仍是未確認 production domain decision。 |
+| Property accounting / financial reports / snapshots | implemented | Accounting titles、entries、月結 snapshot、report/read/export 路徑已存在。月結後補帳與 amendment 未實作。 |
+| Journal logs / repair workflow | implemented | Journal、費用accounting、repair assign/progress/complete/cancel與conditional room recovery已存在。 |
+| Attachments | implemented core / partial operations | Signed upload、register、list、download與多資源關聯已存在；upload-token/GCS cleanup jobs未實作，retention、ID copy、hard-delete與legacy object mapping尚未確認。 |
+| Scheduler endpoints | implemented six jobs | Lease expiry、lease expiring soon、force termination compensation、overdue scan/reminder與monthly snapshots受保護endpoint已存在；production schedule/operations仍需部署確認。 |
+| Email notifications | partial | Onboarding/password reset與部分 scheduler通知有 direct flow；部分 published events只有 trace/reserved，財報 send event沒有 delivery subscriber。 |
+| Brand management / public brand reads | implemented | Brand profile/FAQ admin paths與 approved-view public reads 已存在；brand site deployment屬另一 repo。 |
+| Legacy estate migration | partial / UAT fixture | Properties、rooms、tenants、leases、room status、bills、journal與 validation stages 已存在；accounting、identity/property assignment、attachments與 production completeness仍缺。 |
+| Production cutover | not implemented contract | Write freeze/delta、final sign-off、rollback及 RTO/RPO 尚未確認。 |
+
+OpenAPI目前包含75個paths與103個operations；generated server interface與router policies各有103個對應handler/policy，結構上完整對齊。
+
+## Contract Boundaries
+
+- OpenAPI source 是 `docs/spec/src/**`；`docs/spec/openapi.yaml` 與 `internal/http/api/openapi.gen.go` 是 derived output。
+- DB schema 的執行證據是 `internal/platform/database/migrate/migrations/*.up.sql`；`docs/spec/schema.sql` 是 reference snapshot。
+- API 中沿用的 `BR-*` 標籤描述目前 transport/runtime contract；若該議題列在 [`design/decision-backlog.md`](design/decision-backlog.md)，不代表 production domain decision 已確認。
+- `docs/mirgations` 的 JSON 與 `artifacts` report 是 ignored development/UAT input/evidence，不是版本控制的完成證明。
+
+## Known Consistency Risks
+
+1. Lease建立/終止後的 room與tenant核心狀態透過 post-commit event subscriber更新；commit後 subscriber失敗無 rollback或durable retry。
+2. Legacy migration把部分 meter/payment/rent狀態從不足的來源推導；這只能視為現行 importer行為，不能作為歷史付款真相。
+3. Final legacy validator可證明部分 target內部一致性，但尚未全面強制 `source = mapped + approved skipped`。
+4. `permission_overrides` 已存在資料欄位與API模型，但正式合併、優先順序及限制語意尚未成為 canonical rule。

--- a/docs/design/decision-backlog.md
+++ b/docs/design/decision-backlog.md
@@ -1,0 +1,22 @@
+# Domain Decision Backlog
+
+以下議題尚未被確認，或雖有現行 implementation 但存在 production 風險。它們不是 [`domain-rule.md`](domain-rule.md) 的延伸，也不得從 schema、OpenAPI或 importer現況反推答案。
+
+| 議題 | 類型 | 已知 as-is／風險 | 確認前不得假設 |
+| --- | --- | --- | --- |
+| 歷史付款真相與 legacy accounting mapping | shared cross-module | Estate accounting尚未納入 importer；meter/date不足以證明付款 | paid、overdue、押金與收支狀態 |
+| 提前退租的未來帳單 | Leasing/Billing | runtime有預產帳單與多種終止流程 | 哪些 void、保留、結算或退款 |
+| 強制終止可 write off 範圍 | Leasing/Billing | runtime會處理未結帳單，但語意過寬 | 哪些 bill type、period與狀態可列呆帳 |
+| Lease replacement meter baseline | Leasing/Billing | replacement存在，baseline未定義 | 沿用舊讀數、要求新讀數或其他策略 |
+| 共同承租人 | Leasing | current schema一份租約只連一位tenant；live legacy有雙承租 | 忽略第二人、合併身份或新增關聯模型 |
+| 月結後補帳、重開與 amendment | Billing | snapshot/finalized settlement視為不可變 | 更正方式、版本、沖銷與重開權限 |
+| Tenant去重與自然人identity | Leasing | legacy一個來源ID對一tenant | 同名/同聯絡方式是否為同一自然人 |
+| Owner移轉與歷史owner | Identity/Property | property只有現行owner關聯 | 移轉生效日、歷史查詢與報表顯示 |
+| `permission_overrides` 正式語意 | Identity | 欄位已存在，授權主要使用role/property scope | allow/deny優先序、可覆寫範圍與稽核 |
+| Attachment retention、ID影本與hard delete | shared | runtime支援upload/register/read | 保存年限、合法目的、刪除與稽核 |
+| Legacy attachment object mapping | migration/shared | legacy metadata存在，object尚無stage | resource對應、缺檔、checksum與挑選範圍 |
+| Production cutover write freeze/delta/rollback | migration/operations | importer是one-shot，尚無正式cutover contract | freeze窗口、delta來源、rollback點與責任人 |
+
+## Decision Gate
+
+每一項在移入 canonical rule 前，至少要確認生命週期、授權、歷史資料、刪除/更正、transaction boundary與cross-module side effects。確認結果只寫最終規則；討論過程與方案比較留在對應ADR或Linear工作項。

--- a/docs/design/decisions/0001-authorization-principal.md
+++ b/docs/design/decisions/0001-authorization-principal.md
@@ -1,0 +1,18 @@
+# ADR 0001: DB Principal Is The Authorization Source
+
+- Status: Accepted
+- Last verified: 2026-07-10
+
+## Context
+
+Firebase ID token能證明外部身份，repo同時保存role、property assignments與permission metadata。舊文件曾把Custom Claims描述為runtime authorization authority，會造成claims與DB drift時的雙重真相。
+
+## Decision
+
+Firebase Auth只負責驗證身份。Backend以verified `firebase_uid`載入active DB user，並以DB principal的role與assigned properties執行RBAC/resource authorization。Owner access另以property ownership解析。Custom Claims可以作同步或相容資料，但不得覆蓋DB principal。
+
+## Consequences
+
+- 每個authenticated request需要DB principal lookup。
+- User不存在、停用或DB assignment更新時，以DB現況為準。
+- `permission_overrides`的business semantics未由本ADR決定，仍在decision backlog。

--- a/docs/design/decisions/0002-event-boundary.md
+++ b/docs/design/decisions/0002-event-boundary.md
@@ -1,0 +1,18 @@
+# ADR 0002: Transaction And Post-Commit Event Boundary
+
+- Status: Accepted with known risk
+- Last verified: 2026-07-10
+
+## Context
+
+現行event bus在DB commit後同步dispatch，沒有outbox、retry或durable delivery。部分核心room/tenant lifecycle side effects仍使用這條路徑。
+
+## Decision
+
+需要與command保持強一致的核心狀態與財務side effects，必須在application command的同一DB transaction內direct orchestration。Post-commit subscriber只適用於失敗後不需rollback原command、且沒有durable delivery需求的follow-up。Published-only event不得被文件描述成已實作downstream behavior。
+
+## Consequences
+
+- Payment/accounting、deposit、checkout、journal expense、property account與maintenance/repair creation維持同transaction。
+- Lease與room/tenant status subscribers是current as-is exception與已知風險，不代表此模式適合新增核心狀態。
+- 若要消除exception，需另行決定direct orchestration、reconciliation或durable delivery方案；本文件不改application behavior。

--- a/docs/design/decisions/0003-cloud-baseline.md
+++ b/docs/design/decisions/0003-cloud-baseline.md
@@ -1,0 +1,18 @@
+# ADR 0003: Cloud Architecture Baseline Status
+
+- Status: Proposed for production; verified for the documented staging/UAT slice only
+- Last verified: 2026-07-10
+
+## Context
+
+Repo已有Cloud Run/Cloud Build/Cloud SQL staging部署與runbook證據，但production sizing、HA、backup/PITR、ingress、operator access、cutover與recovery objectives仍未確認。
+
+## Decision
+
+[`../../cloud-architecture.md`](../../cloud-architecture.md)是cloud architecture baseline，不是production final design。[`../../staging-runbook.md`](../../staging-runbook.md)只約束first staging demo/UAT slice。Production必須通過獨立readiness與cutover sign-off，不能由staging成功推定。
+
+## Consequences
+
+- Staging runbook不得承諾production RTO/RPO、rollback或data migration guarantees。
+- Cloud SQL tier、HA、PITR、minimum instances、ingress與production deployment flow維持proposed/TBD。
+- Production gaps集中在[`../../production-readiness.md`](../../production-readiness.md)。

--- a/docs/design/domain-model.md
+++ b/docs/design/domain-model.md
@@ -1,708 +1,141 @@
-Domain Model
+# Domain Model
 
-> 版本：v3.5
-> 更新說明：
-> - v2.0：經四輪多角色設計評審產出
-> - v2.1-v2.8：歷次 Validation 修正
-> - v2.9：補 paymentMethod 欄位、expired → terminated 狀態轉換、Tenant status 轉換邏輯、monthly_snapshots 拆兩層 table、force_termination_bills 拆表移除 bill_ids[]、補 overdue_notice_count Index、Notification event payload 要求
-> - v3.0：認證機制改為 Firebase Auth + Custom Claims，移除自建 JWT 與 password_hash，users table 改存 firebase_uid
-> - v3.2：新增共用附件機制（GCS Signed URL + nonce 綁定 + 各資源獨立附件表），補 BR-18、附件相關 Read Models、排程任務、ADR
-> - v3.3：電費單價改為可接受浮點數；電費帳單 amount 維持台幣整數，計算後採四捨五入
-> - v3.4：補事件邊界分類矩陣，對齊目前 in-process post-commit event bus 與 direct orchestration 邊界
-> - v3.5：補租金帳單 cadence domain rules，明確分離 rent billing cadence 與 electricity billing cadence
+狀態：current as-is model，驗證日期 2026-07-10。
 
----
+本文描述目前 bounded contexts、aggregates、states、lifecycles 與 cross-BC boundaries。它不定義新的 business rules；已確認規則見 [`domain-rule.md`](domain-rule.md)，未確認或具風險的議題見 [`decision-backlog.md`](decision-backlog.md)，技術取捨見 [`decisions/`](decisions/)。
 
 ## Bounded Contexts
 
-| BC 名稱 | 核心職責 | 上游依賴 | 下游消費者 |
-|---------|---------|---------|-----------|
-| Identity & Access | 使用者帳號、角色、權限管理、物業指派 | 無 | 所有 BC |
-| Property | 物業與房間基本資料及狀態管理 | Identity & Access | Leasing, Journal, Billing |
-| Leasing | 租客資料、租約建立／終止、帳單預產 | Property, Identity & Access | Billing, Property, Notification |
-| Billing | 電表抄錄、費用計算、帳單收款、財報產生 | Leasing, Property | Notification |
-| Journal | 物業日誌記錄、維修派工、報修通報、日誌費用 | Property, Identity & Access | Billing, Property, Notification |
-| Notification | 各類通知寄送、收據與財報檔案產生與輸出 | 所有 BC | 無 |
+| Bounded context | 核心責任 | Current status |
+| --- | --- | --- |
+| Identity & Access | Firebase identity對應、DB user、role與property scope | implemented；`permission_overrides`語意 unresolved |
+| Property | Property、Room、occupancy、maintenance與dashboard read models | implemented；lease lifecycle的post-commit occupancy仍有一致性風險 |
+| Leasing | Tenant、Lease、cadence、replacement、termination與checkout settlement | implemented；co-tenant、early termination future bills、replacement meter baseline unresolved |
+| Billing | Bill、meter、payment、accounting、snapshot與financial reports | implemented；historical accounting mapping與post-close amendment unresolved |
+| Journal | JournalLog、expense與RepairRequest workflow | implemented；repair complete/cancel會在同一transaction處理room recovery |
+| Attachment | Upload authorization、metadata registration、resource access | runtime implemented；retention/hard-delete/legacy mapping unresolved |
+| Notification | Email adapter、onboarding與scheduler通知 | partial；多個events只有trace/reserved，非delivery承諾 |
+| Brand Public Read | Approved-view based public profile/FAQ/availability | implemented |
 
-> **v2.1 修正**：Billing 上游依賴移除 Journal（Journal 是事件發出方，Billing 是消費者，非 Billing 主動呼叫 Journal）。Journal 下游消費者補上 Billing。
->
-> **架構說明**：STDS 為單一服務（monolith），BC 為邏輯邊界，不是部署邊界。跨 BC 的協調透過 in-process event bus 或 Application Service 直接呼叫，無需 message queue。
+STDS目前是單一Go service。Bounded context是邏輯與ownership邊界，不代表獨立部署。
 
----
+## Identity And Access
 
-## Bounded Context 說明
+### User
 
-### Identity & Access
+- Firebase Auth管理authentication；DB `users` record透過`firebase_uid`連結外部身份。
+- Request authorization principal由middleware載入DB user後建立；role與property assignments以DB值為runtime source of truth。
+- Roles目前為admin、organizer、staff、owner。
+- Property access由router policy、resource/property resolver與authorization middleware共同執行。
+- Firebase Custom Claims讀寫能力仍存在，但不是runtime authorization authority。
+- `permission_overrides`有storage/API representation，正式allow/deny與priority語意尚未確認。
 
-負責工作室成員與業主的帳號管理，包含角色指派、個別權限覆寫，以及將物業指派給成員。授權模型為混合型：RBAC 做基礎功能控管，物業層級採 resource-based 控管。
+## Property
 
-業主帳號由工作室建立，業主只能登入查看自己物業狀況，無任何修改權限。
+### Property
 
-**物業指派為 Identity BC 的唯一來源**，Property BC 及其他 BC 查詢操作權限時，呼叫 Identity BC 的 Application Service 驗證，不另存副本。
+- 保存owner、名稱、地址、電價與default electricity cadence等現行狀態。
+- Property建立時，PropertyAccount在同一transaction建立。
+- Public brand availability透過approved database view暴露，不允許public handler直接讀取敏感base tables。
 
-**認證機制**：系統使用 Firebase Auth 管理使用者認證。後端不儲存密碼，使用者帳號在 Firebase 建立，DB 的 `users` table 透過 `firebase_uid` 與 Firebase 帳號對應。登入流程由前端 Firebase SDK 處理；建立帳號後的設定密碼信由後端向 Firebase 產生 password reset link，再透過 email 發送。既有使用者若需重寄設定密碼信，由系統管理員透過管理 API 觸發。
+### Room
 
-### Leasing
+- States：`vacant | occupied | maintenance`。
+- 建立lease後，runtime以post-commit `LeaseCreated` subscriber改為occupied。
+- 終止lease後，runtime以post-commit `LeaseTerminated` subscriber改為vacant。
+- 設為maintenance時，room狀態與room-scoped repair request在同一transaction建立。
+- Repair complete/cancel會在同一transaction執行conditional room recovery；仍有其他active repair時維持maintenance。對應event只保留trace。
 
-管理租客資料與租約生命週期。租客資料（Tenant）與租約（Lease）獨立建立，先建 Tenant 再建 Lease。Tenant record 長期保留，退租後再租直接關聯同一 Tenant，新建 Lease。
+Room/tenant lease side effects已實作，但post-commit失敗無durable retry，因此屬已知一致性風險，不是原子保證。
 
-**不支援 LeaseRenewed**：續約一律以「舊租約終止 + 新租約建立」處理，確保帳單和押金歷史清晰。
+## Leasing
 
-租約建立時，系統於整個租約期間預產所有帳單（租金帳單 + 電費帳單）。租金帳單初始狀態為 `pending_payment`，電費帳單初始狀態為 `pending_meter`，等待該帳單所屬 billing period 抄表後更新金額。
+### Tenant
 
-**租金帳單 cadence 與金額語意**：Lease 於建立時決定 `rentBillingCadence`（`monthly | quarterly | semiannual | annual`）。`rentAmount` 是每個租金計費週期的金額，不是月租 baseline。租金 bill period 以 Lease start date 為 anchor，依 `rentBillingCadence` 每次前進 1 / 3 / 6 / 12 個月，且 `dueDate = periodStart`。最後一個不足完整 cadence 的短租金 period 仍收完整 `rentAmount`；first launch 不做租金 proration。例外差額若需要處理，應透過 journal/accounting-style flow 另行記錄，不塞入租金帳單 proration。
+- Tenant與Lease分開保存，tenant可跨多份lease重用。
+- States：`active | inactive`。
+- 新lease的post-commit subscriber可把tenant設為active；lease終止後另一subscriber在沒有active/expired lease時設為inactive。
+- 自然人identity、legacy dedupe與共同承租人仍未定義。
 
-**租金付款日語意**：租金付款日由租金 bill period 決定，固定為該 rent period 的 `periodStart`。付款日不可單獨修改，屬於租約起始條件與 `rentBillingCadence` 的一部分。
+### Lease
 
-Lease 於建立時也決定 `electricityBillingCadence`（`monthly | bimonthly`）。若 request 未帶值，套用 Property 的 `defaultElectricityBillingCadence`。`rentBillingCadence` 與 `electricityBillingCadence` 是兩個獨立租約條件，不可共用驗證或 period generation 規則。Lease 建立後 cadence 不可用一般編輯修改；若需更動 rent 或 electricity cadence、續約重簽、或其他少數條件重建，走 `LeaseReplaced` 流程，以「終止舊 Lease + 建立新 Lease」處理。
+- States：`active | expired | terminated | force_terminated`。
+- 保存rent/electricity billing cadences、deposit、start/end dates、optional actual move-out date、starting meter與settlement detail。
+- Create flow會在transaction內建立lease並預產rent/electricity bills，再於commit後發布`LeaseCreated`。
+- Update flow只支援現行contract允許的租金條件調整；cadence改變使用replacement flow。
+- Replacement flow在同一command中終止舊lease、建立新lease與bills，再發布termination/creation events。Meter baseline仍是decision backlog。
+- Normal termination/checkout finalize在transaction內完成核心lease、deposit、accounting與settlement state，再發布`LeaseTerminated`。
+- Force termination有獨立record與bill write-off流程；允許write off的精確bill集合尚未成為production rule。
 
-租金調整（`LeaseConditionChanged`）時，void 所有 `due_date >= nextRentPeriodStart` 且狀態為 `pending_payment` 的租金帳單（狀態改為 `voided`），從 `nextRentPeriodStart` 起依原 `rentBillingCadence` 重產新金額租金帳單。`nextRentPeriodStart` 為 operationDate 之後的第一個 rent billing period start。當期租金帳單不受影響，即使尚未到期。`LeaseConditionChanged` 僅涵蓋租金金額調整，不含付款日修改與 cadence 修改。
+### Checkout Settlement
 
-### Billing
+- Preview是read/compute operation，不改變state；結果包含blockers、warnings、lines、totals與token。
+- Finalize會在lock/transaction boundary內重算並驗token，保存settlement snapshot、處理deposit/accounting並終止lease。
+- Completed export從persisted settlement snapshot render，不從mutable joins重建。
+- Reopen/amendment尚未實作或確認。
 
-電表抄錄、帳單管理與收款確認。帳單分為租金帳單與電費帳單，電費帳單在租約建立時即依 `electricityBillingCadence` 預產（`pending_meter`）。抄表 command 在同一 transaction 內計算用電金額並將帳單更新為 `pending_payment`，`MeterRecorded` event 僅保留為 domain trace / future extension。
+## Billing
 
-每日排程任務掃描逾期帳單（`due_date < today AND status = pending_payment`），批次更新為 `overdue`。允許 `overdue → paid` 轉換（逾期帳單仍可收款）。
+### Bill
 
-收款確認後在同一 transaction 內產生 `AccountingEntry`；`BillPaid` event 不負責 PropertyAccount 寫入，僅保留為 domain trace / future notification candidate。
-收款金額必須等於帳單金額；系統不支援部分收款或溢收。可收款狀態限 `pending_payment` 與 `overdue`，其中 `overdue → paid` 明確允許。
+- Types：`rent | electricity`。
+- Rent lifecycle包含`pending_payment`、`overdue`、`paid`、`voided`與`written_off`。
+- Electricity lifecycle從`pending_meter`進入付款狀態，並可進入`overdue`、`paid`、`voided`或`written_off`。
+- Meter command在同一transaction計算usage/amount並更新bill；`MeterRecorded`只保留trace/reserved用途。
+- Payment command在同一transaction更新bill並建立AccountingEntry；`BillPaid`不負責補寫accounting。
+- Overdue scanning與reminder由scheduler use cases處理。
 
-**LeaseTerminated 後的處理**：目前沒有 Billing BC runtime subscriber。正常終止時帳單應已全清；強制終止時未結清帳單在 command 內同步標記 `written_off`、記錄 force termination progress，並完成 force termination。若未來需要處理剩餘預產帳單 void，應先確認是否需與 termination command 強一致。
+### PropertyAccount And Reports
 
-**強制終止租約**（呆帳情境）：由主辦以上角色執行，流程記錄於 `force_terminations` table（Billing BC），在同一 command 中同步將未結清帳單標記為 `written_off`、記錄 `termination_date` 與 `deposit_handling` 決策、完成 ForceTermination，並發出 `LeaseTerminated`。`termination_date` 會寫入 `leases.end_date`；`actual_move_out_date` 為可選實際搬出 / 點交日 metadata，不影響 write-off、押金處理或租金退費。
+- PropertyAccount保存當期AccountingEntry；來源包含bill payment、journal expense、deposit/refund/deduction與checkout effects。
+- Monthly snapshot保存finalized entries與當時的accounting title/display facts。
+- Current report組合當期entries與historical snapshots；HTML exports由backend render。
+- 月結後補帳、重開與amendment尚未確認。
 
-### Journal
-
-分為兩個子模組：
-
-- **JournalLog**：純文字紀錄與費用記錄（如日常維護費用），無狀態機
-- **RepairRequest**：報修派工，有完整狀態機，派工對象為系統內員工（員工負責線下聯絡廠商）
-
-### Notification
-
-租客無系統帳號，所有通知以 Email 發送。通知發送紀錄不存儲，發出即視為完成。
-
-**通知觸發時機：**
-
-| 通知類型 | 觸發時機 | 收件人 | 觸發來源 |
-|---------|---------|-------|---------|
-| 帳單通知 | 帳單預產完成 | 租客 | 尚未承諾；`RentBillsGenerated` 不存在於目前 runtime event structs |
-| 收款收據 | 帳單收款確認（`BillPaid`） | 租客 | 尚未承諾；`BillPaid` 目前只保留為 trace / future notification candidate |
-| 逾期催收通知 | 每週排程，最多 3 次 | 租客 | 排程任務 |
-| 退租確認 | `LeaseTerminated`（forced: false **且** isReplacement: false） | 租客 | 尚未承諾 |
-| 強制終止通知 | `LeaseTerminated`（forced: true） | 租客 | 尚未承諾 |
-| 租約到期提醒 | 到期前 30 天排程 | 主辦、員工 | 排程任務 |
-| 財報寄送 | 主辦手動審核後觸發 | 業主 | 應由 send flow direct orchestration 處理 |
-
----
-
-## Aggregates
-
-### Tenant Aggregate（Leasing BC）
-
-- **Root Entity**：Tenant
-- **包含**：基本資料、聯絡方式清單（Value Objects）
-- **status**：`active | inactive`（有效租約時 `active`，所有租約終止後改 `inactive`）
-- **status 轉換邏輯**：Leasing BC Application Service 在 `LeaseTerminated` 後，查詢該 Tenant 是否還有其他 `active` 或 `expired` 的 Lease，若無則自動改為 `inactive`。新建 Lease 時若 Tenant 為 `inactive`，自動改回 `active`。
-- **一致性邊界**：租客資料自成一體，與租約獨立建立；Tenant record 長期保留不刪除
-- **併發策略**：樂觀鎖
-
-### Lease Aggregate（Leasing BC）
-
-- **Root Entity**：Lease
-- **status**：`active | expired | terminated | force_terminated`
-  - `active`：建立時預設
-  - `expired`：到期日到達，排程標記，房間維持 `occupied` 等人工處理；允許直接執行正常終止（補辦手續），條件同正常終止（帳單全清）
-  - `terminated`：正常終止（含從 expired 補辦）
-  - `force_terminated`：強制終止
-- **包含**：
-  - 租約條件（租金、起訖日）
-  - `rentBillingCadence: monthly | quarterly | semiannual | annual`
-  - `electricityBillingCadence: monthly | bimonthly`
-  - `deposit: Deposit`（Value Object）
-    - `amount`（原始押金金額）
-    - `deductionAmount`（optional，扣款金額）
-    - `deductionReason`（optional）
-    - `refundAmount`（optional，退還金額）
-    - `status: held | settled | written_off`（初始狀態為 `held`，租約建立時自動設定）
-      - `settled`：押金處理完畢，涵蓋全額退還（refundAmount = amount）、全額扣款（deductionAmount = amount）、部分扣款後退餘額（deductionAmount + refundAmount = amount）三種情境
-      - `written_off`：強制終止時標記
-- **一致性邊界**：
-  - 帳單隨租約刪除而刪除
-  - 正常終止：需所有帳單結清（含押金狀態確認）才能執行
-  - Lease replacement：作為特殊條件重建例外，允許 `depositHandling = carry_over`，不在終止舊 Lease 時結清押金
-  - 強制終止：主辦以上角色執行，未結清帳單標記 `written_off`，記錄呆帳原因
-  - 押金退還／扣款透過 Lease Aggregate 操作
-- **併發策略**：樂觀鎖
-
-### Property Aggregate（Property BC）
-
-- **Root Entity**：Property
-- **包含**：
-  - Room entities（含狀態）
-  - `electricityUnitPrice`（台幣正數/度，物業層級電價，可接受小數，例：4.5）
-  - `defaultElectricityBillingCadence: monthly | bimonthly`
-- **Room 狀態**：`vacant | occupied | maintenance`
-- **狀態轉換**：
-  - `vacant → occupied`：訂閱 `LeaseCreated`
-  - `occupied → vacant`：訂閱 `LeaseTerminated`
-  - `vacant → maintenance`：主辦或員工透過 `POST /rooms/{id}/maintenance` 手動操作；同一 transaction 內建立 room-scoped `RepairRequest`，並發出 `RoomSetToMaintenance`
-  - `maintenance → vacant`：應由 repair workflow direct orchestration 檢查該 Room 所有 RepairRequest 均為 `completed` 或 `cancelled` 後改回 `vacant`；目前 runtime 尚未實作此後置處理，不應依賴沒有 durable guarantee 的 post-commit subscriber 承擔此強一致性狀態更新
-- **一致性邊界**：房間隨物業刪除而刪除；房間狀態由 Property Aggregate 統一管理
-- **併發策略**：樂觀鎖
-
-### Bill Aggregate（Billing BC）
-
-- **Root Entity**：Bill
-- **包含**：
-  - `type: rent | electricity`（預產時帶入）
-  - `room_id`（從 Lease 取得，直接存入，電表查詢不需 JOIN）
-  - `lease_id`
-  - `periodStart`
-  - `periodEnd`
-  - 付款紀錄（Value Object）
-    - `paymentMethod: cash | transfer | other`（收款確認時填入）
-    - `paidAt`
-    - `paidAmount`
-  - 帳單狀態
-  - `meterReading: MeterReading`（optional Value Object，電費帳單專用）
-    - `previousReading`（系統查詢填入，不由員工輸入；取同 room 最近一張已完成上一個 electricity billing period 的帳單）
-    - `currentReading`
-    - `unitPrice`（抄表當下從 Property 取得並鎖定，台幣正數，可接受小數）
-    - `recordedAt`
-  - `sourceRef`（optional）：`{ type: 'repair', id: RepairRequestId }`（預留，現階段不實作）
-  - `writtenOffReason`（optional，強制終止時使用）
-  - `overdue_notice_count`（整數，逾期催收通知已寄次數，上限 3）
-- **帳單狀態機**：
-  - 租金帳單：`pending_payment → paid | overdue | voided | written_off`
-  - 電費帳單：`pending_meter → pending_payment → paid | overdue | voided | written_off`
-  - 補充轉換：`overdue → paid`（逾期帳單仍可收款）
-- **一致性邊界**：收款確認後產生 `AccountingEntry`，不可重複收款
-- **收款規則**：`paidAmount` 必須等於帳單 `amount`；不支援部分收款或溢收
-- **金額儲存**：台幣整數（無小數）
-- **電費換算規則**：`rawAmount = usage × MeterReading.unitPrice`，`amount = round(rawAmount)`（四捨五入為最終帳單金額）
-- **併發策略**：樂觀鎖（逾期掃描與付款衝突時，樂觀鎖讓一方失敗，付款方優先，批次任務跳過衝突帳單）
-
-### PropertyAccount Aggregate（Billing BC）
-
-- **Root Entity**：PropertyAccount（一個物業一個）
-- **包含**：當月未結算的 AccountingEntry entities
-  - 來源：Bill payment command 直接寫入；Journal expense command 直接寫入並保留 `JournalExpenseRecorded` 作 trace/reserved event；DepositRefunded / DepositDeducted 由押金處理 command 直接寫入；強制終止 `deposit_handling=write_off` 由 force termination command 直接以 `deposit_deduction` 寫入全額押金沒收分錄
-  - `category: rent_payment | electricity_payment | deposit_refund | deposit_deduction | journal_expense`（財報分類用）
-  - `accounting_title_id` / `accounting_title_code` / `accounting_title_name`：穩定會計科目維度；`accounting_titles` 是 runtime master data，`category` 仍是既有財報 total classification，不以 `accounting_titles.kind` 取代收入/支出計算
-  - `source_date` / `room_label` / `tenant_label` / `period_label` / `display_note`：報表列顯示事實；`source_date` 是顯示日期，不是新的 occurred-at domain model；labels/notes 由建立分錄當下保存
-- **寫入邊界**：只載入當月資料，不載入歷史分錄
-- **月結快照**：每月月底排程執行，將當月 AccountingEntry 封存為 `monthly_snapshot_entries`，一併保存 `accounting_title_id`、code/name copy 與 display fields，清空 Aggregate 內當月暫存資料
-- **初始化**：物業建立時由 property creation command direct orchestration 自動建立，生命週期與物業綁定
-- **刪除策略**：物業軟刪除時 PropertyAccount 封存，MonthlySnapshot 永久保留
-- **讀取策略**：
-  - 當月：讀取 PropertyAccount 當月 AccountingEntry
-  - 歷史：讀取 `monthly_snapshot_entries`（直接 SQL，不走 Aggregate），finalized report 使用 snapshot-preserved display fields，不回查 mutable bills/rooms/tenants/leases 重建顯示文字
-  - 財報：組合當月 + 歷史，依 category 分組顯示
-
-### JournalLog Aggregate（Journal BC）
-
-- **Root Entity**：JournalLog
-- **包含**：紀錄內容、費用條目（optional Value Object）
-- **無狀態機**
-- **費用流程**：記錄費用時，Journal command 在同一個 transaction 直接新增 AccountingEntry，並保留 `JournalExpenseRecorded` 作 trace/reserved event；accounting state 不依賴 post-commit subscriber。
-
-### RepairRequest Aggregate（Journal BC）
-
-- **Root Entity**：RepairRequest
-- **包含**：
-  - `title`
-  - `description`
-  - `assignedTo: UserId`（nullable）
-  - `submittedAt`
-  - `assignedAt`（nullable）
-  - `completedAt`（nullable）
-- **建立入口**：可由 Journal BC 的 `POST /repair-requests` 建立，也可由 Property BC 的 `POST /rooms/{id}/maintenance` 在同一 transaction 內建立 room-scoped RepairRequest 並同步將 Room 設為 `maintenance`
-- **狀態機**：
-  - `submitted → assigned → in_progress → completed`
-  - `submitted → cancelled`
-  - `assigned → cancelled`
-  - `in_progress → cancelled`
-- **cancelled / completed 後置處理**：Room 狀態恢復應由 repair workflow direct orchestration 處理；目前 `RepairCompleted` / `RepairCancelled` 已發出 event，但沒有 runtime subscriber。
-- **派工**：指派系統內員工，員工負責線下聯絡廠商
-- **與 Room 狀態關聯**：只要該 Room 尚有未完成且未取消的 RepairRequest，Room 應維持 `maintenance`；因此 BR-08 可由 Room 狀態統一表達，不另定義獨立刪除規則
-
-### User Aggregate（Identity & Access BC）
-
-- **Root Entity**：User
-- **包含**：角色（Value Object）、個別權限覆寫清單、物業指派清單、`firebase_uid`
-- **一致性邊界**：角色與權限同 User 一起管理；認證狀態由 Firebase 管理，不在此 Aggregate 範圍內
-- **併發策略**：樂觀鎖
-
----
-
-## Domain Events
-
-目前 runtime 使用 synchronous in-process post-commit event bus。`txRunner` 在 command transaction commit 成功後才 publish recorded events；subscriber 失敗不能 rollback 原 command，且沒有 outbox、retry queue、dead-letter queue、durable delivery guarantee 或外部 broker。
-
-分類定義：
-
-- `implemented pub/sub and intentionally kept`：目前有 runtime subscriber，且此專案接受 post-commit follow-up 風險。
-- `implemented pub/sub but future consistency concern`：目前有 runtime subscriber，但 side effect 屬於較強一致性資料，未來宜改 direct orchestration。
-- `command-owned direct orchestration and intentionally kept`：目前已由 command transaction 直接完成，或決策上確認應由 command transaction 直接完成，不應改成目前這種 post-commit pub/sub。
-- `published-only/reserved`：event 可作 domain trace、audit 或 future extension；目前沒有 required runtime subscriber。
-- `missing required subscriber candidate`：文件或產品語意看似要求 downstream behavior，但目前 runtime 未實作；後續仍需確認 boundary。
-- `obsolete event expectation`：現有實作已採其他路徑，event/subscriber 不應再被視為主流程承諾。
-- `decision needed`：目前不承諾 runtime behavior，需另行確認。
-
-| Event / side effect | Current runtime implementation | Classification | Transaction consistency reason | Follow-up status |
-|---------------------|--------------------------------|----------------|-------------------------------|------------------|
-| `LeaseCreated -> room occupied` | `LeaseCreated` is recorded by create / replacement lease commands; `OccupyRoomOnLeaseCreatedHandler` is wired in `server.New()` | implemented pub/sub and intentionally kept | Room state is updated after lease commit; this project accepts the post-commit inconsistency risk for now | Verify in #49, including replacement sequence |
-| `LeaseCreated -> tenant active` | `ActivateTenantOnLeaseCreatedHandler` is wired in `server.New()` | implemented pub/sub and intentionally kept | Tenant reactivation is post-commit follow-up; current project risk is acceptable | Verify in #49 |
-| `LeaseTerminated -> room vacant` | Normal termination, force termination, and replacement old-lease termination record `LeaseTerminated`; `ReleaseRoomOnLeaseTerminatedHandler` is wired | implemented pub/sub and intentionally kept | Room release happens after lease commit; replacement emits `LeaseTerminated` before `LeaseCreated`, so tests must confirm final state | Verify in #49, especially replacement |
-| `LeaseTerminated -> tenant inactive` | `DeactivateTenantOnLeaseTerminatedHandler` is wired and checks remaining active / expired leases | implemented pub/sub and intentionally kept | Post-commit tenant deactivation is accepted; replacement should not deactivate when successor lease exists | Verify in #49 |
-| Lease creation / replacement bill pre-generation | Lease create and replacement commands directly create rent and electricity bills in the lease transaction | command-owned direct orchestration and intentionally kept | Lease and initial bills should succeed or fail together | No subscriber needed |
-| Lease rent adjustment bill cleanup / regeneration | `UpdateLeaseService` directly voids future rent bills and creates replacement rent bills | command-owned direct orchestration and intentionally kept | Rent change and generated bill state are one business transaction | No subscriber needed |
-| `LeaseConditionChanged` | Event is recorded after rent adjustment; no runtime subscriber | published-only/reserved | Bill regeneration is already direct; event is trace/future extension only | No implementation commitment |
-| `LeaseReplaced` | Event is recorded after replacement; no runtime subscriber | published-only/reserved | Replacement state changes and bill generation are already direct; notification/audit behavior is not required now | No implementation commitment |
-| Normal termination deposit settlement | Termination command directly settles deposit state, creates deposit accounting entries, then records `DepositRefunded` / `DepositDeducted` when applicable | command-owned direct orchestration and intentionally kept | Lease termination, deposit settlement, and deposit accounting must stay atomic | No subscriber needed |
-| Checkout settlement finalize | Checkout settlement finalize recomputes the preview under lock, verifies the preview token, persists `leases.settlement_detail`, settles deposit/accounting, terminates the lease, then records `LeaseTerminated` | command-owned direct orchestration and intentionally kept | Checkout settlement is irreversible financial state; settlement snapshot, accounting effects, and lease termination must commit or rollback together | Implemented by #120 |
-| `DepositRefunded` / `DepositDeducted -> accounting entry` | Deposit settlement commands directly create AccountingEntry rows; events are recorded only as trace / future extension signals | command-owned direct orchestration and intentionally kept | Deposit accounting is financial state and must stay atomic with lease deposit settlement | Implemented by #51; no subscriber needed |
-| Force termination write-off and completion | `ForceTerminateLeaseService` directly writes off bills, marks force termination bills done, completes force termination, then records `LeaseTerminated` | command-owned direct orchestration and intentionally kept | Write-off progress and force termination completion must be atomic with the command | No subscriber needed |
-| `BillPaid -> accounting entry` | `RecordPaymentService` directly creates AccountingEntry in the payment transaction, then records `BillPaid` | command-owned direct orchestration and intentionally kept | Payment and accounting entry must succeed or fail together | No subscriber needed |
-| `BillPaid` receipt notification | `BillPaid` is recorded; no receipt notification subscriber exists | published-only/reserved | Receipt notification is not committed as required behavior now; do not overload accounting event semantics | No implementation commitment |
-| `MeterRecorded` bill amount / status update | `RecordMeterService` directly calculates amount and updates bill state, then records `MeterRecorded` | command-owned direct orchestration and intentionally kept | Meter command's core output is the updated bill; it must be atomic | Event remains trace/reserved |
-| `JournalExpenseRecorded -> accounting entry` | Journal expense creation command directly creates AccountingEntry in the same transaction; `JournalExpenseRecorded` remains published-only/reserved with no accounting subscriber | command-owned direct orchestration and intentionally kept | Journal expense and accounting entry must succeed or fail together | Implemented by #53; no subscriber needed |
-| `PropertyCreated -> PropertyAccount` | Property creation directly creates PropertyAccount in the same command transaction, then records `PropertyCreated` as trace / future extension | command-owned direct orchestration and intentionally kept | PropertyAccount lifecycle is strongly tied to property creation | No subscriber needed |
-| `RoomSetToMaintenance` | `SetRoomMaintenanceService` directly creates room-scoped RepairRequest and sets room to maintenance, then records event | command-owned direct orchestration and intentionally kept | Room state and repair request creation must be atomic | Event remains trace/reserved; no subscriber needed |
-| `RepairCompleted` / `RepairCancelled -> room vacant` | Repair workflow records events, but room status recovery is not implemented yet | command-owned direct orchestration and intentionally kept | Room recovery affects Property aggregate state and should be strongly consistent with repair workflow | Future implementation should add direct orchestration |
-| `TenantInfoUpdated` | Tenant update records event; no runtime subscriber | published-only/reserved | No required downstream behavior currently exists | No implementation commitment |
-| `FinancialReportSendRequested` | Report send service publishes event directly after validation; no runtime subscriber sends report | obsolete event expectation | User-facing send behavior should be explicit; current event path has no delivery behavior | Future implementation should use direct send/orchestration |
-| `UserPasswordResetRequested` | Subscriber is wired, but current IAM create-user and password-reset flows call notification directly and do not publish this event | obsolete event expectation | Existing direct notification flow controls request failure semantics and is acceptable | Do not treat event path as required |
-| Scheduler overdue reminder notification | Job runner directly increments overdue notice count and sends notification in the job flow | command-owned direct orchestration and intentionally kept | Job summary depends on notification success/failure accounting | No event subscriber needed |
-| Scheduler lease expiring-soon notification | Job runner directly calls notification service per recipient | command-owned direct orchestration and intentionally kept | Job-level success/failure is owned by the scheduler use case | No event subscriber needed |
-
-> `PropertyUnassigned` and `RentBillsGenerated` are older design expectations but do not currently exist as event structs in `internal/domain/events`; they should not be treated as runtime commitments unless reintroduced by a focused issue.
-
----
-
-## Business Rules
-
-| 規則編號 | 規則描述 | 適用條件 | 拒絕行為 | 例外情況 |
-|---------|---------|---------|---------|---------|
-| BR-01 | 租約起始日不得晚於終止日 | 建立或修改租約時 | 拒絕操作 | 無 |
-| BR-02 | 租金不得為零 | 建立或變更租約條件時 | 拒絕操作 | 無 |
-| BR-03 | 押金金額不得為負 | 建立租約時 | 拒絕操作 | 無 |
-| BR-04 | 正常終止：租約終止前所有帳單必須結清 | 執行正常租約終止時 | 拒絕終止，回傳未付帳單清單 | 強制終止（主辦以上）可跳過，未結清帳單標記 written_off |
-| BR-05 | 帳單不得重複收款 | 帳單狀態已為 paid | 拒絕收款操作 | 無 |
-| BR-06 | 電表度數不得小於上月度數 | 輸入電表抄錄時 | 拒絕抄錄 | 無 |
-| BR-07 | 底下有出租中房間的物業不得刪除 | 執行物業刪除時 | 拒絕刪除 | 無 |
-| BR-08 | 出租中或維修中的房間不得刪除 | 執行房間刪除時 | 拒絕刪除 | 無 |
-| BR-09 | ~~正常退押金前必須確認所有帳單結清~~ | ~~已移除~~ | BR-04 已完整涵蓋此規則，退租流程統一由 BR-04 把關，不重複檢查 | — |
-| BR-10 | 押金扣款須填寫扣款原因 | 執行押金扣款時 | 拒絕操作 | 無 |
-| BR-11 | 物業指派對象必須為工作室成員 | 指派對象角色為業主 | 拒絕指派 | 無 |
-| BR-12 | 建立租約時目標房間必須為 vacant，且需取得 Room 的悲觀鎖後才執行檢查 | 建立租約時 | 拒絕建立 | 無 |
-| BR-13 | 系統管理員不得降低自己的角色 | 修改自身角色時 | 拒絕操作 | 無 |
-| BR-14 | 強制終止租約需主辦以上角色執行並填寫原因；`deposit_handling=write_off` 代表全額押金沒收，backend 必須在同一交易中以 `deposit_deduction` / accounting title `4601` 建立押金收入分錄，`source_ref` 保存 `type=ForceTerminationDepositWrittenOff`、`lease_id`、`force_termination_id`、`reason`；`keep_held` 不建立押金 accounting entry | 執行強制終止時 | 員工角色拒絕執行；write_off 任一核心寫入或押金 accounting 失敗則整筆 rollback | 歷史已強制終止且押金 written_off 的 backfill 另案處理，不在 runtime 行為變更內 |
-| BR-15 | 租金付款日固定為 rent billing period 的 `periodStart`；rent period 以租約起始日為 anchor，依 `rentBillingCadence` 前進 1 / 3 / 6 / 12 個月 | 租金帳單預產或租金調整重產時 | 自動計算，無需拒絕 | 最後短 rent period 仍收完整 period rent，不做 proration |
-| BR-16 | 電費帳單金額由系統計算：usage = currentReading - previousReading，rawAmount = usage × MeterReading.unitPrice，amount = round(rawAmount)；不由員工輸入金額 | 抄表送出時 | 系統自動計算並四捨五入為整數，拒絕員工直接輸入金額 | 無 |
-| BR-17 | 修改物業電價（electricityUnitPrice）需主辦以上角色，且電價僅接受大於 0 的數值，可接受小數 | 修改電價時 | 員工角色拒絕；零與負數拒絕 | 無 |
-| BR-18 | 附件允許的 MIME type：`image/jpeg`、`image/png`、`image/heic`、`application/pdf`；單檔上限 20MB | 產生 upload URL 時先驗證；Step 3 登記時再以 GCS metadata 防呆確認 | 拒絕產生 upload URL 或拒絕登記，回傳 422 | 無 |
-| BR-19 | Property 預設電費 cadence 僅影響新建 Lease；既有 Lease 不可用一般編輯修改 rent 或 electricity cadence | 修改物業預設 cadence 或編輯 Lease 時 | 拒絕以編輯 Lease 方式修改 cadence | 若需更動 rent 或 electricity cadence，走 LeaseReplaced |
-| BR-20 | Lease replacement 僅允許在完整 rent billing period boundary 與完整 electricity billing period boundary 執行 | 執行 LeaseReplaced 時 | 拒絕 replacement | 無 |
-| BR-21 | Lease replacement 前，舊 Lease 在 boundary 前的帳單必須全部結清，且不得存在 `pending_meter`、`pending_payment`、`overdue` | 執行 LeaseReplaced 時 | 拒絕 replacement，回傳未結清帳單清單 | 無 |
-| BR-22 | Lease replacement 僅支援同 tenant、同 room、同 property 的條件重建，不得用於搬房或換租客 | 執行 LeaseReplaced 時 | 拒絕 replacement | 無 |
-| BR-23 | Lease replacement 第一版僅支援 `depositHandling = carry_over`，不得在 replacement 當下結清或改寫押金狀態 | 執行 LeaseReplaced 時 | 拒絕 replacement | 需要押金狀態改變時，走其他流程 |
-| BR-24 | `rentBillingCadence` 與 `electricityBillingCadence` 是獨立租約條件，各自有獨立 allowed values、validation 與 period generation 規則 | 建立 Lease、Lease replacement、帳單預產、租金調整重產時 | 拒絕不合法 cadence 或混用 cadence 規則 | 無 |
-| BR-25 | 退租結算 preview 由 backend 計算且不得改變 business state；frontend 只能顯示 backend 回傳的 line items、blockers、warnings、net result 與 preview token | 執行 checkout settlement preview 時 | 無狀態變更；有 blocker 時不提供可 finalize 的 token | 無 |
-| BR-26 | 退租結算 finalize 必須帶入 matching preview token；backend 需在 transaction 中重新計算並比對 token，避免 stale preview 被送出 | 執行 checkout settlement finalize 時 | token 不符時拒絕 finalize，回傳 stale-preview conflict | 無 |
-| BR-27 | 正常退租結算遇到未結帳單時，backend 必須區分可由退租 `final_meter_reading` 解決的最後一期電費與其他未結帳單；可解析的最後一期電費由 backend 產生 `electricity_settlement` charge line，`source_ref` 保存 `previous_reading`、`final_meter_reading`、`usage`、`unit_price`、`amount`、nullable `source_bill_id` 與 `source_type`，即使沒有未結帳 bill 也可產生退租電費並寫入 accounting；其他 `pending_payment`、`overdue`、不可由退租解決的 `pending_meter` 仍回傳 blockers 並不得 finalize；frontend 不可自行計算或折入電費 | 執行 checkout settlement preview/finalize 時 | 有 blocker 時 finalize 拒絕；可解析退租電費納入 backend 回傳 lines/totals/preview token | 強制終止流程另走 force termination；不新增 room-level meter state |
-| BR-28 | finalized checkout settlement snapshot v1 存入 `leases.settlement_detail` 且視為 immutable；completed checkout export 必須從 persisted snapshot render，不從 frontend request 或 mutable joins 重新組出金額 | finalize 後 export/reprint 時 | 缺少 finalized snapshot 時拒絕 export | 後續若需要修正，另開 versioned amendment follow-up |
-| BR-29 | 退租結算相關押金、扣款、退款、accounting effects 與 lease termination 必須由 finalize command 在同一交易中直接完成，不透過 frontend calculation 或 post-commit subscriber 補帳 | 執行 checkout settlement finalize 時 | 任一核心寫入失敗則整筆 rollback | Room/Tenant 後置狀態仍沿用既有 `LeaseTerminated` subscriber |
-
----
-
-## Roles & Permissions
-
-授權模型：混合型（RBAC 基礎功能控管 + Resource-based 物業層級存取控制）
-
-**Resource-based 實作策略**：系統使用 Firebase Auth 管理認證。`role` 與 `assigned_property_ids` 透過 Firebase Custom Claims 存放於 ID token，後端 middleware 以 Firebase Admin SDK 驗證 token 後直接讀取 claims，每個 request 不需要額外查詢 Identity BC。
-
-物業指派變更（`POST /users/{id}/property-assignments`）後，後端須呼叫 Firebase Admin SDK 更新該使用者的 Custom Claims，前端下次 refresh token 後新指派生效。
-
-> **Custom Claims 容量限制**：Firebase Custom Claims 上限為 1000 bytes。`assigned_property_ids` 存放 UUID 陣列，約可容納 20 筆物業指派。若單一成員指派物業數量接近上限，middleware 應改為從 DB 查詢指派清單（搭配 cache），不依賴 token 內的 claims。
-
-| 操作 | 系統管理員 | 主辦 | 員工 | 業主 |
-|------|-----------|------|------|------|
-| **Identity & Access** | | | | |
-| 建立／編輯工作室成員帳號 | ✅ | ❌ | ❌ | ❌ |
-| 建立業主帳號 | ✅ | ✅ | ❌ | ❌ |
-| 角色調整 | ✅ | ❌ | ❌ | ❌ |
-| 物業指派給成員 | ✅ | ❌ | ❌ | ❌ |
-| 重設他人密碼（重寄設定密碼信） | ✅ | ❌ | ❌ | ❌ |
-| 重設自己密碼（Firebase forgot password） | ✅ | ✅ | ✅ | ✅ |
-| **Property** | | | | |
-| 建立／編輯物業和房間 | ✅ | ✅ | ✅ | ❌ |
-| 修改電價（electricityUnitPrice） | ✅ | ✅ | ❌ | ❌ |
-| 刪除物業和房間 | ✅ | ✅ | ❌ | ❌ |
-| 查看物業和房間狀態 | ✅（全部） | ✅（指派） | ✅（指派） | ✅（自己名下） |
-| 設定房間進入維修 | ✅ | ✅ | ✅ | ❌ |
-| **Leasing** | | | | |
-| 建立／編輯 Tenant | ✅ | ✅ | ✅ | ❌ |
-| 建立 Lease | ✅ | ✅ | ✅ | ❌ |
-| Lease replacement | ✅ | ✅ | ✅ | ❌ |
-| 編輯 Lease（僅租金調整） | ✅ | ✅ | ❌ | ❌ |
-| 刪除 Lease | ✅ | ✅ | ❌ | ❌ |
-| 正常終止租約 | ✅ | ✅ | ✅ | ❌ |
-| 強制終止租約 | ✅ | ✅ | ❌ | ❌ |
-| 租金調整（LeaseConditionChanged） | ✅ | ✅ | ❌ | ❌ |
-| **Billing** | | | | |
-| 查看帳單列表／明細 | ✅（全部） | ✅（指派） | ✅（指派） | ✅（自己名下，唯讀） |
-| 電表抄錄 | ✅ | ✅ | ✅ | ❌ |
-| 收款確認 | ✅ | ✅ | ✅ | ❌ |
-| 查看財報 | ✅（全部） | ✅（指派） | ✅（指派） | ✅（自己名下，唯讀） |
-| 匯出租客名冊 HTML | ✅（全部） | ✅（指派） | ✅（指派） | ✅（自己名下，唯讀） |
-| 財報審核與寄送 | ✅ | ✅ | ❌ | ❌ |
-| **Journal** | | | | |
-| 建立／編輯 JournalLog | ✅ | ✅ | ✅ | ❌ |
-| 刪除 JournalLog | ✅ | ✅ | ❌ | ❌ |
-| 建立／編輯 RepairRequest | ✅ | ✅ | ✅ | ❌ |
-| 刪除 RepairRequest | ✅ | ✅ | ❌ | ❌ |
-| 派工（assignedTo） | ✅ | ✅ | ✅ | ❌ |
-| 查看 JournalLog／RepairRequest | ✅（全部） | ✅（指派） | ✅（指派） | ❌ |
-| **Read Models** | | | | |
-| PropertyOwnerView | ✅（全部） | ✅（指派） | ✅（指派） | ✅（自己名下） |
-| 財報摘要（PropertyAccountSummaryQuery） | ✅（全部） | ✅（指派） | ✅（指派） | ✅（自己名下，唯讀） |
-
-> **業主可見範圍說明**：
-> - 帳單列表／明細：可見（唯讀）
-> - 財報摘要：可見（唯讀）
-> - JournalLog / RepairRequest：不可見
-> - 所有寫入操作：不可執行
-
----
+## Journal And Repair
+
+### JournalLog
+
+- 保存文字記錄與optional expense。
+- Expense與AccountingEntry在journal command的同一transaction建立。
+- `JournalExpenseRecorded`只作trace/reserved event。
+
+### RepairRequest
+
+- States：`submitted -> assigned -> in_progress -> completed`，active states也可轉`cancelled`。
+- Assignment對象是system user；vendor coordination不在現行data model。
+- Complete/cancel在同一transaction執行room state recovery；只有沒有其他active repair時恢復vacant。
+
+## Attachments
+
+- 支援property、room、tenant、lease、bill、journal與repair等現行resource associations。
+- Flow分為upload authorization、object upload、metadata verification/registration與authorized read/download。
+- Runtime contract不等於retention policy；ID影本、hard-delete與legacy objects仍是decision backlog。
+
+## Domain Event Boundary
+
+目前event bus是synchronous、in-process、post-commit dispatcher：
+
+1. Application command在DB transaction中record events。
+2. Transaction commit成功後，tx runner依序publish。
+3. Subscriber failure會回傳error，但不能rollback已commit的command。
+4. 沒有outbox、retry queue、dead-letter queue或durable delivery guarantee。
+
+需要與command強一致的財務或核心狀態必須在command transaction內direct orchestration。只有允許commit後失敗且不需rollback的follow-up才適合現行subscriber。完整決策見 [`decisions/0002-event-boundary.md`](decisions/0002-event-boundary.md)。
+
+## Cross-Context Boundary Matrix
+
+| Side effect | Current path | Classification |
+| --- | --- | --- |
+| Lease create/terminate -> room/tenant state | post-commit subscribers | implemented, consistency risk |
+| Payment -> accounting entry | same command transaction | implemented, strong boundary |
+| Journal expense -> accounting entry | same command transaction | implemented, strong boundary |
+| Checkout -> settlement/deposit/accounting/lease termination | same command transaction | implemented, strong boundary |
+| Property -> PropertyAccount | same command transaction | implemented, strong boundary |
+| Room maintenance -> RepairRequest | same command transaction | implemented, strong boundary |
+| Repair complete/cancel -> conditional room recovery | same command transaction | implemented, strong boundary |
+| Receipt/report event -> email delivery | no required subscriber | reserved/not implemented |
 
 ## Read Models
 
-> 所有 Read Model 不走 Aggregate，直接 SQL 查詢組合。
-
-### Identity & Access BC
-
-| 查詢路徑 | 說明 | 主要 Filter |
-|---------|------|------------|
-| `GET /users` | 成員列表 | role |
-| `GET /users/{id}` | 成員詳情 | — |
-| `GET /users/me` | 自己的帳號資料 | JWT |
-
-### Property BC
-
-| 查詢路徑 | 說明 | 主要 Filter |
-|---------|------|------------|
-| `GET /properties` | 物業列表（含房間數、出租率） | 依角色 resource filter |
-| `GET /properties/{id}` | 物業詳情 | — |
-| `GET /properties/{id}/rooms` | 房間列表（含狀態） | status |
-| `GET /rooms/{id}` | 房間詳情 | — |
-
-### Leasing BC
-
-| 查詢路徑 | 說明 | 主要 Filter |
-|---------|------|------------|
-| `GET /tenants` | 租客列表 | — |
-| `GET /tenants/{id}` | 租客詳情 | — |
-| `GET /tenants/{id}/leases` | 某租客的租約歷史 | — |
-| `GET /leases` | 租約列表 | propertyId, roomId, tenantId, status |
-| `GET /leases/{id}` | 租約詳情（含帳單預產狀況、押金狀態） | — |
-
-Operational lease lifecycle changes use terminate, force-terminate, or replacement flows; generic lease deletion is not part of the public API.
-
-### Billing BC
-
-| 查詢路徑 | 說明 | 主要 Filter |
-|---------|------|------------|
-| `GET /bills` | 帳單列表 | propertyId, leaseId, status, month |
-| `GET /bills/{id}` | 帳單詳情（電費帳單自動帶入 previousReading 與 period） | — |
-| `GET /properties/{id}/financial-report` | 財報摘要列表（歷史月份） | year |
-| `GET /properties/{id}/financial-report/{year}/{month}` | 特定月份財報 | — |
-| `GET /properties/{id}/tenant-roster` | 租客名冊 HTML 匯出 | as_of, include_vacant, format |
-
-### Journal BC
-
-| 查詢路徑 | 說明 | 主要 Filter |
-|---------|------|------------|
-| `GET /journal-logs` | 日誌列表 | propertyId |
-| `GET /journal-logs/{id}` | 日誌詳情 | — |
-| `GET /repair-requests` | 維修列表 | propertyId, roomId, status |
-| `GET /repair-requests/{id}` | 維修詳情 | — |
-
-### 電表相關
-
-| 查詢路徑 | 說明 | 主要 Filter |
-|---------|------|------------|
-| `GET /properties/{id}/pending-meter` | 某物業待抄表清單（`pending_meter` 帳單，按 bill period 顯示） | — |
-| `GET /properties/{id}/meter-history` | 某物業全房間電表歷史，按月呈現 | year |
-| `GET /rooms/{id}/meter-history` | 單房間電表歷史 | year, month |
-
-> **previousReading 填入機制**：`GET /bills/{id}` 回傳時，系統自動查詢同一 `room_id` 最近一張屬於上一個已完成 electricity billing period 且 `meter_reading IS NOT NULL` 的電費帳單的 `currentReading`，作為 `previousReading` 帶入 response。員工送出抄表時只傳 `currentReading`。
-
-### 附件查詢
-
-| 查詢路徑 | 說明 |
-|---------|------|
-| `GET /properties/{id}/attachments` | 物業附件列表 |
-| `GET /rooms/{id}/attachments` | 房間附件列表 |
-| `GET /tenants/{id}/attachments` | 租客附件列表（沿用既有 tenant flow 的 property access 規則） |
-| `GET /leases/{id}/attachments` | 租約附件列表 |
-| `GET /journal-logs/{id}/attachments` | 日誌附件列表 |
-| `GET /repair-requests/{id}/attachments` | 維修單附件列表（依 sort_order 排序） |
-| `GET /bills/{id}/attachments` | 帳單附件列表 |
-| `POST /attachments/{id}/download-url` | 產生附件下載 Signed URL |
-| `DELETE /attachments/{id}` | 軟刪除附件 |
-
-### 跨 BC 組合查詢
-
-| 查詢路徑 | 說明 | 資料來源 |
-|---------|------|---------|
-| `GET /properties/{id}/dashboard` | PropertyOwnerView：房間狀態 + 本月收支 + 逾期帳單數 + 最近 5 筆 Journal | Property + Billing + Journal |
-
-### PropertyOwnerView 內容
-
-```
-PropertyOwnerView
-  ├── 各房間狀態（vacant / occupied / maintenance）
-  ├── 本月應收租金總額
-  ├── 本月已收租金總額
-  ├── 逾期未付帳單數量
-  └── 最近 5 筆 Journal 紀錄（JournalLog + RepairRequest）
-```
-
-### PropertyAccountSummaryQuery（財報讀取）
-
-直接 SQL 彙總 MonthlySnapshot + 當月 AccountingEntry，按月分組產出收支報表。
-
-### Runtime HTML Report Export
-
-首次版本的報表／文件匯出由後端在 request 期間產生 HTML 並直接回傳，不寫入 GCS、不建立 attachment record，也不持久化產生的檔案 bytes。瀏覽器／前端負責 preview、print 與 save-as-PDF。
-
-共用 HTML export foundation 僅負責 view model render、print-friendly template、檔名與 response header 行為；各報表自己的 business read model 與資料定義仍由 focused issue 決定。
-
-租客名冊（tenant roster）是第一個 runtime HTML export consumer：
-
-- 查詢物業下房間，依固定報表排序輸出，避免使用資料庫插入順序。
-- `include_vacant=true` 時包含空房；未提供或為 `false` 時只輸出目前有 active lease 的房間。
-- `next_rent_due_date` 為目前未繳租金帳單中最早的 `due_date`；若租金已繳清則為空值。
-- `notes` 欄位在第一版 template 保留顯示位置，但資料先保持空值，待後續確認來源。
-- replacement 或多租戶邊界先依目前 active lease selection rule 決定，不在 template 層做額外業務判斷。
-
-月營運報告（operation report）沿用 runtime HTML export foundation：
-
-- 財務摘要沿用既有 financial-report `category` totals contract；`accounting_titles.kind` 不用來重算收入／支出。
-- 當月報表使用 live `accounting_entries`；歷史月份財務摘要使用 finalized `monthly_snapshots`。
-- 業主收益目前沒有 owner distribution workflow 或 accounting source，第一版固定顯示 `0`，不納入實質分潤計算。
-- 出租異動第一版規則：新租以 `lease.start_date` 落在報表月份計算；退租以 `status IN ('terminated', 'force_terminated')` 且 `updated_at` 落在報表月份計算。replacement 案例可接受被視為退租異動。
-- 管理日誌第一版只納入 repair 類紀錄與新租／退租摘要，不納入一般 journal logs。
-- richer stable display-note snapshot contract（room/tenant labels、period label、source date、report-owned notes）保留給 #123 後續處理；本報表第一版不擴充 snapshot/display schema。
-
----
-
-## 資料庫設計原則
-
-| 項目 | 決策 |
-|------|------|
-| 刪除策略 | 全部軟刪除，加 `deleted_at` 欄位 |
-| 軟刪除 filter | 所有查詢（含排程任務）加 `AND deleted_at IS NULL`，確保軟刪除物業的帳單不被掃到 |
-| 幣別 | 台幣，金額用整數儲存（無小數） |
-| 帳單主要 Index | `(property_id, status, due_date)` |
-| 帳單次要 Index | `(tenant_id, status)`、`(status, due_date)` |
-| 帳單電表 Index | `(property_id, type, due_date)`、`(room_id, type, due_date)` |
-| 帳單催收 Index | `(status, overdue_notice_count)` on bills table |
-| 租約 Index | `(property_id, status)`、`(tenant_id)`、`(end_date, status)` on leases table |
-| Tenant Index | `(status)` on tenants table |
-| 維修 Index | `(property_id, status)` on repair_requests table |
-| 日誌 Index | `(property_id, created_at)` on journal_logs table |
-| ForceTermination table | 欄位：`id, lease_id, initiated_by, reason, deposit_handling: write_off \| keep_held, status: completed, created_at`（bill_ids[] 移除，改用 force_termination_bills table；`in_progress` 為已棄用的補償流程歷史狀態）。強制終止生效日存於 `leases.end_date`；實際搬出 / 點交日可選存於 `leases.actual_move_out_date`。 |
-| PropertyAccount 架構 | 月結快照拆兩層：summary + entries |
-| accounting_titles table | 欄位：`id, code, name, kind: income \| expense, legacy_kind, is_active, created_at, updated_at`；runtime master data；`kind` 不取代 `category` 的財報 total classification |
-| legacy_accounting_title_mappings table | 欄位：`legacy_accounting_id, legacy_accounting_title_id, accounting_title_id, legacy_accounting_kind, legacy_accounting_title, source_table, created_at`；保存 legacy `xx_accounting_title` 對 canonical title 的 mapping |
-| monthly_snapshots table（summary） | 欄位：`id, property_id, year, month, total_income, total_expense, net`；Index：`(property_id, year, month)` |
-| accounting_entries table（當月暫存） | 欄位：`id, property_account_id, category, accounting_title_id, accounting_title_code, accounting_title_name, source_date, room_label, tenant_label, period_label, display_note, description, amount, source_ref, year, month`；`category` 供財報 totals，accounting title 供報表科目顯示與 P&L 聚合，display fields 供報表列日期/標籤/備註穩定顯示 |
-| monthly_snapshot_entries table（明細） | 欄位：`id, snapshot_id, category, accounting_title_id, accounting_title_code, accounting_title_name, source_date, room_label, tenant_label, period_label, display_note, description, amount, source_ref`；Index：`(snapshot_id, category)`；code/name copy 保護 finalized historical report 不受 title rename 影響，display fields 保護 finalized report 不需回查 mutable source tables |
-| MonthlySnapshot 排程 | 排除軟刪除物業：加 `AND deleted_at IS NULL` filter |
-| force_termination_bills table | 欄位：`id, force_termination_id, bill_id, status: pending \| done`；Index：`(force_termination_id, status)`；同步完成後所有追蹤帳單應為 `done` |
-| voided / written_off 帳單 | 狀態轉換（非軟刪除），查詢加 `AND status NOT IN ('voided', 'written_off')` |
-| 資料量預估 | 50 房間 × 24 個月 = 1200 筆預產帳單，現有 Index 足夠，不需分表 |
-| users table 認證欄位 | 存 `firebase_uid VARCHAR(128) UNIQUE NOT NULL`，不存 `password_hash`；密碼由 Firebase 管理 |
-
----
-
-## 退租流程
-
-### 正常退租
-
-```
-發起退租
-  → 檢查所有帳單是否結清
-  → 若有未付帳單 → 拒絕，回傳未付帳單清單
-  → 全部結清 → 確認押金處理（退還或扣款）
-  → 更新押金狀態；DepositRefunded / DepositDeducted event 僅保留為 trace
-  → LeaseTerminated event（forced: false）
-  → Property BC 訂閱 → Room 狀態改為 vacant
-```
-
-### 強制終止（呆帳）
-
-```
-主辦以上角色發起強制終止，填寫原因、termination_date，並可選填 actual_move_out_date
-  → 建立 ForceTermination 記錄（leaseId, force_termination_bills, reason, deposit_handling）
-  → 同步將未結清帳單標記為 written_off，每筆成功記錄進度
-  → 將 leases.end_date 更新為 termination_date，若提供則保存 actual_move_out_date
-  → 全部成功後將 ForceTermination 標記 completed
-  → 全部 written_off 完成 → 依 deposit_handling 人工決定將押金標記 written_off，或維持 held 等待後續押金處理
-  → LeaseTerminated event（forced: true）
-  → Property BC 訂閱 → Room 狀態改為 vacant
-```
-
-> 最後一個月帳單按整月計算，不按天拆分。
-> 空窗期（vacant 期間）不產生任何帳單，超出系統範圍。
-
-### Lease Replacement
-
-```
-發起 Lease replacement
-  → 檢查 replacement reason 與 effective date
-  → 檢查新 Lease 與舊 Lease 是否為同 tenant、同 room、同 property
-  → 檢查 effective date 是否為完整 rent billing period boundary 與完整 electricity billing period boundary
-  → 檢查 boundary 前帳單是否已全部結清
-  → 檢查 depositHandling = carry_over
-  → 正常終止舊 Lease（replacement 專用語意，不在此步結清押金）
-  → 建立新 Lease（帶入新條件、rentBillingCadence 與 electricityBillingCadence）
-  → LeaseTerminated event（forced: false, isRenewal: false, isReplacement: true）
-  → LeaseCreated event
-  → LeaseReplaced event
-```
-
----
-
-## 附件設計
-
-### 設計原則
-
-附件為純 CRUD 輔助資料，不參與任何 BC 的業務規則或 Aggregate 狀態機。生命週期跟隨宿主資源（宿主軟刪除時，應用層於同一 DB transaction 內同步軟刪除其附件）。
-
-### 支援附件的資源
-
-| 資源 | 附件表 | 備註 |
-|------|--------|------|
-| Property | `property_attachments` | 物業照片 |
-| Room | `room_attachments` | 房間照片 |
-| Tenant | `tenant_attachments` | 身份文件等；沿用既有 tenant flow 的 property access 規則 |
-| Lease | `lease_attachments` | 合約掃描等 |
-| JournalLog | `journal_log_attachments` | 日誌附件、費用憑證等 |
-| RepairRequest | `repair_request_attachments` | 維修照片 |
-| Bill | `bill_attachments` | 電表照片等 |
-
-### 附件表 Schema
-
-**共用欄位**（所有附件表均包含）：
-
-```
-id UUID PRIMARY KEY
-object_path TEXT NOT NULL          -- GCS object path（非完整 URL），如 attachments/properties/{id}/{uuid}.jpg
-file_name TEXT NOT NULL            -- 原始檔名（顯示用）
-uploaded_by UUID REFERENCES users(id)
-created_at TIMESTAMPTZ NOT NULL
-deleted_at TIMESTAMPTZ
-```
-
-**`repair_request_attachments` 額外欄位**：
-
-```
-sort_order INT NOT NULL DEFAULT 0
-photo_stage VARCHAR(20) CHECK (photo_stage IN ('before', 'after', 'other'))
-```
-
-**Index**：各附件表的 FK 欄位均加 Index（`property_id`、`room_id`、`tenant_id`、`lease_id`、`journal_log_id`、`repair_request_id`、`bill_id`）。`repair_request_attachments` 加 `(repair_request_id, sort_order)`。
-
-### 上傳流程（Signed URL + nonce 綁定）
-
-```
-Step 1：POST /attachments/upload-url
-  Body: { resource_type, resource_id, file_name, content_type, file_size }
-  → 後端驗證呼叫者對 resource 有寫入權限
-  → 後端驗證 BR-18 MIME type 與 file_size 不超過 20MB
-  → 後端建立暫存 token（nonce, object_path, issued_to, resource_type, resource_id, expires_at）
-  → 回傳 { upload_url, nonce, expires_at }（Signed URL 含鎖定 content_type）
-
-Step 2：Client 直接 PUT 到 GCS（不經後端）
-
-Step 3：POST /{resource}/{id}/attachments
-  Body: { nonce, file_name }
-  → 後端以 nonce 驗證合法性（issued_to、resource_id 需一致）
-  → 後端呼叫 GCS HEAD 確認物件存在，並以 metadata 再確認 content_type 與 size
-  → 寫入對應 attachment table，刪除已用 nonce
-```
-
-Download：`POST /attachments/{id}/download-url` 只對 authenticated caller 回傳 `{ download_url, expires_at }`。呼叫者必須符合附件宿主資源的 property access policy；missing 或已軟刪除附件不回傳可用 URL，且 response 不暴露 object_path、bucket 或 storage internals。
-
-Tenant attachment endpoints use the same tenant access model as tenant detail and lease-history flows. The tenant must exist, and non-admin management roles must have access to one of the tenant's associated properties.
-
-**upload_tokens 暫存表**：
-
-```
-attachment_upload_tokens(
-  id UUID PRIMARY KEY,
-  nonce VARCHAR UNIQUE NOT NULL,
-  object_path TEXT NOT NULL,
-  issued_to UUID NOT NULL,
-  resource_type VARCHAR NOT NULL,
-  resource_id UUID NOT NULL,
-  expires_at TIMESTAMPTZ NOT NULL,
-  created_at TIMESTAMPTZ NOT NULL
-)
-```
-
-**部署前置條件**：GCS bucket 需設定 CORS policy（允許前端 origin，methods: PUT，headers: Content-Type）；後端 Service Account 需具備產生 signed URL、`storage.objects.create`、`storage.objects.get` 權限。後端設定需提供 `GCS_BUCKET_NAME`、`GCS_SIGNED_URL_TTL`，本地 emulator 可使用 `STORAGE_EMULATOR_HOST`。一般 automated tests 應注入 fake storage port，不依賴真 GCS。
-
----
-
-## 排程任務
-
-| 任務 | 頻率 | 說明 |
-|------|------|------|
-| 逾期帳單掃描 | 每日凌晨 | 掃描 `due_date < today AND status = pending_payment AND deleted_at IS NULL`，批次更新為 `overdue`。與付款衝突時樂觀鎖失敗，跳過該筆。 |
-| 逾期帳單催收通知 | 每週一次 | 掃描 `status = overdue AND deleted_at IS NULL`，對租客寄催收 Email，每張帳單最多寄 3 次（記錄 `overdue_notice_count`）。 |
-| 租約到期掃描 | 每日凌晨 | 掃描 `end_date < today AND status = active AND deleted_at IS NULL`，批次更新 Lease status 為 `expired`，Room 維持 `occupied`，不自動終止。 |
-| 租約到期提醒 | 每日凌晨 | 掃描 `end_date = today + 30 days AND status = active`，寄送提醒 Email 給主辦和員工。 |
-| 月結快照產出 | 每月最後一天 23:59 | 將 PropertyAccount 當月 AccountingEntry 封存為 `monthly_snapshot_entries`，排除軟刪除物業（`deleted_at IS NULL`），清空當月暫存資料。 |
-| 強制終止補償 | 已棄用 | 舊設計掃描 `force_terminations WHERE status = in_progress` 續行 written_off；目前強制終止 command 同步完成 write-off 與 ForceTermination completion。 |
-| Upload token 清理 | 每日凌晨 | 清除 `attachment_upload_tokens WHERE expires_at < now`。 |
-| GCS 附件清理 | 每日凌晨 | 掃描 `*_attachments WHERE deleted_at < now - INTERVAL '90 days'`，刪除對應 GCS 物件後硬刪除 DB 記錄。 |
-
----
-
-## 設計決策紀錄（ADR）
-
-| 決策 | 選擇 | 理由 |
-|------|------|------|
-| 押金建模 | Lease 內的 Value Object | 押金生命週期完全跟著租約，不需獨立 Aggregate |
-| 續約處理 | Lease replacement API | 續約只是 replacement 的其中一種 reason，不單獨定義 LeaseRenewed |
-| 租金帳單 cadence | Lease 建立時決定 `rentBillingCadence`，支援 monthly / quarterly / semiannual / annual | `rentAmount` 是每個 rent billing period 的金額；rent period 以 Lease start date 為 anchor，due date 為 period start；最後短 period 收完整 period rent，first launch 不做 proration |
-| 電費帳單 cadence | Property 定義預設值，Lease 建立時決定有效值 | 支援 monthly / bimonthly；既有 Lease 不受 Property 預設值更新影響 |
-| 電費帳單建立 | 租約建立時依 Lease `electricityBillingCadence` 一併預產，初始 pending_meter | 與租金帳單同批預產，Bill 補 periodStart/periodEnd，MeterRecorded 時找對應 period 更新金額 |
-| 租金調整後帳單 | void `due_date >= nextRentPeriodStart` 的租金帳單，從 nextRentPeriodStart 依原 `rentBillingCadence` 重產 | 當期租金帳單不動，業務語意清楚；rent amount 變更只從下一個 rent billing period 生效 |
-| 租金付款日 | 固定為 rent billing period 的 `periodStart`，不可單獨修改 | 消除帳單產生邏輯的邊界案例，paymentDay 欄位移除 |
-| JournalEntry 拆分 | JournalLog + RepairRequest | 兩者行為差異過大，合併導致 schema nullable 欄位過多 |
-| PropertyAccount 架構 | 月結快照：Aggregate 只持有當月，歷史走 MonthlySnapshot | 解決 Aggregate 無限增長問題，寫入效能穩定 |
-| 租客角色 | 無系統帳號，Email 通知 | 降低系統複雜度，租客透過 Email 收帳單 |
-| 代管費 | 超出範圍 | 工作室財務另外處理，不在 STDS 範圍內 |
-| 跨 BC 傳遞 | In-process event bus + command-owned direct orchestration | 單一服務架構，無需 message queue；需要強一致性的 side effect 留在 command transaction |
-| 軟刪除 | 全部軟刪除，所有查詢加 deleted_at IS NULL filter | 歷史帳單和日誌需保留關聯，不可真刪除 |
-| 強制終止租約 | 同步完成 ForceTermination，保留已棄用補償式 `in_progress` 語意作歷史參考 | 目前事件匯流排為 in-process，強制終止 command 在交易內同步完成帳單 write-off、`deposit_handling` 記錄與 `completed` 狀態，避免引入尚未需要的排程補償流程 |
-| Room 競態防護 | 建立租約時對 Room 取悲觀鎖（select for update）再檢查 BR-12 | 防止兩個請求同時對同一 Room 建立租約 |
-| maintenance → vacant 條件 | 該 Room 所有 RepairRequest 均 completed 或 cancelled 才轉回 vacant | 多個 RepairRequest 場景下避免過早開放房間；未來實作應走 repair workflow direct orchestration |
-| BR-09 移除 | 移除，BR-04 已完整涵蓋 | 退租流程統一由 BR-04 把關，不重複檢查 |
-| 物業指派移除 event | 舊設計曾預留 PropertyUnassigned event，進行中操作不撤銷 | 目前 runtime 沒有此 event struct；下次操作時權限自然擋住，不需要複雜的操作撤銷邏輯 |
-| BR-08 維修中刪除 | 移除例外，維修中房間不得刪除；maintenance 狀態由 active RepairRequest 維持 | 刪除維修中 Room 導致 RepairRequest 狀態機孤立 |
-| 逾期競態 | 樂觀鎖，付款優先，批次跳過衝突 | 帳單已付款則批次自然不再掃到，無需額外處理 |
-| overdue → paid | 允許 | 逾期帳單仍應可收款，不因逾期狀態阻斷收款流程 |
-| 押金部分扣款 | Deposit VO 拆分 deductionAmount + refundAmount，status 改為 settled 取代 refunded/deducted | 台灣退租最常見情境是「扣一部分、退餘額」，原 refunded/deducted 二選一無法表達；DepositDeducted + DepositRefunded 兩事件可依序發出，但 PropertyAccount 分錄應由押金處理 command direct accounting 寫入 |
-| Lease replacement 通知語意 | LeaseTerminated 加 `isReplacement: bool`，並新增 LeaseReplaced event | Notification BC 對 replacement 不寄退租確認；LeaseReplaced 目前作為審計 / future notification candidate |
-| 認證機制 | Firebase Auth + Custom Claims | 降低自建 JWT 與密碼管理複雜度；Custom Claims 支援 server-side 更新，可在物業指派變更後立即同步 role 與 assigned_property_ids 至 token；users table 改存 firebase_uid 取代 password_hash |
-| 附件業務定位 | 純 CRUD，不參與業務規則 | 附件為輔助資訊，不影響任何 Aggregate 狀態機或業務決策；保持模型簡潔，避免過度設計 |
-| 附件表架構 | 方案 B：各資源獨立附件表 | 維持真實 FK 約束，符合現有 BC 邊界設計風格；軟刪除 cascade 由應用層 transaction 保證 |
-| 附件上傳機制 | Signed URL + nonce 綁定 | Client 直傳 GCS 減少後端 I/O；nonce 機制防止任意 object_path 注入；Step 3 GCS HEAD 確認物件存在 |
-| GCS 部署依賴 | CORS 與 IAM 為部署前置條件（accepted risk） | Signed URL 直傳需要瀏覽器 CORS 支援；Service Account 權限不足會導致 URL 產生失敗；兩者屬基礎設施設定，在首次部署前完成 |
+Read APIs與reports可以使用query repositories直接組合DTO，不必經aggregate。這是read/write responsibility分離，不允許read model繞過authorization scope，也不把read projection升格成business truth。

--- a/docs/design/domain-rule.md
+++ b/docs/design/domain-rule.md
@@ -1,0 +1,83 @@
+# Domain Rules
+
+本文件只收錄已確認、足以約束 schema 與 API 設計的 business rules。它不記錄 implementation status、issue、transport shape、schema欄位或未來假設。現行實作若不同，差異應記入 [`decision-backlog.md`](decision-backlog.md)，不得直接改寫本文件。
+
+## Shared Rules
+
+### DR-S01 Authorization Scope
+
+系統以角色決定可使用的功能，並以物業關聯限制可存取的資源。業主只能讀取自己名下物業的允許資訊；工作室成員只能存取其被授權的物業，系統管理員的例外不得跳過資源識別與不存在檢查。
+
+### DR-S02 Financial Atomicity
+
+會改變付款、押金、結算或會計分錄的單一業務操作，其核心狀態與對應會計效果必須同時成功或同時失敗，不得依賴無持久保證的 post-commit side effect 補寫。
+
+### DR-S03 Historical Report Facts
+
+已完成的財務快照與退租結算必須保存當時使用的金額與顯示事實；重印或查閱歷史結果時，不得用後續已變更的租客、房間、租約或科目資料重新解釋。
+
+## Identity And Access
+
+### DR-I01 Property Assignment Eligibility
+
+物業工作指派只適用於工作室成員，不得把業主當作工作人員指派。
+
+### DR-I02 Administrator Self-Protection
+
+系統管理員不得透過自助操作降低自己的管理角色。
+
+## Property
+
+### DR-P01 Property And Room Deletion
+
+仍有出租中房間的物業不得刪除。出租中或維修中的房間不得刪除。
+
+### DR-P02 Room Availability For A New Lease
+
+建立租約時，房間必須仍為空置；系統必須在可防止並行重複出租的鎖定邊界內再次確認。
+
+### DR-P03 Electricity Price
+
+物業電價必須大於零，可包含小數；只有系統管理員或主辦可修改。
+
+## Leasing
+
+### DR-L01 Lease Inputs
+
+租約起始日不得晚於契約終止日，租金必須大於零，押金不得為負。
+
+### DR-L02 Independent Billing Cadences
+
+租金與電費的計費週期是兩個獨立租約條件，必須分別驗證與產生期次。物業預設電費週期只影響新租約；既有租約不得以一般編輯改變任一計費週期。
+
+### DR-L03 Rent Period Semantics
+
+租金付款日是租金期次起日。租金期次以租約起始日為基準，依約定週期推進；最後不足完整週期的短期次仍收完整期次租金，第一版不自動按日比例計算。
+
+### DR-L04 Normal Termination
+
+正常終止租約前，不能保留尚未處理的帳單；押金有扣款時必須記錄原因。強制終止適用不同流程，但其可 write off 範圍仍待確認，不能由本規則推定。
+
+### DR-L05 Lease Replacement Scope
+
+租約條件重建只適用於同一租客、同一房間與同一物業，且只能在租金與電費的完整計費邊界進行。邊界前帳單必須處理完畢，第一版押金只可延續到新租約。
+
+### DR-L06 Checkout Preview And Finalization
+
+退租預覽由後端計算且不得改變業務狀態。正式結算必須以未過期且內容相符的預覽結果為基礎，在同一交易內重新計算、保存不可變結算事實、處理押金與會計效果並終止租約。
+
+## Billing
+
+### DR-B01 Meter Reading
+
+本期電表讀數不得小於前期讀數。電費由系統以用量乘抄表時適用的單價計算，最終台幣帳單金額四捨五入為整數，不由操作人員直接輸入。
+
+### DR-B02 Payment
+
+帳單不得重複收款；收款金額必須等於帳單金額，第一版不支援部分收款或溢收。逾期帳單仍可正常收款。
+
+## Attachments
+
+### DR-A01 Upload Limits
+
+可上傳格式限 JPEG、PNG、HEIC 與 PDF，單檔上限 20 MB。產生上傳授權與正式登記時都必須驗證；保存期限、身分證件與刪除政策另待確認。

--- a/docs/infra-guideline.md
+++ b/docs/infra-guideline.md
@@ -406,9 +406,9 @@ Repository 原則：
 策略：
 
 - API authentication 使用 Firebase ID token
-- Firebase custom claims 承載 `role` 與 `assigned_property_ids`
-- middleware 驗證 token 後，仍會載入 DB user
-- request context 內最終使用的是 normalized principal
+- Firebase ID token 用於驗證外部身份與取得 `firebase_uid`
+- middleware 驗證 token 後載入 active DB user
+- request context 的 normalized principal 使用 DB `role` 與 `assigned_property_ids`；Custom Claims 不覆蓋 DB principal
 
 你開發時要記得：
 

--- a/docs/local-operations.md
+++ b/docs/local-operations.md
@@ -357,5 +357,9 @@ brand service or requires stronger database credential isolation.
 
 ## Legacy migration planning
 
-- Validate the checked-in legacy JSON exports and generate the Task 5 architecture report: `go run ./cmd/migrate_legacy plan`
+- Validate the private, ignored development/UAT legacy JSON exports and generate the architecture report: `go run ./cmd/migrate_legacy plan`
 - Override source/report directories when needed: `go run ./cmd/migrate_legacy plan --source-dir docs/mirgations --report-dir artifacts/legacy_migration`
+
+The version-controlled migration scope, validation, evidence, and cutover
+contracts live under [`docs/migration/`](migration/README.md). Do not force-add
+`docs/mirgations`, `artifacts`, dumps, or reports.

--- a/docs/migration/README.md
+++ b/docs/migration/README.md
@@ -1,0 +1,28 @@
+# Legacy Migration Documentation
+
+本目錄只保存可版本控制、可審查且不含production data的migration contract。既有`docs/mirgations/`（歷史拼字）是ignored development/UAT input；`artifacts/`是ignored reports/dumps。兩者都不是canonical documentation，也不得force-add。
+
+## Scope And Authority
+
+- [`legacy-estate-scope.md`](legacy-estate-scope.md)：現行importer scope、mapping狀態與known gaps。
+- [`accepted-losses.md`](accepted-losses.md)：只收使用者已核准的loss reason；目前production registry為空。
+- [`validation-contract.md`](validation-contract.md)：production migration必須滿足的完整性等式與sign-off gates。
+- [`run-manifest-contract.md`](run-manifest-contract.md)：private immutable evidence bundle的metadata contract。
+- [`production-cutover.md`](production-cutover.md)：尚待確認的freeze/delta/rollback框架。
+
+DB migrations定義新系統schema；本目錄定義legacy data如何被解釋、驗證與切換。Importer implementation只能證明as-is，不能自動建立legacy accounting或business truth。
+
+## Data Classification
+
+| Artifact | Storage | Git policy |
+| --- | --- | --- |
+| Mapping/validation/cutover rules | `docs/migration/**` | tracked，禁止PII與runtime identifiers |
+| Development/UAT JSON fixtures | `docs/mirgations/**` | ignored/private；freshness不是缺陷 |
+| Stage/validation reports | `artifacts/legacy_migration/**` | ignored/private |
+| SQL dumps | `artifacts/db_dumps/**` | ignored/private，可能含application users與tenant data |
+| Production source export/object manifest | private immutable run directory | 不進repo；只在manifest記checksum/count/classification |
+| Attachment objects | private source/target storage | 不進repo；只保存必要checksum/size/result evidence |
+
+## Fixture And Production Evidence Boundary
+
+Development fixtures可以固定在某次export以支援rerun與UAT，無須追隨live runtime。Production rehearsal/cutover則必須使用當次final-format export、immutable manifest與完整validation evidence；不得把舊UAT report當作production sign-off。

--- a/docs/migration/accepted-losses.md
+++ b/docs/migration/accepted-losses.md
@@ -1,0 +1,19 @@
+# Accepted Migration Losses
+
+- Status: Canonical registry
+- Production accepted losses: none recorded as of 2026-07-10
+
+本文件只記錄使用者已明確核准的legacy data loss或降階保存。未確認項目不得放在這裡，應留在[`../design/decision-backlog.md`](../design/decision-backlog.md)或[`legacy-estate-scope.md`](legacy-estate-scope.md)。Importer目前跳過、flatten、default或placeholder的行為不等於accepted loss。
+
+## Required Entry Shape
+
+每一筆accepted loss必須包含：
+
+- Stable reason code。
+- Source entity/field或record class，不放production PII。
+- 核准的loss/transform語意與理由。
+- 對finance、history、authorization、attachments與reporting的影響。
+- Blocking validation如何計數`approved_skipped_count`。
+- 使用者確認日期或private approval reference。
+
+在第一筆明確核准前，本registry保持空白；production validation不得把任何skip計入`approved_skipped_count`。

--- a/docs/migration/legacy-estate-scope.md
+++ b/docs/migration/legacy-estate-scope.md
@@ -1,0 +1,48 @@
+# Legacy Estate Migration Scope
+
+狀態：current as-is + production gaps，驗證日期2026-07-10。
+
+## Current Importer
+
+| Scope | Status | Production note |
+| --- | --- | --- |
+| Properties / placeholder owners | implemented | 必須reconcile真實owner與登入身份 |
+| Rooms | implemented | orphan policy與source completeness仍需sign-off |
+| Tenants | implemented | natural-person dedupe與co-tenant unresolved |
+| Leases | partial | cadence、starting meter、actual move-out與legacy-only semantics需reconcile |
+| Room status | implemented reconciliation | 仍需驗overlapping lease與orphan policy |
+| Electricity/rent bills | risky as-is | meter history與dates不能單獨證明paid/overdue |
+| Journal / repair | partial | actor、reply flattening、accounting與attachments有loss/gaps |
+| Legacy mapping tables | implemented | 需擴充所有production entities與approved loss reasons |
+| Final validation | partial | 現況主要證明target consistency，尚非source completeness gate |
+| Estate-linked accounting | not implemented | production blocker |
+| Active identities/property assignments | not implemented | production blocker |
+| Attachment metadata/object copy | not implemented | production blocker |
+
+現有foundation應延伸而非推倒重寫；它可支援dev/UAT，但不能宣告production-ready。
+
+## Mapping Classification
+
+每一類source record與field都必須在mapping spec標示下列其中一種：
+
+- `confirmed mapping`：domain semantics已確認，且target能無損表達。
+- `as-is importer`：程式目前如此處理，但business truth尚未確認。
+- `approved loss`：使用者已核准不搬或降階保存，具有stable reason code。
+- `unresolved loss`：仍待決策；production blocking validation必須失敗。
+- `out of scope`：與estate migration無關，且範圍經明確界定。
+
+不得用`default`、`unknown`或placeholder掩蓋unresolved loss。Placeholder identity若保留，必須逐筆核准或在production gate歸零。
+
+## Accounting And Payment Truth
+
+Legacy meter readings證明用量，不證明付款；日期經過也不證明欠租。Rent、electricity、deposit、refund、checkout與journal expense狀態必須以納入scope的estate-linked accounting evidence與已確認mapping重建。
+
+在該mapping確認前：
+
+- 不得把歷史meter row默認成paid electricity bill。
+- 不得只因due date早於migration date就默認成overdue rent。
+- accepted loss與unresolved loss必須分開計數。
+
+## Additional Decision Backlog
+
+除canonical [`../design/decision-backlog.md`](../design/decision-backlog.md)外，migration還需確認：facility data、reply representation與actor fallback、orphan handling、early/continue/pet semantics、第一筆與vacancy-period meter readings。未確認前只能列為unresolved，不能寫進canonical domain rules。

--- a/docs/migration/production-cutover.md
+++ b/docs/migration/production-cutover.md
@@ -1,0 +1,31 @@
+# Production Cutover Contract
+
+- Status: Needs decision
+- Production use: blocked until every TBD below is confirmed and rehearsed
+
+本文只列出必須決定與驗證的cutover邊界，不替產品或operator選答案。Staging/UAT dump/import流程不能直接升格為production contract。
+
+## Required Decisions
+
+| Decision | Status | Required output |
+| --- | --- | --- |
+| Legacy write freeze owner、start/end與例外 | TBD | 可執行freeze checklist與責任人 |
+| Freeze前後delta capture來源與ordering | TBD | Delta format、dedupe/idempotency與final watermark |
+| Final export與immutable manifest交付 | TBD | Export command、checksum/count與custody evidence |
+| Go/no-go authority與blocking gate處理 | TBD | Sign-off matrix與abort conditions |
+| Runtime traffic switch順序 | TBD | Rehearsed sequence與read/write smoke |
+| Rollback point與data divergence處理 | TBD | Restore/roll-forward criteria與maximum window |
+| RTO / RPO | TBD | Approved objectives與measured rehearsal evidence |
+| Attachment/object cutover | TBD | Copy/freeze/delta/verification order |
+
+## Minimum Rehearsal
+
+1. 使用當次final-format export與private immutable manifest。
+2. 在空白、隔離的PostgreSQL執行完整schema migrations與所有legacy stages。
+3. 執行full rerun，證明idempotency與locking/uniqueness behavior。
+4. 通過[`validation-contract.md`](validation-contract.md)所有blocking gates。
+5. 執行authorized API/UI spot checks與finance/access/attachment sign-off。
+6. 演練abort/rollback並量測實際時間與data loss boundary。
+7. 保存private evidence bundle，不把dump/report/PII加入Git或PR。
+
+在上述decision與rehearsal完成前，production migration readiness維持unresolved。

--- a/docs/migration/run-manifest-contract.md
+++ b/docs/migration/run-manifest-contract.md
@@ -1,0 +1,24 @@
+# Private Run Manifest Contract
+
+每次production rehearsal/cutover使用一個private immutable run directory。Repo只版本控制本contract，不保存實際manifest、source data、dump、credentials、PII、完整object URLs或runtime reports。
+
+## Required Metadata
+
+- Run ID與purpose：rehearsal或cutover。
+- Source system identifier、source schema/version、export timestamp與timezone。
+- Source code/version或bundle checksum；不得包含credential。
+- 每個source file/object的logical name、SHA-256、byte size、row count與PII classification。
+- Export query/tool version與target application commit/tool version。
+- Target DB schema migration version。
+- Stage execution order、start/end time、exit status與report checksum。
+- Mapping/validation contract version。
+- Approved loss reason codes與核准reference；敏感細節留private evidence。
+- Operator/reviewer role identifiers與sign-off timestamps；避免不必要個資。
+- Artifact retention/expiry與storage access policy。
+
+## Immutability And Security
+
+- Manifest寫入後以checksum與read-only/immutable storage policy保護。
+- Secret、token、database URL、OAuth JSON、signed URL與raw PII不可寫入manifest或log。
+- Report失敗但DB已commit時，run必須標記`evidence-incomplete`並停止promotion；不得重跑後覆蓋原run directory。
+- Correction建立新run或versioned addendum，不修改既有evidence。

--- a/docs/migration/validation-contract.md
+++ b/docs/migration/validation-contract.md
@@ -1,0 +1,57 @@
+# Legacy Migration Validation Contract
+
+本文件定義production rehearsal與cutover的blocking validation。Development/UAT可以產生非blocking report，但不得沿用「validation pass」名稱宣稱production complete。
+
+## Completeness Equations
+
+每一個source entity與stable subgroup都必須滿足：
+
+```text
+source_count = mapped_count + approved_skipped_count
+unresolved_skipped_count = 0
+duplicate_target_count = 0
+invalid_target_reference_count = 0
+```
+
+所有approved skip必須具有stable reason code、source identifier hash或private reference，以及核准依據。Manual follow-up不等於approved skip。
+
+## Blocking Gates
+
+### Structural
+
+- Source files、schema/version與checksum和immutable run manifest一致。
+- Migration order、tool version與target schema migration version已記錄。
+- Target foreign keys、required fields、mapping uniqueness與entity counts有效。
+- Full run後rerun不產生非預期insert/update，rollback/failure evidence可重現。
+
+### Leasing And Billing
+
+- 不存在未核准的overlapping active leases。
+- Rent/electricity cadence分布與source/mapping一致。
+- Starting meter與actual move-out保存數量可以reconcile。
+- Generated bill periods不重複，且每筆都有明確source/mapping basis。
+- 每個paid/overdue/written-off狀態都有已核准的source evidence與mapping rule。
+
+### Accounting
+
+- Property/month/category收入支出可對帳。
+- Rent、electricity、deposit、refund、deduction與checkout totals有獨立equation。
+- Journal expense/accounting title mapping完整，unknown title有approved handling。
+
+### Identity And Access
+
+- Active owner/staff identity可登入且property scope正確。
+- Placeholder identity為零，或每筆都有明確production核准。
+- Owner/member/property assignment source均納入completeness equation。
+
+### Attachments
+
+- Metadata resource mapping完整。
+- 每個需複製object的source checksum/size、target existence/checksum與result已記錄。
+- Missing、excluded與redacted objects分別使用approved reason code；不得抓取或提交整包未篩選uploads。
+
+### Application Sign-Off
+
+- 每個property有代表性的authorized API/read-model spot checks。
+- Financial、access、attachment與checkout結果經business reviewer sign-off。
+- Blocking gates全過後才能產生production sign-off；單一Task/stage report不能替代整體證據。

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -1,0 +1,22 @@
+# Production Readiness
+
+- Status: Unresolved
+- Scope: production only
+
+Staging runbook只證明first demo/UAT slice。Production deployment、migration、recovery與service objectives必須另行確認。
+
+## Required Sign-Off Areas
+
+| Area | Current status | Production decision/evidence required |
+| --- | --- | --- |
+| Cloud SQL sizing/HA | proposed | Tier、HA topology、connection limits與load evidence |
+| Backup/PITR | unresolved | Retention、restore test、operator access與measured restore time |
+| RTO/RPO | unresolved | Approved objectives與rehearsal results |
+| Ingress/auth hardening | partial | Public/default URL policy、frontend origins、scheduler/admin access |
+| Deployment promotion | staging-only | Production branch/environment approval、image provenance、rollback |
+| Observability/on-call | partial | Alerts、owner、runbooks、redaction與incident escalation |
+| Legacy migration | not ready | [`migration/validation-contract.md`](migration/validation-contract.md)與cutover decisions |
+| Attachments/PII | unresolved | Retention、ID copy、hard-delete、object migration與access review |
+| Data rollback | unresolved | Write freeze/delta/divergence/restore or roll-forward contract |
+
+Production readiness不能由staging smoke、successful deploy或UAT fixture validation單獨推定。

--- a/docs/spec/error-codes.md
+++ b/docs/spec/error-codes.md
@@ -1,5 +1,9 @@
 # Error Code 規劃
 
+> Status: current guidance mixed with historical planning. OpenAPI response
+> contracts in `docs/spec/src/**` and runtime error mapping take precedence;
+> issue/order notes below are not an implementation completion source.
+
 產出日期：2026-04-15
 
 ## 目標

--- a/docs/spec/schema.sql
+++ b/docs/spec/schema.sql
@@ -1,8 +1,9 @@
 -- ============================================================
--- STDS Database Schema
--- 產出依據：docs/design/domain-model.md v3.3
+-- STDS Database Schema Reference
+-- Physical schema source of truth: internal/platform/database/migrate/migrations/*.up.sql
+-- This file is a human-readable reference and must not override migrations.
 -- 設計原則：
---   - 全部軟刪除，加 deleted_at 欄位
+--   - Mutable business entities generally use deleted_at; immutable snapshots and execution records may not
 --   - 金額用整數儲存（台幣，無小數）
 --   - 樂觀鎖 aggregate 加 version 欄位
 --   - Value Object 展開為多欄位（欄位數少、查詢頻繁）或 JSONB（結構化但不查詢）
@@ -28,14 +29,13 @@ CREATE TABLE users (
     email           VARCHAR(255) NOT NULL,
     name            VARCHAR(100) NOT NULL,
     -- role 為 Value Object，展開為欄位；RBAC 授權模型基礎
-    -- role 與 assigned_property_ids 也透過 Firebase Custom Claims 存於 ID token
+    -- runtime authorization loads role from the active DB user principal
     role            VARCHAR(50)  NOT NULL CHECK (role IN ('admin', 'organizer', 'staff', 'owner')),
     -- permission_overrides：個別權限覆寫清單，結構化但不需獨立查詢，用 JSONB
     -- 選擇 JSONB 原因：覆寫清單無需 JOIN 查詢，直接序列化隨 User 讀取即可
     permission_overrides JSONB   NOT NULL DEFAULT '[]',
-    -- assigned_property_ids：物業指派清單，透過 Firebase Custom Claims 存於 ID token；用 JSONB array 避免額外 table
-    -- 選擇 JSONB 原因：domain model 指出指派清單整批寫入 Custom Claims，不需獨立 JOIN 查詢
-    -- 注意：Custom Claims 上限 1000 bytes，接近上限時 middleware 改從 DB 查詢（搭配 cache）
+    -- assigned_property_ids：物業指派清單；middleware uses this DB value for runtime property scope
+    -- Firebase Custom Claims may be synchronized as a secondary copy but do not override the DB principal
     assigned_property_ids JSONB  NOT NULL DEFAULT '[]',
     deleted_at      TIMESTAMPTZ,
     created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
@@ -527,6 +527,9 @@ CREATE TABLE journal_logs (
     -- 選擇展開原因：費用資料結構簡單（金額 + 描述），展開後可直接彙總
     expense_amount      INTEGER,        -- null 表示無費用
     expense_description TEXT,
+    expense_accounting_title_id UUID REFERENCES accounting_titles(id),
+    expense_accounting_title_code VARCHAR(20),
+    expense_accounting_title_name VARCHAR(100),
     deleted_at  TIMESTAMPTZ,
     created_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
@@ -537,6 +540,7 @@ CREATE TABLE journal_logs (
 CREATE INDEX idx_journal_logs_property_created_at ON journal_logs (property_id, created_at DESC) WHERE deleted_at IS NULL;
 -- idx_journal_logs_room_id: 外鍵關聯
 CREATE INDEX idx_journal_logs_room_id ON journal_logs (room_id) WHERE deleted_at IS NULL AND room_id IS NOT NULL;
+CREATE INDEX idx_journal_logs_expense_accounting_title_id ON journal_logs (expense_accounting_title_id);
 
 
 -- ============================================================
@@ -768,7 +772,7 @@ CREATE INDEX idx_bill_attachments_bill_id ON bill_attachments (bill_id) WHERE de
 -- RBAC 支援表（混合型授權：RBAC 基礎功能控管）
 -- 說明: 混合型授權模型，role 欄位在 users table 中已定義（RBAC 基礎）；
 --       resource-based 控制透過 users.assigned_property_ids 與 properties.owner_id 實作。
---       認證由 Firebase Auth 管理，role 與 assigned_property_ids 透過 Firebase Custom Claims 存於 ID token。
---       後端 middleware 以 Firebase Admin SDK 驗證 token 後直接讀取 claims，不需每次查詢 DB。
+--       認證由 Firebase Auth 管理；後端 middleware 驗證 token 後以 firebase_uid 載入 active DB principal。
+--       runtime authorization 使用 DB role、assigned_property_ids 與 properties.owner_id；Custom Claims 只可作 secondary copy。
 --       現階段 role 已內建於 users.role 欄位，權限在應用層硬編碼，不建立 role_permissions 表。
 -- ============================================================

--- a/docs/spec/tasks.md
+++ b/docs/spec/tasks.md
@@ -1,5 +1,7 @@
 # 實作任務清單
 
+> Status: historical roadmap. Checkbox狀態已落後現行implementation，不得用來判斷完成度或建立現行contract。Current state見[`../current-state.md`](../current-state.md)，工程規範見[`../.rules/`](../.rules/)。
+
 產出依據：docs/design/domain-model.md v3.3
 
 ---

--- a/docs/spec/tech-stack.md
+++ b/docs/spec/tech-stack.md
@@ -1,176 +1,78 @@
 # Tech Stack
 
-產出日期：2026-04-15
-基於：domain-model.md v3.0 + spec 文件 + 使用者情境
+- Status: current implementation + proposed production settings
+- Last verified: 2026-07-10
 
-## 情境摘要
+本文分開描述repo已採用技術與尚未確認的production infrastructure。即時版本/行為以`go.mod`、Dockerfile、workflows、DB migrations與runtime wiring為準。
 
-10 人內部工具，同時上線人數極低（個位數）。1 人開發，後端 Go + Gin，前端 React + Ant Design + Vite（AI 輔助）。部署全採 GCP，預算上限 1500 TWD/月（約 $46 USD）。認證已確定使用 Firebase Auth + Custom Claims。系統有 8 個 Aggregate、跨 BC 事件傳遞、6 個排程任務、以及 Email 通知需求。
+## Current Implementation
 
----
+### Language And Runtime
 
-## 選型決策
+- Go 1.24（`go.mod`與Dockerfile builder）。
+- Gin HTTP framework。
+- Single deployable monolith；bounded contexts是code ownership boundaries，不是microservices。
+- OpenAPI-first：source在`docs/spec/src/**`，bundle與Go bindings由script產生。
 
-### 語言 & 框架
+### Persistence
 
-**後端**
-- **選擇**：Go 1.23 + Gin
-- **理由**：團隊熟悉度確定，Gin 輕量適合單體架構，Go 的靜態型別有助於 DDD domain 層的 Business Rule 實作
-- **放棄的選項**：無，已確定
+- PostgreSQL + `database/sql`，主要driver為pgx stdlib。
+- SQL migrations是physical schema source of truth。
+- Repositories/query adapters使用explicit SQL；repo沒有GORM runtime dependency。
+- Transactions由application use case與`txrunner`協調；business rules不放進DB triggers。
+- `docs/spec/schema.sql`是derived/reference snapshot，不是第二套schema authority。
 
-**前端**
-- **選擇**：React + Ant Design + Vite
-- **理由**：團隊已確定，Ant Design 內建 Table/Form 元件適合內部管理工具
-- **放棄的選項**：無，已確定
+### Authentication And Authorization
 
-**架構模式**
-- **選擇**：單體（Monolith）
-- **理由**：10 人工具、1 人開發，微服務只會增加部署複雜度與成本。Go Gin 單一 binary 部署 Cloud Run 即可
-- **放棄的選項**：微服務（過度設計）
-
----
-
-### 資料庫
-
-- **選擇**：Cloud SQL for PostgreSQL — `db-f1-micro`（1 shared vCPU, 0.6 GB RAM）
-- **理由**：spec 已確定 PostgreSQL（JSONB、UUID、樂觀鎖、悲觀鎖 SELECT FOR UPDATE）。db-f1-micro 約 $7–10 USD/月，10 人內部工具流量完全可承受
-- **設定建議**：asia-east1（台灣）、自動備份每日一次、啟用 `pgcrypto` extension（gen_random_uuid）
-- **放棄的選項**：
-  - db-g1-small（$25/month，超預算且超出需求）
-  - Neon/Supabase（非 GCP 全套）
-
-### Brand Public Read Boundary
-
-- **用途**：core backend 透過獨立 public namespace 提供品牌頁 build-time 需要的 read-only endpoints，不直接暴露 admin brand management endpoints。
-- **Core migration 責任**：建立 approved views，例如 `approved_brand_profile_v1`、`approved_brand_faq_items_v1`、`approved_brand_property_availability_v1`。
-- **Public endpoint 責任**：只讀 approved views，不直接讀 `properties`、`rooms`、`brand_profiles`、`brand_faq_items`、tenant、lease、bill、deposit、attachment、accounting 等 base tables。
-- **Credential 邊界**：第一版使用 core backend runtime DB credential，避免為低流量 build-time brand site 增加額外 readonly credential / service 部署複雜度。approved views 仍是 public data exposure boundary。
-- **測試策略**：repo 的 PostgreSQL migration contract test 繼續使用 ephemeral equivalent role 驗證 approved views 可讀、base tables 不可讀；本地 `brand_readonly` helper 保留作為歷史/診斷用途，不是現行 brand site deployment dependency。
-
-### Persistence / Data Access
-
-- **整體策略**：SQL-first；migration、schema、index、constraint 以 SQL 為準，business rule 不下沉至 DB trigger / stored procedure
-- **GORM 使用邊界**：
-  - 可用於簡單 insert/update/select 與 persistence mapping
-  - 不作為架構中心，不依賴 hook、auto preload、隱式 transaction
-  - 複雜查詢、報表、scheduler scan、locking query（如 `SELECT ... FOR UPDATE`）可直接使用 raw SQL
-- **分層方式**：
-  - `model`：大致對應 table，負責 persistence mapping
-  - `repository`：對應 use case / aggregate / bounded context，只提供當前業務切片真正需要的方法
-  - `query`：服務 read model、報表、scheduler scan，直接回 DTO 或輕量 query object
-- **實作原則**：
-  - 不採「每個 table 先建完整 CRUD repo」策略
-  - persistence model、domain model、API model 明確分離
-  - Read API 可直接走 query repository；Write API 走 application service + repository
-- **理由**：符合目前 vertical slice 開發方式，也保留 PostgreSQL 在鎖定、聚合查詢、批次處理上的優勢
-
----
-
-### Auth（認證與授權）
-
-- **認證方式**：Firebase Auth（已確定於 schema）
-- **授權實作**：
-  - RBAC：Go middleware 驗證 Firebase ID token 後，以 `firebase_uid` 載入 DB user principal，使用 DB role（admin/organizer/staff/owner）判斷
-  - Resource-based：middleware 使用 DB user principal 內的 `assigned_property_ids` 驗證請求是否在允許的 property 範圍內；owner 以 `properties.owner_id` 判斷
-- **Go 整合**：`firebase.google.com/go/v4` Admin SDK，middleware 驗證 ID Token → 載入 DB user principal → 注入 context
-- **理由**：Firebase Auth 負責身份驗證，DB user principal 作為授權 source of truth，避免 Custom Claims 與 DB drift 影響 runtime authorization
-- **放棄的選項**：JWT 自建（多餘複雜度，Firebase 已包含）、session-based（Cloud Run 無狀態不適合）
-
----
+- Firebase Auth驗證ID token與外部身份。
+- Backend以`firebase_uid`載入active DB user principal。
+- Runtime RBAC/property scope使用DB `role`、`assigned_property_ids`與property ownership。
+- Firebase Custom Claims可以同步，但不覆蓋DB principal。
+- `permission_overrides`目前只保存/回傳，正式授權語意尚未確認。
 
 ### Domain Events
 
-- **選擇**：In-process Event Bus（Go channel / 同步 dispatcher）
-- **理由**：所有 BC 在同一個 Go process 內，10 人工具無需跨服務事件。同步 dispatcher 在同一個 transaction 內處理跨 BC 副作用（Room 狀態更新、AccountingEntry 建立），實作最簡單且可靠
-- **實作方式**：`DomainEvent` interface + Application Service 層在 transaction commit 後觸發 handlers
-- **放棄的選項**：Cloud Pub/Sub（外部 message queue，增加成本與複雜度，此規模不需要）
+- Synchronous in-process dispatcher，publish發生在command DB transaction commit之後。
+- 無outbox、retry、dead-letter queue或durable delivery。
+- 強一致的核心/財務side effects使用同transaction direct orchestration。
+- Lease room/tenant lifecycle仍使用post-commit subscribers，列為current consistency risk。
 
----
+### External Services
 
-### Email 通知
+- Email：Resend adapter；password reset/onboarding與部分scheduler通知已實作。
+- LINE：只有stub，runtime未實作。
+- Attachments：Google Cloud Storage signed upload URLs與metadata verification；test/e2e可使用受限fake mode。
+- Observability：structured `slog`、request middleware、Cloud Logging/Monitoring compatible exporters。
 
-- **選擇**：Resend
-- **理由**：API 介面簡潔，官方 Go SDK 可直接整合，適合目前後端主導的通知流程。現階段 email 量低，足以支撐 onboarding、催收、到期提醒、財報寄送等場景
-- **補充**：notification infrastructure 先抽象為 `email` / `line` 兩種 channel；本期只落地 email，LINE 只保留抽象介面
-- **放棄的選項**：Firebase Extension "Trigger Email"（依賴 Firestore，與 PostgreSQL 架構不搭）、SendGrid（不再採用）
+### Brand Public Read Boundary
 
----
+- Core backend public namespace只讀approved PostgreSQL views。
+- Public handlers不得直接查詢tenant、lease、bill、attachment、deposit/accounting或其他未核准base tables。
+- 現行brand architecture不需要獨立`brand_readonly`production principal；repo保留ephemeral-role contract tests與local diagnostic helper。
 
-### 部署 & 基礎建設
+### CI And Staging Deployment
 
-- **後端容器化**：Docker，multi-stage build（builder: golang:1.23-alpine → runtime: alpine）壓縮 image 大小
-- **後端部署**：Cloud Run（asia-east1）
-  - 最小實例：0（省錢，冷啟動對內部工具可接受）
-  - 最大實例：2（避免意外擴展產生費用）
-  - 記憶體：512 MB，CPU：1
-- **前端部署**：admin frontend 使用 Firebase Hosting；brand frontend 使用 Cloudflare Pages 靜態部署與 preview。
-- **Container Registry**：Artifact Registry（$0.10/GB/月，image 小費用極低）
-- **CI/CD**：Cloud Build
-  - 免費 tier：120 build-minutes/day，完全足夠
-  - 觸發條件：push to `main` branch
-  - Pipeline：test → build image → push to Artifact Registry → deploy to Cloud Run
-- **排程任務**：Cloud Scheduler（前 3 個 job 免費，第 4–6 個約 $0.30/月）→ 呼叫 Cloud Run HTTP endpoints
-  - 排程邏輯仍實作於本 backend repo，由 application service / repository 負責執行
-  - 觸發方式採外部 scheduler 呼叫受保護 endpoint，不在 app 內維護常駐 cron，也不以 CLI job 為主要模式
-  - job endpoint 必須支援 idempotency、鎖定策略與失敗重跑
+- PR/push gates由GitHub Actions執行Go tests/build、OpenAPI lint/generate diff與migration checks。
+- Staging deployment intent來自`staging` branch或controlled manual dispatch；GitHub Actions提交Cloud Build，建置Artifact Registry image並部署Cloud Run。
+- Admin frontend使用Firebase Hosting；brand frontend是另一repo的Cloudflare Pages deployment。
+- Scheduler use cases與protected HTTP endpoints已存在；first staging demo runbook不包含Cloud Scheduler provisioning。
 
-**預估月費（asia-east1）**
+## Proposed Production Baseline
 
-| 服務 | 費用估計 |
-|------|---------|
-| Cloud SQL db-f1-micro | ~$8–10 USD |
-| Cloud Run | ~$0–2 USD（極低流量） |
-| Firebase Auth + Hosting | 免費 |
-| Cloud Build | 免費 |
-| Artifact Registry | ~$0.10 USD |
-| Cloud Scheduler (6 jobs) | ~$0.30 USD |
-| Cloud Logging / Monitoring | 免費 tier |
-| Resend | 低量通知可控 |
-| **合計** | **~$9–13 USD（約 270–400 TWD）** |
+下列項目不是final production contract：
 
-> 遠低於 1500 TWD 上限，有充裕空間。
+- Cloud Run region、min/max instances、CPU/memory與ingress policy。
+- Cloud SQL tier、HA、backup window、PITR、maintenance與connection budget。
+- Production promotion workflow、operator DB access、rollback與alert ownership。
+- Cloud Scheduler job provisioning與failure operations。
+- Monthly cost estimates。
 
----
+Production決策與證據集中在[`../production-readiness.md`](../production-readiness.md)；staging成功不能替代production sign-off。
 
-### 可觀測性
+## Stable Engineering Choices
 
-- **Logging**：Cloud Logging
-  - Go 使用 `log/slog`（標準庫，Go 1.21+）輸出 JSON structured log
-  - Gin middleware 記錄每個 request：method、path、status、latency、user_id、property_id
-  - 錯誤 log 包含 error code、stack trace
-- **Metrics**：Cloud Monitoring
-  - Cloud Run 自動提供：request count、latency、instance count
-  - Cloud SQL 自動提供：CPU、memory、connection count
-  - 設定基本 alerting policy：Cloud Run error rate > 5% 發 email 通知
-- **Tracing**：不實作（單體 + 10 人工具，無此需求）
-- **理由**：GCP 原生方案，零額外成本，無需 Prometheus/Grafana
-
----
-
-### Error Handling
-
-- **策略**：Gin middleware 統一處理，domain 層 error 往上傳遞，API 層轉換為 HTTP response
-- **格式**：對應 OpenAPI spec 的統一 error response
-  ```json
-  {
-    "code": "LEASE_HAS_UNPAID_BILLS",
-    "message": "...",
-    "details": { ... }
-  }
-  ```
-- **Domain error**：定義 `DomainError` struct，含 `Code`（對應 OpenAPI error code）、`HTTPStatus`、`Details`
-- **Panic recovery**：Gin 內建 Recovery middleware，捕捉 panic 回傳 500，並寫入 Cloud Logging
-
----
-
-## [需確認]
-
-**1. Cloud SQL 實例大小**
-db-f1-micro 是共享 CPU，偶爾會有 CPU throttling。對 10 人工具通常沒問題，但若排程任務（月結快照、逾期掃描）與一般操作同時執行時可能出現短暫延遲。
-- 選項 A：維持 db-f1-micro（約 $8/月，接受偶發延遲）
-- 選項 B：升級為 db-g1-small（約 $25/月，穩定 CPU，仍在預算內）
-
-**2. Cloud Run 冷啟動**
-最小實例設為 0 時，若長時間無請求後第一個 request 會有 1–3 秒冷啟動延遲。對內部工具通常可接受。
-- 選項 A：最小實例 = 0（省錢，約省 $5–8/月）
-- 選項 B：最小實例 = 1（無冷啟動，增加約 $5–8/月費用，仍在預算內）
+- Keep the service monolithic unless a separately confirmed operational need justifies a deployment split.
+- Keep API, domain, persistence and generated models separate.
+- Use read/query repositories for projections and application services for commands.
+- Keep Firebase responsible for identity and DB principal responsible for authorization.
+- Keep strong state changes inside the command transaction; do not add critical post-commit subscribers without an explicit reliability decision.

--- a/docs/staging-runbook.md
+++ b/docs/staging-runbook.md
@@ -1,8 +1,10 @@
 # Staging Deployment Runbook
 
-Status: staging v1 contract for the first demo wave.
+Status: staging v1 contract for the first demo/UAT wave; not a production contract.
 
-This runbook defines the repository-side staging contract. The human operator
+This runbook defines the repository-side staging contract. Production
+readiness, migration cutover, rollback, RTO and RPO are tracked separately in
+[`production-readiness.md`](production-readiness.md). The human operator
 performs GCP Console or `gcloud` changes. Do not paste secret values, tokens,
 private keys, database passwords, or full bearer credentials into issues, pull
 requests, logs, or evidence.

--- a/docs/vertical-slice-handbook.md
+++ b/docs/vertical-slice-handbook.md
@@ -1,5 +1,7 @@
 # STDS Backend Vertical Slice Handbook
 
+> Status: historical implementation example. 現行layer與testing規範以[`docs/.rules/coding-style.md`](.rules/coding-style.md)與[`docs/.rules/testing.md`](.rules/testing.md)為準。
+
 這份文件用這次實作的兩支 API 當範本：
 
 - Read API：`GET /users/me`
@@ -37,8 +39,8 @@
 
 對應程式：
 
-- [internal/http/handler/api_server.go](/Users/cheni-fan/stds_backend/internal/http/handler/api_server.go:226)
-- [internal/platform/database/users/repository.go](/Users/cheni-fan/stds_backend/internal/platform/database/users/repository.go:89)
+- [`internal/http/handler/api_server.go`](../internal/http/handler/api_server.go)
+- [`internal/platform/database/users/repository.go`](../internal/platform/database/users/repository.go)
 
 ### 2. Write API：`POST /users`
 
@@ -54,9 +56,9 @@
 
 對應程式：
 
-- [internal/application/iam/create_user.go](/Users/cheni-fan/stds_backend/internal/application/iam/create_user.go:11)
-- [internal/http/handler/api_server.go](/Users/cheni-fan/stds_backend/internal/http/handler/api_server.go:205)
-- [internal/platform/database/users/repository.go](/Users/cheni-fan/stds_backend/internal/platform/database/users/repository.go:111)
+- [`internal/application/iam/create_user.go`](../internal/application/iam/create_user.go)
+- [`internal/http/handler/api_server.go`](../internal/http/handler/api_server.go)
+- [`internal/platform/database/users/repository.go`](../internal/platform/database/users/repository.go)
 
 ### 3. Wiring
 
@@ -67,8 +69,8 @@
 
 對應程式：
 
-- [internal/server/server.go](/Users/cheni-fan/stds_backend/internal/server/server.go:42)
-- [internal/http/router/router.go](/Users/cheni-fan/stds_backend/internal/http/router/router.go:17)
+- [`internal/server/server.go`](../internal/server/server.go)
+- [`internal/http/router/router.go`](../internal/http/router/router.go)
 
 ### 4. 測試
 
@@ -79,8 +81,8 @@
 
 對應程式：
 
-- [internal/application/iam/create_user_test.go](/Users/cheni-fan/stds_backend/internal/application/iam/create_user_test.go:1)
-- [internal/http/router/router_test.go](/Users/cheni-fan/stds_backend/internal/http/router/router_test.go:1)
+- [`internal/application/iam/create_user_test.go`](../internal/application/iam/create_user_test.go)
+- [`internal/http/router/router_test.go`](../internal/http/router/router_test.go)
 
 ---
 
@@ -102,11 +104,11 @@
 
 關鍵檔案：
 
-- [internal/http/router/router.go](/Users/cheni-fan/stds_backend/internal/http/router/router.go:16)
-- [internal/http/middleware/auth.go](/Users/cheni-fan/stds_backend/internal/http/middleware/auth.go:14)
-- [internal/http/middleware/authorization.go](/Users/cheni-fan/stds_backend/internal/http/middleware/authorization.go:16)
-- [internal/http/middleware/error_handler.go](/Users/cheni-fan/stds_backend/internal/http/middleware/error_handler.go:14)
-- [internal/platform/database/postgres.go](/Users/cheni-fan/stds_backend/internal/platform/database/postgres.go:14)
+- [`internal/http/router/router.go`](../internal/http/router/router.go)
+- [`internal/http/middleware/auth.go`](../internal/http/middleware/auth.go)
+- [`internal/http/middleware/authorization.go`](../internal/http/middleware/authorization.go)
+- [`internal/http/middleware/error_handler.go`](../internal/http/middleware/error_handler.go)
+- [`internal/platform/database/postgres.go`](../internal/platform/database/postgres.go)
 
 實務上你要記住的是：**新的 API 通常不需要再碰 middleware 與 server bootstrap，除非你真的引入了新的 cross-cutting concern。**
 
@@ -241,7 +243,7 @@
 
 ### 你可以直接沿用的錯誤型別
 
-在 [internal/shared/apperr/common.go](/Users/cheni-fan/stds_backend/internal/shared/apperr/common.go:5) 已經有基礎錯誤，這次又補了：
+在 [`internal/shared/apperr/common.go`](../internal/shared/apperr/common.go) 已經有基礎錯誤，這次又補了：
 
 - `USER_NOT_FOUND`
 - `EMAIL_ALREADY_EXISTS`

--- a/docs/wiki-drafts/staging-v1-operator-handbook-2026-05-15-v1.md
+++ b/docs/wiki-drafts/staging-v1-operator-handbook-2026-05-15-v1.md
@@ -1,8 +1,12 @@
 # Staging v1 Operator Handbook
 
+> Status: historical publishing snapshot dated 2026-05-15. This file is not a
+> deployment or production source of truth; use `docs/staging-runbook.md` for the
+> repo staging contract and verify any live Wiki content separately.
+
 Target: GitHub Wiki page
 
-Source of truth for operator handbook; repo docs keep contracts/checklists.
+Historical source snapshot for the operator handbook; repo docs keep contracts/checklists.
 
 This handbook captures the staging v1 setup as operated through issue #202. It
 is meant to be pasted into the GitHub Wiki and kept as the non-secret operator


### PR DESCRIPTION
Fixes IFAN-13

## Summary

- Publish a single documentation authority entry point, current-state inventory, confirmed domain rules, decision backlog, ADRs, migration contracts, and production-readiness gates.
- Reclassify legacy roadmap, handbook, staging, architecture, and schema-reference documents so they cannot override canonical contracts.
- Include the user-authorized `.antigravitycli` project setting as a regular JSON file (not a machine-local symlink).

## Rationale

This fixes the documentation authority order before production-readiness work proceeds, preventing current implementation, generated artifacts, or historical planning documents from being inferred as business truth.

## Scope and out of scope

- Documentation only; no application, API, schema migration, or runtime behavior changes.
- Unconfirmed domain decisions remain in the decision backlog rather than becoming canonical rules.
- Exception: the issue originally excluded `.antigravitycli/`; this PR includes the user-explicitly-authorized, credential-screened project setting.

## Validation

- `ruby` relative Markdown-link check: 27 Markdown files passed.
- `npm run openapi:lint`: passed with 3 pre-existing warnings for public GET operations lacking a 4XX response.
- `npm run openapi:generate`: passed; bundled OpenAPI and generated Go bindings have no diff.
- `go test ./...`: passed.
- Schema-reference parity: checked the journal expense-accounting fields and index against migration `000018`.
- `git diff --check`: passed.

## Tests

Documentation-only change; no new Go tests added. Existing full suite passed.