### PR TITLE
test: stabilize dashboard monthly rent fixture

### DIFF
--- a/test/e2e/dashboard_read_model_test.go
+++ b/test/e2e/dashboard_read_model_test.go
@@ -39,13 +39,18 @@ func TestE2EDashboardReadModelsAcceptance(t *testing.T) {
 	createRoom(t, ctx, adminClient, assignedProperty.ID, "E2E Dashboard Vacant Room")
 	createRoom(t, ctx, adminClient, unassignedProperty.ID, "E2E Dashboard Unassigned Room")
 	tenant := createTenant(t, ctx, adminClient)
+	const expectedRent = 18000
+	taipei := time.FixedZone("Asia/Taipei", 8*60*60)
+	currentMonth := time.Now().In(taipei)
+	leaseStart := time.Date(currentMonth.Year(), currentMonth.Month(), 1, 0, 0, 0, 0, taipei)
+	leaseEnd := leaseStart.AddDate(0, 1, -1)
 	leaseLifecycleE2ECreateLease(t, ctx, adminClient, leaseLifecycleE2ECreateLeaseParams{
 		PropertyID: assignedProperty.ID,
 		RoomID:     occupiedRoom.ID,
 		TenantID:   tenant.ID,
-		StartDate:  "2026-05-01",
-		EndDate:    "2026-06-30",
-		RentAmount: 18000,
+		StartDate:  leaseStart.Format("2006-01-02"),
+		EndDate:    leaseEnd.Format("2006-01-02"),
+		RentAmount: expectedRent,
 		Deposit:    36000,
 		Cadence:    "monthly",
 	})
@@ -128,8 +133,8 @@ func TestE2EDashboardReadModelsAcceptance(t *testing.T) {
 		if dashboard.PropertySummaries[0].PropertyID != assignedProperty.ID {
 			t.Fatalf("expected assigned property summary %q, got %q", assignedProperty.ID, dashboard.PropertySummaries[0].PropertyID)
 		}
-		if dashboard.MonthlyBillingSummary.ExpectedRent == 0 {
-			t.Fatalf("expected backend monthly billing summary to include generated rent: %+v", dashboard.MonthlyBillingSummary)
+		if dashboard.MonthlyBillingSummary.ExpectedRent != expectedRent {
+			t.Fatalf("expected current-month rent %d, got %+v", expectedRent, dashboard.MonthlyBillingSummary)
 		}
 	})
 }


### PR DESCRIPTION
Fixes IFAN-49

## Summary

- Build the dashboard E2E lease fixture for the current Asia/Taipei month.
- Assert that the monthly billing summary reports the exact expected rent of 18,000.

## Rationale

The fixture previously used a fixed 2026-05 to 2026-06 lease, so the dashboard's current-month query returned zero rent after that period.

## Scope

Only `test/e2e/dashboard_read_model_test.go` changes. Dashboard runtime behavior, SQL, billing rules, OpenAPI, and IFAN-13 documentation are out of scope.

## Validation

- `./scripts/e2e_test.sh -run '^TestE2EDashboardReadModelsAcceptance$' -count=1`
- `./scripts/e2e_test.sh`
- `go test ./...`

## Docs and tests

E2E test-only change; no documentation update is required.
